### PR TITLE
Phase 4: Blind Commit-Reveal Reputation

### DIFF
--- a/programs/escrow/Cargo.toml
+++ b/programs/escrow/Cargo.toml
@@ -20,7 +20,8 @@ custom-heap = []
 custom-panic = []
 
 [dependencies]
-anchor-lang = "1.0.0"
+anchor-lang = { version = "1.0.0", features = ["init-if-needed"] }
+sha2 = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 litesvm = "0.10.0"
@@ -28,6 +29,7 @@ solana-message = "3.0.1"
 solana-transaction = "3.0.2"
 solana-signer = "3.0.0"
 solana-keypair = "3.0.1"
+sha2 = { version = "0.10", default-features = false }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }

--- a/programs/escrow/src/constants.rs
+++ b/programs/escrow/src/constants.rs
@@ -1,4 +1,11 @@
+use anchor_lang::prelude::{pubkey, Pubkey};
+
 pub const ESCROW_SEED: &[u8] = b"escrow";
+pub const AGENT_SEED: &[u8] = b"agent";
 pub const ESCROW_DISCRIMINATOR_SIZE: usize = 8;
 /// Minimum slots before a payer can cancel (~7 days at 400ms/slot)
 pub const CANCEL_WINDOW_SLOTS: u64 = 50_400;
+
+pub const AGENT_REGISTRATION_FEE: u64 = 10_000_000; // 0.01 SOL in lamports
+pub const AGENT_MODEL_MAX_LEN: usize = 64;
+pub const AGENT_FEE_BURN_ADDRESS: Pubkey = pubkey!("1nc1nerator11111111111111111111111111111111");

--- a/programs/escrow/src/constants.rs
+++ b/programs/escrow/src/constants.rs
@@ -9,3 +9,9 @@ pub const CANCEL_WINDOW_SLOTS: u64 = 50_400;
 pub const AGENT_REGISTRATION_FEE: u64 = 10_000_000; // 0.01 SOL in lamports
 pub const AGENT_MODEL_MAX_LEN: usize = 64;
 pub const AGENT_FEE_BURN_ADDRESS: Pubkey = pubkey!("1nc1nerator11111111111111111111111111111111");
+
+pub const RATING_SEED: &[u8] = b"rating";
+/// 7 days in slots at ~400ms/slot
+pub const RATING_EXPIRE_SLOTS: u64 = 1_512_000;
+/// Reputation penalty for non-commitment on expiry (5.00 points)
+pub const RATING_EXPIRE_PENALTY: u16 = 500;

--- a/programs/escrow/src/error.rs
+++ b/programs/escrow/src/error.rs
@@ -31,4 +31,22 @@ pub enum EscrowError {
 
     #[msg("Agent is not active")]
     AgentNotActive,
+
+    #[msg("Rating commitment already submitted")]
+    AlreadyCommitted,
+
+    #[msg("Cannot reveal until both parties commit")]
+    BothMustCommitFirst,
+
+    #[msg("Commitment hash mismatch")]
+    CommitmentMismatch,
+
+    #[msg("Score must be 1-10")]
+    InvalidScore,
+
+    #[msg("Rating has not expired")]
+    NotExpired,
+
+    #[msg("Rating already finalised")]
+    AlreadyFinalised,
 }

--- a/programs/escrow/src/error.rs
+++ b/programs/escrow/src/error.rs
@@ -25,4 +25,10 @@ pub enum EscrowError {
 
     #[msg("Invalid payee")]
     InvalidPayee,
+
+    #[msg("Model string exceeds maximum length")]
+    ModelTooLong,
+
+    #[msg("Agent is not active")]
+    AgentNotActive,
 }

--- a/programs/escrow/src/instructions.rs
+++ b/programs/escrow/src/instructions.rs
@@ -1,13 +1,19 @@
 pub mod cancel_escrow;
+pub mod commit_rating;
 pub mod deregister_agent;
+pub mod expire_rating;
 pub mod lock_escrow;
 pub mod register_agent;
 pub mod release_escrow;
+pub mod reveal_rating;
 pub mod update_agent;
 
 pub use cancel_escrow::*;
+pub use commit_rating::*;
 pub use deregister_agent::*;
+pub use expire_rating::*;
 pub use lock_escrow::*;
 pub use register_agent::*;
 pub use release_escrow::*;
+pub use reveal_rating::*;
 pub use update_agent::*;

--- a/programs/escrow/src/instructions.rs
+++ b/programs/escrow/src/instructions.rs
@@ -1,7 +1,13 @@
 pub mod cancel_escrow;
+pub mod deregister_agent;
 pub mod lock_escrow;
+pub mod register_agent;
 pub mod release_escrow;
+pub mod update_agent;
 
 pub use cancel_escrow::*;
+pub use deregister_agent::*;
 pub use lock_escrow::*;
+pub use register_agent::*;
 pub use release_escrow::*;
+pub use update_agent::*;

--- a/programs/escrow/src/instructions/cancel_escrow.rs
+++ b/programs/escrow/src/instructions/cancel_escrow.rs
@@ -24,7 +24,11 @@ pub fn cancel_escrow_handler(ctx: Context<CancelEscrow>) -> Result<()> {
     let amount = ctx.accounts.escrow.amount;
 
     // Transfer lamports from escrow PDA back to payer
-    **ctx.accounts.escrow.to_account_info().try_borrow_mut_lamports()? -= amount;
+    **ctx
+        .accounts
+        .escrow
+        .to_account_info()
+        .try_borrow_mut_lamports()? -= amount;
     **ctx.accounts.payer.try_borrow_mut_lamports()? += amount;
 
     // Mark cancelled (account will be closed by `close = payer` constraint)

--- a/programs/escrow/src/instructions/commit_rating.rs
+++ b/programs/escrow/src/instructions/commit_rating.rs
@@ -1,0 +1,89 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::RATING_SEED;
+use crate::error::EscrowError;
+use crate::state::{RatingAccount, RatingRole, RatingState};
+
+/// Submit a blind commitment for a job rating.
+///
+/// The first caller (either consumer or specialist) creates the `RatingAccount`
+/// PDA and records **both** party pubkeys.  This means both agent addresses must
+/// be known at job start — which is always the case: the consumer knows who they
+/// hired, and the specialist knows who hired them.  Recording both pubkeys upfront
+/// ensures `expire_rating` can always load both `AgentAccount` PDAs, even when
+/// one party later ghosts.
+///
+/// The second caller just fills in their commitment hash.
+pub fn commit_rating_handler(
+    ctx: Context<CommitRating>,
+    _job_id: [u8; 16],
+    commitment: [u8; 32],
+    role: RatingRole,
+    consumer_pk: Pubkey,
+    specialist_pk: Pubkey,
+) -> Result<()> {
+    let rating = &mut ctx.accounts.rating;
+    let clock = Clock::get()?;
+    let signer = ctx.accounts.signer.key();
+
+    // Reject if already finalised
+    require!(
+        rating.state != RatingState::Revealed && rating.state != RatingState::Expired,
+        EscrowError::AlreadyFinalised
+    );
+
+    // On first commit: initialise metadata and store both party pubkeys
+    if rating.created_at == 0 {
+        rating.job_id = _job_id;
+        rating.consumer = consumer_pk;
+        rating.specialist = specialist_pk;
+        rating.created_at = clock.unix_timestamp;
+        rating.created_slot = clock.slot;
+        rating.state = RatingState::Pending;
+        rating.bump = ctx.bumps.rating;
+    }
+
+    match role {
+        RatingRole::Consumer => {
+            require!(signer == rating.consumer, EscrowError::UnauthorisedSigner);
+            require!(
+                rating.consumer_commitment == [0u8; 32],
+                EscrowError::AlreadyCommitted
+            );
+            rating.consumer_commitment = commitment;
+        }
+        RatingRole::Specialist => {
+            require!(signer == rating.specialist, EscrowError::UnauthorisedSigner);
+            require!(
+                rating.specialist_commitment == [0u8; 32],
+                EscrowError::AlreadyCommitted
+            );
+            rating.specialist_commitment = commitment;
+        }
+    }
+
+    // Advance to BothCommitted when both commitments are set
+    if rating.consumer_commitment != [0u8; 32] && rating.specialist_commitment != [0u8; 32] {
+        rating.state = RatingState::BothCommitted;
+    }
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(job_id: [u8; 16])]
+pub struct CommitRating<'info> {
+    #[account(
+        init_if_needed,
+        payer = signer,
+        space = RatingAccount::LEN,
+        seeds = [RATING_SEED, job_id.as_ref()],
+        bump,
+    )]
+    pub rating: Account<'info, RatingAccount>,
+
+    #[account(mut)]
+    pub signer: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}

