### PR TITLE
fix: clippy manual_range_contains — CI green

### DIFF
--- a/programs/escrow/src/instructions/attest_quality.rs
+++ b/programs/escrow/src/instructions/attest_quality.rs
@@ -24,7 +24,7 @@ pub fn attest_quality_handler(
 
     // Validate all scores 1-10
     for &s in scores.iter() {
-        require!(s >= 1 && s <= 10, EscrowError::AttestationScoreOutOfRange);
+        require!((1..=10).contains(&s), EscrowError::AttestationScoreOutOfRange);
     }
 
     let attestation = &mut ctx.accounts.attestation;

--- a/programs/escrow/src/instructions/reveal_rating.rs
+++ b/programs/escrow/src/instructions/reveal_rating.rs
@@ -25,7 +25,7 @@ pub fn reveal_rating_handler(
     );
 
     // Score range check
-    require!(score >= 1 && score <= 10, EscrowError::InvalidScore);
+    require!((1..=10).contains(&score), EscrowError::InvalidScore);
 
     // Compute sha256(score || salt)
     let mut hasher = Sha256::new();


### PR DESCRIPTION
## Problem

CI was failing on the `Clippy lint` step:

```
error: manual RangeInclusive::contains implementation
  --> programs/escrow/src/instructions/attest_quality.rs:27
     s >= 1 && s <= 10
error: manual RangeInclusive::contains implementation
  --> programs/escrow/src/instructions/reveal_rating.rs:28
     score >= 1 && score <= 10
```

`-D warnings` promotes these to errors under Rust 1.89.0 + Anchor 1.0.0.

## Fix

Both replaced with `(1..=10).contains(&x)` — exact suggestion from clippy.

## Verification

- `cargo clippy --manifest-path programs/escrow/Cargo.toml -- -D warnings` → clean (0 warnings, 0 errors)
- `cargo test --manifest-path programs/escrow/Cargo.toml` → 30 passed, 1 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)