### PR TITLE
fix: Vercel build — ES2020 target + exclude packages/ from Next.js tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "packages"]
 }


### PR DESCRIPTION
## Problem

Vercel deployments were failing due to two TypeScript errors during `next build`:

1. **BigInt literals not allowed at ES2017 target** — `lib/useOnchainAgents.ts` uses `0n`/`58n` BigInt literals in the inline `toBase58()` base58 encoder. ES2020 is required.

2. **`packages/` included in Next.js typecheck** — `tsconfig.json` matched `**/*.ts` which pulled in `packages/demo-agents/src/demo.ts` and other CLI scripts. These are ts-node scripts with `Buffer`/`Uint8Array` type mismatches not relevant to the web app.

## Fix

- `tsconfig.json`: bump `target` from `ES2017` to `ES2020`  
- `tsconfig.json`: add `"packages"` to `exclude` array

## Verification

```
npm run build → 14 routes, 0 type errors, 0 warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)