--- a/programs/escrow/src/instructions/deregister_agent.rs
+++ b/programs/escrow/src/instructions/deregister_agent.rs
@@ -1,0 +1,23 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::AGENT_SEED;
+use crate::state::AgentAccount;
+
+pub fn deregister_agent_handler(_ctx: Context<DeregisterAgent>) -> Result<()> {
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct DeregisterAgent<'info> {
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, owner.key().as_ref()],
+        bump = agent.bump,
+        has_one = owner,
+        close = owner,
+    )]
+    pub agent: Account<'info, AgentAccount>,
+
+    #[account(mut)]
+    pub owner: Signer<'info>,
+}

--- a/programs/escrow/src/instructions/expire_rating.rs
+++ b/programs/escrow/src/instructions/expire_rating.rs
@@ -1,0 +1,79 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::{AGENT_SEED, RATING_EXPIRE_PENALTY, RATING_EXPIRE_SLOTS, RATING_SEED};
+use crate::error::EscrowError;
+use crate::state::{AgentAccount, RatingAccount, RatingState};
+
+/// Expire a rating where one party committed and the other timed out.
+///
+/// Callable by either party after RATING_EXPIRE_SLOTS slots have elapsed
+/// from account creation.  Penalises the non-committing party's reputation.
+pub fn expire_rating_handler(ctx: Context<ExpireRating>, _job_id: [u8; 16]) -> Result<()> {
+    let clock = Clock::get()?;
+    let rating = &mut ctx.accounts.rating;
+
+    // Only Pending ratings can expire
+    require!(
+        rating.state == RatingState::Pending,
+        EscrowError::AlreadyFinalised
+    );
+
+    // Time-lock: must have waited long enough
+    let elapsed = clock.slot.saturating_sub(rating.created_slot);
+    require!(elapsed >= RATING_EXPIRE_SLOTS, EscrowError::NotExpired);
+
+    rating.state = RatingState::Expired;
+
+    // Penalise the party that did NOT commit
+    let consumer_committed = rating.consumer_commitment != [0u8; 32];
+    let specialist_committed = rating.specialist_commitment != [0u8; 32];
+
+    if consumer_committed && !specialist_committed {
+        // Specialist ghosted — penalise specialist
+        let specialist = &mut ctx.accounts.specialist_agent;
+        specialist.reputation_score = specialist
+            .reputation_score
+            .saturating_sub(RATING_EXPIRE_PENALTY);
+        specialist.jobs_failed = specialist.jobs_failed.saturating_add(1);
+    } else if specialist_committed && !consumer_committed {
+        // Consumer ghosted — penalise consumer
+        let consumer = &mut ctx.accounts.consumer_agent;
+        consumer.reputation_score = consumer
+            .reputation_score
+            .saturating_sub(RATING_EXPIRE_PENALTY);
+        consumer.jobs_failed = consumer.jobs_failed.saturating_add(1);
+    }
+    // If somehow neither committed (shouldn't happen in Pending), no penalty
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(job_id: [u8; 16])]
+pub struct ExpireRating<'info> {
+    #[account(
+        mut,
+        seeds = [RATING_SEED, job_id.as_ref()],
+        bump = rating.bump,
+    )]
+    pub rating: Account<'info, RatingAccount>,
+
+    /// Either consumer or specialist may trigger expiry
+    pub caller: Signer<'info>,
+
+    /// Specialist AgentAccount — may be penalised
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, rating.specialist.as_ref()],
+        bump = specialist_agent.bump,
+    )]
+    pub specialist_agent: Account<'info, AgentAccount>,
+
+    /// Consumer AgentAccount — may be penalised
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, rating.consumer.as_ref()],
+        bump = consumer_agent.bump,
+    )]
+    pub consumer_agent: Account<'info, AgentAccount>,
+}

--- a/programs/escrow/src/instructions/lock_escrow.rs
+++ b/programs/escrow/src/instructions/lock_escrow.rs
@@ -7,14 +7,10 @@ use crate::state::{EscrowAccount, EscrowStatus};
 
 /// Lock SOL into an escrow PDA.
 /// Called by Agent A (payer) to initiate a payment to Agent B (payee).
-/// 
+///
 /// PDA: seeds = [b"escrow", payer, nonce]
 /// This prevents duplicate nonces for the same payer.
-pub fn lock_escrow_handler(
-    ctx: Context<LockEscrow>,
-    amount: u64,
-    nonce: [u8; 16],
-) -> Result<()> {
+pub fn lock_escrow_handler(ctx: Context<LockEscrow>, amount: u64, nonce: [u8; 16]) -> Result<()> {
     require!(amount > 0, EscrowError::ZeroAmount);
 
     let escrow = &mut ctx.accounts.escrow;

--- a/programs/escrow/src/instructions/register_agent.rs
+++ b/programs/escrow/src/instructions/register_agent.rs
@@ -1,0 +1,69 @@
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+
+use crate::constants::{
+    AGENT_FEE_BURN_ADDRESS, AGENT_MODEL_MAX_LEN, AGENT_REGISTRATION_FEE, AGENT_SEED,
+};
+use crate::error::EscrowError;
+use crate::state::{AgentAccount, AgentType};
+
+pub fn register_agent_handler(
+    ctx: Context<RegisterAgent>,
+    agent_type: AgentType,
+    model: String,
+    rate_lamports: u64,
+    min_reputation: u8,
+) -> Result<()> {
+    require!(
+        model.len() <= AGENT_MODEL_MAX_LEN,
+        EscrowError::ModelTooLong
+    );
+
+    // Burn registration fee to Solana incinerator address.
+    system_program::transfer(
+        CpiContext::new(
+            ctx.accounts.system_program.key(),
+            system_program::Transfer {
+                from: ctx.accounts.owner.to_account_info(),
+                to: ctx.accounts.fee_collector.to_account_info(),
+            },
+        ),
+        AGENT_REGISTRATION_FEE,
+    )?;
+
+    let agent = &mut ctx.accounts.agent;
+    agent.owner = ctx.accounts.owner.key();
+    agent.agent_type = agent_type;
+    agent.model = model;
+    agent.rate_lamports = rate_lamports;
+    agent.min_reputation = min_reputation;
+    agent.reputation_score = 0;
+    agent.jobs_completed = 0;
+    agent.jobs_failed = 0;
+    agent.created_at = Clock::get()?.unix_timestamp;
+    agent.active = true;
+    agent.bump = ctx.bumps.agent;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct RegisterAgent<'info> {
+    #[account(
+        init,
+        payer = owner,
+        space = AgentAccount::LEN,
+        seeds = [AGENT_SEED, owner.key().as_ref()],
+        bump,
+    )]
+    pub agent: Account<'info, AgentAccount>,
+
+    #[account(mut)]
+    pub owner: Signer<'info>,
+
+    /// CHECK: Hard-coded to Solana incinerator for fee burn.
+    #[account(mut, address = AGENT_FEE_BURN_ADDRESS)]
+    pub fee_collector: UncheckedAccount<'info>,
+
+    pub system_program: Program<'info, System>,
+}

