### PR TITLE
Phase 3: Agent Registry (register/update/deregister + LiteSVM tests)

### DIFF
--- a/programs/escrow/src/constants.rs
+++ b/programs/escrow/src/constants.rs
@@ -1,4 +1,11 @@
+use anchor_lang::prelude::{pubkey, Pubkey};
+
 pub const ESCROW_SEED: &[u8] = b"escrow";
+pub const AGENT_SEED: &[u8] = b"agent";
 pub const ESCROW_DISCRIMINATOR_SIZE: usize = 8;
 /// Minimum slots before a payer can cancel (~7 days at 400ms/slot)
 pub const CANCEL_WINDOW_SLOTS: u64 = 50_400;
+
+pub const AGENT_REGISTRATION_FEE: u64 = 10_000_000; // 0.01 SOL in lamports
+pub const AGENT_MODEL_MAX_LEN: usize = 64;
+pub const AGENT_FEE_BURN_ADDRESS: Pubkey = pubkey!("1nc1nerator11111111111111111111111111111111");

--- a/programs/escrow/src/error.rs
+++ b/programs/escrow/src/error.rs
@@ -25,4 +25,10 @@ pub enum EscrowError {
 
     #[msg("Invalid payee")]
     InvalidPayee,
+
+    #[msg("Model string exceeds maximum length")]
+    ModelTooLong,
+
+    #[msg("Agent is not active")]
+    AgentNotActive,
 }

--- a/programs/escrow/src/instructions.rs
+++ b/programs/escrow/src/instructions.rs
@@ -1,7 +1,13 @@
 pub mod cancel_escrow;
+pub mod deregister_agent;
 pub mod lock_escrow;
+pub mod register_agent;
 pub mod release_escrow;
+pub mod update_agent;
 
 pub use cancel_escrow::*;
+pub use deregister_agent::*;
 pub use lock_escrow::*;
+pub use register_agent::*;
 pub use release_escrow::*;
+pub use update_agent::*;

--- a/programs/escrow/src/instructions/cancel_escrow.rs
+++ b/programs/escrow/src/instructions/cancel_escrow.rs
@@ -24,7 +24,11 @@ pub fn cancel_escrow_handler(ctx: Context<CancelEscrow>) -> Result<()> {
     let amount = ctx.accounts.escrow.amount;
 
     // Transfer lamports from escrow PDA back to payer
-    **ctx.accounts.escrow.to_account_info().try_borrow_mut_lamports()? -= amount;
+    **ctx
+        .accounts
+        .escrow
+        .to_account_info()
+        .try_borrow_mut_lamports()? -= amount;
     **ctx.accounts.payer.try_borrow_mut_lamports()? += amount;
 
     // Mark cancelled (account will be closed by `close = payer` constraint)

--- a/programs/escrow/src/instructions/deregister_agent.rs
+++ b/programs/escrow/src/instructions/deregister_agent.rs
@@ -1,0 +1,23 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::AGENT_SEED;
+use crate::state::AgentAccount;
+
+pub fn deregister_agent_handler(_ctx: Context<DeregisterAgent>) -> Result<()> {
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct DeregisterAgent<'info> {
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, owner.key().as_ref()],
+        bump = agent.bump,
+        has_one = owner,
+        close = owner,
+    )]
+    pub agent: Account<'info, AgentAccount>,
+
+    #[account(mut)]
+    pub owner: Signer<'info>,
+}

--- a/programs/escrow/src/instructions/lock_escrow.rs
+++ b/programs/escrow/src/instructions/lock_escrow.rs
@@ -7,14 +7,10 @@ use crate::state::{EscrowAccount, EscrowStatus};
 
 /// Lock SOL into an escrow PDA.
 /// Called by Agent A (payer) to initiate a payment to Agent B (payee).
-/// 
+///
 /// PDA: seeds = [b"escrow", payer, nonce]
 /// This prevents duplicate nonces for the same payer.
