### PR TITLE
Phase 4b: Attestation Judge System

### DIFF
--- a/programs/escrow/src/constants.rs
+++ b/programs/escrow/src/constants.rs
@@ -15,3 +15,7 @@ pub const RATING_SEED: &[u8] = b"rating";
 pub const RATING_EXPIRE_SLOTS: u64 = 1_512_000;
 /// Reputation penalty for non-commitment on expiry (5.00 points)
 pub const RATING_EXPIRE_PENALTY: u16 = 500;
+
+pub const ATTESTATION_SEED: &[u8] = b"attestation";
+/// Weight applied to attestation_accuracy on confirmation (10.00 points)
+pub const ATTESTATION_CONFIRM_WEIGHT: u16 = 1000;

--- a/programs/escrow/src/error.rs
+++ b/programs/escrow/src/error.rs
@@ -49,4 +49,16 @@ pub enum EscrowError {
 
     #[msg("Rating already finalised")]
     AlreadyFinalised,
+
+    #[msg("Agent type does not permit attestation")]
+    NotAttestationAgent,
+
+    #[msg("Attestation already exists for this job")]
+    AttestationAlreadyExists,
+
+    #[msg("Attestation already resolved")]
+    AttestationAlreadyResolved,
+
+    #[msg("Score must be between 1 and 10")]
+    AttestationScoreOutOfRange,
 }

--- a/programs/escrow/src/instructions.rs
+++ b/programs/escrow/src/instructions.rs
@@ -1,6 +1,9 @@
+pub mod attest_quality;
 pub mod cancel_escrow;
 pub mod commit_rating;
+pub mod confirm_attestation;
 pub mod deregister_agent;
+pub mod dispute_attestation;
 pub mod expire_rating;
 pub mod lock_escrow;
 pub mod register_agent;
@@ -8,9 +11,12 @@ pub mod release_escrow;
 pub mod reveal_rating;
 pub mod update_agent;
 
+pub use attest_quality::*;
 pub use cancel_escrow::*;
 pub use commit_rating::*;
+pub use confirm_attestation::*;
 pub use deregister_agent::*;
+pub use dispute_attestation::*;
 pub use expire_rating::*;
 pub use lock_escrow::*;
 pub use register_agent::*;

--- a/programs/escrow/src/instructions/attest_quality.rs
+++ b/programs/escrow/src/instructions/attest_quality.rs
@@ -1,0 +1,66 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::{AGENT_SEED, ATTESTATION_SEED};
+use crate::error::EscrowError;
+use crate::state::{AgentAccount, AgentType, AttestationAccount};
+
+/// Create an attestation record for a completed job.
+///
+/// Only agents registered as `Attestation` or `Both` may call this.
+/// Creates an `AttestationAccount` PDA; duplicate attestations on the same
+/// job_id are rejected via Anchor's `init` constraint.
+pub fn attest_quality_handler(
+    ctx: Context<AttestQuality>,
+    _job_id: [u8; 16],
+    scores: [u8; 5],
+    consumer: Pubkey,
+) -> Result<()> {
+    // Validate agent type
+    let agent_type = &ctx.accounts.judge_agent.agent_type;
+    require!(
+        *agent_type == AgentType::Attestation || *agent_type == AgentType::Both,
+        EscrowError::NotAttestationAgent
+    );
+
+    // Validate all scores 1-10
+    for &s in scores.iter() {
+        require!(s >= 1 && s <= 10, EscrowError::AttestationScoreOutOfRange);
+    }
+
+    let attestation = &mut ctx.accounts.attestation;
+    attestation.job_id = _job_id;
+    attestation.judge = ctx.accounts.judge.key();
+    attestation.consumer = consumer;
+    attestation.scores = scores;
+    attestation.confirmed = None;
+    attestation.created_at = Clock::get()?.unix_timestamp;
+    attestation.bump = ctx.bumps.attestation;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(job_id: [u8; 16])]
+pub struct AttestQuality<'info> {
+    /// Attestation PDA — init enforces one-per-job dedup
+    #[account(
+        init,
+        payer = judge,
+        space = AttestationAccount::LEN,
+        seeds = [ATTESTATION_SEED, job_id.as_ref()],
+        bump,
+    )]
+    pub attestation: Account<'info, AttestationAccount>,
+
+    /// Judge's AgentAccount — must be Attestation or Both
+    #[account(
+        seeds = [AGENT_SEED, judge.key().as_ref()],
+        bump = judge_agent.bump,
+    )]
+    pub judge_agent: Account<'info, AgentAccount>,
+
+    #[account(mut)]
+    pub judge: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}