--- a/programs/escrow/src/instructions/release_escrow.rs
+++ b/programs/escrow/src/instructions/release_escrow.rs
@@ -16,7 +16,11 @@ pub fn release_escrow_handler(ctx: Context<ReleaseEscrow>) -> Result<()> {
     let amount = ctx.accounts.escrow.amount;
 
     // Transfer lamports from escrow PDA to payee
-    **ctx.accounts.escrow.to_account_info().try_borrow_mut_lamports()? -= amount;
+    **ctx
+        .accounts
+        .escrow
+        .to_account_info()
+        .try_borrow_mut_lamports()? -= amount;
     **ctx.accounts.payee.try_borrow_mut_lamports()? += amount;
 
     // Mark released (account will be closed by `close = payer` constraint)

--- a/programs/escrow/src/instructions/reveal_rating.rs
+++ b/programs/escrow/src/instructions/reveal_rating.rs
@@ -1,0 +1,116 @@
+use anchor_lang::prelude::*;
+use sha2::{Digest, Sha256};
+
+use crate::constants::{AGENT_SEED, RATING_SEED};
+use crate::error::EscrowError;
+use crate::state::{AgentAccount, RatingAccount, RatingState};
+
+/// Reveal a committed rating score.
+///
+/// Verifies the sha256 commitment, records the score, and — once both
+/// parties have revealed — applies a rolling reputation update to both
+/// AgentAccounts.
+pub fn reveal_rating_handler(
+    ctx: Context<RevealRating>,
+    _job_id: [u8; 16],
+    score: u8,
+    salt: [u8; 32],
+) -> Result<()> {
+    let signer = ctx.accounts.signer.key();
+
+    // Must be in BothCommitted state
+    require!(
+        ctx.accounts.rating.state == RatingState::BothCommitted,
+        EscrowError::BothMustCommitFirst
+    );
+
+    // Score range check
+    require!(score >= 1 && score <= 10, EscrowError::InvalidScore);
+
+    // Compute sha256(score || salt)
+    let mut hasher = Sha256::new();
+    hasher.update([score]);
+    hasher.update(salt);
+    let computed_bytes: [u8; 32] = hasher.finalize().into();
+
+    let rating = &mut ctx.accounts.rating;
+
+    // Determine role and verify commitment
+    let is_consumer = signer == rating.consumer;
+    let is_specialist = signer == rating.specialist;
+
+    if is_consumer {
+        require!(
+            computed_bytes == rating.consumer_commitment,
+            EscrowError::CommitmentMismatch
+        );
+        rating.consumer_score = Some(score);
+    } else if is_specialist {
+        require!(
+            computed_bytes == rating.specialist_commitment,
+            EscrowError::CommitmentMismatch
+        );
+        rating.specialist_score = Some(score);
+    } else {
+        // Signer is neither party — reject
+        return err!(EscrowError::UnauthorisedSigner);
+    }
+
+    // Both revealed → finalize
+    if rating.consumer_score.is_some() && rating.specialist_score.is_some() {
+        rating.state = RatingState::Revealed;
+
+        // Update specialist's reputation based on consumer's score
+        if let Some(consumer_given) = rating.consumer_score {
+            let specialist = &mut ctx.accounts.specialist_agent;
+            apply_reputation_update(specialist, consumer_given);
+        }
+
+        // Update consumer's reputation based on specialist's score
+        if let Some(specialist_given) = rating.specialist_score {
+            let consumer = &mut ctx.accounts.consumer_agent;
+            apply_reputation_update(consumer, specialist_given);
+        }
+    }
+
+    Ok(())
+}
+
+/// Rolling average: new_score = (old_score * 9 + new_rating_scaled) / 10
+/// `rating_1_10` is 1-10 → scale to 0-10000 as `rating * 1000`
+fn apply_reputation_update(agent: &mut Account<AgentAccount>, rating_1_10: u8) {
+    let new_scaled = (rating_1_10 as u32) * 1000;
+    let old = agent.reputation_score as u32;
+    let updated = (old * 9 + new_scaled) / 10;
+    agent.reputation_score = updated.min(10000) as u16;
+    agent.jobs_completed = agent.jobs_completed.saturating_add(1);
+}
+
+#[derive(Accounts)]
+#[instruction(job_id: [u8; 16])]
+pub struct RevealRating<'info> {
+    #[account(
+        mut,
+        seeds = [RATING_SEED, job_id.as_ref()],
+        bump = rating.bump,
+    )]
+    pub rating: Account<'info, RatingAccount>,
+
+    pub signer: Signer<'info>,
+
+    /// Specialist AgentAccount — receives consumer's rating
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, rating.specialist.as_ref()],
+        bump = specialist_agent.bump,
+    )]
+    pub specialist_agent: Account<'info, AgentAccount>,
+
+    /// Consumer AgentAccount — receives specialist's rating
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, rating.consumer.as_ref()],
+        bump = consumer_agent.bump,
+    )]
+    pub consumer_agent: Account<'info, AgentAccount>,
+}

--- a/programs/escrow/src/instructions/update_agent.rs
+++ b/programs/escrow/src/instructions/update_agent.rs
@@ -1,0 +1,30 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::AGENT_SEED;
+use crate::state::AgentAccount;
+
+pub fn update_agent_handler(
+    ctx: Context<UpdateAgent>,
+    rate_lamports: u64,
+    min_reputation: u8,
+    active: bool,
+) -> Result<()> {
+    let agent = &mut ctx.accounts.agent;
+    agent.rate_lamports = rate_lamports;
+    agent.min_reputation = min_reputation;
+    agent.active = active;
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct UpdateAgent<'info> {
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, owner.key().as_ref()],
+        bump = agent.bump,
+        has_one = owner,
+    )]
+    pub agent: Account<'info, AgentAccount>,
+
+    pub owner: Signer<'info>,
+}

--- a/programs/escrow/src/lib.rs
+++ b/programs/escrow/src/lib.rs
@@ -11,37 +11,27 @@ pub use constants::*;
 pub use instructions::*;
 pub use state::*;
 
