### PR TITLE
Phase 7: Frontend Sync — /register + /agents wired to devnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Running a local Ollama instance to offer agent services is the same spirit as running a blockchain validator. You contribute real compute to a decentralised network. No permission needed. Your infrastructure, your rules. The protocol enforces honesty — not a whitelist.
 
 🌐 **Live:** https://agent-protocol.reddi.tech  
-📦 **Protocol repo:** https://github.com/reddinft/reddi-agent-protocol  
+📦 **Protocol repo:** https://github.com/nissan/reddi-agent-protocol  
 🔗 **Solana program (devnet):** see below
 
 ---
@@ -52,7 +52,7 @@ See the full setup guide: **https://agent-protocol.reddi.tech/setup**
 Quick version:
 ```bash
 # 1. Clone and install
-git clone https://github.com/reddinft/reddi-agent-protocol
+git clone https://github.com/nissan/reddi-agent-protocol
 cd reddi-agent-protocol
 npm install
 
@@ -152,7 +152,11 @@ npm run test:e2e
 
 ## Solana program (devnet)
 
-Program ID and live explorer links available at [agent-protocol.reddi.tech](https://agent-protocol.reddi.tech).
+**Program ID:** `77rkRQxe4GRzHU56H6JuWPFe27g4NoRBz4GGftuUZXmX`
+
+[View on Solana Explorer](https://explorer.solana.com/address/77rkRQxe4GRzHU56H6JuWPFe27g4NoRBz4GGftuUZXmX?cluster=devnet)
+
+Deployed 2026-04-10 with Anchor 1.0.0 + Rust 1.89.0. Redeployment instructions in [`DEPLOY.md`](DEPLOY.md).
 
 ---
 

--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import seedAgents, { SeedAgent, formatLamportsUsd } from "@/lib/agents";
+import { useOnchainAgents, type OnchainAgentWithPda } from "@/lib/useOnchainAgents";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -95,16 +96,65 @@ function SeedAgentCard({ agent }: { agent: SeedAgent }) {
   );
 }
 
+// ── On-chain Agent Card ───────────────────────────────────────────────────────
+
+function OnchainAgentCard({ agent }: { agent: OnchainAgentWithPda }) {
+  const typeCls =
+    agent.agentType === "Primary"
+      ? "bg-[#9945FF]/20 text-[#9945FF] border-[#9945FF]/30"
+      : "bg-[#14F195]/20 text-[#14F195] border-[#14F195]/30";
+  const solRate = (Number(agent.rateLamports) / 1_000_000_000).toFixed(4);
+  const shortPda = `${agent.pda.slice(0, 4)}…${agent.pda.slice(-4)}`;
+
+  return (
+    <div data-testid="onchain-agent-card" className="rounded-xl border border-[#14F195]/30 bg-card/30 hover:border-[#14F195]/50 transition-all flex flex-col gap-3 p-4">
+      {/* Live badge */}
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-mono text-muted-foreground/60">{shortPda}</span>
+        <span className="text-xs px-2 py-0.5 rounded-full border border-[#14F195]/40 bg-[#14F195]/10 text-[#14F195]">
+          ⚡ Live on devnet
+        </span>
+      </div>
+
+      {/* Type + model */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="font-mono text-xs px-2 py-0.5 rounded border border-white/10 bg-white/5 text-muted-foreground">
+          {agent.model || "unknown"}
+        </span>
+        <Badge variant="outline" className={`text-xs ${typeCls}`}>
+          {agent.agentType}
+        </Badge>
+      </div>
+
+      {/* Rate + reputation */}
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground font-mono">{solRate} SOL / call</span>
+        <span style={{ color: "#14F195" }}>
+          rep {agent.reputationScore}
+          <span className="text-muted-foreground ml-1">· {Number(agent.jobsCompleted)} jobs</span>
+        </span>
+      </div>
+
+      {/* Owner */}
+      <p className="text-xs text-muted-foreground/60 font-mono truncate">
+        {agent.owner.slice(0, 8)}…{agent.owner.slice(-8)}
+      </p>
+    </div>
+  );
+}
+
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function AgentsPage() {
   const [demoMode, setDemoMode] = useState(false);
+  const { agents: onchainAgents, loading: onchainLoading, error: onchainError } = useOnchainAgents();
 
   const visibleAgents = demoMode
     ? seedAgents.filter((a) => a.available_by_default)
     : seedAgents;
 
   const onlineCount = seedAgents.filter((a) => a.available_by_default).length;
+  const totalCount = seedAgents.length + onchainAgents.length;
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
@@ -113,8 +163,11 @@ export default function AgentsPage() {
         <div>
           <h1 className="text-3xl font-bold">Browse Specialists</h1>
           <p className="text-muted-foreground mt-1">
-            {seedAgents.length} agents registered ·{" "}
+            {totalCount} agents registered ·{" "}
             <span className="text-green-400">{onlineCount} online now</span>
+            {onchainAgents.length > 0 && (
+              <span className="text-[#14F195] ml-2">· {onchainAgents.length} live on-chain</span>
+            )}
           </p>
         </div>
 
@@ -150,11 +203,44 @@ export default function AgentsPage() {
         </div>
       )}
 
-      {/* Agent grid */}
-      <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
-        {visibleAgents.map((agent) => (
-          <SeedAgentCard key={agent.id} agent={agent} />
-        ))}
+      {/* Live on-chain agents (devnet) */}
+      {!demoMode && (
+        <div className="mb-8">
+          <div className="flex items-center gap-2 mb-3">
+            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+              Live on devnet
+            </h2>
+            {onchainLoading && (
+              <span className="text-xs text-muted-foreground animate-pulse">fetching…</span>
+            )}
+          </div>
+          {onchainError && (
+            <p className="text-xs text-amber-400 mb-3">⚠️ Could not reach devnet: {onchainError}</p>
+          )}
+          {!onchainLoading && onchainAgents.length === 0 && !onchainError && (
+            <p className="text-xs text-muted-foreground">
+              No agents registered on devnet yet.{" "}
+              <a href="/register" className="text-[#14F195] hover:underline">Be the first →</a>
+            </p>
+          )}
+          {onchainAgents.length > 0 && (
+            <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
+              {onchainAgents.map((agent) => (
+                <OnchainAgentCard key={agent.pda} agent={agent} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Seed agents */}
+      <div>
+        {!demoMode && <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">All Specialists</h2>}
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
+          {visibleAgents.map((agent) => (
+            <SeedAgentCard key={agent.id} agent={agent} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,7 +1,22 @@
 "use client";
 
 import { useState } from "react";
-import { useWallet } from "@solana/wallet-adapter-react";
+import { useWallet, useConnection } from "@solana/wallet-adapter-react";
+import {
+  Connection,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  SystemProgram,
+} from "@solana/web3.js";
+import {
+  ESCROW_PROGRAM_ID,
+  DEVNET_RPC,
+  AGENT_TYPE_ENUM,
+  buildRegisterAgentData,
+  agentPda,
+  INCINERATOR,
+} from "@/lib/program";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import LinkButton from "@/components/LinkButton";
@@ -59,29 +74,86 @@ const REGISTRATION_FEE_SOL = 0.01;
 const RENT_SOL = 0.00057;
 
 export default function RegisterPage() {
-  const { connected, publicKey } = useWallet();
+  const { connected, publicKey, sendTransaction } = useWallet();
+  const { connection: walletConnection } = useConnection();
   const [step, setStep] = useState<Step>(1);
   const [form, setForm] = useState<FormData>(INITIAL_FORM);
   const [registering, setRegistering] = useState(false);
   const [success, setSuccess] = useState(false);
   const [txSig, setTxSig] = useState<string | null>(null);
+  const [txError, setTxError] = useState<string | null>(null);
 
   const isJudge = form.agentType === "attestation" || form.agentType === "both";
 
   const handleRegister = async () => {
+    if (!publicKey || !sendTransaction) return;
     setRegistering(true);
-    // Mock/simulation mode — program may not be deployed
-    await new Promise((r) => setTimeout(r, 2000));
+    setTxError(null);
 
-    const mockSig = "5" + Array.from({ length: 87 }, () =>
-      "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"[
-        Math.floor(Math.random() * 58)
-      ]
-    ).join("");
+    try {
+      // Use wallet connection (adapter-configured) or fall back to devnet
+      const conn = walletConnection ?? new Connection(DEVNET_RPC, "confirmed");
 
-    setTxSig(mockSig);
-    setSuccess(true);
-    setRegistering(false);
+      const agentTypeByte =
+        form.agentType === "primary"
+          ? AGENT_TYPE_ENUM.Primary
+          : form.agentType === "attestation"
+          ? AGENT_TYPE_ENUM.Attestation
+          : AGENT_TYPE_ENUM.Both;
+
+      const rateLamports = BigInt(
+        Math.round(
+          parseFloat(
+            form.agentType === "attestation"
+              ? form.attestationRate || "0.0005"
+              : form.primaryRate || "0.001"
+          ) * 1_000_000_000
+        )
+      );
+
+      const modelName = form.model || "unknown";
+      const minRep = form.minConsumerRep ?? 0;
+
+      const pda = agentPda(publicKey);
+      const data = buildRegisterAgentData(agentTypeByte, modelName, rateLamports, minRep);
+
+      const ix = new TransactionInstruction({
+        programId: ESCROW_PROGRAM_ID,
+        keys: [
+          { pubkey: pda, isSigner: false, isWritable: true },
+          { pubkey: publicKey, isSigner: true, isWritable: true },
+          { pubkey: INCINERATOR, isSigner: false, isWritable: true },
+          { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        ],
+        data,
+      });
+
+      const { blockhash } = await conn.getLatestBlockhash();
+      const tx = new Transaction();
+      tx.recentBlockhash = blockhash;
+      tx.feePayer = publicKey;
+      tx.add(ix);
+
+      const sig = await sendTransaction(tx, conn);
+      await conn.confirmTransaction(sig, "confirmed");
+
+      setTxSig(sig);
+      setSuccess(true);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Graceful fallback: show error but don't crash the page
+      setTxError(msg);
+      // Still allow user to see what would have happened (sim mode)
+      const mockSig = "5" + Array.from({ length: 87 }, () =>
+        "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"[
+          Math.floor(Math.random() * 58)
+        ]
+      ).join("");
+      setTxSig(mockSig);
+      setSuccess(true);
+    } finally {
+      setRegistering(false);
+    }
   };
 
   if (success) {
@@ -93,10 +165,29 @@ export default function RegisterPage() {
           <strong className="text-foreground">{form.name}</strong> has been registered
           on-chain. Your endpoint is ready to receive requests.
         </p>
+        {txError && (
+          <div className="p-4 rounded-lg border border-amber-500/30 bg-amber-500/10 text-left">
+            <p className="text-xs text-amber-400 mb-1">⚠️ On-chain tx failed — showing simulated sig</p>
+            <p className="font-mono text-xs text-amber-200/80 break-all">{txError}</p>
+          </div>
+        )}
         {txSig && (
           <div className="p-4 rounded-lg border border-white/10 bg-card/30 text-left">
-            <p className="text-xs text-muted-foreground mb-1">Transaction (simulated)</p>
-            <p className="font-mono text-xs break-all text-[#14F195]">{txSig}</p>
+            <p className="text-xs text-muted-foreground mb-1">
+              {txError ? "Transaction (simulated)" : "Transaction"}
+            </p>
+            {!txError ? (
+              <a
+                href={`https://explorer.solana.com/tx/${txSig}?cluster=devnet`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-xs break-all text-[#14F195] hover:underline"
+              >
+                {txSig}
+              </a>
+            ) : (
+              <p className="font-mono text-xs break-all text-[#14F195]">{txSig}</p>
+            )}
           </div>
         )}
         {form.endpoint && (
@@ -119,12 +210,12 @@ export default function RegisterPage() {
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-10 space-y-8">
-      {/* Demo mode disclosure */}
-      <div className="w-full bg-amber-500/10 border border-amber-500/30 rounded-lg px-4 py-3 flex items-center gap-3 text-sm">
-        <span className="text-amber-400 text-base">⚠️</span>
-        <span className="text-amber-200">
-          <span className="font-semibold">Demo mode</span> — no real SOL will be spent. 
-          Registration simulates the on-chain flow without submitting a live transaction.
+      {/* Devnet notice */}
+      <div className="w-full bg-[#14F195]/5 border border-[#14F195]/20 rounded-lg px-4 py-3 flex items-center gap-3 text-sm">
+        <span className="text-[#14F195] text-base">⚡</span>
+        <span className="text-muted-foreground">
+          <span className="font-semibold text-[#14F195]">Devnet</span> — registration submits a real on-chain transaction.
+          Requires a connected wallet with ~0.011 SOL (0.01 fee + rent).
         </span>
       </div>
       <div>

--- a/lib/program.ts
+++ b/lib/program.ts
@@ -1,0 +1,154 @@
+/**
+ * On-chain program configuration for the Reddi Agent Protocol.
+ *
+ * Program deployed to Solana devnet.
+ * To redeploy after funding blitz-dev wallet:
+ *   anchor keys sync && anchor build && anchor deploy --provider.cluster devnet
+ */
+import { createHash } from "crypto";
+import { PublicKey } from "@solana/web3.js";
+
+/** Deployed program address on devnet */
+export const ESCROW_PROGRAM_ID = new PublicKey(
+  "77rkRQxe4GRzHU56H6JuWPFe27g4NoRBz4GGftuUZXmX"
+);
+
+/** Solana devnet RPC */
+export const DEVNET_RPC = "https://api.devnet.solana.com";
+
+// ── PDA seeds (must match programs/escrow/src/constants.rs) ──────────────────
+
+export const ESCROW_SEED = Buffer.from("escrow");
+export const AGENT_SEED = Buffer.from("agent");
+export const RATING_SEED = Buffer.from("rating");
+export const ATTESTATION_SEED = Buffer.from("attestation");
+
+// ── IDL-derived Anchor discriminators ────────────────────────────────────────
+// Formula: SHA256("global:<ix_name>")[0..8]  (instructions)
+//          SHA256("account:<AccountName>")[0..8]  (account discriminators)
+
+function disc(prefix: "global" | "account", name: string): Buffer {
+  return createHash("sha256")
+    .update(`${prefix}:${name}`)
+    .digest()
+    .subarray(0, 8);
+}
+
+export const IX = {
+  register_agent: disc("global", "register_agent"),
+  update_agent: disc("global", "update_agent"),
+  deregister_agent: disc("global", "deregister_agent"),
+  lock_escrow: disc("global", "lock_escrow"),
+  release_escrow: disc("global", "release_escrow"),
+  release_escrow_per: disc("global", "release_escrow_per"),
+  delegate_escrow: disc("global", "delegate_escrow"),
+  commit_rating: disc("global", "commit_rating"),
+  reveal_rating: disc("global", "reveal_rating"),
+  attest_quality: disc("global", "attest_quality"),
+  confirm_attestation: disc("global", "confirm_attestation"),
+  dispute_attestation: disc("global", "dispute_attestation"),
+} as const;
+
+export const ACCOUNT_DISC = {
+  AgentAccount: disc("account", "AgentAccount"),
+  EscrowAccount: disc("account", "EscrowAccount"),
+  RatingAccount: disc("account", "RatingAccount"),
+  AttestationAccount: disc("account", "AttestationAccount"),
+} as const;
+
+// ── Agent type encoding (matches Anchor borsh enum) ───────────────────────────
+
+export const AGENT_TYPE_ENUM = {
+  Primary: 0,
+  Attestation: 1,
+  Both: 2,
+} as const;
+
+export type AgentTypeEnum = keyof typeof AGENT_TYPE_ENUM;
+
+// ── On-chain AgentAccount decoder ─────────────────────────────────────────────
+// Layout (post-discriminator, from programs/escrow/src/state.rs):
+//   32  owner (Pubkey)
+//   1   agent_type (u8 enum: 0=Primary, 1=Attestation, 2=Both)
+//   4   model string length (u32 le)
+//   N   model string (UTF-8)
+//   8   rate_lamports (u64 le)
+//   1   min_reputation (u8)
+//   2   reputation_score (u16 le)
+//   8   jobs_completed (u64 le)
+//   8   jobs_failed (u64 le)
+//   8   created_at (i64 le)
+//   1   active (bool)
+//   2   attestation_accuracy (u16 le)
+//   1   bump
+
+export interface OnchainAgent {
+  owner: string;
+  agentType: AgentTypeEnum;
+  model: string;
+  rateLamports: bigint;
+  minReputation: number;
+  reputationScore: number;
+  jobsCompleted: bigint;
+  jobsFailed: bigint;
+  createdAt: bigint;
+  active: boolean;
+  attestationAccuracy: number;
+}
+
+export function decodeAgentAccount(data: Buffer): OnchainAgent | null {
+  try {
+    let off = 8; // skip discriminator
+    const owner = new PublicKey(data.subarray(off, off + 32)).toBase58(); off += 32;
+    const agentTypeRaw = data.readUInt8(off); off += 1;
+    const agentType: AgentTypeEnum =
+      agentTypeRaw === 0 ? "Primary" : agentTypeRaw === 1 ? "Attestation" : "Both";
+    const modelLen = data.readUInt32LE(off); off += 4;
+    const model = data.subarray(off, off + modelLen).toString("utf-8"); off += modelLen;
+    const rateLamports = data.readBigUInt64LE(off); off += 8;
+    const minReputation = data.readUInt8(off); off += 1;
+    const reputationScore = data.readUInt16LE(off); off += 2;
+    const jobsCompleted = data.readBigUInt64LE(off); off += 8;
+    const jobsFailed = data.readBigUInt64LE(off); off += 8;
+    const createdAt = data.readBigInt64LE(off); off += 8;
+    const active = data.readUInt8(off) !== 0; off += 1;
+    const attestationAccuracy = off < data.length ? data.readUInt16LE(off) : 0;
+    return {
+      owner, agentType, model, rateLamports, minReputation,
+      reputationScore, jobsCompleted, jobsFailed, createdAt, active, attestationAccuracy,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ── register_agent instruction builder ───────────────────────────────────────
+
+export function buildRegisterAgentData(
+  agentType: number,
+  model: string,
+  rateLamports: bigint,
+  minReputation: number
+): Buffer {
+  const modelBytes = Buffer.from(model, "utf-8");
+  const buf = Buffer.alloc(8 + 1 + 4 + modelBytes.length + 8 + 1);
+  let o = 0;
+  IX.register_agent.copy(buf, o); o += 8;
+  buf.writeUInt8(agentType, o); o += 1;
+  buf.writeUInt32LE(modelBytes.length, o); o += 4;
+  modelBytes.copy(buf, o); o += modelBytes.length;
+  buf.writeBigUInt64LE(rateLamports, o); o += 8;
+  buf.writeUInt8(minReputation, o);
+  return buf;
+}
+
+/** Derive the AgentAccount PDA for a given owner. */
+export function agentPda(ownerPubkey: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [AGENT_SEED, ownerPubkey.toBytes()],
+    ESCROW_PROGRAM_ID
+  )[0];
+}
+
+/** Hardcoded incinerator address (matches on-chain AGENT_FEE_BURN_ADDRESS) */
+export const INCINERATOR = new PublicKey("1nc1nerator11111111111111111111111111111111");

--- a/lib/useOnchainAgents.ts
+++ b/lib/useOnchainAgents.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Connection } from "@solana/web3.js";
+import {
+  ESCROW_PROGRAM_ID,
+  DEVNET_RPC,
+  ACCOUNT_DISC,
+  decodeAgentAccount,
+  type OnchainAgent,
+} from "@/lib/program";
+
+export interface OnchainAgentWithPda extends OnchainAgent {
+  pda: string;
+}
+
+export function useOnchainAgents(): {
+  agents: OnchainAgentWithPda[];
+  loading: boolean;
+  error: string | null;
+} {
+  const [agents, setAgents] = useState<OnchainAgentWithPda[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetch() {
+      setLoading(true);
+      setError(null);
+      try {
+        const conn = new Connection(DEVNET_RPC, "confirmed");
+        const disc = ACCOUNT_DISC.AgentAccount;
+
+        const accounts = await conn.getProgramAccounts(ESCROW_PROGRAM_ID, {
+          commitment: "confirmed",
+          filters: [
+            {
+              // AgentAccount discriminator is the first 8 bytes
+              memcmp: { offset: 0, bytes: Buffer.from(disc).toString("base64") },
+            },
+            // Minimum size: discriminator(8) + fixed fields — filter out dust
+            { dataSize: 150 },
+          ],
+        });
+
+        if (cancelled) return;
+
+        const decoded = accounts
+          .map(({ pubkey, account }) => {
+            const agent = decodeAgentAccount(Buffer.from(account.data));
+            if (!agent) return null;
+            return { ...agent, pda: pubkey.toBase58() };
+          })
+          .filter((a): a is OnchainAgentWithPda => a !== null);
+
+        setAgents(decoded);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to fetch on-chain agents");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetch();
+    return () => { cancelled = true; };
+  }, []);
+
+  return { agents, loading, error };
+}


### PR DESCRIPTION
## Summary

- **`lib/program.ts`** — single source of truth for the deployed program: `ESCROW_PROGRAM_ID`, IDL-derived Anchor discriminators (SHA256 formula), `AgentAccount` borsh decoder, `register_agent` instruction builder, PDA helpers
- **`lib/useOnchainAgents.ts`** — React hook that queries live `AgentAccount` PDAs via `getProgramAccounts` (filtered by 8-byte discriminator)
- **`app/register/page.tsx`** — replaces the demo mock with a real `register_agent` transaction submitted via Solana wallet adapter; falls back to sim mode with amber error banner on tx failure (devnet UX stays intact if wallet unfunded)
- **`app/agents/page.tsx`** — shows live on-chain agents above seed agents; loading indicator, error banner, "no agents yet → /register" CTA when devnet is empty
- **`README.md`** — program ID + Solana Explorer link + canonical repo URL updated to `nissan/`

## Test plan

- [ ] `/register` — connect Phantom/Backpack to devnet, submit form, confirm tx lands on-chain (Explorer link appears in success state)
- [ ] `/register` — no wallet connected: shows "Connect wallet" instead of submit
- [ ] `/agents` — on-chain agents (A/B/C from `register-agents.ts`) appear in "Live on devnet" section with `⚡` badge
- [ ] `/agents` — devnet unreachable: amber error banner, seed agents still render
- [ ] `npm run build` — no TypeScript errors

## Devnet context

Program `77rkRQxe4GRzHU56H6JuWPFe27g4NoRBz4GGftuUZXmX` deployed 2026-04-10. Agent wallets A/B/C registered via `packages/demo-agents/src/register-agents.ts`. See `DEPLOY.md` for redeployment steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)