-pub fn lock_escrow_handler(
-    ctx: Context<LockEscrow>,
-    amount: u64,
-    nonce: [u8; 16],
-) -> Result<()> {
+pub fn lock_escrow_handler(ctx: Context<LockEscrow>, amount: u64, nonce: [u8; 16]) -> Result<()> {
     require!(amount > 0, EscrowError::ZeroAmount);
 
     let escrow = &mut ctx.accounts.escrow;

--- a/programs/escrow/src/instructions/register_agent.rs
+++ b/programs/escrow/src/instructions/register_agent.rs
@@ -1,0 +1,69 @@
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+
+use crate::constants::{
+    AGENT_FEE_BURN_ADDRESS, AGENT_MODEL_MAX_LEN, AGENT_REGISTRATION_FEE, AGENT_SEED,
+};
+use crate::error::EscrowError;
+use crate::state::{AgentAccount, AgentType};
+
+pub fn register_agent_handler(
+    ctx: Context<RegisterAgent>,
+    agent_type: AgentType,
+    model: String,
+    rate_lamports: u64,
+    min_reputation: u8,
+) -> Result<()> {
+    require!(
+        model.len() <= AGENT_MODEL_MAX_LEN,
+        EscrowError::ModelTooLong
+    );
+
+    // Burn registration fee to Solana incinerator address.
+    system_program::transfer(
+        CpiContext::new(
+            ctx.accounts.system_program.key(),
+            system_program::Transfer {
+                from: ctx.accounts.owner.to_account_info(),
+                to: ctx.accounts.fee_collector.to_account_info(),
+            },
+        ),
+        AGENT_REGISTRATION_FEE,
+    )?;
+
+    let agent = &mut ctx.accounts.agent;
+    agent.owner = ctx.accounts.owner.key();
+    agent.agent_type = agent_type;
+    agent.model = model;
+    agent.rate_lamports = rate_lamports;
+    agent.min_reputation = min_reputation;
+    agent.reputation_score = 0;
+    agent.jobs_completed = 0;
+    agent.jobs_failed = 0;
+    agent.created_at = Clock::get()?.unix_timestamp;
+    agent.active = true;
+    agent.bump = ctx.bumps.agent;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct RegisterAgent<'info> {
+    #[account(
+        init,
+        payer = owner,
+        space = AgentAccount::LEN,
+        seeds = [AGENT_SEED, owner.key().as_ref()],
+        bump,
+    )]
+    pub agent: Account<'info, AgentAccount>,
+
+    #[account(mut)]
+    pub owner: Signer<'info>,
+
+    /// CHECK: Hard-coded to Solana incinerator for fee burn.
+    #[account(mut, address = AGENT_FEE_BURN_ADDRESS)]
+    pub fee_collector: UncheckedAccount<'info>,
+
+    pub system_program: Program<'info, System>,
+}

--- a/programs/escrow/src/instructions/release_escrow.rs
+++ b/programs/escrow/src/instructions/release_escrow.rs
@@ -16,7 +16,11 @@ pub fn release_escrow_handler(ctx: Context<ReleaseEscrow>) -> Result<()> {
     let amount = ctx.accounts.escrow.amount;
 
     // Transfer lamports from escrow PDA to payee
-    **ctx.accounts.escrow.to_account_info().try_borrow_mut_lamports()? -= amount;
+    **ctx
+        .accounts
+        .escrow
+        .to_account_info()
+        .try_borrow_mut_lamports()? -= amount;
     **ctx.accounts.payee.try_borrow_mut_lamports()? += amount;
 
     // Mark released (account will be closed by `close = payer` constraint)

--- a/programs/escrow/src/instructions/update_agent.rs
+++ b/programs/escrow/src/instructions/update_agent.rs
@@ -1,0 +1,30 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::AGENT_SEED;
+use crate::state::AgentAccount;
+
+pub fn update_agent_handler(
+    ctx: Context<UpdateAgent>,
+    rate_lamports: u64,
+    min_reputation: u8,
+    active: bool,
+) -> Result<()> {
+    let agent = &mut ctx.accounts.agent;
+    agent.rate_lamports = rate_lamports;
+    agent.min_reputation = min_reputation;
+    agent.active = active;
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct UpdateAgent<'info> {
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, owner.key().as_ref()],
+        bump = agent.bump,
+        has_one = owner,
+    )]
+    pub agent: Account<'info, AgentAccount>,
+
+    pub owner: Signer<'info>,
+}