--- a/programs/escrow/src/instructions/confirm_attestation.rs
+++ b/programs/escrow/src/instructions/confirm_attestation.rs
@@ -1,0 +1,68 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::{AGENT_SEED, ATTESTATION_CONFIRM_WEIGHT, ATTESTATION_SEED};
+use crate::error::EscrowError;
+use crate::state::{AgentAccount, AttestationAccount};
+
+/// Consumer agrees with the judge's assessment.
+///
+/// - Marks `attestation.confirmed = Some(true)`
+/// - Rewards the judge: rolling average on `reputation_score` and
+///   increment of `attestation_accuracy`
+pub fn confirm_attestation_handler(
+    ctx: Context<ConfirmAttestation>,
+    _job_id: [u8; 16],
+) -> Result<()> {
+    let attestation = &mut ctx.accounts.attestation;
+
+    // Only the job consumer can confirm
+    require!(
+        ctx.accounts.consumer.key() == attestation.consumer,
+        EscrowError::UnauthorisedSigner
+    );
+
+    // Cannot resolve twice
+    require!(
+        attestation.confirmed.is_none(),
+        EscrowError::AttestationAlreadyResolved
+    );
+
+    attestation.confirmed = Some(true);
+
+    // Reward judge's attestation_accuracy
+    let judge = &mut ctx.accounts.judge_agent;
+    judge.attestation_accuracy = judge
+        .attestation_accuracy
+        .saturating_add(ATTESTATION_CONFIRM_WEIGHT)
+        .min(10_000);
+
+    // Rolling average reputation bump: treat confirmation as score=10 (max quality)
+    let new_scaled: u32 = 10_000; // 10 * 1000
+    let old = judge.reputation_score as u32;
+    let updated = (old * 9 + new_scaled) / 10;
+    judge.reputation_score = updated.min(10_000) as u16;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(job_id: [u8; 16])]
+pub struct ConfirmAttestation<'info> {
+    #[account(
+        mut,
+        seeds = [ATTESTATION_SEED, job_id.as_ref()],
+        bump = attestation.bump,
+    )]
+    pub attestation: Account<'info, AttestationAccount>,
+
+    /// Judge's AgentAccount — receives the reward
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, attestation.judge.as_ref()],
+        bump = judge_agent.bump,
+    )]
+    pub judge_agent: Account<'info, AgentAccount>,
+
+    /// The job consumer (must match attestation.consumer)
+    pub consumer: Signer<'info>,
+}