-// Program ID placeholder — will be replaced after first `anchor build` + keypair generation.
-// TODO: Run `anchor keys sync` after generating a fresh deploy keypair for devnet.
 declare_id!("BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv");
 
 #[program]
 pub mod escrow {
     use super::*;
 
-    /// Lock SOL into a trustless escrow PDA.
-    /// Called by Agent A (payer) to pay Agent B (payee) via x402.
-    ///
-    /// # Arguments
-    /// * `amount` — lamports to lock
-    /// * `nonce` — 16-byte unique identifier scoped to the payer (prevents duplicate escrows)
+    // ── Phase 2: Escrow ──────────────────────────────────────────────────────
+
     pub fn lock_escrow(ctx: Context<LockEscrow>, amount: u64, nonce: [u8; 16]) -> Result<()> {
         instructions::lock_escrow::lock_escrow_handler(ctx, amount, nonce)
     }
 
-    /// Release locked SOL to the payee.
-    /// Called by Agent A (payer) once services are delivered.
-    /// Closes the PDA and returns rent to payer.
     pub fn release_escrow(ctx: Context<ReleaseEscrow>) -> Result<()> {
         instructions::release_escrow::release_escrow_handler(ctx)
     }
 
-    /// Cancel escrow and refund the payer.
-    /// Called by Agent A (payer) — e.g. timeout or service refused.
-    /// Closes the PDA and returns rent + funds to payer.
     pub fn cancel_escrow(ctx: Context<CancelEscrow>) -> Result<()> {
         instructions::cancel_escrow::cancel_escrow_handler(ctx)
     }
+
+    // ── Phase 3: Agent Registry ──────────────────────────────────────────────
 
     pub fn register_agent(
         ctx: Context<RegisterAgent>,
@@ -70,5 +60,38 @@ pub mod escrow {
 
     pub fn deregister_agent(ctx: Context<DeregisterAgent>) -> Result<()> {
         instructions::deregister_agent::deregister_agent_handler(ctx)
+    }
+
+    // ── Phase 4: Reputation ───────────────────────────────────────────────────
+
+    pub fn commit_rating(
+        ctx: Context<CommitRating>,
+        job_id: [u8; 16],
+        commitment: [u8; 32],
+        role: RatingRole,
+        consumer_pk: Pubkey,
+        specialist_pk: Pubkey,
+    ) -> Result<()> {
+        instructions::commit_rating::commit_rating_handler(
+            ctx,
+            job_id,
+            commitment,
+            role,
+            consumer_pk,
+            specialist_pk,
+        )
+    }
+
+    pub fn reveal_rating(
+        ctx: Context<RevealRating>,
+        job_id: [u8; 16],
+        score: u8,
+        salt: [u8; 32],
+    ) -> Result<()> {
+        instructions::reveal_rating::reveal_rating_handler(ctx, job_id, score, salt)
+    }
+
+    pub fn expire_rating(ctx: Context<ExpireRating>, job_id: [u8; 16]) -> Result<()> {
+        instructions::expire_rating::expire_rating_handler(ctx, job_id)
     }
 }

--- a/programs/escrow/src/lib.rs
+++ b/programs/escrow/src/lib.rs
@@ -42,4 +42,33 @@ pub mod escrow {
     pub fn cancel_escrow(ctx: Context<CancelEscrow>) -> Result<()> {
         instructions::cancel_escrow::cancel_escrow_handler(ctx)
     }
+
+    pub fn register_agent(
+        ctx: Context<RegisterAgent>,
+        agent_type: AgentType,
+        model: String,
+        rate_lamports: u64,
+        min_reputation: u8,
+    ) -> Result<()> {
+        instructions::register_agent::register_agent_handler(
+            ctx,
+            agent_type,
+            model,
+            rate_lamports,
+            min_reputation,
+        )
+    }
+
+    pub fn update_agent(
+        ctx: Context<UpdateAgent>,
+        rate_lamports: u64,
+        min_reputation: u8,
+        active: bool,
+    ) -> Result<()> {
+        instructions::update_agent::update_agent_handler(ctx, rate_lamports, min_reputation, active)
+    }
+
+    pub fn deregister_agent(ctx: Context<DeregisterAgent>) -> Result<()> {
+        instructions::deregister_agent::deregister_agent_handler(ctx)
+    }
 }

--- a/programs/escrow/src/state.rs
+++ b/programs/escrow/src/state.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 /// State of an escrow PDA
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq, Debug)]
 pub enum EscrowStatus {
     /// Funds locked, awaiting release or cancellation
     Locked,
@@ -85,4 +85,69 @@ pub struct AgentAccount {
 impl AgentAccount {
     /// 8 (discriminator) + 32 + 1 + 68 (4+64 string) + 8 + 1 + 2 + 8 + 8 + 8 + 1 + 1
     pub const LEN: usize = 148;
+}
+
+/// Blind commit-reveal rating account.
+/// PDA seeds: [b"rating", job_id.as_ref()]
+#[account]
+pub struct RatingAccount {
+    /// Unique job identifier (UUID bytes)
+    pub job_id: [u8; 16],
+    /// The hiring party
+    pub consumer: Pubkey,
+    /// The hired party
+    pub specialist: Pubkey,
+    /// sha256(consumer_score as u8 || consumer_salt as [u8;32])
+    pub consumer_commitment: [u8; 32],
+    /// sha256(specialist_score as u8 || specialist_salt as [u8;32])
+    pub specialist_commitment: [u8; 32],
+    /// Revealed score from consumer (1-10), None until revealed
+    pub consumer_score: Option<u8>,
+    /// Revealed score from specialist (1-10), None until revealed
+    pub specialist_score: Option<u8>,
+    /// Current lifecycle state
+    pub state: RatingState,
+    /// Unix timestamp when account was created
+    pub created_at: i64,
+    /// Slot when account was created (for expiry enforcement)
+    pub created_slot: u64,
+    /// PDA bump seed
+    pub bump: u8,
+}
+
+impl RatingAccount {
+    // 8  discriminator
+    // 16  job_id
+    // 32  consumer
+    // 32  specialist
+    // 32  consumer_commitment
+    // 32  specialist_commitment
+    // 2   consumer_score  (Option<u8>: 1 discriminant + 1 value)
+    // 2   specialist_score
+    // 1   state (enum variant)
+    // 8   created_at
+    // 8   created_slot
+    // 1   bump
+    // = 175
+    pub const LEN: usize = 175;
+}
+
+/// Lifecycle state of a blind commit-reveal rating.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq, Debug)]
+pub enum RatingState {
+    /// Awaiting one or both commitments
+    Pending,
+    /// Both parties have committed; neither has revealed
+    BothCommitted,
+    /// Both parties have revealed their scores
+    Revealed,
+    /// One party committed; the other timed out
+    Expired,
+}
+
+/// Which party is submitting a commitment or reveal.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq, Debug)]
+pub enum RatingRole {
+    Consumer,
+    Specialist,
 }

--- a/programs/escrow/src/state.rs
+++ b/programs/escrow/src/state.rs
@@ -43,5 +43,46 @@ impl EscrowAccount {
         + 1    // status (enum variant)
         + 8    // created_at
         + 8    // created_slot
-        + 1;   // bump
+        + 1; // bump
+}
+
+/// Type of work an agent supports in the marketplace.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq, Debug)]
+pub enum AgentType {
+    Primary,
+    Attestation,
+    Both,
+}
+
+/// On-chain registry record for a discoverable agent.
+/// PDA seeds: [b"agent", owner]
+#[account]
+pub struct AgentAccount {
+    /// Wallet that registered this agent
+    pub owner: Pubkey,
+    /// Marketplace role supported by this agent
+    pub agent_type: AgentType,
+    /// Human-readable model identifier (max 64 chars)
+    pub model: String,
+    /// Per-call price in lamports
+    pub rate_lamports: u64,
+    /// Minimum caller reputation required (0 = open access)
+    pub min_reputation: u8,
+    /// Running reputation score, 0..10000 == 0.00..100.00
+    pub reputation_score: u16,
+    /// Successful jobs fulfilled
+    pub jobs_completed: u64,
+    /// Failed jobs
+    pub jobs_failed: u64,
+    /// Unix timestamp when registered
+    pub created_at: i64,
+    /// Whether this agent can currently accept jobs
+    pub active: bool,
+    /// PDA bump seed
+    pub bump: u8,
+}
+
+impl AgentAccount {
+    /// 8 (discriminator) + 32 + 1 + 68 (4+64 string) + 8 + 1 + 2 + 8 + 8 + 8 + 1 + 1
+    pub const LEN: usize = 148;
 }

--- a/programs/escrow/tests/reputation.rs
+++ b/programs/escrow/tests/reputation.rs
@@ -1,0 +1,506 @@
+/// Phase 4 — Blind Commit-Reveal Reputation
+///
+/// Tests the commit_rating / reveal_rating / expire_rating instruction suite.
+/// All tests use LiteSVM in-process.
+use {
+    anchor_lang::{
+        solana_program::instruction::Instruction, AccountDeserialize, InstructionData,
+        ToAccountMetas,
+    },
+    escrow::{
+        accounts::{CommitRating, ExpireRating, RegisterAgent, RevealRating},
+        constants::{AGENT_FEE_BURN_ADDRESS, AGENT_SEED, RATING_EXPIRE_SLOTS, RATING_SEED},
+        instruction,
+        state::{AgentAccount, AgentType, RatingAccount, RatingRole, RatingState},
+    },
+    litesvm::LiteSVM,
+    sha2::{Digest, Sha256},
+    solana_keypair::Keypair,
+    solana_message::{Message, VersionedMessage},
+    solana_signer::Signer,
+    solana_transaction::versioned::VersionedTransaction,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_svm() -> LiteSVM {
+    let mut svm = LiteSVM::new();
+    let bytes = include_bytes!("../../../target/deploy/escrow.so");
+    svm.add_program(escrow::id(), bytes).unwrap();
+    svm
+}
+
+fn send_ok(svm: &mut LiteSVM, ix: Instruction, signers: &[&Keypair]) {
+    let payer_pk = signers[0].pubkey();
+    let bh = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(&[ix], Some(&payer_pk), &bh);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    svm.send_transaction(tx).expect("tx should succeed");
+}
+
+fn send_err(svm: &mut LiteSVM, ix: Instruction, signers: &[&Keypair]) -> String {
+    let payer_pk = signers[0].pubkey();
+    let bh = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(&[ix], Some(&payer_pk), &bh);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    match svm.send_transaction(tx) {
+        Ok(_) => panic!("expected tx to fail but it succeeded"),
+        Err(e) => format!("{:?}", e),
+    }
+}
+
+type Pk = anchor_lang::prelude::Pubkey;
+
+fn agent_pda(owner: &Pk) -> (Pk, u8) {
+    Pk::find_program_address(&[AGENT_SEED, owner.as_ref()], &escrow::id())
+}
+
+fn rating_pda(job_id: &[u8; 16]) -> (Pk, u8) {
+    Pk::find_program_address(&[RATING_SEED, job_id.as_ref()], &escrow::id())
+}
+
+fn sha256_commitment(score: u8, salt: &[u8; 32]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update([score]);
+    h.update(salt);
+    h.finalize().into()
+}
+
+fn register_agent_for(svm: &mut LiteSVM, owner: &Keypair) -> Pk {
+    let (agent_pk, _) = agent_pda(&owner.pubkey());
+    let ix = Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::RegisterAgent {
+            agent_type: AgentType::Primary,
+            model: "test".to_string(),
+            rate_lamports: 1_000_000,
+            min_reputation: 0,
+        }
+        .data(),
+        RegisterAgent {
+            agent: agent_pk,
+            owner: owner.pubkey(),
+            fee_collector: AGENT_FEE_BURN_ADDRESS,
+            system_program: anchor_lang::solana_program::system_program::id(),
+        }
+        .to_account_metas(None),
+    );
+    send_ok(svm, ix, &[owner]);
+    agent_pk
+}
+
+fn fetch_agent(svm: &LiteSVM, pk: &Pk) -> AgentAccount {
+    let raw = svm.get_account(pk).expect("agent must exist");
+    AgentAccount::try_deserialize(&mut raw.data.as_slice()).expect("deser AgentAccount")
+}
+
+fn fetch_rating(svm: &LiteSVM, pk: &Pk) -> RatingAccount {
+    let raw = svm.get_account(pk).expect("rating must exist");
+    RatingAccount::try_deserialize(&mut raw.data.as_slice()).expect("deser RatingAccount")
+}
+
+/// Build a commit_rating instruction.
+///
+/// Both `consumer_pk` and `specialist_pk` must be passed so the on-chain
+/// program can store them on first commit and later load both AgentAccounts
+/// in reveal/expire.
+fn commit_ix(
+    job_id: [u8; 16],
+    commitment: [u8; 32],
+    role: RatingRole,
+    signer: &Keypair,
+    consumer_pk: Pk,
+    specialist_pk: Pk,
+) -> Instruction {
+    let (rating_pk, _) = rating_pda(&job_id);
+    Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::CommitRating {
+            job_id,
+            commitment,
+            role,
+            consumer_pk,
+            specialist_pk,
+        }
+        .data(),
+        CommitRating {
+            rating: rating_pk,
+            signer: signer.pubkey(),
+            system_program: anchor_lang::solana_program::system_program::id(),
+        }
+        .to_account_metas(None),
+    )
+}
+
+fn reveal_ix(
+    job_id: [u8; 16],
+    score: u8,
+    salt: [u8; 32],
+    signer: &Keypair,
+    consumer_agent: Pk,
+    specialist_agent: Pk,
+) -> Instruction {
+    let (rating_pk, _) = rating_pda(&job_id);
+    Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::RevealRating {
+            job_id,
+            score,
+            salt,
+        }
+        .data(),
+        RevealRating {
+            rating: rating_pk,
+            signer: signer.pubkey(),
+            specialist_agent,
+            consumer_agent,
+        }
+        .to_account_metas(None),
+    )
+}
+
+fn expire_ix(
+    job_id: [u8; 16],
+    caller: &Keypair,
+    consumer_agent: Pk,
+    specialist_agent: Pk,
+) -> Instruction {
+    let (rating_pk, _) = rating_pda(&job_id);
+    Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::ExpireRating { job_id }.data(),
+        ExpireRating {
+            rating: rating_pk,
+            caller: caller.pubkey(),
+            specialist_agent,
+            consumer_agent,
+        }
+        .to_account_metas(None),
+    )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Test 1: full happy path — both commit, both reveal, scores applied.
+#[test]
+fn test_commit_and_reveal_both() {
+    let mut svm = make_svm();
+    let consumer = Keypair::new();
+    let specialist = Keypair::new();
+    svm.airdrop(&consumer.pubkey(), 2_000_000_000).unwrap();
+    svm.airdrop(&specialist.pubkey(), 2_000_000_000).unwrap();
+
+    let consumer_agent = register_agent_for(&mut svm, &consumer);
+    let specialist_agent = register_agent_for(&mut svm, &specialist);
+
+    let job_id = [1u8; 16];
+    let (rating_pk, _) = rating_pda(&job_id);
+    let c_salt = [0xAAu8; 32];
+    let s_salt = [0xBBu8; 32];
+    let c_score: u8 = 8;
+    let s_score: u8 = 7;
+
+    // Both commit (consumer goes first, passing both pubkeys)
+    send_ok(
+        &mut svm,
+        commit_ix(
+            job_id,
+            sha256_commitment(c_score, &c_salt),
+            RatingRole::Consumer,
+            &consumer,
+            consumer.pubkey(),
+            specialist.pubkey(),
+        ),
+        &[&consumer],
+    );
+    send_ok(
+        &mut svm,
+        commit_ix(
+            job_id,
+            sha256_commitment(s_score, &s_salt),
+            RatingRole::Specialist,
+            &specialist,
+            consumer.pubkey(),
+            specialist.pubkey(),
+        ),
+        &[&specialist],
+    );
+
+    assert_eq!(
+        fetch_rating(&svm, &rating_pk).state,
+        RatingState::BothCommitted
+    );
+
+    // Consumer reveals first
+    send_ok(
+        &mut svm,
+        reveal_ix(
+            job_id,
+            c_score,
+            c_salt,
+            &consumer,
+            consumer_agent,
+            specialist_agent,
+        ),
+        &[&consumer],
+    );
+
+    // Specialist reveals — triggers finalisation
+    send_ok(
+        &mut svm,
+        reveal_ix(
+            job_id,
+            s_score,
+            s_salt,
+            &specialist,
+            consumer_agent,
+            specialist_agent,
+        ),
+        &[&specialist],
+    );
+
+    let r = fetch_rating(&svm, &rating_pk);
+    assert_eq!(r.state, RatingState::Revealed);
+    assert_eq!(r.consumer_score, Some(c_score));
+    assert_eq!(r.specialist_score, Some(s_score));
+
+    let spec = fetch_agent(&svm, &specialist_agent);
+    assert!(
+        spec.reputation_score > 0,
+        "specialist reputation should update"
+    );
+    assert_eq!(spec.jobs_completed, 1);
+
+    let cons = fetch_agent(&svm, &consumer_agent);
+    assert!(
+        cons.reputation_score > 0,
+        "consumer reputation should update"
+    );
+    assert_eq!(cons.jobs_completed, 1);
+}
+
+/// Test 2: reveal rejected before both parties commit → BothMustCommitFirst.
+#[test]
+fn test_reveal_rejected_before_both_commit() {
+    let mut svm = make_svm();
+    let consumer = Keypair::new();
+    let specialist = Keypair::new();
+    svm.airdrop(&consumer.pubkey(), 2_000_000_000).unwrap();
+    svm.airdrop(&specialist.pubkey(), 2_000_000_000).unwrap();
+
+    let consumer_agent = register_agent_for(&mut svm, &consumer);
+    let specialist_agent = register_agent_for(&mut svm, &specialist);
+
+    let job_id = [2u8; 16];
+    let c_salt = [0xAAu8; 32];
+    let c_score: u8 = 9;
+
+    // Only consumer commits
+    send_ok(
+        &mut svm,
+        commit_ix(
+            job_id,
+            sha256_commitment(c_score, &c_salt),
+            RatingRole::Consumer,
+            &consumer,
+            consumer.pubkey(),
+            specialist.pubkey(),
+        ),
+        &[&consumer],
+    );
+
+    // Consumer tries to reveal immediately — state is Pending, not BothCommitted
+    let err = send_err(
+        &mut svm,
+        reveal_ix(
+            job_id,
+            c_score,
+            c_salt,
+            &consumer,
+            consumer_agent,
+            specialist_agent,
+        ),
+        &[&consumer],
+    );
+
+    assert!(
+        err.contains("BothMustCommitFirst") || err.contains("6011"),
+        "expected BothMustCommitFirst, got: {err}"
+    );
+}
+
+/// Test 3: tampered reveal rejected — wrong salt → CommitmentMismatch.
+#[test]
+fn test_tampered_reveal_rejected() {
+    let mut svm = make_svm();
+    let consumer = Keypair::new();
+    let specialist = Keypair::new();
+    svm.airdrop(&consumer.pubkey(), 2_000_000_000).unwrap();
+    svm.airdrop(&specialist.pubkey(), 2_000_000_000).unwrap();
+
+    let consumer_agent = register_agent_for(&mut svm, &consumer);
+    let specialist_agent = register_agent_for(&mut svm, &specialist);
+
+    let job_id = [3u8; 16];
+    let real_salt = [0x11u8; 32];
+    let wrong_salt = [0xFFu8; 32];
+    let c_score: u8 = 5;
+    let s_score: u8 = 5;
+
+    send_ok(
+        &mut svm,
+        commit_ix(
+            job_id,
+            sha256_commitment(c_score, &real_salt),
+            RatingRole::Consumer,
+            &consumer,
+            consumer.pubkey(),
+            specialist.pubkey(),
+        ),
+        &[&consumer],
+    );
+    send_ok(
+        &mut svm,
+        commit_ix(
+            job_id,
+            sha256_commitment(s_score, &real_salt),
+            RatingRole::Specialist,
+            &specialist,
+            consumer.pubkey(),
+            specialist.pubkey(),
+        ),
+        &[&specialist],
+    );
+
+    // Consumer reveals with wrong salt → CommitmentMismatch
+    let err = send_err(
+        &mut svm,
+        reveal_ix(
+            job_id,
+            c_score,
+            wrong_salt,
+            &consumer,
+            consumer_agent,
+            specialist_agent,
+        ),
+        &[&consumer],
+    );
+
+    assert!(
+        err.contains("CommitmentMismatch") || err.contains("6012"),
+        "expected CommitmentMismatch, got: {err}"
+    );
+}
+
+/// Test 4: duplicate commit rejected → AlreadyCommitted.
+#[test]
+fn test_duplicate_commit_rejected() {
+    let mut svm = make_svm();
+    let consumer = Keypair::new();
+    let specialist = Keypair::new();
+    svm.airdrop(&consumer.pubkey(), 2_000_000_000).unwrap();
+    svm.airdrop(&specialist.pubkey(), 500_000_000).unwrap();
+
+    register_agent_for(&mut svm, &consumer);
+    register_agent_for(&mut svm, &specialist);
+
+    let job_id = [4u8; 16];
+    let salt = [0x55u8; 32];
+
+    send_ok(
+        &mut svm,
+        commit_ix(
+            job_id,
+            sha256_commitment(8, &salt),
+            RatingRole::Consumer,
+            &consumer,
+            consumer.pubkey(),
+            specialist.pubkey(),
+        ),
+        &[&consumer],
+    );
+
+    let err = send_err(
+        &mut svm,
+        commit_ix(
+            job_id,
+            sha256_commitment(9, &salt),
+            RatingRole::Consumer,
+            &consumer,
+            consumer.pubkey(),
+            specialist.pubkey(),
+        ),
+        &[&consumer],
+    );
+
+    assert!(
+        err.contains("AlreadyCommitted") || err.contains("6010"),
+        "expected AlreadyCommitted, got: {err}"
+    );
+}
+
+/// Test 5: expire penalises the non-committing party.
+///
+/// Setup: consumer commits, specialist ghosts.  Both pubkeys are recorded on
+/// consumer's commit so expire_rating can load both AgentAccount PDAs.
+#[test]
+fn test_expire_penalises_non_committer() {
+    let mut svm = make_svm();
+    let consumer = Keypair::new();
+    let specialist = Keypair::new();
+    svm.airdrop(&consumer.pubkey(), 2_000_000_000).unwrap();
+    svm.airdrop(&specialist.pubkey(), 2_000_000_000).unwrap();
+
+    let consumer_agent = register_agent_for(&mut svm, &consumer);
+    let specialist_agent = register_agent_for(&mut svm, &specialist);
+
+    let job_id = [5u8; 16];
+    let (rating_pk, _) = rating_pda(&job_id);
+    let c_salt = [0xCCu8; 32];
+
+    // Consumer commits and records both pubkeys — specialist ghosts
+    send_ok(
+        &mut svm,
+        commit_ix(
+            job_id,
+            sha256_commitment(9, &c_salt),
+            RatingRole::Consumer,
+            &consumer,
+            consumer.pubkey(),
+            specialist.pubkey(),
+        ),
+        &[&consumer],
+    );
+
+    let spec_before = fetch_agent(&svm, &specialist_agent);
+
+    // Warp past the 7-day expiry window
+    svm.warp_to_slot(RATING_EXPIRE_SLOTS + 100);
+
+    // Consumer triggers expiry — specialist ghosted, so specialist is penalised
+    send_ok(
+        &mut svm,
+        expire_ix(job_id, &consumer, consumer_agent, specialist_agent),
+        &[&consumer],
+    );
+
+    let r = fetch_rating(&svm, &rating_pk);
+    assert_eq!(r.state, RatingState::Expired);
+
+    let spec_after = fetch_agent(&svm, &specialist_agent);
+    assert!(
+        spec_after.reputation_score < spec_before.reputation_score
+            || spec_before.reputation_score == 0,
+        "specialist reputation should decrease (floor 0): before={}, after={}",
+        spec_before.reputation_score,
+        spec_after.reputation_score
+    );
+    assert_eq!(spec_after.jobs_failed, spec_before.jobs_failed + 1);
+
+    // Consumer should NOT be penalised
+    let cons = fetch_agent(&svm, &consumer_agent);
+    assert_eq!(
+        cons.jobs_failed, 0,
+        "consumer committed — should not be penalised"
+    );
+}