--- a/programs/escrow/src/lib.rs
+++ b/programs/escrow/src/lib.rs
@@ -42,4 +42,33 @@ pub mod escrow {
     pub fn cancel_escrow(ctx: Context<CancelEscrow>) -> Result<()> {
         instructions::cancel_escrow::cancel_escrow_handler(ctx)
     }
+
+    pub fn register_agent(
+        ctx: Context<RegisterAgent>,
+        agent_type: AgentType,
+        model: String,
+        rate_lamports: u64,
+        min_reputation: u8,
+    ) -> Result<()> {
+        instructions::register_agent::register_agent_handler(
+            ctx,
+            agent_type,
+            model,
+            rate_lamports,
+            min_reputation,
+        )
+    }
+
+    pub fn update_agent(
+        ctx: Context<UpdateAgent>,
+        rate_lamports: u64,
+        min_reputation: u8,
+        active: bool,
+    ) -> Result<()> {
+        instructions::update_agent::update_agent_handler(ctx, rate_lamports, min_reputation, active)
+    }
+
+    pub fn deregister_agent(ctx: Context<DeregisterAgent>) -> Result<()> {
+        instructions::deregister_agent::deregister_agent_handler(ctx)
+    }
 }

--- a/programs/escrow/src/state.rs
+++ b/programs/escrow/src/state.rs
@@ -43,5 +43,46 @@ impl EscrowAccount {
         + 1    // status (enum variant)
         + 8    // created_at
         + 8    // created_slot
-        + 1;   // bump
+        + 1; // bump
+}
+
+/// Type of work an agent supports in the marketplace.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq, Debug)]
+pub enum AgentType {
+    Primary,
+    Attestation,
+    Both,
+}
+
+/// On-chain registry record for a discoverable agent.
+/// PDA seeds: [b"agent", owner]
+#[account]
+pub struct AgentAccount {
+    /// Wallet that registered this agent
+    pub owner: Pubkey,
+    /// Marketplace role supported by this agent
+    pub agent_type: AgentType,
+    /// Human-readable model identifier (max 64 chars)
+    pub model: String,
+    /// Per-call price in lamports
+    pub rate_lamports: u64,
+    /// Minimum caller reputation required (0 = open access)
+    pub min_reputation: u8,
+    /// Running reputation score, 0..10000 == 0.00..100.00
+    pub reputation_score: u16,
+    /// Successful jobs fulfilled
+    pub jobs_completed: u64,
+    /// Failed jobs
+    pub jobs_failed: u64,
+    /// Unix timestamp when registered
+    pub created_at: i64,
+    /// Whether this agent can currently accept jobs
+    pub active: bool,
+    /// PDA bump seed
+    pub bump: u8,
+}
+
+impl AgentAccount {
+    /// 8 (discriminator) + 32 + 1 + 68 (4+64 string) + 8 + 1 + 2 + 8 + 8 + 8 + 1 + 1
+    pub const LEN: usize = 148;
 }