--- a/programs/escrow/src/instructions/dispute_attestation.rs
+++ b/programs/escrow/src/instructions/dispute_attestation.rs
@@ -1,0 +1,58 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::{AGENT_SEED, ATTESTATION_SEED, RATING_EXPIRE_PENALTY};
+use crate::error::EscrowError;
+use crate::state::{AgentAccount, AttestationAccount};
+
+/// Consumer disagrees with the judge's assessment.
+///
+/// - Marks `attestation.confirmed = Some(false)`
+/// - Penalises the judge: decrement `reputation_score` by `RATING_EXPIRE_PENALTY`
+pub fn dispute_attestation_handler(
+    ctx: Context<DisputeAttestation>,
+    _job_id: [u8; 16],
+) -> Result<()> {
+    let attestation = &mut ctx.accounts.attestation;
+
+    // Only the job consumer can dispute
+    require!(
+        ctx.accounts.consumer.key() == attestation.consumer,
+        EscrowError::UnauthorisedSigner
+    );
+
+    // Cannot resolve twice
+    require!(
+        attestation.confirmed.is_none(),
+        EscrowError::AttestationAlreadyResolved
+    );
+
+    attestation.confirmed = Some(false);
+
+    // Penalise judge's reputation
+    let judge = &mut ctx.accounts.judge_agent;
+    judge.reputation_score = judge.reputation_score.saturating_sub(RATING_EXPIRE_PENALTY);
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(job_id: [u8; 16])]
+pub struct DisputeAttestation<'info> {
+    #[account(
+        mut,
+        seeds = [ATTESTATION_SEED, job_id.as_ref()],
+        bump = attestation.bump,
+    )]
+    pub attestation: Account<'info, AttestationAccount>,
+
+    /// Judge's AgentAccount — receives the penalty
+    #[account(
+        mut,
+        seeds = [AGENT_SEED, attestation.judge.as_ref()],
+        bump = judge_agent.bump,
+    )]
+    pub judge_agent: Account<'info, AgentAccount>,
+
+    /// The job consumer (must match attestation.consumer)
+    pub consumer: Signer<'info>,
+}

--- a/programs/escrow/src/lib.rs
+++ b/programs/escrow/src/lib.rs
@@ -94,4 +94,23 @@ pub mod escrow {
     pub fn expire_rating(ctx: Context<ExpireRating>, job_id: [u8; 16]) -> Result<()> {
         instructions::expire_rating::expire_rating_handler(ctx, job_id)
     }
+
+    // ── Phase 4b: Attestation Judges ─────────────────────────────────────────
+
+    pub fn attest_quality(
+        ctx: Context<AttestQuality>,
+        job_id: [u8; 16],
+        scores: [u8; 5],
+        consumer: Pubkey,
+    ) -> Result<()> {
+        instructions::attest_quality::attest_quality_handler(ctx, job_id, scores, consumer)
+    }
+
+    pub fn confirm_attestation(ctx: Context<ConfirmAttestation>, job_id: [u8; 16]) -> Result<()> {
+        instructions::confirm_attestation::confirm_attestation_handler(ctx, job_id)
+    }
+
+    pub fn dispute_attestation(ctx: Context<DisputeAttestation>, job_id: [u8; 16]) -> Result<()> {
+        instructions::dispute_attestation::dispute_attestation_handler(ctx, job_id)
+    }
 }

--- a/programs/escrow/src/state.rs
+++ b/programs/escrow/src/state.rs
@@ -78,13 +78,15 @@ pub struct AgentAccount {
     pub created_at: i64,
     /// Whether this agent can currently accept jobs
     pub active: bool,
+    /// Running attestation accuracy score (confirmed / total, 0–10000)
+    pub attestation_accuracy: u16,
     /// PDA bump seed
     pub bump: u8,
 }
 
 impl AgentAccount {
-    /// 8 (discriminator) + 32 + 1 + 68 (4+64 string) + 8 + 1 + 2 + 8 + 8 + 8 + 1 + 1
-    pub const LEN: usize = 148;
+    /// 8 (discriminator) + 32 + 1 + 68 (4+64 string) + 8 + 1 + 2 + 8 + 8 + 8 + 1 + 2 + 1
+    pub const LEN: usize = 150;
 }
 
 /// Blind commit-reveal rating account.