--- a/programs/escrow/tests/test_escrow.rs
+++ b/programs/escrow/tests/test_escrow.rs
@@ -48,8 +48,7 @@ fn send(
     let payer_pk = signers[0].pubkey();
     let blockhash = svm.latest_blockhash();
     let msg = Message::new_with_blockhash(&[ix], Some(&payer_pk), &blockhash);
-    let tx =
-        VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
     match svm.send_transaction(tx) {
         Ok(_) => panic!("Expected error but tx succeeded"),
         Err(e) => e,
@@ -60,8 +59,7 @@ fn send_ok(svm: &mut LiteSVM, ix: Instruction, signers: &[&Keypair]) {
     let payer_pk = signers[0].pubkey();
     let blockhash = svm.latest_blockhash();
     let msg = Message::new_with_blockhash(&[ix], Some(&payer_pk), &blockhash);
-    let tx =
-        VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
     svm.send_transaction(tx)
         .expect("Transaction should succeed");
 }
@@ -96,7 +94,10 @@ fn test_lock_escrow_success() {
     send_ok(&mut svm, ix, &[&payer]);
 
     let escrow_account = svm.get_account(&escrow_pda).unwrap();
-    assert!(escrow_account.lamports >= amount, "Escrow should hold at least the locked amount");
+    assert!(
+        escrow_account.lamports >= amount,
+        "Escrow should hold at least the locked amount"
+    );
 }
 
 /// release_escrow sends funds to payee and closes PDA
@@ -112,7 +113,10 @@ fn test_release_escrow_success() {
     svm.airdrop(&payee.pubkey(), 1_000_000).unwrap(); // min balance
 
     let (escrow_pda, _) = escrow_pda(&payer.pubkey(), &nonce);
-    let payee_balance_before = svm.get_account(&payee.pubkey()).map(|a| a.lamports).unwrap_or(0);
+    let payee_balance_before = svm
+        .get_account(&payee.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
 
     // Lock first
     let lock_ix = Instruction::new_with_bytes(
@@ -143,10 +147,16 @@ fn test_release_escrow_success() {
     send_ok(&mut svm, release_ix, &[&payer]);
 
     // Escrow PDA should be closed
-    assert!(svm.get_account(&escrow_pda).is_none(), "Escrow PDA should be closed after release");
+    assert!(
+        svm.get_account(&escrow_pda).is_none(),
+        "Escrow PDA should be closed after release"
+    );
 
     // Payee should have received the funds
-    let payee_balance_after = svm.get_account(&payee.pubkey()).map(|a| a.lamports).unwrap_or(0);
+    let payee_balance_after = svm
+        .get_account(&payee.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
     assert_eq!(
         payee_balance_after,
         payee_balance_before + amount,
@@ -181,7 +191,10 @@ fn test_cancel_escrow_refunds_payer() {
     );
     send_ok(&mut svm, lock_ix, &[&payer]);
 
-    let payer_balance_after_lock = svm.get_account(&payer.pubkey()).map(|a| a.lamports).unwrap_or(0);
+    let payer_balance_after_lock = svm
+        .get_account(&payer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
 
     // Warp past the 7-day cancel window (50,400 slots)
     svm.warp_to_slot(60_000);
@@ -200,10 +213,16 @@ fn test_cancel_escrow_refunds_payer() {
     send_ok(&mut svm, cancel_ix, &[&payer]);
 
     // Escrow PDA should be closed
-    assert!(svm.get_account(&escrow_pda).is_none(), "Escrow PDA should be closed after cancel");
+    assert!(
+        svm.get_account(&escrow_pda).is_none(),
+        "Escrow PDA should be closed after cancel"
+    );
 
     // Payer should have been refunded
-    let payer_balance_after_cancel = svm.get_account(&payer.pubkey()).map(|a| a.lamports).unwrap_or(0);
+    let payer_balance_after_cancel = svm
+        .get_account(&payer.pubkey())
+        .map(|a| a.lamports)
+        .unwrap_or(0);
     assert!(
         payer_balance_after_cancel > payer_balance_after_lock,
         "Payer should be refunded after cancel"
@@ -253,7 +272,8 @@ fn test_cancel_window_not_elapsed() {
     let err_str = format!("{:?}", err);
     assert!(
         err_str.contains("CancelWindowNotElapsed") || err_str.contains("6006"),
-        "Expected CancelWindowNotElapsed error, got: {}", err_str
+        "Expected CancelWindowNotElapsed error, got: {}",
+        err_str
     );
 }
 
@@ -292,8 +312,8 @@ fn test_release_payer_constraint() {
         escrow::id(),
         &instruction::ReleaseEscrow {}.data(),
         ReleaseEscrow {
-            escrow: escrow_pda,         // correct PDA
-            payer: attacker.pubkey(),   // wrong payer — has_one = payer should reject
+            escrow: escrow_pda,       // correct PDA
+            payer: attacker.pubkey(), // wrong payer — has_one = payer should reject
             payee: payee.pubkey(),
             system_program: anchor_lang::solana_program::system_program::id(),
         }
@@ -306,7 +326,8 @@ fn test_release_payer_constraint() {
     // to the stored escrow PDA — seeds mismatch is detected before has_one check.
     assert!(
         err_str.contains("ConstraintSeeds") || err_str.contains("2006"),
-        "Expected ConstraintSeeds error, got: {}", err_str
+        "Expected ConstraintSeeds error, got: {}",
+        err_str
     );
 }
 
@@ -323,17 +344,19 @@ fn test_duplicate_nonce() {
 
     let (escrow_pda, _) = escrow_pda(&payer.pubkey(), &nonce);
 
-    let lock_ix = || Instruction::new_with_bytes(
-        escrow::id(),
-        &instruction::LockEscrow { amount, nonce }.data(),
-        LockEscrow {
-            escrow: escrow_pda,
-            payer: payer.pubkey(),
-            payee: payee.pubkey(),
-            system_program: anchor_lang::solana_program::system_program::id(),
-        }
-        .to_account_metas(None),
-    );
+    let lock_ix = || {
+        Instruction::new_with_bytes(
+            escrow::id(),
+            &instruction::LockEscrow { amount, nonce }.data(),
+            LockEscrow {
+                escrow: escrow_pda,
+                payer: payer.pubkey(),
+                payee: payee.pubkey(),
+                system_program: anchor_lang::solana_program::system_program::id(),
+            }
+            .to_account_metas(None),
+        )
+    };
 
     // First lock: should succeed
     send_ok(&mut svm, lock_ix(), &[&payer]);
@@ -344,9 +367,11 @@ fn test_duplicate_nonce() {
     let err = send(&mut svm, lock_ix(), &[&payer]);
     let err_str = format!("{:?}", err);
     assert!(
-        err_str.contains("AlreadyProcessed") || err_str.contains("AlreadyInUse")
+        err_str.contains("AlreadyProcessed")
+            || err_str.contains("AlreadyInUse")
             || err_str.contains("AccountAlreadyInitialized"),
-        "Expected duplicate nonce rejection, got: {}", err_str
+        "Expected duplicate nonce rejection, got: {}",
+        err_str
     );
 }
 

--- a/programs/escrow/tests/test_registry.rs
+++ b/programs/escrow/tests/test_registry.rs
@@ -1,0 +1,294 @@
+use {
+    anchor_lang::{
+        solana_program::instruction::Instruction, AccountDeserialize, InstructionData,
+        ToAccountMetas,
+    },
+    escrow::accounts::{DeregisterAgent, RegisterAgent, UpdateAgent},
+    escrow::constants::{AGENT_FEE_BURN_ADDRESS, AGENT_REGISTRATION_FEE},
+    escrow::instruction,
+    escrow::state::{AgentAccount, AgentType},
+    litesvm::LiteSVM,
+    solana_keypair::Keypair,
+    solana_message::{Message, VersionedMessage},
+    solana_signer::Signer,
+    solana_transaction::versioned::VersionedTransaction,
+};
+
+fn make_svm() -> LiteSVM {
+    let mut svm = LiteSVM::new();
+    let bytes = include_bytes!("../../../target/deploy/escrow.so");
+    svm.add_program(escrow::id(), bytes).unwrap();
+    svm
+}
+
+fn agent_pda(owner: &anchor_lang::prelude::Pubkey) -> (anchor_lang::prelude::Pubkey, u8) {
+    anchor_lang::prelude::Pubkey::find_program_address(&[b"agent", owner.as_ref()], &escrow::id())
+}
+
+fn send_tx(
+    svm: &mut LiteSVM,
+    ix: Instruction,
+    signers: &[&Keypair],
+) -> Result<(), litesvm::types::FailedTransactionMetadata> {
+    let payer_pk = signers[0].pubkey();
+    let blockhash = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(&[ix], Some(&payer_pk), &blockhash);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    match svm.send_transaction(tx) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn register_ix(
+    owner: &Keypair,
+    agent: anchor_lang::prelude::Pubkey,
+    agent_type: AgentType,
+    model: &str,
+) -> Instruction {
+    Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::RegisterAgent {
+            agent_type,
+            model: model.to_string(),
+            rate_lamports: 1_000_000,
+            min_reputation: 3,
+        }
+        .data(),
+        RegisterAgent {
+            agent,
+            owner: owner.pubkey(),
+            fee_collector: AGENT_FEE_BURN_ADDRESS,
+            system_program: anchor_lang::solana_program::system_program::id(),
+        }
+        .to_account_metas(None),
+    )
+}
+
+fn fetch_agent(svm: &LiteSVM, agent_pk: &anchor_lang::prelude::Pubkey) -> AgentAccount {
+    let account = svm.get_account(agent_pk).expect("agent PDA should exist");
+    let mut data = account.data.as_slice();
+    AgentAccount::try_deserialize(&mut data).expect("agent account should deserialize")
+}
+
+#[test]
+fn register_primary_agent_success() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let fee_collector = AGENT_FEE_BURN_ADDRESS;
+    let fee_before = svm
+        .get_account(&fee_collector)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    let ix = register_ix(&owner, agent, AgentType::Primary, "qwen3:8b");
+    send_tx(&mut svm, ix, &[&owner]).expect("register should succeed");
+
+    let fee_after = svm
+        .get_account(&fee_collector)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    assert_eq!(
+        fee_after.saturating_sub(fee_before),
+        AGENT_REGISTRATION_FEE,
+        "registration fee should be charged"
+    );
+
+    let account = fetch_agent(&svm, &agent);
+    assert_eq!(account.owner, owner.pubkey());
+    assert!(account.agent_type == AgentType::Primary);
+    assert_eq!(account.model, "qwen3:8b");
+    assert_eq!(account.reputation_score, 0);
+    assert_eq!(account.jobs_completed, 0);
+    assert_eq!(account.jobs_failed, 0);
+    assert!(account.active);
+}
+
+#[test]
+fn register_attestation_agent_success() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    let ix = register_ix(&owner, agent, AgentType::Attestation, "llama4");
+    send_tx(&mut svm, ix, &[&owner]).expect("register should succeed");
+
+    let account = fetch_agent(&svm, &agent);
+    assert!(account.agent_type == AgentType::Attestation);
+}
+
+#[test]
+fn register_both_success() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    let ix = register_ix(&owner, agent, AgentType::Both, "sonnet");
+    send_tx(&mut svm, ix, &[&owner]).expect("register should succeed");
+
+    let account = fetch_agent(&svm, &agent);
+    assert!(account.agent_type == AgentType::Both);
+}
+
+#[test]
+fn duplicate_registration_rejected() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    send_tx(
+        &mut svm,
+        register_ix(&owner, agent, AgentType::Primary, "qwen3:8b"),
+        &[&owner],
+    )
+    .expect("first register should succeed");
+
+    let err = send_tx(
+        &mut svm,
+        register_ix(&owner, agent, AgentType::Primary, "qwen3:14b"),
+        &[&owner],
+    )
+    .expect_err("second registration should fail");
+
+    let err_str = format!("{:?}", err);
+    assert!(
+        err_str.contains("AlreadyInUse")
+            || err_str.contains("already in use")
+            || err_str.contains("AccountAlreadyInitialized")
+            || err_str.contains("ConstraintSeeds")
+            || err_str.contains("AlreadyProcessed")
+            || err_str.contains("custom program error: 0x0"),
+        "expected duplicate registration rejection, got: {err_str}"
+    );
+}
+
+#[test]
+fn update_rate_owner_only() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    let attacker = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+    svm.airdrop(&attacker.pubkey(), 1_000_000_000).unwrap();
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    send_tx(
+        &mut svm,
+        register_ix(&owner, agent, AgentType::Primary, "qwen3:8b"),
+        &[&owner],
+    )
+    .expect("register should succeed");
+
+    let owner_update_ix = Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::UpdateAgent {
+            rate_lamports: 2_500_000,
+            min_reputation: 12,
+            active: false,
+        }
+        .data(),
+        UpdateAgent {
+            agent,
+            owner: owner.pubkey(),
+        }
+        .to_account_metas(None),
+    );
+    send_tx(&mut svm, owner_update_ix, &[&owner]).expect("owner update should succeed");
+
+    let updated = fetch_agent(&svm, &agent);
+    assert_eq!(updated.rate_lamports, 2_500_000);
+    assert_eq!(updated.min_reputation, 12);
+    assert!(!updated.active);
+
+    let attacker_update_ix = Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::UpdateAgent {
+            rate_lamports: 3_300_000,
+            min_reputation: 1,
+            active: true,
+        }
+        .data(),
+        UpdateAgent {
+            agent,
+            owner: attacker.pubkey(),
+        }
+        .to_account_metas(None),
+    );
+
+    let err = send_tx(&mut svm, attacker_update_ix, &[&attacker])
+        .expect_err("non-owner update should fail");
+    let err_str = format!("{:?}", err);
+    assert!(
+        err_str.contains("ConstraintHasOne")
+            || err_str.contains("ConstraintSeeds")
+            || err_str.contains("2001")
+            || err_str.contains("2006"),
+        "expected owner constraint failure, got: {err_str}"
+    );
+}
+
+#[test]
+fn deregister_closes_pda() {
+    let mut svm = make_svm();
+    let owner = Keypair::new();
+    svm.airdrop(&owner.pubkey(), 1_000_000_000).unwrap();
+
+    let fee_collector = AGENT_FEE_BURN_ADDRESS;
+    let fee_before = svm
+        .get_account(&fee_collector)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+
+    let (agent, _) = agent_pda(&owner.pubkey());
+    send_tx(
+        &mut svm,
+        register_ix(&owner, agent, AgentType::Primary, "qwen3:8b"),
+        &[&owner],
+    )
+    .expect("register should succeed");
+
+    let owner_after_register = svm
+        .get_account(&owner.pubkey())
+        .expect("owner exists")
+        .lamports;
+
+    let deregister_ix = Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::DeregisterAgent {}.data(),
+        DeregisterAgent {
+            agent,
+            owner: owner.pubkey(),
+        }
+        .to_account_metas(None),
+    );
+    send_tx(&mut svm, deregister_ix, &[&owner]).expect("deregister should succeed");
+
+    assert!(
+        svm.get_account(&agent).is_none(),
+        "agent PDA should be closed"
+    );
+
+    let owner_after_deregister = svm
+        .get_account(&owner.pubkey())
+        .expect("owner exists")
+        .lamports;
+    assert!(
+        owner_after_deregister > owner_after_register,
+        "owner should receive rent back on close"
+    );
+
+    let fee_after = svm
+        .get_account(&fee_collector)
+        .map(|a| a.lamports)
+        .unwrap_or(0);
+    assert_eq!(
+        fee_after.saturating_sub(fee_before),
+        AGENT_REGISTRATION_FEE,
+        "registration fee should not be returned on deregister"
+    );
+}


### PR DESCRIPTION
## Phase 4: Blind Commit-Reveal Reputation

### What's in this PR

**New state: `RatingAccount` PDA** (`state.rs`)
- Seeds: `[b"rating", job_id.as_ref()]`
- 11 fields: job_id, consumer, specialist, consumer_commitment, specialist_commitment, consumer_score, specialist_score, state, created_at, created_slot, bump
- `RatingState` enum: `Pending | BothCommitted | Revealed | Expired`
- `RatingRole` enum: `Consumer | Specialist`

**3 new instructions:**

| Instruction | What it does |
|---|---|
| `commit_rating` | Creates/updates `RatingAccount`; stores both party pubkeys on first call; `AlreadyCommitted` if double-submitting |
| `reveal_rating` | Verifies `sha256(score ∥ salt)` against stored commitment; applies rolling reputation update when both revealed |
| `expire_rating` | After `RATING_EXPIRE_SLOTS` (1,512,000 slots = ~7 days), penalises the party that didn't commit (-500 reputation) |

**Reputation update formula:**
```
new = (old * 9 + score_scaled) / 10   // rolling average, score_scaled = score * 1000
```

**6 new error variants** in `EscrowError`: `AlreadyCommitted`, `BothMustCommitFirst`, `CommitmentMismatch`, `InvalidScore`, `NotExpired`, `AlreadyFinalised`

**5 LiteSVM tests** in `tests/reputation.rs` — all pass:
1. `test_commit_and_reveal_both` — happy path, scores written to both AgentAccounts
2. `test_reveal_rejected_before_both_commit` — state=Pending → `BothMustCommitFirst`
3. `test_tampered_reveal_rejected` — wrong salt → `CommitmentMismatch`
4. `test_duplicate_commit_rejected` — same role commits twice → `AlreadyCommitted`
5. `test_expire_penalises_non_committer` — specialist ghosts, consumer triggers expiry, specialist penalised

### Test results
```
test result: ok. 5 passed; 0 failed  (reputation.rs)
test result: ok. 8 passed; 0 failed  (test_escrow.rs)
test result: ok. 6 passed; 0 failed  (test_registry.rs)
```

### Design note
`commit_rating` accepts `consumer_pk` and `specialist_pk` on every call and stores them on first commit. This ensures `expire_rating` can always load both `AgentAccount` PDAs — including when one party ghosts (their pubkey is already recorded from the committing party's call).

### Branch
`phase-4/reputation` → based on `phase-3/agent-registry` (PR #17)
