### PR TITLE
Phase 7 polish: address Oli notes (memcmp, stale fetch, error headline)

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -159,11 +159,15 @@ export default function RegisterPage() {
   if (success) {
     return (
       <div className="max-w-xl mx-auto px-4 py-16 text-center space-y-6">
-        <div className="text-5xl">🎉</div>
-        <h1 className="text-3xl font-bold sol-gradient-text">Your agent is live.</h1>
+        <div className="text-5xl">{txError ? "⚠️" : "🎉"}</div>
+        <h1 className="text-3xl font-bold sol-gradient-text">
+          {txError ? "Transaction failed." : "Your agent is live."}
+        </h1>
         <p className="text-muted-foreground">
-          <strong className="text-foreground">{form.name}</strong> has been registered
-          on-chain. Your endpoint is ready to receive requests.
+          {txError
+            ? "The on-chain transaction could not be submitted. Check your wallet balance and try again."
+            : <><strong className="text-foreground">{form.name}</strong> has been registered on-chain. Your endpoint is ready to receive requests.</>
+          }
         </p>
         {txError && (
           <div className="p-4 rounded-lg border border-amber-500/30 bg-amber-500/10 text-left">

--- a/lib/useOnchainAgents.ts
+++ b/lib/useOnchainAgents.ts
@@ -10,6 +10,15 @@ import {
   type OnchainAgent,
 } from "@/lib/program";
 
+const BASE58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+function toBase58(bytes: Buffer): string {
+  let x = BigInt("0x" + bytes.toString("hex") || "0");
+  let out = "";
+  while (x > 0n) { out = BASE58[Number(x % 58n)] + out; x /= 58n; }
+  for (const b of bytes) { if (b !== 0) break; out = "1" + out; }
+  return out;
+}
+
 export interface OnchainAgentWithPda extends OnchainAgent {
   pda: string;
 }
@@ -38,7 +47,8 @@ export function useOnchainAgents(): {
           filters: [
             {
               // AgentAccount discriminator is the first 8 bytes
-              memcmp: { offset: 0, bytes: Buffer.from(disc).toString("base64") },
+              // memcmp.bytes must be base58-encoded per Solana JSON-RPC spec
+              memcmp: { offset: 0, bytes: toBase58(disc) },
             },
             // Minimum size: discriminator(8) + fixed fields — filter out dust
             { dataSize: 150 },
@@ -65,7 +75,9 @@ export function useOnchainAgents(): {
     }
 
     fetch();
-    return () => { cancelled = true; };
+    // Refresh every 30s so newly registered agents appear without page reload
+    const timer = setInterval(fetch, 30_000);
+    return () => { cancelled = true; clearInterval(timer); };
   }, []);
 
   return { agents, loading, error };


### PR DESCRIPTION
## Summary

Addresses the three non-blocking notes from the Phase 7 (PR #24) Oli gate:

**1. memcmp bytes format (base64 → base58)**
`useOnchainAgents.ts` was passing `Buffer.from(disc).toString("base64")` for the `memcmp.bytes` field. The Solana JSON-RPC spec requires base58. Added an inline `toBase58()` encoder (8-line pure-JS, no new dependency).

**2. Stale fetch interval**
`useOnchainAgents` previously fetched once on mount. Now polls every 30s via `setInterval` so newly registered agents appear without a page reload.

**3. Misleading headline on tx failure**
The register success state always showed "Your agent is live." even when the tx had failed and a simulated sig was shown. Now: "Transaction failed." + error guidance when `txError` is set; "Your agent is live." only on a real confirmed tx.

## Test plan

- [ ] `/agents` — discriminator filter returns agents on devnet (not empty due to encoding mismatch)
- [ ] `/agents` — on-chain section refreshes ~30s after a new registration without page reload
- [ ] `/register` with unfunded wallet — shows "Transaction failed." headline + amber error, not "Your agent is live."
- [ ] `/register` with funded wallet — shows "Your agent is live." + Explorer link

🤖 Generated with [Claude Code](https://claude.com/claude-code)