@@ -150,4 +152,37 @@ pub enum RatingState {
 pub enum RatingRole {
     Consumer,
     Specialist,
+}
+
+/// On-chain attestation record from a judge agent.
+/// PDA seeds: [b"attestation", job_id.as_ref()]
+#[account]
+pub struct AttestationAccount {
+    /// Unique job identifier (UUID bytes)
+    pub job_id: [u8; 16],
+    /// The judge agent's wallet
+    pub judge: Pubkey,
+    /// The consumer who hired (and can confirm/dispute)
+    pub consumer: Pubkey,
+    /// Quality scores: [accuracy, completeness, relevance, format, latency] each 1-10
+    pub scores: [u8; 5],
+    /// None = pending, Some(true) = confirmed, Some(false) = disputed
+    pub confirmed: Option<bool>,
+    /// Unix timestamp when account was created
+    pub created_at: i64,
+    /// PDA bump seed
+    pub bump: u8,
+}
+
+impl AttestationAccount {
+    // 8  discriminator
+    // 16  job_id
+    // 32  judge
+    // 32  consumer
+    // 5   scores ([u8; 5])
+    // 2   confirmed (Option<bool>: 1 discriminant + 1 value)
+    // 8   created_at
+    // 1   bump
+    // = 105
+    pub const LEN: usize = 105;
 }

--- a/programs/escrow/tests/attestation.rs
+++ b/programs/escrow/tests/attestation.rs
@@ -1,0 +1,352 @@
+/// Phase 4b — Attestation Judge system
+///
+/// Tests the attest_quality / confirm_attestation / dispute_attestation instructions.
+use {
+    anchor_lang::{
+        solana_program::instruction::Instruction, AccountDeserialize, InstructionData,
+        ToAccountMetas,
+    },
+    escrow::{
+        accounts::{AttestQuality, ConfirmAttestation, DisputeAttestation, RegisterAgent},
+        constants::{AGENT_FEE_BURN_ADDRESS, AGENT_SEED, ATTESTATION_SEED},
+        instruction,
+        state::{AgentAccount, AgentType, AttestationAccount},
+    },
+    litesvm::LiteSVM,
+    solana_keypair::Keypair,
+    solana_message::{Message, VersionedMessage},
+    solana_signer::Signer,
+    solana_transaction::versioned::VersionedTransaction,
+};
+
+type Pk = anchor_lang::prelude::Pubkey;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_svm() -> LiteSVM {
+    let mut svm = LiteSVM::new();
+    let bytes = include_bytes!("../../../target/deploy/escrow.so");
+    svm.add_program(escrow::id(), bytes).unwrap();
+    svm
+}
+
+fn send_ok(svm: &mut LiteSVM, ix: Instruction, signers: &[&Keypair]) {
+    let payer = signers[0].pubkey();
+    let bh = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(&[ix], Some(&payer), &bh);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    svm.send_transaction(tx).expect("tx should succeed");
+}
+
+fn send_err(svm: &mut LiteSVM, ix: Instruction, signers: &[&Keypair]) -> String {
+    let payer = signers[0].pubkey();
+    let bh = svm.latest_blockhash();
+    let msg = Message::new_with_blockhash(&[ix], Some(&payer), &bh);
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), signers).unwrap();
+    match svm.send_transaction(tx) {
+        Ok(_) => panic!("expected tx to fail but it succeeded"),
+        Err(e) => format!("{:?}", e),
+    }
+}
+
+fn agent_pda(owner: &Pk) -> (Pk, u8) {
+    Pk::find_program_address(&[AGENT_SEED, owner.as_ref()], &escrow::id())
+}
+
+fn attestation_pda(job_id: &[u8; 16]) -> (Pk, u8) {
+    Pk::find_program_address(&[ATTESTATION_SEED, job_id.as_ref()], &escrow::id())
+}
+
+fn register_agent(svm: &mut LiteSVM, owner: &Keypair, agent_type: AgentType) -> Pk {
+    let (agent_pk, _) = agent_pda(&owner.pubkey());
+    let ix = Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::RegisterAgent {
+            agent_type,
+            model: "judge-model".to_string(),
+            rate_lamports: 500_000,
+            min_reputation: 0,
+        }
+        .data(),
+        RegisterAgent {
+            agent: agent_pk,
+            owner: owner.pubkey(),
+            fee_collector: AGENT_FEE_BURN_ADDRESS,
+            system_program: anchor_lang::solana_program::system_program::id(),
+        }
+        .to_account_metas(None),
+    );
+    send_ok(svm, ix, &[owner]);
+    agent_pk
+}
+
+fn fetch_agent(svm: &LiteSVM, pk: &Pk) -> AgentAccount {
+    let raw = svm.get_account(pk).expect("agent must exist");
+    AgentAccount::try_deserialize(&mut raw.data.as_slice()).expect("deser AgentAccount")
+}
+
+fn fetch_attestation(svm: &LiteSVM, pk: &Pk) -> AttestationAccount {
+    let raw = svm.get_account(pk).expect("attestation must exist");
+    AttestationAccount::try_deserialize(&mut raw.data.as_slice()).expect("deser AttestationAccount")
+}
+
+fn attest_ix(
+    job_id: [u8; 16],
+    scores: [u8; 5],
+    judge: &Keypair,
+    judge_agent: Pk,
+    consumer: Pk,
+) -> Instruction {
+    let (attestation_pk, _) = attestation_pda(&job_id);
+    Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::AttestQuality {
+            job_id,
+            scores,
+            consumer,
+        }
+        .data(),
+        AttestQuality {
+            attestation: attestation_pk,
+            judge_agent,
+            judge: judge.pubkey(),
+            system_program: anchor_lang::solana_program::system_program::id(),
+        }
+        .to_account_metas(None),
+    )
+}
+
+fn confirm_ix(job_id: [u8; 16], consumer: &Keypair, judge_agent: Pk) -> Instruction {
+    let (attestation_pk, _) = attestation_pda(&job_id);
+    Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::ConfirmAttestation { job_id }.data(),
+        ConfirmAttestation {
+            attestation: attestation_pk,
+            judge_agent,
+            consumer: consumer.pubkey(),
+        }
+        .to_account_metas(None),
+    )
+}
+
+fn dispute_ix(job_id: [u8; 16], consumer: &Keypair, judge_agent: Pk) -> Instruction {
+    let (attestation_pk, _) = attestation_pda(&job_id);
+    Instruction::new_with_bytes(
+        escrow::id(),
+        &instruction::DisputeAttestation { job_id }.data(),
+        DisputeAttestation {
+            attestation: attestation_pk,
+            judge_agent,
+            consumer: consumer.pubkey(),
+        }
+        .to_account_metas(None),
+    )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Test 1: judge attests → consumer confirms → judge attestation_accuracy increases.
+#[test]
+fn test_confirm_increases_judge_accuracy() {
+    let mut svm = make_svm();
+    let judge = Keypair::new();
+    let consumer = Keypair::new();
+    svm.airdrop(&judge.pubkey(), 2_000_000_000).unwrap();
+    svm.airdrop(&consumer.pubkey(), 1_000_000_000).unwrap();
+
+    let judge_agent = register_agent(&mut svm, &judge, AgentType::Attestation);
+
+    let judge_before = fetch_agent(&svm, &judge_agent);
+
+    let job_id = [1u8; 16];
+    let scores = [8u8, 9, 7, 8, 9];
+    let (attestation_pk, _) = attestation_pda(&job_id);
+
+    // Judge attests
+    send_ok(
+        &mut svm,
+        attest_ix(job_id, scores, &judge, judge_agent, consumer.pubkey()),
+        &[&judge],
+    );
+
+    let attest = fetch_attestation(&svm, &attestation_pk);
+    assert_eq!(attest.scores, scores);
+    assert_eq!(attest.confirmed, None);
+    assert_eq!(attest.judge, judge.pubkey());
+    assert_eq!(attest.consumer, consumer.pubkey());
+
+    // Consumer confirms
+    send_ok(
+        &mut svm,
+        confirm_ix(job_id, &consumer, judge_agent),
+        &[&consumer],
+    );
+
+    let attest = fetch_attestation(&svm, &attestation_pk);
+    assert_eq!(attest.confirmed, Some(true));
+
+    let judge_after = fetch_agent(&svm, &judge_agent);
+    assert!(
+        judge_after.attestation_accuracy > judge_before.attestation_accuracy,
+        "attestation_accuracy should increase on confirm: before={}, after={}",
+        judge_before.attestation_accuracy,
+        judge_after.attestation_accuracy
+    );
+    assert!(
+        judge_after.reputation_score >= judge_before.reputation_score,
+        "reputation should increase on confirm"
+    );
+}
+
+/// Test 2: judge attests → consumer disputes → judge reputation penalised.
+#[test]
+fn test_dispute_penalises_judge() {
+    let mut svm = make_svm();
+    let judge = Keypair::new();
+    let consumer = Keypair::new();
+    svm.airdrop(&judge.pubkey(), 2_000_000_000).unwrap();
+    svm.airdrop(&consumer.pubkey(), 1_000_000_000).unwrap();
+
+    let judge_agent = register_agent(&mut svm, &judge, AgentType::Both);
+
+    // Give judge some starting reputation so we can verify it drops
+    // (newly registered agents have reputation_score = 0; saturating_sub floors at 0)
+    let judge_before = fetch_agent(&svm, &judge_agent);
+
+    let job_id = [2u8; 16];
+    let scores = [3u8, 2, 4, 3, 2]; // low quality scores
+
+    send_ok(
+        &mut svm,
+        attest_ix(job_id, scores, &judge, judge_agent, consumer.pubkey()),
+        &[&judge],
+    );
+
+    // Consumer disputes
+    send_ok(
+        &mut svm,
+        dispute_ix(job_id, &consumer, judge_agent),
+        &[&consumer],
+    );
+
+    let attest = fetch_attestation(&svm, &attestation_pda(&job_id).0);
+    assert_eq!(attest.confirmed, Some(false));
+
+    let judge_after = fetch_agent(&svm, &judge_agent);
+    // Reputation should decrease or stay at 0 (saturating_sub)
+    assert!(
+        judge_after.reputation_score <= judge_before.reputation_score,
+        "reputation should decrease on dispute: before={}, after={}",
+        judge_before.reputation_score,
+        judge_after.reputation_score
+    );
+}
+
+/// Test 3: non-attestation agent (Primary) calls attest_quality → rejected.
+#[test]
+fn test_non_attestation_agent_rejected() {
+    let mut svm = make_svm();
+    let impostor = Keypair::new();
+    let consumer = Keypair::new();
+    svm.airdrop(&impostor.pubkey(), 2_000_000_000).unwrap();
+
+    // Register as Primary — not allowed to attest
+    let impostor_agent = register_agent(&mut svm, &impostor, AgentType::Primary);
+
+    let job_id = [3u8; 16];
+    let scores = [8u8, 8, 8, 8, 8];
+
+    let err = send_err(
+        &mut svm,
+        attest_ix(job_id, scores, &impostor, impostor_agent, consumer.pubkey()),
+        &[&impostor],
+    );
+
+    assert!(
+        err.contains("NotAttestationAgent") || err.contains("6016"),
+        "expected NotAttestationAgent, got: {err}"
+    );
+}
+
+/// Test 4: non-consumer calls confirm_attestation → rejected.
+#[test]
+fn test_non_consumer_confirm_rejected() {
+    let mut svm = make_svm();
+    let judge = Keypair::new();
+    let consumer = Keypair::new();
+    let attacker = Keypair::new();
+    svm.airdrop(&judge.pubkey(), 2_000_000_000).unwrap();
+    svm.airdrop(&consumer.pubkey(), 1_000_000_000).unwrap();
+    svm.airdrop(&attacker.pubkey(), 1_000_000_000).unwrap();
+
+    let judge_agent = register_agent(&mut svm, &judge, AgentType::Attestation);
+
+    let job_id = [4u8; 16];
+    let scores = [7u8, 8, 7, 8, 7];
+
+    send_ok(
+        &mut svm,
+        attest_ix(job_id, scores, &judge, judge_agent, consumer.pubkey()),
+        &[&judge],
+    );
+
+    // Attacker (not the consumer) tries to confirm
+    let err = send_err(
+        &mut svm,
+        confirm_ix(job_id, &attacker, judge_agent),
+        &[&attacker],
+    );
+
+    assert!(
+        err.contains("UnauthorisedSigner") || err.contains("6000"),
+        "expected UnauthorisedSigner, got: {err}"
+    );
+
+    // Original consumer can still confirm successfully
+    send_ok(
+        &mut svm,
+        confirm_ix(job_id, &consumer, judge_agent),
+        &[&consumer],
+    );
+    let attest = fetch_attestation(&svm, &attestation_pda(&job_id).0);
+    assert_eq!(attest.confirmed, Some(true));
+}
+
+/// Test 5: duplicate attestation on same job_id → rejected.
+#[test]
+fn test_duplicate_attestation_rejected() {
+    let mut svm = make_svm();
+    let judge = Keypair::new();
+    let consumer = Keypair::new();
+    svm.airdrop(&judge.pubkey(), 2_000_000_000).unwrap();
+
+    let judge_agent = register_agent(&mut svm, &judge, AgentType::Attestation);
+
+    let job_id = [5u8; 16];
+    let scores = [9u8, 9, 9, 9, 9];
+
+    // First attestation succeeds
+    send_ok(
+        &mut svm,
+        attest_ix(job_id, scores, &judge, judge_agent, consumer.pubkey()),
+        &[&judge],
+    );
+
+    // Second attestation on the same job_id → Anchor's `init` rejects it
+    let err = send_err(
+        &mut svm,
+        attest_ix(job_id, scores, &judge, judge_agent, consumer.pubkey()),
+        &[&judge],
+    );
+
+    assert!(
+        err.contains("AttestationAlreadyExists")
+            || err.contains("6017")
+            || err.contains("AlreadyInUse")
+            || err.contains("AlreadyProcessed")
+            || err.contains("already in use")
+            || err.contains("custom program error: 0x0"),
+        "expected duplicate attestation rejection, got: {err}"
+    );
+}


### PR DESCRIPTION
## Phase 4b: Attestation Judge System

### What's in this PR

**New state: `AttestationAccount` PDA** (appended to `state.rs`)
- Seeds: `[b"attestation", job_id.as_ref()]`
- Fields: `job_id`, `judge`, `consumer`, `scores: [u8; 5]`, `confirmed: Option<bool>`, `created_at`, `bump`
- `scores` = [accuracy, completeness, relevance, format, latency], each 1-10

**3 new instructions:**

| Instruction | What it does |
|---|---|
| `attest_quality(job_id, scores, consumer)` | Creates `AttestationAccount`; rejects non-Attestation/Both agents; validates scores 1-10; dedup via `init` |
| `confirm_attestation(job_id)` | Consumer confirms; rolling reputation bump (treated as score=10); `attestation_accuracy += 1000` |
| `dispute_attestation(job_id)` | Consumer disputes; reputation penalised by `RATING_EXPIRE_PENALTY = 500` |

**`AgentAccount` field added:** `attestation_accuracy: u16` — tracks judge accuracy score. `LEN` updated 148→150.

**4 new error variants:** `NotAttestationAgent`, `AttestationAlreadyExists`, `AttestationAlreadyResolved`, `AttestationScoreOutOfRange`

**1 new constant:** `ATTESTATION_CONFIRM_WEIGHT = 1000`

**5 LiteSVM tests** in `tests/attestation.rs`:
1. `test_confirm_increases_judge_accuracy` — attest → confirm → accuracy/reputation increase
2. `test_dispute_penalises_judge` — attest → dispute → reputation decreases
3. `test_non_attestation_agent_rejected` — Primary agent → `NotAttestationAgent`
4. `test_non_consumer_confirm_rejected` — wrong signer → `UnauthorisedSigner`
5. `test_duplicate_attestation_rejected` — same job_id → rejected

### Test results
```
test result: ok. 5 passed; 0 failed  (attestation.rs)
test result: ok. 5 passed; 0 failed  (reputation.rs)
test result: ok. 8 passed; 0 failed  (test_escrow.rs)
test result: ok. 6 passed; 0 failed  (test_registry.rs)
25/25 total
```