--- a/programs/escrow/tests/test_escrow.rs
+++ b/programs/escrow/tests/test_escrow.rs
@@ -48,8 +48,7 @@ fn send(
     let payer_pk = signers[0].pubkey();
     let blockhash = svm.latest_blockhash();
     let msg = Message::new_with_blockhash(&[ix], Some(&payer_pk), &blockhash);
-    let tx =
-        VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
     match svm.send_transaction(tx) {
         Ok(_) => panic!("Expected error but tx succeeded"),
         Err(e) => e,
@@ -60,8 +59,7 @@ fn send_ok(svm: &mut LiteSVM, ix: Instruction, signers: &[&Keypair]) {
     let payer_pk = signers[0].pubkey();
     let blockhash = svm.latest_blockhash();
     let msg = Message::new_with_blockhash(&[ix], Some(&payer_pk), &blockhash);
-    let tx =
-        VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
     svm.send_transaction(tx)
         .expect("Transaction should succeed");
 }
@@ -96,7 +94,10 @@ fn test_lock_escrow_success() {
     send_ok(&mut svm, ix, &[&payer]);
 
     let escrow_account = svm.get_account(&escrow_pda).unwrap();
-    assert!(escrow_account.lamports >= amount, "Escrow should hold at least the locked amount");
+    assert!(
+        escrow_account.lamports >= amount,
+        "Escrow should hold at least the locked amount"
+    );
 }
 
 /// release_escrow sends funds to payee and closes PDA
@@ -112,7 +113,10 @@ fn test_release_escrow_success() {
     svm.airdrop(&payee.pubkey(), 1_000_000).unwrap(); // min balance
 
     let (escrow_pda, _) = escrow_pda(&payer.pubkey(), &nonce);
-    let payee_balance_before = svm.get_account(&payee.pubkey()).map(|a| a.lamports).unwrap_or(0);
+    let payee_balance_before = svm
+        .get_account(&payee.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
 
     // Lock first
     let lock_ix = Instruction::new_with_bytes(
@@ -143,10 +147,16 @@ fn test_release_escrow_success() {
     send_ok(&mut svm, release_ix, &[&payer]);
 
     // Escrow PDA should be closed
-    assert!(svm.get_account(&escrow_pda).is_none(), "Escrow PDA should be closed after release");
+    assert!(
+        svm.get_account(&escrow_pda).is_none(),
+        "Escrow PDA should be closed after release"
+    );
 
     // Payee should have received the funds
-    let payee_balance_after = svm.get_account(&payee.pubkey()).map(|a| a.lamports).unwrap_or(0);
+    let payee_balance_after = svm
+        .get_account(&payee.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
     assert_eq!(
         payee_balance_after,
         payee_balance_before + amount,
@@ -181,7 +191,10 @@ fn test_cancel_escrow_refunds_payer() {
     );
     send_ok(&mut svm, lock_ix, &[&payer]);
 
-    let payer_balance_after_lock = svm.get_account(&payer.pubkey()).map(|a| a.lamports).unwrap_or(0);
+    let payer_balance_after_lock = svm
+        .get_account(&payer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
 
     // Warp past the 7-day cancel window (50,400 slots)
     svm.warp_to_slot(60_000);
@@ -200,10 +213,16 @@ fn test_cancel_escrow_refunds_payer() {
     send_ok(&mut svm, cancel_ix, &[&payer]);
 
     // Escrow PDA should be closed
-    assert!(svm.get_account(&escrow_pda).is_none(), "Escrow PDA should be closed after cancel");
+    assert!(
+        svm.get_account(&escrow_pda).is_none(),
+        "Escrow PDA should be closed after cancel"
+    );
 
     // Payer should have been refunded
-    let payer_balance_after_cancel = svm.get_account(&payer.pubkey()).map(|a| a.lamports).unwrap_or(0);
+    let payer_balance_after_cancel = svm
+        .get_account(&payer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
     assert!(
         payer_balance_after_cancel > payer_balance_after_lock,
         "Payer should be refunded after cancel"
@@ -253,7 +272,8 @@ fn test_cancel_window_not_elapsed() {
     let err_str = format!("{:?}", err);
     assert!(
         err_str.contains("CancelWindowNotElapsed") || err_str.contains("6006"),
-        "Expected CancelWindowNotElapsed error, got: {}", err_str
+        "Expected CancelWindowNotElapsed error, got: {}",
+        err_str
     );
 }
 
@@ -292,8 +312,8 @@ fn test_release_payer_constraint() {
         escrow::id(),
         &instruction::ReleaseEscrow {}.data(),
         ReleaseEscrow {
-            escrow: escrow_pda,         // correct PDA
-            payer: attacker.pubkey(),   // wrong payer — has_one = payer should reject
+            escrow: escrow_pda,       // correct PDA
+            payer: attacker.pubkey(), // wrong payer — has_one = payer should reject
             payee: payee.pubkey(),
             system_program: anchor_lang::solana_program::system_program::id(),
         }
@@ -306,7 +326,8 @@ fn test_release_payer_constraint() {
     // to the stored escrow PDA — seeds mismatch is detected before has_one check.
     assert!(
         err_str.contains("ConstraintSeeds") || err_str.contains("2006"),
-        "Expected ConstraintSeeds error, got: {}", err_str
+        "Expected ConstraintSeeds error, got: {}",
+        err_str
     );
 }
 
@@ -323,17 +344,19 @@ fn test_duplicate_nonce() {
 
     let (escrow_pda, _) = escrow_pda(&payer.pubkey(), &nonce);
 
-    let lock_ix = || Instruction::new_with_bytes(
-        escrow::id(),
-        &instruction::LockEscrow { amount, nonce }.data(),
-        LockEscrow {
-            escrow: escrow_pda,
-            payer: payer.pubkey(),
-            payee: payee.pubkey(),
-            system_program: anchor_lang::solana_program::system_program::id(),
-        }
-        .to_account_metas(None),
-    );
+    let lock_ix = || {
+        Instruction::new_with_bytes(
+            escrow::id(),
+            &instruction::LockEscrow { amount, nonce }.data(),
+            LockEscrow {
+                escrow: escrow_pda,
+                payer: payer.pubkey(),
+                payee: payee.pubkey(),
+                system_program: anchor_lang::solana_program::system_program::id(),
+            }
+            .to_account_metas(None),
+        )
+    };
 
     // First lock: should succeed
     send_ok(&mut svm, lock_ix(), &[&payer]);
@@ -344,9 +367,11 @@ fn test_duplicate_nonce() {
     let err = send(&mut svm, lock_ix(), &[&payer]);
     let err_str = format!("{:?}", err);
     assert!(
-        err_str.contains("AlreadyProcessed") || err_str.contains("AlreadyInUse")
+        err_str.contains("AlreadyProcessed")
+            || err_str.contains("AlreadyInUse")
             || err_str.contains("AccountAlreadyInitialized"),
-        "Expected duplicate nonce rejection, got: {}", err_str
+        "Expected duplicate nonce rejection, got: {}",
+        err_str
     );
 }
 

--- a/programs/escrow/tests/test_registry.rs
+++ b/programs/escrow/tests/test_registry.rs
@@ -1,0 +1,294 @@
+use {
+    anchor_lang::{
+        solana_program::instruction::Instruction, AccountDeserialize, InstructionData,
+        ToAccountMetas,
+    },
+    escrow::accounts::{DeregisterAgent, RegisterAgent, UpdateAgent},
+    escrow::constants::{AGENT_FEE_BURN_ADDRESS, AGENT_REGISTRATION_FEE},
+    escrow::instruction,
+    escrow::state::{AgentAccount, AgentType},
+    litesvm::LiteSVM,
+    solana_keypair::Keypair,
+    solana_message::{Message, VersionedMessage},
+    solana_signer::Signer,
+    solana_transaction::versioned::VersionedTransaction,
+};
+
+fn make_svm() -> LiteSVM {
+    let mut svm = LiteSVM::new();
+    let bytes = include_bytes!("../../../target/deploy/escrow.so");
+    svm.add_program(escrow::id(), bytes).unwrap();
+    svm
+}
+
+fn agent_pda(owner: &anchor_lang::prelude::Pubkey) -> (anchor_lang::prelude::Pubkey, u8) {
+    anchor_lang::prelude::Pubkey::find_program_address(&[b"agent", owner.as_ref()], &escrow::id())
+}
+
+fn send_tx(
+    svm: &mut LiteSVM,
+    ix: Instruction,
+    signers: &[&Keypair],
+) -> Result<(), litesvm::types::FailedTransactionMetadata> {
+    let payer_pk = signers[0].pubkey();
+    let blockhash = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(&[ix], Some(&payer_pk), &blockhash);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    match svm.send_transaction(tx) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn register_ix(
+    owner: &Keypair,
+    agent: anchor_lang::prelude::Pubkey,
+    agent_type: AgentType,
+    model: &str,
+) -> Instruction {
+    Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::RegisterAgent {
+            agent_type,
+            model: model.to_string(),
+            rate_lamports: 1_000_000,
+            min_reputation: 3,
+        }
+        .data(),
+        RegisterAgent {
+            agent,
+            owner: owner.pubkey(),
+            fee_collector: AGENT_FEE_BURN_ADDRESS,
+            system_program: anchor_lang::solana_program::system_program::id(),
+        }
+        .to_account_metas(None),
+    )
+}
+
+fn fetch_agent(svm: &LiteSVM, agent_pk: &anchor_lang::prelude::Pubkey) -> AgentAccount {
+    let account = svm.get_account(agent_pk).expect("agent PDA should exist");
+    let mut data = account.data.as_slice();
+    AgentAccount::try_deserialize(&mut data).expect("agent account should deserialize")
+}
+
+#[test]
+fn register_primary_agent_success() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let fee_collector = AGENT_FEE_BURN_ADDRESS;
+    let fee_before = svm
+        .get_account(&fee_collector)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    let ix = register_ix(&owner, agent, AgentType::Primary, "qwen3:8b");
+    send_tx(&mut svm, ix, &[&owner]).expect("register should succeed");
+
+    let fee_after = svm
+        .get_account(&fee_collector)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    assert_eq!(
+        fee_after.saturating_sub(fee_before),
+        AGENT_REGISTRATION_FEE,
+        "registration fee should be charged"
+    );
+
+    let account = fetch_agent(&svm, &agent);
+    assert_eq!(account.owner, owner.pubkey());
+    assert!(account.agent_type == AgentType::Primary);
+    assert_eq!(account.model, "qwen3:8b");
+    assert_eq!(account.reputation_score, 0);
+    assert_eq!(account.jobs_completed, 0);
+    assert_eq!(account.jobs_failed, 0);
+    assert!(account.active);
+}
+
+#[test]
+fn register_attestation_agent_success() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    let ix = register_ix(&owner, agent, AgentType::Attestation, "llama4");
+    send_tx(&mut svm, ix, &[&owner]).expect("register should succeed");
+
+    let account = fetch_agent(&svm, &agent);
+    assert!(account.agent_type == AgentType::Attestation);
+}
+
+#[test]
+fn register_both_success() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    let ix = register_ix(&owner, agent, AgentType::Both, "sonnet");
+    send_tx(&mut svm, ix, &[&owner]).expect("register should succeed");
+
+    let account = fetch_agent(&svm, &agent);
+    assert!(account.agent_type == AgentType::Both);
+}
+
+#[test]
+fn duplicate_registration_rejected() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    send_tx(
+        &mut svm,
+        register_ix(&owner, agent, AgentType::Primary, "qwen3:8b"),
+        &[&owner],
+    )
+    .expect("first register should succeed");
+
+    let err = send_tx(
+        &mut svm,
+        register_ix(&owner, agent, AgentType::Primary, "qwen3:14b"),
+        &[&owner],
+    )
+    .expect_err("second registration should fail");
+
+    let err_str = format!("{:?}", err);
+    assert!(
+        err_str.contains("AlreadyInUse")
+            || err_str.contains("already in use")
+            || err_str.contains("AccountAlreadyInitialized")
+            || err_str.contains("ConstraintSeeds")
+            || err_str.contains("AlreadyProcessed")
+            || err_str.contains("custom program error: 0x0"),
+        "expected duplicate registration rejection, got: {err_str}"
+    );
+}
+
+#[test]
+fn update_rate_owner_only() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    let attacker = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+    svm.airdrop(&attacker.pubkey(), 1_000_000_000).unwrap();
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    send_tx(
+        &mut svm,
+        register_ix(&owner, agent, AgentType::Primary, "qwen3:8b"),
+        &[&owner],
+    )
+    .expect("register should succeed");
+
+    let owner_update_ix = Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::UpdateAgent {
+            rate_lamports: 2_500_000,
+            min_reputation: 12,
+            active: false,
+        }
+        .data(),
+        UpdateAgent {
+            agent,
+            owner: owner.pubkey(),
+        }
+        .to_account_metas(None),
+    );
+    send_tx(&mut svm, owner_update_ix, &[&owner]).expect("owner update should succeed");
+
+    let updated = fetch_agent(&svm, &agent);
+    assert_eq!(updated.rate_lamports, 2_500_000);
+    assert_eq!(updated.min_reputation, 12);
+    assert!(!updated.active);
+
+    let attacker_update_ix = Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::UpdateAgent {
+            rate_lamports: 3_300_000,
+            min_reputation: 1,
+            active: true,
+        }
+        .data(),
+        UpdateAgent {
+            agent,
+            owner: attacker.pubkey(),
+        }
+        .to_account_metas(None),
+    );
+
+    let err = send_tx(&mut svm, attacker_update_ix, &[&attacker])
+        .expect_err("non-owner update should fail");
+    let err_str = format!("{:?}", err);
+    assert!(
+        err_str.contains("ConstraintHasOne")
+            || err_str.contains("ConstraintSeeds")
+            || err_str.contains("2001")
+            || err_str.contains("2006"),
+        "expected owner constraint failure, got: {err_str}"
+    );
+}
+
+#[test]
+fn deregister_closes_pda() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let fee_collector = AGENT_FEE_BURN_ADDRESS;
+    let fee_before = svm
+        .get_account(&fee_collector)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    send_tx(
+        &mut svm,
+        register_ix(&owner, agent, AgentType::Primary, "qwen3:8b"),
+        &[&owner],
+    )
+    .expect("register should succeed");
+
+    let owner_after_register = svm
+        .get_account(&owner.pubkey())
+        .expect("owner exists")
+        .lamports;
+
+    let deregister_ix = Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::DeregisterAgent {}.data(),
+        DeregisterAgent {
+            agent,
+            owner: owner.pubkey(),
+        }
+        .to_account_metas(None),
+    );
+    send_tx(&mut svm, deregister_ix, &[&owner]).expect("deregister should succeed");
+
+    assert!(
+        svm.get_account(&agent).is_none(),
+        "agent PDA should be closed"
+    );
+
+    let owner_after_deregister = svm
+        .get_account(&owner.pubkey())
+        .expect("owner exists")
+        .lamports;
+    assert!(
+        owner_after_deregister > owner_after_register,
+        "owner should receive rent back on close"
+    );
+
+    let fee_after = svm
+        .get_account(&fee_collector)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    assert_eq!(
+        fee_after.saturating_sub(fee_before),
+        AGENT_REGISTRATION_FEE,
+        "registration fee should not be returned on deregister"
+    );
+}


### PR DESCRIPTION
## Summary
- adds on-chain `AgentAccount` PDA registry with seeds `[b"agent", owner]`
- adds `AgentType` enum (`Primary`, `Attestation`, `Both`)
- adds `register_agent`, `update_agent`, and `deregister_agent` instructions
- enforces model length via `AGENT_MODEL_MAX_LEN = 64` and `ModelTooLong` error
- charges `AGENT_REGISTRATION_FEE = 10_000_000` lamports on registration
- enforces owner-only updates and `close = owner` on deregistration
- includes 6 new LiteSVM tests in `programs/escrow/tests/test_registry.rs`

## Validation
- `~/.cargo/bin/cargo test --manifest-path programs/escrow/Cargo.toml`
- `PATH="$HOME/.cargo/bin:$PATH" ~/.avm/bin/anchor build --ignore-keys`

## Notes
- Anchor 1.0 only permits one `#[error_code]` enum per program, so registry errors were appended to existing `EscrowError` (including `ModelTooLong`).
- registration fee is transferred to Solana incinerator address, so it is not returned on deregistration.
