### PR TITLE
fix: Suspense boundary for useSearchParams — unblocks Vercel build

### DIFF
--- a/app/planner/page.tsx
+++ b/app/planner/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { Suspense } from "react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
 import dynamic from "next/dynamic"
@@ -76,7 +77,7 @@ function launchConfetti() {
 
 const STEPS = ["Describe task", "Select specialist", "Execute", "Feedback"]
 
-export default function PlannerPage() {
+function PlannerInner() {
   const { connected } = useWallet()
   const searchParams = useSearchParams()
   const preferredWallet = searchParams.get("specialist") ?? ""
@@ -389,5 +390,13 @@ export default function PlannerPage() {
         </div>
       ) : null}
     </div>
+  )
+}
+
+export default function PlannerPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-page flex items-center justify-center"><p className="text-gray-400">Loading planner…</p></div>}>
+      <PlannerInner />
+    </Suspense>
   )
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useWallet, useConnection } from "@solana/wallet-adapter-react";
 import {
@@ -120,7 +121,7 @@ const ENDPOINT_HELP_STEPS: HelpStep[] = [
   },
 ];
 
-export default function RegisterPage() {
+function RegisterInner() {
   const { connected, publicKey, sendTransaction } = useWallet();
   const { connection: walletConnection } = useConnection();
   const searchParams = useSearchParams();
@@ -918,5 +919,13 @@ export default function RegisterPage() {
         </div>
       )}
     </div>
+  );
+}
+
+export default function RegisterPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-page flex items-center justify-center"><p className="text-gray-400">Loading…</p></div>}>
+      <RegisterInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Problem
Next.js 16 requires `useSearchParams()` to be wrapped in a `<Suspense>` boundary during static page generation. Both `/planner` and `/register` were failing the production build with:
```
useSearchParams() should be wrapped in a suspense boundary
```

## Fix
- Split each page into an `Inner` component (contains `useSearchParams`) and a default export wrapper with `<Suspense>`
- `/planner` → `PlannerInner` + `PlannerPage`
- `/register` → `RegisterInner` + `RegisterPage`

## Verified
`npm run build` — all 46 pages compile successfully ✅