### PR TITLE
feat: wire demo-c-protocol.mp4 into tour Watch Video modal

### DIFF
--- a/app/tour/page.tsx
+++ b/app/tour/page.tsx
@@ -231,14 +231,18 @@ export default function TourPage() {
             </button>
             <video
               ref={videoRef}
-              src="https://github.com/reddinft/reddi-agent-protocol/releases/download/v1.0-tour/tour-walkthrough.mp4"
               controls
               autoPlay
               className="w-full rounded-xl border border-white/10 shadow-2xl"
               style={{ aspectRatio: '1280/800' }}
-            />
+            >
+              <source
+                type="video/mp4"
+                src="https://github.com/nissan/reddi-agent-protocol/releases/download/demo-videos-v1/demo-c-protocol.mp4"
+              />
+            </video>
             <p className="text-xs text-white/30 text-center mt-3">
-              Full walkthrough · 4m 26s · narrated by Loki
+              The Protocol — Technical Explainer · 2 min
             </p>
           </div>
         </div>


### PR DESCRIPTION
Uploads demo-c-protocol.mp4 to GitHub release `demo-videos-v1` and wires it into the `/tour` page Watch Video modal.

- Video: The Protocol — Technical Explainer (120s)
- Uses `<source type="video/mp4">` pattern for CDN redirect compatibility
- Release also contains demo-a and demo-b for future use

Ready for review.