### PR TITLE
wire: Switch frontend to Quasar-deployed programs on devnet

### DIFF
--- a/lib/program.ts
+++ b/lib/program.ts
@@ -8,9 +8,9 @@
 import { createHash } from "crypto";
 import { PublicKey } from "@solana/web3.js";
 
-/** Deployed program address on devnet */
+/** Deployed program address on devnet (Quasar) */
 export const ESCROW_PROGRAM_ID = new PublicKey(
-  "77rkRQxe4GRzHU56H6JuWPFe27g4NoRBz4GGftuUZXmX"
+  "VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW"
 );
 
 /** Solana devnet RPC */


### PR DESCRIPTION
## Wire frontend to Quasar program IDs

Updates `ESCROW_PROGRAM_ID` in `lib/program.ts` from the old Anchor testnet program to the Quasar mainline deployment confirmed live on devnet.

### Change
- `77rkRQxe4GRzHU56H6JuWPFe27g4NoRBz4GGftuUZXmX` → `VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW`

Anchor 1.0.0 discriminators are deterministic based on instruction/account names, so no account decoder changes are needed.

### Verification
- `npm run build` ✅
- `npx tsc --noEmit` ✅
- `npx eslint --max-warnings 0 lib/program.ts` ✅