### PR TITLE
feat: Sora + JetBrains Mono font upgrade

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,9 +7,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  --font-sans: var(--font-sora);
+  --font-mono: var(--font-jetbrains-mono);
+  --font-heading: var(--font-sora);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -95,6 +95,14 @@
   }
   html {
     @apply font-sans;
+  }
+  h1, h2, h3, h4 {
+    font-family: var(--font-sora), sans-serif;
+    letter-spacing: -0.02em;
+    font-weight: 700;
+  }
+  code, pre, kbd, .font-mono {
+    font-family: var(--font-jetbrains-mono), monospace;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,20 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Sora, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import WalletProvider from "@/components/WalletProvider";
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const sora = Sora({
+  variable: "--font-sora",
   subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700", "800"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
+  weight: ["400", "500", "600"],
 });
 
 export const metadata: Metadata = {
@@ -28,7 +30,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-background`}
+        className={`${sora.variable} ${jetbrainsMono.variable} antialiased min-h-screen bg-background`}
       >
         <WalletProvider>
           <NavBar />


### PR DESCRIPTION
Replaces default Geist fonts with:
- **Sora** — geometric, technical, used by Linear/Vercel-adjacent projects. Weights 300–800 loaded. Headings get -0.02em letter-spacing for tighter display.
- **JetBrains Mono** — replaces Geist Mono for all code/mono elements. Better terminal aesthetic, ligature support in code snippets.

CSS variables `--font-sans`, `--font-mono`, `--font-heading` all updated. No component changes needed.

Ready for review.