### PR TITLE
feat: devnet banner + role dashboards + comprehensive BDD hardening

### DIFF
--- a/.github/workflows/bdd-bucket-sweep-confidence.yml
+++ b/.github/workflows/bdd-bucket-sweep-confidence.yml
@@ -27,6 +27,10 @@ jobs:
         run: npm run test:bdd:sweep
         continue-on-error: true
 
+      - name: Print latest sweep quick status
+        if: always()
+        run: npm run test:bdd:status
+
       - name: Upload sweep artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bdd-bucket-sweep-confidence.yml
+++ b/.github/workflows/bdd-bucket-sweep-confidence.yml
@@ -24,14 +24,14 @@ jobs:
         run: npm ci
 
       - name: Run representative BDD bucket sweep (non-blocking)
-        run: npm run test:bdd:sweep | tee bdd-bucket-sweep.log
+        run: npm run test:bdd:sweep
         continue-on-error: true
 
-      - name: Upload sweep log
+      - name: Upload sweep artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: bdd-bucket-sweep-log-${{ github.run_id }}
-          path: bdd-bucket-sweep.log
+          name: bdd-bucket-sweep-artifacts-${{ github.run_id }}
+          path: artifacts/bdd-sweep/
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/bdd-bucket-sweep-confidence.yml
+++ b/.github/workflows/bdd-bucket-sweep-confidence.yml
@@ -1,0 +1,37 @@
+name: BDD Bucket Sweep Confidence
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 19 * * *" # daily confidence sweep (UTC)
+
+jobs:
+  bdd-bucket-sweep:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run representative BDD bucket sweep (non-blocking)
+        run: npm run test:bdd:sweep | tee bdd-bucket-sweep.log
+        continue-on-error: true
+
+      - name: Upload sweep log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdd-bucket-sweep-log-${{ github.run_id }}
+          path: bdd-bucket-sweep.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/bdd-bucket-sweep-confidence.yml
+++ b/.github/workflows/bdd-bucket-sweep-confidence.yml
@@ -31,6 +31,21 @@ jobs:
         if: always()
         run: npm run test:bdd:status
 
+      - name: Write GitHub step summary
+        if: always()
+        run: |
+          STATUS_LINE="$(npm run -s test:bdd:status || true)"
+          SUMMARY_PATH="$(printf "%s" "$STATUS_LINE" | sed -n 's/.*summary=\(.*\)$/\1/p')"
+
+          {
+            echo "## BDD Bucket Sweep Confidence"
+            echo
+            echo "- Status line: \`${STATUS_LINE:-BDD_SWEEP_STATUS unavailable}\`"
+            if [ -n "$SUMMARY_PATH" ]; then
+              echo "- Summary artifact path: \`${SUMMARY_PATH}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload sweep artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bdd-index-guard.yml
+++ b/.github/workflows/bdd-index-guard.yml
@@ -1,0 +1,31 @@
+name: BDD Feature Index Guard
+
+on:
+  pull_request:
+    paths:
+      - "docs/bdd/**"
+      - "scripts/check-bdd-feature-index.sh"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+jobs:
+  bdd-index-guard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify BDD feature index drift guard
+        run: npm run test:bdd:index

--- a/app/api/onboarding/consumers/route.ts
+++ b/app/api/onboarding/consumers/route.ts
@@ -1,0 +1,18 @@
+import { listConsumers } from "@/lib/onboarding/consumer-registry";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const result = listConsumers();
+    return Response.json({ ok: true, result });
+  } catch (error) {
+    return Response.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : "Consumer listing failed",
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/app/attestation/page.tsx
+++ b/app/attestation/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useWallet } from "@solana/wallet-adapter-react";
+
+type AuditAttestation = {
+  timestamp: string;
+  job_id: string;
+  tx_signature: string | null;
+  local_only: boolean;
+  wallet_address: string;
+  endpoint_url: string;
+};
+
+type RevealCommit = {
+  runId?: string;
+  revealedAt?: string;
+  revealTxSignature?: string;
+  specialistWallet?: string;
+};
+
+export default function AttestationDashboardPage() {
+  const { connected } = useWallet();
+  const [attestations, setAttestations] = useState<AuditAttestation[]>([]);
+  const [commits, setCommits] = useState<RevealCommit[]>([]);
+
+  useEffect(() => {
+    if (!connected) return;
+    (async () => {
+      try {
+        const [auditRes, revealRes] = await Promise.all([
+          fetch("/api/onboarding/audit", { cache: "no-store" }),
+          fetch("/api/onboarding/planner/reveal", { cache: "no-store" }),
+        ]);
+        const [audit, reveal] = await Promise.all([auditRes.json(), revealRes.json()]);
+        setAttestations(Array.isArray(audit?.attestations) ? audit.attestations : []);
+        setCommits(Array.isArray(reveal?.result?.entries) ? reveal.result.entries : Array.isArray(reveal?.result) ? reveal.result : []);
+      } catch {
+        setAttestations([]);
+        setCommits([]);
+      }
+    })();
+  }, [connected]);
+
+  const onchainCount = useMemo(() => attestations.filter((a) => Boolean(a.tx_signature)).length, [attestations]);
+
+  if (!connected) {
+    return <PageNotice title="Attestation Dashboard" text="Connect wallet to review attestation-owner protocol statistics." />;
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">Attestation Owner Dashboard</h1>
+        <p className="text-sm text-muted-foreground">Track judging and attestation protocol events.</p>
+      </header>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Stat label="Attestation records" value={attestations.length} />
+        <Stat label="On-chain attestations" value={onchainCount} />
+        <Stat label="Reveal commits" value={commits.length} />
+      </div>
+
+      <section className="rounded-xl border border-white/10 bg-card/20 p-5 space-y-3">
+        <h2 className="text-lg font-semibold">Recent attestation records</h2>
+        {attestations.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No attestation records found yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-muted-foreground border-b border-white/10">
+                  <th className="py-2 pr-4">Time</th>
+                  <th className="py-2 pr-4">Wallet</th>
+                  <th className="py-2 pr-4">On-chain</th>
+                  <th className="py-2">Job</th>
+                </tr>
+              </thead>
+              <tbody>
+                {attestations.slice(0, 12).map((a) => (
+                  <tr key={`${a.job_id}-${a.timestamp}`} className="border-b border-white/5">
+                    <td className="py-2 pr-4 text-xs">{a.timestamp ? new Date(a.timestamp).toLocaleString() : "—"}</td>
+                    <td className="py-2 pr-4 font-mono text-xs">{short(a.wallet_address)}</td>
+                    <td className="py-2 pr-4">{a.tx_signature ? "yes" : "local"}</td>
+                    <td className="py-2 font-mono text-xs">{short(a.job_id)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function short(v?: string) {
+  if (!v) return "—";
+  return v.length > 14 ? `${v.slice(0, 8)}…${v.slice(-4)}` : v;
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-card/30 p-4">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold mt-1">{value}</p>
+    </div>
+  );
+}
+
+function PageNotice({ title, text }: { title: string; text: string }) {
+  return (
+    <div className="mx-auto max-w-xl px-4 py-24 text-center space-y-3">
+      <h1 className="text-3xl font-bold">{title}</h1>
+      <p className="text-muted-foreground">{text}</p>
+    </div>
+  );
+}

--- a/app/consumer/page.tsx
+++ b/app/consumer/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useWallet } from "@solana/wallet-adapter-react";
+
+type ConsumerProfile = {
+  walletAddress: string;
+  updatedAt: string;
+  reputation?: { score5?: number; totalRatings?: number };
+};
+
+type PlannerRun = {
+  runId: string;
+  createdAt?: string;
+  status?: string;
+  selectedWallet?: string;
+  paymentSatisfied?: boolean;
+};
+
+type PlannerFeedback = {
+  runId: string;
+  score?: number;
+  consumerWallet?: string;
+  createdAt?: string;
+};
+
+export default function ConsumerDashboardPage() {
+  const { connected, publicKey } = useWallet();
+  const [profiles, setProfiles] = useState<ConsumerProfile[]>([]);
+  const [runs, setRuns] = useState<PlannerRun[]>([]);
+  const [feedback, setFeedback] = useState<PlannerFeedback[]>([]);
+
+  useEffect(() => {
+    if (!connected) return;
+    (async () => {
+      try {
+        const [profilesRes, runsRes, feedbackRes] = await Promise.all([
+          fetch("/api/onboarding/consumers", { cache: "no-store" }),
+          fetch("/api/onboarding/planner/execute", { cache: "no-store" }),
+          fetch("/api/onboarding/planner/feedback", { cache: "no-store" }),
+        ]);
+
+        const [p, r, f] = await Promise.all([profilesRes.json(), runsRes.json(), feedbackRes.json()]);
+        setProfiles(Array.isArray(p?.result?.results) ? p.result.results : []);
+        setRuns(Array.isArray(r?.result?.runs) ? r.result.runs : []);
+        setFeedback(Array.isArray(f?.result?.entries) ? f.result.entries : Array.isArray(f?.result) ? f.result : []);
+      } catch {
+        setProfiles([]);
+        setRuns([]);
+        setFeedback([]);
+      }
+    })();
+  }, [connected]);
+
+  const wallet = publicKey?.toBase58() ?? "";
+  const mine = useMemo(() => profiles.find((p) => p.walletAddress === wallet) ?? null, [profiles, wallet]);
+  const myFeedback = useMemo(
+    () => feedback.filter((x) => x.consumerWallet && x.consumerWallet === wallet),
+    [feedback, wallet]
+  );
+
+  const completedRuns = runs.filter((r) => r.status === "completed").length;
+
+  if (!connected) {
+    return <PageNotice title="Consumer Dashboard" text="Connect wallet to review consumer-owner protocol statistics." />;
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">Consumer Owner Dashboard</h1>
+        <p className="text-sm text-muted-foreground">Track planner usage, feedback, and consumer-profile reputation.</p>
+      </header>
+
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
+        <Stat label="Consumer profile" value={mine ? 1 : 0} />
+        <Stat label="Profile reputation" value={mine?.reputation?.score5 ? Number(mine.reputation.score5.toFixed(2)) : 0} />
+        <Stat label="Planner runs (global)" value={runs.length} />
+        <Stat label="Completed runs (global)" value={completedRuns} />
+      </div>
+
+      <section className="rounded-xl border border-white/10 bg-card/20 p-5 space-y-3">
+        <h2 className="text-lg font-semibold">Your consumer profile</h2>
+        {mine ? (
+          <div className="text-sm space-y-1">
+            <p><span className="text-muted-foreground">Wallet:</span> <span className="font-mono">{mine.walletAddress}</span></p>
+            <p><span className="text-muted-foreground">Ratings:</span> {mine.reputation?.totalRatings ?? 0}</p>
+            <p><span className="text-muted-foreground">Updated:</span> {mine.updatedAt ? new Date(mine.updatedAt).toLocaleString() : "—"}</p>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">No consumer profile registered for this wallet yet. Use planner tools register-consumer flow first.</p>
+        )}
+      </section>
+
+      <section className="rounded-xl border border-white/10 bg-card/20 p-5 space-y-3">
+        <h2 className="text-lg font-semibold">Recent feedback from your wallet</h2>
+        {myFeedback.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No wallet-scoped feedback records found yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-muted-foreground border-b border-white/10">
+                  <th className="py-2 pr-4">Run</th>
+                  <th className="py-2 pr-4">Score</th>
+                  <th className="py-2">Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {myFeedback.slice(0, 12).map((f) => (
+                  <tr key={`${f.runId}-${f.createdAt}`} className="border-b border-white/5">
+                    <td className="py-2 pr-4 font-mono text-xs">{short(f.runId)}</td>
+                    <td className="py-2 pr-4">{f.score ?? "—"}</td>
+                    <td className="py-2 text-xs">{f.createdAt ? new Date(f.createdAt).toLocaleString() : "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function short(v?: string) {
+  if (!v) return "—";
+  return v.length > 14 ? `${v.slice(0, 8)}…${v.slice(-4)}` : v;
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-card/30 p-4">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold mt-1">{value}</p>
+    </div>
+  );
+}
+
+function PageNotice({ title, text }: { title: string; text: string }) {
+  return (
+    <div className="mx-auto max-w-xl px-4 py-24 text-center space-y-3">
+      <h1 className="text-3xl font-bold">{title}</h1>
+      <p className="text-muted-foreground">{text}</p>
+    </div>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,86 +1,51 @@
 "use client";
 
-import { useWallet } from "@solana/wallet-adapter-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import LinkButton from "@/components/LinkButton";
-import AgentCard, { AgentData } from "@/components/AgentCard";
-import SolAmount from "@/components/SolAmount";
+import { useEffect, useState } from "react";
+import { useWallet } from "@solana/wallet-adapter-react";
 
 const WalletMultiButton = dynamic(
-  async () =>
-    (await import("@solana/wallet-adapter-react-ui")).WalletMultiButton,
+  async () => (await import("@solana/wallet-adapter-react-ui")).WalletMultiButton,
   { ssr: false }
 );
 
-const MOCK_AGENTS: AgentData[] = [
-  {
-    pubkey: "8xWmNT4EfAeEnLb947izUX8u2U3Kw8BL4vd85x65w24A",
-    name: "my-research-agent",
-    agent_type: "both",
-    privacy_tier: "local",
-    rate_lamports: 1_500_000,
-    attestation_rate_lamports: 600_000,
-    reputation_avg: 4.3,
-    reputation_count: 47,
-    attestation_accuracy: 0.89,
-    completed_jobs: 47,
-    model: "qwen3:8b",
-  },
-];
+type HubStats = {
+  specialists: number;
+  consumerProfiles: number;
+  attestationRecords: number;
+};
 
-const MOCK_ESCROW_ACTIVITY = [
-  {
-    type: "primary_release",
-    amount: 1_500_000,
-    counter_party: "5xR...2kH",
-    status: "settled",
-    timestamp: "2026-03-23 18:42",
-    earned: 1_249_500,
-  },
-  {
-    type: "attestation",
-    amount: 600_000,
-    counter_party: "9mP...8vQ",
-    status: "agreed",
-    timestamp: "2026-03-23 16:15",
-    earned: 499_800,
-  },
-  {
-    type: "primary_release",
-    amount: 1_500_000,
-    counter_party: "3bK...7rN",
-    status: "settled",
-    timestamp: "2026-03-23 14:30",
-    earned: 1_249_500,
-  },
-  {
-    type: "attestation",
-    amount: 600_000,
-    counter_party: "1cJ...4sL",
-    status: "disagreed",
-    timestamp: "2026-03-22 22:10",
-    earned: 0,
-  },
-];
-
-const totalEarned = MOCK_ESCROW_ACTIVITY.reduce((sum, e) => sum + e.earned, 0);
-const totalJobs = MOCK_AGENTS.reduce((sum, a) => sum + a.completed_jobs, 0);
-const avgRep = MOCK_AGENTS.reduce((sum, a) => sum + (a.reputation_avg || 0), 0) / MOCK_AGENTS.length;
-
-export default function DashboardPage() {
+export default function DashboardHubPage() {
   const { connected, publicKey } = useWallet();
+  const [stats, setStats] = useState<HubStats>({ specialists: 0, consumerProfiles: 0, attestationRecords: 0 });
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [specRes, consumerRes, auditRes] = await Promise.all([
+          fetch("/api/onboarding/capabilities", { cache: "no-store" }),
+          fetch("/api/onboarding/consumers", { cache: "no-store" }),
+          fetch("/api/onboarding/audit", { cache: "no-store" }),
+        ]);
+
+        const [spec, consumers, audit] = await Promise.all([specRes.json(), consumerRes.json(), auditRes.json()]);
+        setStats({
+          specialists: Array.isArray(spec?.result?.results) ? spec.result.results.length : 0,
+          consumerProfiles: Array.isArray(consumers?.result?.results) ? consumers.result.results.length : 0,
+          attestationRecords: Array.isArray(audit?.attestations) ? audit.attestations.length : 0,
+        });
+      } catch {
+        // no-op: hub still renders links
+      }
+    })();
+  }, []);
 
   if (!connected) {
     return (
-      <div className="max-w-xl mx-auto px-4 py-24 text-center space-y-6">
-        <div className="text-4xl">👋</div>
-        <h1 className="text-3xl font-bold">My Dashboard</h1>
-        <p className="text-muted-foreground">
-          Connect your wallet to see your registered agents, earnings, and escrow activity.
-        </p>
+      <div className="mx-auto max-w-xl px-4 py-24 text-center space-y-5">
+        <h1 className="text-3xl font-bold">Role Dashboards</h1>
+        <p className="text-muted-foreground">Connect your wallet to access specialist, attestation, and consumer dashboard views.</p>
         <WalletMultiButton
           style={{
             background: "linear-gradient(135deg, #9945FF 0%, #14F195 100%)",
@@ -90,178 +55,61 @@ export default function DashboardPage() {
             margin: "0 auto",
           }}
         />
-        <p className="text-xs text-muted-foreground">
-          Using mock data below ↓
-        </p>
-        <DashboardContent />
       </div>
     );
   }
 
   return (
-    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold">My Dashboard</h1>
-          {publicKey && (
-            <p className="text-xs text-muted-foreground font-mono mt-1">
-              {publicKey.toBase58()}
-            </p>
-          )}
-        </div>
-        <LinkButton
-          href="/register"
-          style={{
-            background: "linear-gradient(135deg, #9945FF, #14F195)",
-            color: "#000",
-            fontWeight: 600,
-          }}
-        >
-          + Add Another Agent
-        </LinkButton>
+    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">Protocol Dashboards</h1>
+        <p className="text-sm text-muted-foreground">
+          Wallet: <span className="font-mono">{publicKey?.toBase58()}</span>
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <StatCard label="Specialists in index" value={stats.specialists} />
+        <StatCard label="Consumer profiles" value={stats.consumerProfiles} />
+        <StatCard label="Attestation records" value={stats.attestationRecords} />
       </div>
 
-      <DashboardContent />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <RoleCard
+          title="Specialist Owner"
+          desc="Track capability, health, attestation, and routing signals for your specialist wallet."
+          href="/specialist"
+        />
+        <RoleCard
+          title="Attestation Owner"
+          desc="Review attestation events, reveal flow state, and audit-oriented judging telemetry."
+          href="/attestation"
+        />
+        <RoleCard
+          title="Consumer Owner"
+          desc="Review consumer profile, planner run outcomes, and feedback activity on protocol paths."
+          href="/consumer"
+        />
+      </div>
     </div>
   );
 }
 
-function DashboardContent() {
+function StatCard({ label, value }: { label: string; value: number }) {
   return (
-    <div className="max-w-6xl mx-auto w-full space-y-8">
-      {/* Stats row */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        {[
-          { label: "Total Agents", value: MOCK_AGENTS.length.toString(), unit: "" },
-          { label: "Jobs Completed", value: totalJobs.toString(), unit: "" },
-          { label: "Avg Reputation", value: avgRep.toFixed(1), unit: "★" },
-          { label: "Total Earned", value: (totalEarned / 1e9).toFixed(6), unit: "SOL" },
-        ].map((stat) => (
-          <div
-            key={stat.label}
-            className="p-4 rounded-xl border border-white/10 bg-card/30 space-y-1"
-          >
-            <p className="text-xs text-muted-foreground">{stat.label}</p>
-            <p className="text-2xl font-bold font-mono">
-              <span style={{ color: "#14F195" }}>{stat.value}</span>
-              {stat.unit && <span className="text-sm text-muted-foreground ml-1">{stat.unit}</span>}
-            </p>
-          </div>
-        ))}
-      </div>
-
-      {/* Agents */}
-      <section className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-semibold">Your Agents</h2>
-          <LinkButton href="/register" variant="outline" size="sm" className="border-white/10">
-            + Register Agent
-          </LinkButton>
-        </div>
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {MOCK_AGENTS.map((agent) => (
-            <div key={agent.pubkey} className="space-y-2">
-              <AgentCard agent={agent} compact />
-              <div className="grid grid-cols-3 gap-2 text-xs">
-                <div className="p-2 rounded-lg border border-white/10 bg-card/20 text-center">
-                  <p className="text-muted-foreground">Jobs</p>
-                  <p className="font-mono font-bold">{agent.completed_jobs}</p>
-                </div>
-                <div className="p-2 rounded-lg border border-white/10 bg-card/20 text-center">
-                  <p className="text-muted-foreground">Rep</p>
-                  <p className="font-mono font-bold">
-                    {agent.reputation_avg?.toFixed(1) || "—"}
-                  </p>
-                </div>
-                <div className="p-2 rounded-lg border border-white/10 bg-card/20 text-center">
-                  <p className="text-muted-foreground">Accuracy</p>
-                  <p className="font-mono font-bold">
-                    {agent.attestation_accuracy
-                      ? `${(agent.attestation_accuracy * 100).toFixed(0)}%`
-                      : "—"}
-                  </p>
-                </div>
-              </div>
-            </div>
-          ))}
-
-          {/* Add agent CTA card */}
-          <Link
-            href="/register"
-            className="flex flex-col items-center justify-center p-6 rounded-xl border border-dashed border-white/20 hover:border-[#9945FF]/50 transition-colors bg-card/10 hover:bg-[#9945FF]/5 group cursor-pointer"
-          >
-            <span className="text-3xl mb-2 text-muted-foreground group-hover:text-[#9945FF] transition-colors">+</span>
-            <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
-              Add another agent
-            </span>
-          </Link>
-        </div>
-      </section>
-
-      {/* Escrow activity */}
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">Recent Escrow Activity</h2>
-        <div className="rounded-xl border border-white/10 overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-white/10 bg-white/2">
-                <th className="px-4 py-3 text-left text-xs text-muted-foreground font-medium">Type</th>
-                <th className="px-4 py-3 text-left text-xs text-muted-foreground font-medium">Counterparty</th>
-                <th className="px-4 py-3 text-left text-xs text-muted-foreground font-medium">Status</th>
-                <th className="px-4 py-3 text-right text-xs text-muted-foreground font-medium">Earned</th>
-                <th className="px-4 py-3 text-right text-xs text-muted-foreground font-medium">Time</th>
-              </tr>
-            </thead>
-            <tbody>
-              {MOCK_ESCROW_ACTIVITY.map((e, i) => (
-                <tr
-                  key={i}
-                  className="border-b border-white/5 last:border-0 hover:bg-white/2 transition-colors"
-                >
-                  <td className="px-4 py-3">
-                    <Badge
-                      variant="outline"
-                      className={`text-xs ${
-                        e.type === "primary_release"
-                          ? "border-[#9945FF]/30 text-[#9945FF] bg-[#9945FF]/10"
-                          : "border-blue-500/30 text-blue-400 bg-blue-500/10"
-                      }`}
-                    >
-                      {e.type === "primary_release" ? "Specialist" : "Attestation"}
-                    </Badge>
-                  </td>
-                  <td className="px-4 py-3 font-mono text-muted-foreground">
-                    {e.counter_party}
-                  </td>
-                  <td className="px-4 py-3">
-                    <Badge
-                      variant="outline"
-                      className={`text-xs ${
-                        e.status === "settled" || e.status === "agreed"
-                          ? "border-[#14F195]/30 text-[#14F195] bg-[#14F195]/10"
-                          : "border-red-500/30 text-red-400 bg-red-500/10"
-                      }`}
-                    >
-                      {e.status}
-                    </Badge>
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    {e.earned > 0 ? (
-                      <SolAmount lamports={e.earned} className="text-xs" />
-                    ) : (
-                      <span className="text-muted-foreground text-xs">—</span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-right text-xs text-muted-foreground">
-                    {e.timestamp}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+    <div className="rounded-xl border border-white/10 bg-card/30 p-4">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold mt-1">{value}</p>
     </div>
+  );
+}
+
+function RoleCard({ title, desc, href }: { title: string; desc: string; href: string }) {
+  return (
+    <Link href={href} className="rounded-xl border border-white/10 bg-card/20 p-5 hover:border-[#9945FF]/40 transition-colors">
+      <p className="text-lg font-semibold">{title}</p>
+      <p className="text-sm text-muted-foreground mt-2">{desc}</p>
+      <p className="text-sm mt-4 text-[#14F195]">Open dashboard →</p>
+    </Link>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import WalletProvider from "@/components/WalletProvider";
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
+import DevnetModeBanner from "@/components/DevnetModeBanner";
 
 const dmSans = DM_Sans({
   variable: "--font-dm-sans",
@@ -36,6 +37,7 @@ export default function RootLayout({
       >
         <WalletProvider>
           <NavBar />
+          <DevnetModeBanner />
           <main className="min-h-[calc(100vh-4rem)]">{children}</main>
           <Footer />
         </WalletProvider>

--- a/components/DevnetModeBanner.tsx
+++ b/components/DevnetModeBanner.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useWallet } from "@solana/wallet-adapter-react";
+
+export default function DevnetModeBanner() {
+  const { connected } = useWallet();
+
+  if (!connected) return null;
+
+  return (
+    <div className="border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-200">
+      <div className="mx-auto max-w-7xl">
+        <span className="font-semibold">Devnet mode:</span> all wallet operations, registrations, escrow actions, and attestations are currently restricted to Solana devnet until audited production programs are approved.
+      </div>
+    </div>
+  );
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -21,7 +21,10 @@ const navLinks: { href: string; label: string; badge?: string }[] = [
   { href: "/runs", label: "History" },
   { href: "/leaderboard", label: "Leaderboard" },
   { href: "/onboarding", label: "Register" },
-  { href: "/specialist", label: "My Dashboard" },
+  { href: "/dashboard", label: "Dashboards" },
+  { href: "/specialist", label: "Specialist" },
+  { href: "/attestation", label: "Attestation" },
+  { href: "/consumer", label: "Consumer" },
   { href: "/audit", label: "Audit Trail" },
   { href: "/orchestrator", label: "Settings" },
 ];

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
@@ -99,4 +99,7 @@ Per iteration:
 
 ## Immediate Iteration Target
 - Completed: end-to-end confidence pass + closure snapshot published.
-- Operate in maintain mode with CI guards/sweeps; reopen gap-closure loop only on new scope or regressions.
+- Reopened for new scope request (while preserving one-agent-per-wallet):
+  - authenticated devnet-mode banner across app surfaces
+  - owner dashboards for specialist, attestation, and consumer roles
+- Current status: implemented; next hardening target is lightweight e2e smoke checks for the new dashboard pages.

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
@@ -51,7 +51,7 @@ Validate that all built infrastructure is justified by BDD buckets/use-cases/sce
 ## Key Remaining Gaps (prioritized)
 
 ### P0 (in progress)
-1. ✅ **Bucket A route-contract expansion (slice 1+2 complete)**
+1. ✅ **Bucket A route-contract expansion (slice 1+2+3 complete)**
    - Added direct tests for onboarding APIs:
      - `/api/onboarding/wallet`
      - `/api/onboarding/healthcheck`
@@ -60,11 +60,17 @@ Validate that all built infrastructure is justified by BDD buckets/use-cases/sce
      - `/api/onboarding/endpoint`
      - `/api/onboarding/capabilities` (GET/POST)
      - `/api/onboarding/audit` (GET)
+     - `/api/onboarding/wallet/recovery` (GET)
+     - `/api/onboarding/settlement-config` (GET)
+     - `/api/onboarding/planner/execute` (GET/POST)
+     - `/api/onboarding/planner/feedback` (GET/POST)
+     - `/api/onboarding/planner/reveal` (GET/POST)
    - Evidence:
      - `lib/__tests__/onboarding-routes-core.test.ts`
      - `lib/__tests__/onboarding-routes-support.test.ts`
-     - combined run: 13/13 pass
-   - Remaining in Bucket A expansion: add direct contracts for wallet recovery + settlement-config + planner execute/feedback/reveal onboarding wrappers (lower priority vs core onboarding path).
+     - `lib/__tests__/onboarding-routes-wrappers.test.ts`
+     - combined run: 18/18 pass
+   - Result: core onboarding and wrapper route coverage now directly test-backed.
 
 ### P1
 2. **Bucket A/B onboarding support routes**
@@ -88,4 +94,4 @@ Per iteration:
 5. Commit with an intelligent scoped message.
 
 ## Immediate Iteration Target
-- Continue P1: add targeted contracts for remaining onboarding support wrappers (`wallet/recovery`, `settlement-config`, `planner/execute|feedback|reveal`) and tighten E1 deterministic reliability contracts.
+- Continue P1: tighten E1 deterministic reliability contracts (offline/online transitions and quick-fix guidance behavior) with route-unit evidence where feasible.

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
@@ -98,4 +98,5 @@ Per iteration:
 5. Commit with an intelligent scoped message.
 
 ## Immediate Iteration Target
-- Run end-to-end confidence pass and publish final gap-closure snapshot note (coverage status + residual risks).
+- Completed: end-to-end confidence pass + closure snapshot published.
+- Operate in maintain mode with CI guards/sweeps; reopen gap-closure loop only on new scope or regressions.

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
@@ -1,0 +1,84 @@
+# BDD Comprehensive Review + Gap Plan (2026-04-19 v2)
+
+## Objective
+Validate that all built infrastructure is justified by BDD buckets/use-cases/scenarios, identify remaining build/testing gaps, and run an iterative closure loop with verification + retrospective updates + commit each iteration.
+
+## Coverage Snapshot (current)
+
+## Bucket A — Onboarding
+- **Spec artifacts:** `docs/bdd/features/bucket-a-onboarding.feature`
+- **Build state:** Implemented (wizard + runtime + endpoint + wallet + attestation + audit)
+- **Test state:** Partial-to-good
+  - Covered: operator key/status checks, critical onboarding UI step gates
+  - Gap: direct route-level contracts for wallet/healthcheck/attestation/audit/capabilities/endpoint/runtime not yet broadly covered
+
+## Bucket B — Discovery + Capability Index
+- **Spec artifacts:** `docs/bdd/features/bucket-b-discovery.feature`
+- **Build state:** Implemented
+- **Test state:** Good
+  - Covered: filter/sort contracts, default order, unsupported sort stability, ranking tie-breakers
+
+## Bucket C — Planner-Native Consumption
+- **Spec artifacts:** `docs/bdd/features/bucket-c-planner-consumption.feature`
+- **Build state:** Implemented
+- **Test state:** Good at route/unit, integration dependent for full runtime path
+
+## Bucket D/E — Security + Reliability
+- **Spec artifacts:** `docs/bdd/features/bucket-d-e-reliability.feature`
+- **Build state:** Implemented
+- **Test state:** Good for D1/E2/E3 contracts; E1 infra/runtime behavior remains partly observational/integration-dependent
+
+## Bucket F — Jupiter Settlement
+- **Spec artifacts:** `docs/bdd/features/bucket-f-jupiter-settlement.feature`
+- **Build state:** Implemented
+- **Test state:** Good
+  - Covered in `lib/__tests__/jupiter-client.test.ts` + `packages/x402-solana/tests/payment.test.ts`
+
+## Bucket G — Torque Retention
+- **Spec artifacts:** `docs/bdd/features/bucket-g-torque-retention.feature`
+- **Build state:** Implemented
+- **Test state:** Good
+  - Covered by torque route/client tests and leaderboard surface checks
+
+## Bucket H — Consumer Orchestrator
+- **Spec artifacts:** `docs/bdd/features/bucket-h-consumer-orchestrator.feature`
+- **Build state:** Implemented
+- **Test state:** Good
+  - Route contracts and auditability coverage in place
+
+---
+
+## Key Remaining Gaps (prioritized)
+
+### P0 (in progress)
+1. ✅ **Bucket A route-contract expansion (slice 1 complete)**
+   - Added direct tests for onboarding APIs:
+     - `/api/onboarding/wallet`
+     - `/api/onboarding/healthcheck`
+     - `/api/onboarding/attestation`
+   - Evidence: `lib/__tests__/onboarding-routes-core.test.ts` (6/6 pass)
+   - Remaining in Bucket A expansion: extend direct contracts for runtime/endpoint/capabilities/audit routes.
+
+### P1
+2. **Bucket A/B onboarding support routes**
+   - Add route tests for `/api/onboarding/capabilities`, `/api/onboarding/endpoint`, `/api/onboarding/runtime`, `/api/onboarding/audit`.
+
+3. **Bucket E1 runtime reliability explicit contracts**
+   - Add focused checks for offline/online transitions and quick-fix surfacing behavior where feasible via deterministic mocks.
+
+### P2
+4. **Confidence-lane reporting polish**
+   - Keep sweep artifacts + quick status, and add workflow step summary output for at-a-glance CI run interpretation.
+
+---
+
+## Iteration Execution Contract (active)
+Per iteration:
+1. Review this plan and pick highest-priority open slice.
+2. Implement one slice.
+3. Verify with explicit tests/commands.
+4. Retrospective: update plan + iteration log + status + memory.
+5. Commit with an intelligent scoped message.
+
+## Immediate Iteration Target
+- Continue P0.2: extend onboarding route contracts for runtime + endpoint + capabilities + audit.

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
@@ -77,7 +77,10 @@ Validate that all built infrastructure is justified by BDD buckets/use-cases/sce
    - Add route tests for `/api/onboarding/capabilities`, `/api/onboarding/endpoint`, `/api/onboarding/runtime`, `/api/onboarding/audit`.
 
 3. **Bucket E1 runtime reliability explicit contracts**
-   - Add focused checks for offline/online transitions and quick-fix surfacing behavior where feasible via deterministic mocks.
+   - ✅ Added focused checks for offline/online transitions and quick-fix surfacing behavior:
+     - `lib/__tests__/endpoint-manager-reliability.test.ts`
+   - Remaining reliability follow-up:
+     - Evaluate remediation-branch logic for tunnel guidance text, because current heartbeat/status formula makes some tunnel-note conditions hard to hit deterministically.
 
 ### P2
 4. **Confidence-lane reporting polish**
@@ -94,4 +97,4 @@ Per iteration:
 5. Commit with an intelligent scoped message.
 
 ## Immediate Iteration Target
-- Continue P1: tighten E1 deterministic reliability contracts (offline/online transitions and quick-fix guidance behavior) with route-unit evidence where feasible.
+- Continue P1 reliability hardening: review endpoint remediation-branch semantics and decide whether tunnel guidance branch should be made reachable or removed.

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
@@ -85,7 +85,7 @@ Validate that all built infrastructure is justified by BDD buckets/use-cases/sce
 
 ### P2
 4. **Confidence-lane reporting polish**
-   - Keep sweep artifacts + quick status, and add workflow step summary output for at-a-glance CI run interpretation.
+   - ✅ Keep sweep artifacts + quick status, and add workflow step summary output for at-a-glance CI run interpretation.
 
 ---
 
@@ -98,4 +98,4 @@ Per iteration:
 5. Commit with an intelligent scoped message.
 
 ## Immediate Iteration Target
-- Continue P2 reporting polish (GitHub step summary output for sweep confidence workflow).
+- Run end-to-end confidence pass and publish final gap-closure snapshot note (coverage status + residual risks).

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
@@ -51,13 +51,20 @@ Validate that all built infrastructure is justified by BDD buckets/use-cases/sce
 ## Key Remaining Gaps (prioritized)
 
 ### P0 (in progress)
-1. ✅ **Bucket A route-contract expansion (slice 1 complete)**
+1. ✅ **Bucket A route-contract expansion (slice 1+2 complete)**
    - Added direct tests for onboarding APIs:
      - `/api/onboarding/wallet`
      - `/api/onboarding/healthcheck`
      - `/api/onboarding/attestation`
-   - Evidence: `lib/__tests__/onboarding-routes-core.test.ts` (6/6 pass)
-   - Remaining in Bucket A expansion: extend direct contracts for runtime/endpoint/capabilities/audit routes.
+     - `/api/onboarding/runtime`
+     - `/api/onboarding/endpoint`
+     - `/api/onboarding/capabilities` (GET/POST)
+     - `/api/onboarding/audit` (GET)
+   - Evidence:
+     - `lib/__tests__/onboarding-routes-core.test.ts`
+     - `lib/__tests__/onboarding-routes-support.test.ts`
+     - combined run: 13/13 pass
+   - Remaining in Bucket A expansion: add direct contracts for wallet recovery + settlement-config + planner execute/feedback/reveal onboarding wrappers (lower priority vs core onboarding path).
 
 ### P1
 2. **Bucket A/B onboarding support routes**
@@ -81,4 +88,4 @@ Per iteration:
 5. Commit with an intelligent scoped message.
 
 ## Immediate Iteration Target
-- Continue P0.2: extend onboarding route contracts for runtime + endpoint + capabilities + audit.
+- Continue P1: add targeted contracts for remaining onboarding support wrappers (`wallet/recovery`, `settlement-config`, `planner/execute|feedback|reveal`) and tighten E1 deterministic reliability contracts.

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md
@@ -79,8 +79,9 @@ Validate that all built infrastructure is justified by BDD buckets/use-cases/sce
 3. **Bucket E1 runtime reliability explicit contracts**
    - ✅ Added focused checks for offline/online transitions and quick-fix surfacing behavior:
      - `lib/__tests__/endpoint-manager-reliability.test.ts`
-   - Remaining reliability follow-up:
-     - Evaluate remediation-branch logic for tunnel guidance text, because current heartbeat/status formula makes some tunnel-note conditions hard to hit deterministically.
+   - ✅ Follow-up completed: remediation-branch semantics reviewed and tightened.
+     - Online status now requires runtime + remote endpoint reachability.
+     - Tunnel remediation branch is now reachable/tested when runtime+proxy are up but remote endpoint is down.
 
 ### P2
 4. **Confidence-lane reporting polish**
@@ -97,4 +98,4 @@ Per iteration:
 5. Commit with an intelligent scoped message.
 
 ## Immediate Iteration Target
-- Continue P1 reliability hardening: review endpoint remediation-branch semantics and decide whether tunnel guidance branch should be made reachable or removed.
+- Continue P2 reporting polish (GitHub step summary output for sweep confidence workflow).

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -212,5 +212,14 @@ For each iteration:
 - Verified:
   - local guard command remains green (`npm run test:bdd:index` -> OK)
 
+## Iteration 21 retrospective (completed)
+- Added one-command representative per-bucket sweep:
+  - `scripts/run-bdd-bucket-sweep.sh`
+  - npm command `test:bdd:sweep`
+- Verified:
+  - `npm run test:bdd:sweep` -> representative suites across buckets A-H all green
+  - aggregate in run output: 19 suites, 80/80 tests passing
+- FEATURE-INDEX updated with sweep command section.
+
 ## Next iteration candidates
-1. Add a single command/script to run a representative per-bucket verification sweep.
+1. Add CI/manual-dispatch workflow for `test:bdd:sweep` (non-blocking confidence lane).

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -293,5 +293,15 @@ For each iteration:
 - Plan amendment:
   - E1 is now route/unit-backed; remaining follow-up is remediation-branch semantics review for tunnel-guidance reachability.
 
+## Iteration 30 retrospective (completed)
+- Reviewed and resolved endpoint remediation-branch semantics.
+- Implemented in `lib/onboarding/endpoint-manager.ts`:
+  - online status requires local runtime + remote endpoint reachability
+  - proxy-offline and tunnel-down remediation branches are now explicit and reachable
+- Verified:
+  - `npx jest lib/__tests__/endpoint-manager-reliability.test.ts lib/__tests__/endpoint-security-compat.test.ts --runInBand` -> 7/7 passing.
+- Plan amendment:
+  - E1 follow-up closed; move to reporting polish (`$GITHUB_STEP_SUMMARY`).
+
 ## Next iteration candidates
-1. Review endpoint remediation-branch semantics and decide whether tunnel guidance branch should be made reachable or removed.
+1. Continue P2 reporting polish: add `$GITHUB_STEP_SUMMARY` output to sweep confidence workflow.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -188,5 +188,11 @@ For each iteration:
     - `npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/torque-client.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-leaderboard-route.test.ts lib/__tests__/torque-onboarding-event.test.ts --runInBand` -> 25/25
     - `cd packages/x402-solana && npm test -- --runInBand tests/payment.test.ts` -> 19/19
 
+## Iteration 18 retrospective (completed)
+- Added: `docs/bdd/FEATURE-INDEX.md` linking each bucket feature file to mapped verification commands.
+- Verified:
+  - index references all current feature files (7/7 coverage).
+  - `rg` + directory count cross-check confirms no missing bucket feature linkage.
+
 ## Next iteration candidates
-1. Add a generated index doc linking all feature files to mapped test commands.
+1. Add a lightweight script to validate feature-index coverage automatically (prevent drift).

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -241,5 +241,14 @@ For each iteration:
 - Verified:
   - `npm run test:bdd:sweep` generated summary artifact with per-step pass/fail table.
 
+## Iteration 24 retrospective (completed)
+- Added quick-status helper for latest sweep artifacts:
+  - `scripts/bdd-sweep-latest-status.sh`
+  - npm command `test:bdd:status`
+- Verified:
+  - `./scripts/bdd-sweep-latest-status.sh` outputs one-line status with timestamp, pass/total, fail count, and summary path
+  - `npm run test:bdd:status` matches script output
+- FEATURE-INDEX updated with status helper command.
+
 ## Next iteration candidates
-1. Add a small helper script to emit latest sweep summary as one-line quick status for chat updates.
+1. Add CI step to print `test:bdd:status` after sweep for faster workflow log readability.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -250,5 +250,11 @@ For each iteration:
   - `npm run test:bdd:status` matches script output
 - FEATURE-INDEX updated with status helper command.
 
+## Iteration 25 retrospective (completed)
+- Added CI quick-status log step in sweep confidence workflow:
+  - `.github/workflows/bdd-bucket-sweep-confidence.yml` now runs `npm run test:bdd:status` after sweep (always).
+- Verified:
+  - local quick-status command remains green (`npm run test:bdd:status`).
+
 ## Next iteration candidates
-1. Add CI step to print `test:bdd:status` after sweep for faster workflow log readability.
+1. Add GitHub step summary output (`$GITHUB_STEP_SUMMARY`) with latest sweep status and summary artifact path.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -303,5 +303,15 @@ For each iteration:
 - Plan amendment:
   - E1 follow-up closed; move to reporting polish (`$GITHUB_STEP_SUMMARY`).
 
+## Iteration 31 retrospective (completed)
+- Completed P2 reporting polish by adding GitHub step summary output.
+- Implemented in:
+  - `.github/workflows/bdd-bucket-sweep-confidence.yml`
+- Behavior:
+  - writes `## BDD Bucket Sweep Confidence` block to `$GITHUB_STEP_SUMMARY`
+  - includes quick status line and summary artifact path when available
+- Verified:
+  - local dry-run of summary block using `npm run -s test:bdd:status` output renders expected markdown.
+
 ## Next iteration candidates
-1. Continue P2 reporting polish: add `$GITHUB_STEP_SUMMARY` output to sweep confidence workflow.
+1. Run end-to-end confidence pass (`test:bdd:index` + `test:bdd:sweep`) and publish final gap-closure snapshot note.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -322,5 +322,17 @@ For each iteration:
 - Verified:
   - sweep summary artifact indicates 8/8 step passes (`artifacts/bdd-sweep/20260419-180815/SUMMARY.md`).
 
+## Iteration 33 retrospective (completed)
+- New scope execution (post-closure) per user directive:
+  - keep one-agent-per-wallet unchanged
+  - implement authenticated devnet banner and role dashboards
+- Delivered:
+  - `components/DevnetModeBanner.tsx` + layout wiring
+  - dashboard hub + dedicated attestation/consumer dashboards
+  - consumer-list API route + route-unit test
+  - nav routing updates
+- Verified:
+  - `npx jest lib/__tests__/onboarding-consumers-route.test.ts lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/onboarding-routes-wrappers.test.ts --runInBand` -> 20/20 passing.
+
 ## Next iteration candidates
-1. Maintain mode: continue CI guards/sweeps; open new iteration only for new scope or regressions.
+1. Add lightweight e2e smoke checks for `/dashboard`, `/attestation`, and `/consumer` pages.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -275,5 +275,14 @@ For each iteration:
 - Plan amendment:
   - Bucket A core onboarding route coverage substantially closed; remaining wrappers moved to next candidate list.
 
+## Iteration 28 retrospective (completed)
+- Added onboarding wrapper-route contracts:
+  - `lib/__tests__/onboarding-routes-wrappers.test.ts`
+  - scope: `/api/onboarding/wallet/recovery`, `/api/onboarding/settlement-config`, `/api/onboarding/planner/execute`, `/api/onboarding/planner/feedback`, `/api/onboarding/planner/reveal`
+- Verified:
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/onboarding-routes-wrappers.test.ts --runInBand` -> 18/18 passing.
+- Plan amendment:
+  - Bucket A onboarding route-contract expansion is now substantially closed; next highest gap is E1 deterministic reliability contracts.
+
 ## Next iteration candidates
-1. Add contracts for remaining onboarding wrappers (`wallet/recovery`, `settlement-config`, `planner/execute|feedback|reveal`).
+1. Implement E1 deterministic reliability contracts (offline/online transitions + remediation guidance checks).

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -284,5 +284,14 @@ For each iteration:
 - Plan amendment:
   - Bucket A onboarding route-contract expansion is now substantially closed; next highest gap is E1 deterministic reliability contracts.
 
+## Iteration 29 retrospective (completed)
+- Implemented E1 deterministic reliability contracts.
+- Added:
+  - `lib/__tests__/endpoint-manager-reliability.test.ts`
+- Verified:
+  - `npx jest lib/__tests__/endpoint-manager-reliability.test.ts lib/__tests__/endpoint-security-compat.test.ts --runInBand` -> 6/6 passing.
+- Plan amendment:
+  - E1 is now route/unit-backed; remaining follow-up is remediation-branch semantics review for tunnel-guidance reachability.
+
 ## Next iteration candidates
-1. Implement E1 deterministic reliability contracts (offline/online transitions + remediation guidance checks).
+1. Review endpoint remediation-branch semantics and decide whether tunnel guidance branch should be made reachable or removed.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -265,5 +265,15 @@ For each iteration:
   - `npx jest lib/__tests__/onboarding-routes-core.test.ts --runInBand` -> 6/6 passing.
 - Updated mapping docs to reflect direct route-test evidence.
 
+## Iteration 27 retrospective (completed)
+- Continued comprehensive-review P0 onboarding contract expansion with support routes.
+- Added direct contracts:
+  - `lib/__tests__/onboarding-routes-support.test.ts`
+  - scope: `/api/onboarding/runtime`, `/api/onboarding/endpoint`, `/api/onboarding/capabilities` (GET/POST), `/api/onboarding/audit` (GET)
+- Verified:
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts --runInBand` -> 13/13 passing.
+- Plan amendment:
+  - Bucket A core onboarding route coverage substantially closed; remaining wrappers moved to next candidate list.
+
 ## Next iteration candidates
-1. Continue P0 with onboarding route tests for runtime + endpoint + capabilities + audit.
+1. Add contracts for remaining onboarding wrappers (`wallet/recovery`, `settlement-config`, `planner/execute|feedback|reveal`).

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -203,5 +203,14 @@ For each iteration:
   - `npm run test:bdd:index` -> OK
 - FEATURE-INDEX now includes the drift-guard command section.
 
+## Iteration 20 retrospective (completed)
+- Added PR-time CI enforcement for BDD index drift guard:
+  - `.github/workflows/bdd-index-guard.yml`
+- Workflow behavior:
+  - triggers on pull requests touching `docs/bdd/**`, guard script, or package manifests
+  - runs `npm run test:bdd:index`
+- Verified:
+  - local guard command remains green (`npm run test:bdd:index` -> OK)
+
 ## Next iteration candidates
-1. Add CI workflow step to run `npm run test:bdd:index` on PRs touching `docs/bdd/**`.
+1. Add a single command/script to run a representative per-bucket verification sweep.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -194,5 +194,14 @@ For each iteration:
   - index references all current feature files (7/7 coverage).
   - `rg` + directory count cross-check confirms no missing bucket feature linkage.
 
+## Iteration 19 retrospective (completed)
+- Added BDD feature-index drift guard automation:
+  - `scripts/check-bdd-feature-index.sh`
+  - npm command `test:bdd:index`
+- Verified:
+  - `./scripts/check-bdd-feature-index.sh` -> OK
+  - `npm run test:bdd:index` -> OK
+- FEATURE-INDEX now includes the drift-guard command section.
+
 ## Next iteration candidates
-1. Add a lightweight script to validate feature-index coverage automatically (prevent drift).
+1. Add CI workflow step to run `npm run test:bdd:index` on PRs touching `docs/bdd/**`.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -313,5 +313,14 @@ For each iteration:
 - Verified:
   - local dry-run of summary block using `npm run -s test:bdd:status` output renders expected markdown.
 
+## Iteration 32 retrospective (completed)
+- Ran end-to-end confidence pass:
+  - `npm run test:bdd:index` -> PASS
+  - `npm run test:bdd:sweep` -> PASS
+- Added closure snapshot:
+  - `docs/BDD-GAP-CLOSURE-SNAPSHOT-2026-04-19.md`
+- Verified:
+  - sweep summary artifact indicates 8/8 step passes (`artifacts/bdd-sweep/20260419-180815/SUMMARY.md`).
+
 ## Next iteration candidates
-1. Run end-to-end confidence pass (`test:bdd:index` + `test:bdd:sweep`) and publish final gap-closure snapshot note.
+1. Maintain mode: continue CI guards/sweeps; open new iteration only for new scope or regressions.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -231,5 +231,15 @@ For each iteration:
 - Verified:
   - local sweep remains green (`npm run test:bdd:sweep`) -> 19 suites, 80/80 pass
 
+## Iteration 23 retrospective (completed)
+- Added structured sweep artifact generation in `run-bdd-bucket-sweep.sh`:
+  - `artifacts/bdd-sweep/<timestamp>/SUMMARY.md`
+  - `artifacts/bdd-sweep/<timestamp>/bdd-sweep.log`
+  - `artifacts/bdd-sweep/<timestamp>/steps.tsv`
+- Updated CI confidence lane to upload full sweep artifact directory:
+  - `.github/workflows/bdd-bucket-sweep-confidence.yml` now uploads `artifacts/bdd-sweep/`.
+- Verified:
+  - `npm run test:bdd:sweep` generated summary artifact with per-step pass/fail table.
+
 ## Next iteration candidates
-1. Add sweep markdown summary artifact generation and publish in CI artifacts.
+1. Add a small helper script to emit latest sweep summary as one-line quick status for chat updates.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -221,5 +221,15 @@ For each iteration:
   - aggregate in run output: 19 suites, 80/80 tests passing
 - FEATURE-INDEX updated with sweep command section.
 
+## Iteration 22 retrospective (completed)
+- Added CI/manual-dispatch BDD confidence lane for representative bucket sweep:
+  - `.github/workflows/bdd-bucket-sweep-confidence.yml`
+- Workflow behavior:
+  - scheduled daily + manual dispatch
+  - runs `npm run test:bdd:sweep` with non-blocking step semantics
+  - uploads `bdd-bucket-sweep.log` artifact (14-day retention)
+- Verified:
+  - local sweep remains green (`npm run test:bdd:sweep`) -> 19 suites, 80/80 pass
+
 ## Next iteration candidates
-1. Add CI/manual-dispatch workflow for `test:bdd:sweep` (non-blocking confidence lane).
+1. Add sweep markdown summary artifact generation and publish in CI artifacts.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -1,0 +1,192 @@
+# BDD Gap Closure Execution Plan (2026-04-19)
+
+## Goal
+Close highest-impact BDD build/testing gaps so submission claims are backed by active executable coverage.
+
+## Scope
+From `docs/BDD-COVERAGE-REVIEW-2026-04-19.md`.
+
+## Phase P0 (completed)
+
+### P0.1 Unskip critical onboarding scenarios ✅
+Target file: `e2e/onboarding.spec.ts`
+
+Covered:
+1. Consent gating requires both checkboxes
+2. Next advances to Runtime
+3. Back returns to Consent
+4. Runtime step Next disabled until runtime ready
+5. Step 8 run button disabled with empty prompt
+
+Verification:
+- Targeted Playwright set green (5/5)
+
+### P0.2 Add planner contract tests ✅
+Added route-level tests:
+1. `GET /api/planner/tools` manifest contract
+2. `POST /api/planner/tools/resolve`
+   - task required validation
+   - no-candidate error path
+   - success shape path
+
+Verification:
+- Jest suites green for new planner contract tests
+
+### P0.3 Add endpoint security compatibility tests (Bucket D) ✅
+Added tests verifying:
+1. x402 public paths bypass token-gated proxy (`/v1/*`, `/x402/*`, `/healthz`)
+2. non-public paths require token
+
+Verification:
+- `lib/__tests__/endpoint-security-compat.test.ts` green
+
+## Phase P1 (completed)
+1. ✅ E3 RPC config tests (env override + fallback)
+2. ✅ H4.3 auditability contract coverage (settlement vs rating independently auditable)
+3. ✅ E2.2 operator key rotation runbook + verification tests
+4. ✅ Operator status route contract tests (`/api/onboarding/operator-key`, `/api/onboarding/attestation-operator`)
+
+## Iteration loop (active)
+For each iteration:
+1. Review plan + open gaps.
+2. Implement one slice.
+3. Verify with explicit tests.
+4. Run retrospective and amend plan/docs.
+
+## Iteration 1 retrospective (completed)
+- Changed: Step 8 onboarding harness moved from flaky to deterministic (`page.addInitScript` + storage seeding).
+- Removed: `test.fixme` blocker for Step 8 disabled-run-button case.
+- Verified: targeted onboarding Playwright set reached 5/5.
+
+## Iteration 2 retrospective (completed)
+- Added: Bucket B route-level discovery/ranking contract suite `lib/__tests__/registry-route.test.ts`.
+- Covered:
+  - Filters: `taskType`, `inputMode`, `privacyMode`, `runtimeCap`, `attested`, `health`
+  - Sorts: `ranking`, `reputation`, `cost`, `feedback`
+- Verified:
+  - `npx jest lib/__tests__/registry-route.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand` → 8/8 passing
+
+## Iteration 3 retrospective (completed)
+- Added: default bridge-sort regression test `lib/__tests__/registry-bridge-sort.test.ts`.
+- Covered: default ordering contract `attested > health > feedback` when no explicit `sortBy` is requested.
+- Verified:
+  - `npx jest lib/__tests__/registry-bridge-sort.test.ts lib/__tests__/registry-route.test.ts --runInBand` → 6/6 passing
+
+## Iteration 4 retrospective (completed)
+- Added: infra-backed integration-lane artifact runner `scripts/run-integration-lane.sh`.
+- Wired: npm command `test:e2e:integration-lane` in `package.json`.
+- Verified:
+  - `npm run test:e2e:integration-lane` produced timestamped artifacts under `artifacts/integration-lane/*`.
+  - Latest lane: 4 passed, 0 skipped, 0 failed (`20260419-130442/SUMMARY.md`).
+
+## Iteration 5 retrospective (completed)
+- Added: foundational scenario-ID map `docs/BDD-SCENARIO-ID-MAP.md` for Buckets A-H.
+- Added: append-amended iteration journal `docs/BDD-ITERATION-LOG-2026-04-19.md` to preserve per-loop notes.
+- Verified:
+  - map includes all bucket sections (A-H) and explicit gap list.
+
+## Iteration 6 retrospective (completed)
+- Added: Bucket B tag-filter contract coverage in `lib/__tests__/registry-route.test.ts`.
+- Implemented: `/api/registry` now supports `tag=<value>` and `tags=<csv>` query filters.
+- Verified:
+  - `npx jest lib/__tests__/registry-route.test.ts lib/__tests__/registry-bridge-sort.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand` → 10/10 passing.
+
+## Iteration 7 retrospective (completed)
+- Added: route-level unsupported-sort stability contract in `lib/__tests__/registry-route.test.ts`.
+- Verified:
+  - `npx jest lib/__tests__/registry-route.test.ts lib/__tests__/registry-bridge-sort.test.ts --runInBand` → 8/8 passing.
+- Behavior locked: unknown `sortBy` values do not fail request and preserve incoming bridge order.
+
+## Iteration 8 retrospective (completed)
+- Added: executable freshness/latency ranking policy for Bucket B.
+- Implemented in `/api/registry` ranking sort:
+  1) `ranking_score` (desc),
+  2) freshness (`health.lastCheckedAt`, desc),
+  3) latency/cost proxy (`perCallUsd`, asc).
+- Verified:
+  - `npx jest lib/__tests__/registry-route.test.ts lib/__tests__/registry-bridge-sort.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand` → 12/12 passing.
+
+## Iteration 9 retrospective (completed)
+- Added: CI/nightly integration artifact retention hook via `.github/workflows/integration-lane-nightly.yml`.
+- Workflow behavior:
+  - schedule + manual dispatch
+  - runs `npm run test:e2e:integration-lane`
+  - uploads `artifacts/integration-lane/` (14-day retention)
+- Verification:
+  - workflow is present and wired to the integration-lane command surface.
+
+## Iteration 10 retrospective (completed)
+- Added: readiness telemetry in integration summary artifacts.
+- `scripts/run-integration-lane.sh` now records:
+  - Ollama status/model
+  - validator status
+  - Playwright infra hint line
+- Verified:
+  - `npm run test:e2e:integration-lane` → artifact `artifacts/integration-lane/20260419-160720/SUMMARY.md` with enriched readiness block.
+
+## Iteration 11 retrospective (completed)
+- Added: explicit model-source normalization telemetry in integration-lane artifacts.
+- Summary now reports:
+  - probe model,
+  - test-selected model,
+  - effective model,
+  - source label (`probe|playwright`),
+  - mismatch flag.
+- Verified:
+  - `npm run test:e2e:integration-lane` -> `artifacts/integration-lane/20260419-161403/SUMMARY.md`.
+
+## Iteration 12 retrospective (completed)
+- Started Gherkin extraction from scenario map with Bucket B feature file:
+  - `docs/bdd/features/bucket-b-discovery.feature`
+- Includes tagged scenarios: `@B2.1`, `@B2.2`, `@B2.3`, `@B2.default-order` mapped to existing route tests.
+- Verified:
+  - scenario tags present via `rg` check.
+
+## Iteration 13 retrospective (completed)
+- Added Bucket H Gherkin extraction:
+  - `docs/bdd/features/bucket-h-consumer-orchestrator.feature`
+- Verified:
+  - scenario tags present via `rg`
+  - mapped planner H-suite remains green:
+    - `npx jest lib/__tests__/planner-register-consumer-route.test.ts lib/__tests__/planner-tools-manifest-route.test.ts lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-resolve-attestor-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-release-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/planner-auditability.test.ts --runInBand`
+    - result: 8 suites, 16/16 passing
+
+## Iteration 14 retrospective (completed)
+- Added Bucket A Gherkin extraction:
+  - `docs/bdd/features/bucket-a-onboarding.feature`
+- Verified:
+  - scenario tags present via `rg`
+  - mapped operator/onboarding gates remain green:
+    - `npx jest lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand` -> 6/6
+    - `npx playwright test e2e/onboarding.spec.ts --grep "consent gates|next button advances|back button returns|step 2 runtime — next is disabled|run button disabled when prompt is empty"` -> 5/5
+
+## Iteration 15 retrospective (completed)
+- Added Bucket D/E Gherkin extraction:
+  - `docs/bdd/features/bucket-d-e-reliability.feature`
+- Verified:
+  - scenario tags present via `rg`
+  - mapped D/E contract suites green:
+    - `npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts lib/__tests__/program-rpc-config.test.ts --runInBand`
+    - result: 4 suites, 11/11 passing
+
+## Iteration 16 retrospective (completed)
+- Added Bucket C Gherkin extraction:
+  - `docs/bdd/features/bucket-c-planner-consumption.feature`
+- Verified:
+  - scenario tags present via `rg`
+  - mapped C-suite contracts green:
+    - `npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-client.test.ts --runInBand`
+    - result: 5 suites, 20/20 passing
+
+## Iteration 17 retrospective (completed)
+- Added Bucket F/G Gherkin extraction:
+  - `docs/bdd/features/bucket-f-jupiter-settlement.feature`
+  - `docs/bdd/features/bucket-g-torque-retention.feature`
+- Verified:
+  - tags present via `rg` checks
+  - mapped F/G suites green:
+    - `npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/torque-client.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-leaderboard-route.test.ts lib/__tests__/torque-onboarding-event.test.ts --runInBand` -> 25/25
+    - `cd packages/x402-solana && npm test -- --runInBand tests/payment.test.ts` -> 19/19
+
+## Next iteration candidates
+1. Add a generated index doc linking all feature files to mapped test commands.

--- a/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-EXECUTION-PLAN-2026-04-19.md
@@ -256,5 +256,14 @@ For each iteration:
 - Verified:
   - local quick-status command remains green (`npm run test:bdd:status`).
 
+## Iteration 26 retrospective (completed)
+- Began execution of comprehensive review v2 P0 onboarding contract expansion.
+- Added direct onboarding route tests:
+  - `lib/__tests__/onboarding-routes-core.test.ts`
+  - scope: `/api/onboarding/wallet`, `/api/onboarding/healthcheck`, `/api/onboarding/attestation`
+- Verified:
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts --runInBand` -> 6/6 passing.
+- Updated mapping docs to reflect direct route-test evidence.
+
 ## Next iteration candidates
-1. Add GitHub step summary output (`$GITHUB_STEP_SUMMARY`) with latest sweep status and summary artifact path.
+1. Continue P0 with onboarding route tests for runtime + endpoint + capabilities + audit.

--- a/docs/BDD-GAP-CLOSURE-SNAPSHOT-2026-04-19.md
+++ b/docs/BDD-GAP-CLOSURE-SNAPSHOT-2026-04-19.md
@@ -1,0 +1,32 @@
+# BDD Gap Closure Snapshot — 2026-04-19
+
+## End-to-end confidence pass
+- `npm run test:bdd:index` -> PASS
+- `npm run test:bdd:sweep` -> PASS
+  - Sweep artifact: `artifacts/bdd-sweep/20260419-180815/SUMMARY.md`
+  - Step summary: 8/8 step passes
+
+## Bucket coverage state
+- **A (Onboarding):** direct route contracts + critical UI gates covered (`onboarding-routes-core/support/wrappers` + onboarding e2e gate set)
+- **B (Discovery):** filter/sort/default-order/tie-break contracts covered
+- **C (Planner consumption):** resolve/invoke/signal + event-path contracts covered
+- **D/E (Security/Reliability):** endpoint security + RPC config + E1 reliability semantics covered
+- **F (Jupiter settlement):** web route + package payment contracts covered
+- **G (Torque retention):** client/event/leaderboard contracts covered
+- **H (Consumer orchestrator):** lifecycle contracts covered (register/resolve/invoke/release/signal/auditability)
+
+## Infrastructure justification status
+- Scenario map -> feature files -> verification commands -> drift guard -> CI confidence lane -> step summary reporting are all wired.
+- Representative confidence lane is automated and artifacted (`bdd-bucket-sweep-confidence.yml`).
+
+## Residual risks / known constraints
+1. Full runtime integration still depends on environment availability (local validator + Ollama + tunnel conditions).
+2. Some scenarios remain integration/manual by nature (true on-chain + external network behavior), but are now bounded by route/unit contracts + artifacted confidence checks.
+3. Sweep is representative by design (fast signal), not exhaustive of all tests each run.
+
+## Recommendation
+- Keep current loop policy:
+  - per change: affected bucket tests
+  - daily/manual: `test:bdd:sweep`
+  - CI PR guard: `test:bdd:index`
+- Trigger a deeper full-suite pass before external milestone demos/releases.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -313,5 +313,18 @@ This log is append-amended each loop: plan review -> implementation -> verificat
   - Scenario map + feature index updated with direct E1 evidence.
   - Comprehensive plan updated: E1 contracts added; remaining reliability follow-up is remediation-branch semantics review.
 
+## Iteration 30
+- Focus: resolve endpoint remediation-branch semantics gap from reliability follow-up.
+- Delivered:
+  - Updated `lib/onboarding/endpoint-manager.ts` heartbeat semantics:
+    - online now requires local runtime **and** remote endpoint reachability
+    - remediation branches now distinguish proxy-offline vs tunnel-down deterministically
+  - Expanded E1 test coverage in `lib/__tests__/endpoint-manager-reliability.test.ts` to assert tunnel-remediation branch reachability.
+- Verified:
+  - `npx jest lib/__tests__/endpoint-manager-reliability.test.ts lib/__tests__/endpoint-security-compat.test.ts --runInBand` -> 2 suites, 7/7 pass
+- Retrospective amendments:
+  - Comprehensive plan updated to mark E1 semantics follow-up closed.
+  - Reliability guidance branch no longer theoretical, now test-backed.
+
 ## Next loop candidates
-1. Review endpoint remediation-branch semantics and decide whether tunnel guidance branch should be made reachable or removed.
+1. Continue P2 reporting polish: add `$GITHUB_STEP_SUMMARY` output to sweep confidence workflow.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -249,5 +249,17 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - CI confidence lane now preserves structured sweep summaries, not raw logs only.
 
+## Iteration 24
+- Focus: add a chat-ready one-line status helper for latest sweep artifacts.
+- Delivered:
+  - `scripts/bdd-sweep-latest-status.sh`
+  - npm command `test:bdd:status`
+  - FEATURE-INDEX updated with status helper command
+- Verified:
+  - `./scripts/bdd-sweep-latest-status.sh` -> `BDD_SWEEP_STATUS ok ts=20260419-171809 passed=8/8 failed=0 ...`
+  - `npm run test:bdd:status` -> same one-line status output
+- Retrospective amendments:
+  - Sweep artifacts now support quick status extraction for chat updates without opening markdown manually.
+
 ## Next loop candidates
-1. Add a tiny parser script to aggregate latest sweep SUMMARY.md into a short status line for quick chat updates.
+1. Add CI step to print `test:bdd:status` after sweep for faster workflow log readability.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -261,5 +261,14 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - Sweep artifacts now support quick status extraction for chat updates without opening markdown manually.
 
+## Iteration 25
+- Focus: print one-line quick status directly in CI sweep workflow logs.
+- Delivered:
+  - `.github/workflows/bdd-bucket-sweep-confidence.yml` now runs `npm run test:bdd:status` after sweep (always).
+- Verified:
+  - Local status helper remains green: `npm run test:bdd:status`.
+- Retrospective amendments:
+  - CI logs now surface a compact status line without opening artifacts.
+
 ## Next loop candidates
-1. Add CI step to print `test:bdd:status` after sweep for faster workflow log readability.
+1. Add GitHub step summary (`$GITHUB_STEP_SUMMARY`) with latest sweep status and summary artifact path.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -280,5 +280,16 @@ This log is append-amended each loop: plan review -> implementation -> verificat
   - Comprehensive plan updated (`BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md`) to mark P0 slice 1 complete.
   - Scenario map and feature index updated to reference new onboarding route test evidence.
 
+## Iteration 27
+- Focus: continue comprehensive-review P0 by expanding onboarding route contracts.
+- Delivered:
+  - `lib/__tests__/onboarding-routes-support.test.ts`
+  - Covered routes: `/api/onboarding/runtime`, `/api/onboarding/endpoint`, `/api/onboarding/capabilities` (GET/POST), `/api/onboarding/audit` (GET)
+- Verified:
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts --runInBand` -> 2 suites, 13/13 pass
+- Retrospective amendments:
+  - Comprehensive plan updated: Bucket A core route-contract expansion marked slice 1+2 complete.
+  - Scenario map + feature index updated with direct route-test evidence.
+
 ## Next loop candidates
-1. Continue comprehensive-review P0 with route tests for onboarding runtime + endpoint + capabilities + audit.
+1. Add contracts for remaining onboarding wrappers (`wallet/recovery`, `settlement-config`, `planner/execute|feedback|reveal`).

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -291,5 +291,16 @@ This log is append-amended each loop: plan review -> implementation -> verificat
   - Comprehensive plan updated: Bucket A core route-contract expansion marked slice 1+2 complete.
   - Scenario map + feature index updated with direct route-test evidence.
 
+## Iteration 28
+- Focus: close remaining onboarding wrapper-route contract gaps from comprehensive plan.
+- Delivered:
+  - `lib/__tests__/onboarding-routes-wrappers.test.ts`
+  - Covered wrappers: `/wallet/recovery`, `/settlement-config`, `/planner/execute`, `/planner/feedback`, `/planner/reveal`
+- Verified:
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/onboarding-routes-wrappers.test.ts --runInBand` -> 3 suites, 18/18 pass
+- Retrospective amendments:
+  - Comprehensive review plan v2 updated: Bucket A route-contract expansion now slice 1+2+3 complete.
+  - Feature index and scenario map refreshed to reference wrapper-route evidence.
+
 ## Next loop candidates
-1. Add contracts for remaining onboarding wrappers (`wallet/recovery`, `settlement-config`, `planner/execute|feedback|reveal`).
+1. Implement E1 deterministic reliability contracts (offline/online transition + quick-fix guidance behavior).

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -349,5 +349,22 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - Comprehensive review cycle now has explicit closure snapshot with residual-risk callouts.
 
+## Iteration 33
+- Focus: execute new scope request after closure snapshot (keep 1-agent-per-wallet, deliver devnet banner + role dashboards).
+- Delivered:
+  - Global authenticated devnet banner via `components/DevnetModeBanner.tsx` injected in `app/layout.tsx`.
+  - Dashboard hub refresh in `app/dashboard/page.tsx` with role routing.
+  - New role dashboards:
+    - `app/attestation/page.tsx`
+    - `app/consumer/page.tsx`
+  - New consumer stats API route: `app/api/onboarding/consumers/route.ts`
+  - Nav updates to expose dashboard routes.
+  - New route test: `lib/__tests__/onboarding-consumers-route.test.ts`.
+- Verified:
+  - `npx jest lib/__tests__/onboarding-consumers-route.test.ts lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/onboarding-routes-wrappers.test.ts --runInBand` -> 4 suites, 20/20 pass
+- Retrospective amendments:
+  - Confirmed wallet limit remains unchanged (one-agent-per-wallet) per user direction.
+  - Added explicit surfaces for specialist, attestation, and consumer owners to view protocol stats.
+
 ## Next loop candidates
-1. Maintain mode: keep CI/reporting lanes running and only open new iterations when new scope or regressions appear.
+1. Add lightweight e2e smoke checks for new `/dashboard`, `/attestation`, and `/consumer` surfaces.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -222,5 +222,17 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - Per-bucket confidence checks are now runnable from a single command.
 
+## Iteration 22
+- Focus: wire CI/manual-dispatch confidence lane for one-command bucket sweep.
+- Delivered:
+  - `.github/workflows/bdd-bucket-sweep-confidence.yml`
+  - triggers: daily schedule + manual dispatch
+  - runs `npm run test:bdd:sweep` (non-blocking) and uploads sweep log artifact (14-day retention)
+- Verified:
+  - Local representative sweep still green: `npm run test:bdd:sweep`
+  - Aggregate observed: 19 suites, 80/80 tests passing
+- Retrospective amendments:
+  - BDD confidence lane now has both local one-command execution and CI-run artifact capture.
+
 ## Next loop candidates
-1. Add CI/manual-dispatch workflow for `test:bdd:sweep` (non-blocking confidence lane).
+1. Add summary artifact generation for sweep (markdown snapshot) and upload in CI.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -234,5 +234,20 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - BDD confidence lane now has both local one-command execution and CI-run artifact capture.
 
+## Iteration 23
+- Focus: add structured markdown summary artifacts to bucket sweep and upload them in CI.
+- Delivered:
+  - `scripts/run-bdd-bucket-sweep.sh` now writes timestamped artifacts:
+    - `artifacts/bdd-sweep/<timestamp>/SUMMARY.md`
+    - `artifacts/bdd-sweep/<timestamp>/bdd-sweep.log`
+    - `artifacts/bdd-sweep/<timestamp>/steps.tsv`
+  - `.github/workflows/bdd-bucket-sweep-confidence.yml` updated to upload `artifacts/bdd-sweep/` instead of a single log file.
+  - `docs/bdd/FEATURE-INDEX.md` updated with summary/log artifact paths.
+- Verified:
+  - `npm run test:bdd:sweep` produced summary artifact at `artifacts/bdd-sweep/20260419-171809/SUMMARY.md`.
+  - Summary includes per-step pass/fail table and artifact links.
+- Retrospective amendments:
+  - CI confidence lane now preserves structured sweep summaries, not raw logs only.
+
 ## Next loop candidates
-1. Add summary artifact generation for sweep (markdown snapshot) and upload in CI.
+1. Add a tiny parser script to aggregate latest sweep SUMMARY.md into a short status line for quick chat updates.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -187,5 +187,17 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - BDD feature extraction now has an operational command index for fast per-bucket verification.
 
+## Iteration 19
+- Focus: add drift-check automation so feature index cannot silently fall out of sync.
+- Delivered:
+  - `scripts/check-bdd-feature-index.sh`
+  - npm command: `test:bdd:index`
+  - FEATURE-INDEX drift-guard section updated
+- Verified:
+  - `./scripts/check-bdd-feature-index.sh` -> OK
+  - `npm run test:bdd:index` -> OK
+- Retrospective amendments:
+  - Index maintenance is now enforceable as a command, not just manual convention.
+
 ## Next loop candidates
-1. Add a lightweight script to validate feature-index coverage automatically (prevent drift).
+1. Add CI workflow step to run `npm run test:bdd:index` on PRs touching `docs/bdd/**`.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -178,5 +178,14 @@ This log is append-amended each loop: plan review -> implementation -> verificat
   - Gherkin extraction now covers Buckets A, B, C, D/E, F, G, and H.
   - Remaining extraction work is effectively closed for listed buckets.
 
+## Iteration 18
+- Focus: add a single index linking all Gherkin features to executable verification commands.
+- Delivered: `docs/bdd/FEATURE-INDEX.md`.
+- Verified:
+  - `rg` confirms all 7 feature files are referenced in index.
+  - feature count cross-check: index references = 7, `docs/bdd/features` files = 7.
+- Retrospective amendments:
+  - BDD feature extraction now has an operational command index for fast per-bucket verification.
+
 ## Next loop candidates
-1. Add a generated index doc linking all feature files to mapped test commands.
+1. Add a lightweight script to validate feature-index coverage automatically (prevent drift).

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -1,0 +1,182 @@
+# BDD Iteration Log — 2026-04-19
+
+This log is append-amended each loop: plan review -> implementation -> verification -> retrospective changes.
+
+## Iteration 1
+- Focus: close remaining onboarding Step 8 deterministic harness gap.
+- Delivered: removed `test.fixme` and stabilized with `page.addInitScript` seeding.
+- Verified: targeted onboarding Playwright set 5/5 passing.
+- Retrospective: moved onboarding critical coverage from unstable to complete.
+
+## Iteration 2
+- Focus: Bucket B route-level discovery/ranking contract coverage.
+- Delivered: `lib/__tests__/registry-route.test.ts`.
+- Verified: `jest registry-route + planner-resolve` -> 8/8 passing.
+- Retrospective: route filters/sorts now explicitly covered.
+
+## Iteration 3
+- Focus: default discovery ordering regression protection.
+- Delivered: `lib/__tests__/registry-bridge-sort.test.ts`.
+- Verified: `jest registry-bridge-sort + registry-route` -> 6/6 passing.
+- Retrospective: no-sort ordering contract locked (`attested > health > feedback`).
+
+## Iteration 4
+- Focus: infra-backed integration-lane artifacting.
+- Delivered: `scripts/run-integration-lane.sh`, npm script `test:e2e:integration-lane`.
+- Verified: latest lane summary `artifacts/integration-lane/20260419-130442/SUMMARY.md` -> 4 passed, 0 skipped, 0 failed.
+- Retrospective: local artifact generation complete; CI/nightly upload remains.
+
+## Iteration 5
+- Focus: P2 scenario-ID mapping foundation across Buckets A-H.
+- Delivered: `docs/BDD-SCENARIO-ID-MAP.md`.
+- Verified:
+  - Bucket headers present for A-H
+  - Explicit gaps section captured for next loop
+- Retrospective amendments:
+  - Added map as new canonical index for BDD ID -> test file -> lane.
+  - Next loop should convert map gaps into executable tests and CI retention tasks.
+
+## Iteration 6
+- Focus: close Bucket B tag-filter gap from scenario map.
+- Delivered:
+  - `/api/registry` support for `tag=<value>` and `tags=<csv>` filters.
+  - Added direct contract assertions in `lib/__tests__/registry-route.test.ts`.
+- Verified: `jest registry-route + registry-bridge-sort + planner-resolve` -> 10/10 passing.
+- Retrospective amendments:
+  - Updated `docs/BDD-SCENARIO-ID-MAP.md` to mark B2.1 complete.
+  - Removed tag-filter item from active gaps.
+
+## Iteration 7
+- Focus: route stability guard for unsupported sort values.
+- Delivered: added unsupported-sort resilience contract in `lib/__tests__/registry-route.test.ts`.
+- Verified: `jest registry-route + registry-bridge-sort` -> 8/8 passing.
+- Retrospective amendments:
+  - Stability behavior now explicit: unknown `sortBy` values return 200 and preserve bridge order.
+
+## Iteration 8
+- Focus: codify freshness/latency semantics into executable ranking contract.
+- Delivered:
+  - Updated `/api/registry` ranking sort tie-break policy: ranking_score -> freshness (`health.lastCheckedAt`) -> cost/latency proxy (`perCallUsd`).
+  - Added tie-break contract test in `lib/__tests__/registry-route.test.ts`.
+- Verified: `jest registry-route + registry-bridge-sort + planner-resolve` -> 12/12 passing.
+- Retrospective amendments:
+  - Scenario map `B2.3` now marked complete with explicit policy note.
+  - Remaining map gap reduced to CI/nightly integration-artifact retention.
+
+## Iteration 9
+- Focus: close CI/nightly artifact retention gap for integration lane.
+- Delivered: `.github/workflows/integration-lane-nightly.yml` (schedule + manual dispatch + artifact upload retention 14 days).
+- Verified: workflow file added and aligned with local integration-lane command (`npm run test:e2e:integration-lane`).
+- Retrospective amendments:
+  - Scenario map gap reduced from “policy missing” to “infra availability environment-dependent”.
+
+## Iteration 10
+- Focus: add integration-lane readiness telemetry to artifacts.
+- Delivered:
+  - Enhanced `scripts/run-integration-lane.sh` summary with explicit pre-run fields:
+    - Ollama up/down + detected model
+    - validator up/down
+    - Playwright infra hint line
+- Verified:
+  - `npm run test:e2e:integration-lane` produced enriched summaries:
+    - `artifacts/integration-lane/20260419-160720/SUMMARY.md` (4 passed, 0 skipped, 0 failed)
+- Retrospective amendments:
+  - CI artifact now carries both result counts and infra-readiness context.
+
+## Iteration 11
+- Focus: normalize probe-vs-test model ambiguity in integration-lane summaries.
+- Delivered:
+  - `run-integration-lane.sh` now records probe model, test-selected model, effective model, source label, and mismatch flag.
+- Verified:
+  - `npm run test:e2e:integration-lane` -> `artifacts/integration-lane/20260419-161403/SUMMARY.md`
+  - Summary now explicitly reports: probe model `mistral:latest`, selected model `qwen3:8b`, source `playwright`, mismatch `yes`.
+- Retrospective amendments:
+  - Ambiguity removed from artifact interpretation; mismatch is now explicit telemetry rather than hidden drift.
+
+## Iteration 12
+- Focus: start Gherkin extraction from scenario-ID map.
+- Delivered: `docs/bdd/features/bucket-b-discovery.feature` with tagged scenarios:
+  - `@B2.1` tag filtering
+  - `@B2.2` attestation/health filtering
+  - `@B2.3` ranking tie-break semantics
+  - `@B2.default-order` no-sort bridge ordering
+- Verified:
+  - `rg` confirms all scenario tags present in feature file.
+- Retrospective amendments:
+  - Shifted from map-only governance to executable BDD artifacting start.
+
+## Iteration 13
+- Focus: continue Gherkin extraction with Bucket H orchestrator lifecycle.
+- Delivered: `docs/bdd/features/bucket-h-consumer-orchestrator.feature` with tagged scenarios:
+  - `@H1.1..@H1.4` registration + manifest
+  - `@H2.1..@H2.3` specialist/attestor resolution
+  - `@H3.1..@H3.5` invoke + settlement lifecycle
+  - `@H4.1..@H4.3` signaling + independent auditability
+- Verified:
+  - Tag presence check via `rg`
+  - Mapped executable suite green:
+    - `npx jest ...planner-register-consumer...planner-auditability... --runInBand` -> 8 suites, 16/16 tests passing.
+- Retrospective amendments:
+  - Gherkin extraction now covers Buckets B and H.
+  - Next extraction should prioritize Bucket A onboarding lifecycle.
+
+## Iteration 14
+- Focus: continue Gherkin extraction with Bucket A onboarding lifecycle.
+- Delivered: `docs/bdd/features/bucket-a-onboarding.feature` with tagged scenario groups:
+  - `@A1.1..@A1.8` onboarding progression + registration/integration notes
+  - `@A2.1..@A2.6` healthcheck/attestation/audit/operator-signer behavior
+- Verified:
+  - Tag presence check via `rg`
+  - Mapped executable checks:
+    - `npx jest lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand` -> 2 suites, 6/6 pass
+    - targeted onboarding Playwright gate set -> 5/5 pass
+- Retrospective amendments:
+  - Gherkin extraction now covers Buckets A, B, and H.
+  - Hydration-mismatch warning persists in Next render logs (non-blocking for current assertions).
+
+## Iteration 15
+- Focus: continue Gherkin extraction with Bucket D/E security + reliability.
+- Delivered: `docs/bdd/features/bucket-d-e-reliability.feature` with tagged scenario groups:
+  - `@D1.1..@D1.3` endpoint security compatibility
+  - `@E2.1..@E2.2` operator key reliability + rotation
+  - `@E3.1..@E3.3` RPC config override/fallback consistency
+  - `@E.integration` runtime-lane artifact evidence
+- Verified:
+  - Tag presence check via `rg`
+  - Mapped executable suite green:
+    - `npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts lib/__tests__/program-rpc-config.test.ts --runInBand` -> 4 suites, 11/11 pass
+- Retrospective amendments:
+  - Gherkin extraction now covers Buckets A, B, D/E, and H.
+  - Remaining extraction candidates are Bucket C, F, G.
+
+## Iteration 16
+- Focus: continue Gherkin extraction with Bucket C planner-native consumption.
+- Delivered: `docs/bdd/features/bucket-c-planner-consumption.feature` with tagged scenario groups:
+  - `@C1.1..@C1.3` resolution policy + deterministic candidate behavior
+  - `@C2.1..@C2.3` invoke policy/trace contracts
+  - `@C3.1..@C3.2` quality signal persistence/trigger behavior
+  - `@C4.1..@C4.3` reputation-event pathway coverage linkage
+- Verified:
+  - Tag presence check via `rg`
+  - Mapped executable suite green:
+    - `npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-client.test.ts --runInBand` -> 5 suites, 20/20 pass
+- Retrospective amendments:
+  - Gherkin extraction now covers Buckets A, B, C, D/E, and H.
+  - Remaining extraction candidates are Bucket F and G.
+
+## Iteration 17
+- Focus: continue Gherkin extraction with Bucket F and Bucket G.
+- Delivered:
+  - `docs/bdd/features/bucket-f-jupiter-settlement.feature`
+  - `docs/bdd/features/bucket-g-torque-retention.feature`
+- Verified:
+  - Tag presence checks via `rg` for F/G scenario tags.
+  - Mapped executable suites green:
+    - `npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/torque-client.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-leaderboard-route.test.ts lib/__tests__/torque-onboarding-event.test.ts --runInBand` -> 6 suites, 25/25 pass
+    - `cd packages/x402-solana && npm test -- --runInBand tests/payment.test.ts` -> 1 suite, 19/19 pass
+- Retrospective amendments:
+  - Gherkin extraction now covers Buckets A, B, C, D/E, F, G, and H.
+  - Remaining extraction work is effectively closed for listed buckets.
+
+## Next loop candidates
+1. Add a generated index doc linking all feature files to mapped test commands.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -302,5 +302,16 @@ This log is append-amended each loop: plan review -> implementation -> verificat
   - Comprehensive review plan v2 updated: Bucket A route-contract expansion now slice 1+2+3 complete.
   - Feature index and scenario map refreshed to reference wrapper-route evidence.
 
+## Iteration 29
+- Focus: execute next highest gap, E1 deterministic reliability contracts.
+- Delivered:
+  - `lib/__tests__/endpoint-manager-reliability.test.ts`
+  - Covered behaviors: offline classification + remediation note, heartbeat recovery to online, proxy-offline quick-fix guidance.
+- Verified:
+  - `npx jest lib/__tests__/endpoint-manager-reliability.test.ts lib/__tests__/endpoint-security-compat.test.ts --runInBand` -> 2 suites, 6/6 pass
+- Retrospective amendments:
+  - Scenario map + feature index updated with direct E1 evidence.
+  - Comprehensive plan updated: E1 contracts added; remaining reliability follow-up is remediation-branch semantics review.
+
 ## Next loop candidates
-1. Implement E1 deterministic reliability contracts (offline/online transition + quick-fix guidance behavior).
+1. Review endpoint remediation-branch semantics and decide whether tunnel guidance branch should be made reachable or removed.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -338,5 +338,16 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - CI run pages now show sweep status inline without opening full logs/artifacts.
 
+## Iteration 32
+- Focus: run end-to-end confidence pass and publish final gap-closure snapshot note.
+- Delivered:
+  - Executed `npm run test:bdd:index` (PASS)
+  - Executed `npm run test:bdd:sweep` (PASS)
+  - Added `docs/BDD-GAP-CLOSURE-SNAPSHOT-2026-04-19.md`
+- Verified:
+  - Sweep artifact `artifacts/bdd-sweep/20260419-180815/SUMMARY.md` shows 8/8 step passes.
+- Retrospective amendments:
+  - Comprehensive review cycle now has explicit closure snapshot with residual-risk callouts.
+
 ## Next loop candidates
-1. Run one end-to-end confidence pass (`test:bdd:index` + `test:bdd:sweep`) and publish a final gap-closure snapshot note.
+1. Maintain mode: keep CI/reporting lanes running and only open new iterations when new scope or regressions appear.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -326,5 +326,17 @@ This log is append-amended each loop: plan review -> implementation -> verificat
   - Comprehensive plan updated to mark E1 semantics follow-up closed.
   - Reliability guidance branch no longer theoretical, now test-backed.
 
+## Iteration 31
+- Focus: finish P2 reporting polish by adding GitHub step summary output for sweep workflow.
+- Delivered:
+  - `.github/workflows/bdd-bucket-sweep-confidence.yml` now writes a `$GITHUB_STEP_SUMMARY` section with:
+    - one-line sweep status
+    - latest summary artifact path (when available)
+- Verified:
+  - local dry-run of summary block renders expected markdown using `npm run -s test:bdd:status` output.
+  - quick-status command remains green.
+- Retrospective amendments:
+  - CI run pages now show sweep status inline without opening full logs/artifacts.
+
 ## Next loop candidates
-1. Continue P2 reporting polish: add `$GITHUB_STEP_SUMMARY` output to sweep confidence workflow.
+1. Run one end-to-end confidence pass (`test:bdd:index` + `test:bdd:sweep`) and publish a final gap-closure snapshot note.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -270,5 +270,15 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - CI logs now surface a compact status line without opening artifacts.
 
+## Iteration 26
+- Focus: execute comprehensive-review P0 start by adding direct onboarding route contracts.
+- Delivered:
+  - `lib/__tests__/onboarding-routes-core.test.ts` covering wallet, healthcheck, and attestation routes.
+- Verified:
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts --runInBand` -> 1 suite, 6/6 pass.
+- Retrospective amendments:
+  - Comprehensive plan updated (`BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-19-v2.md`) to mark P0 slice 1 complete.
+  - Scenario map and feature index updated to reference new onboarding route test evidence.
+
 ## Next loop candidates
-1. Add GitHub step summary (`$GITHUB_STEP_SUMMARY`) with latest sweep status and summary artifact path.
+1. Continue comprehensive-review P0 with route tests for onboarding runtime + endpoint + capabilities + audit.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -199,5 +199,16 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - Index maintenance is now enforceable as a command, not just manual convention.
 
+## Iteration 20
+- Focus: enforce BDD index drift guard in CI on relevant PR changes.
+- Delivered:
+  - `.github/workflows/bdd-index-guard.yml`
+  - Triggered on PRs touching `docs/bdd/**`, guard script, or package manifests.
+  - Runs `npm run test:bdd:index` in CI.
+- Verified:
+  - local command remains green: `npm run test:bdd:index` -> OK
+- Retrospective amendments:
+  - Drift guard now has both local and PR-time enforcement.
+
 ## Next loop candidates
-1. Add CI workflow step to run `npm run test:bdd:index` on PRs touching `docs/bdd/**`.
+1. Add a single command/script to run a representative per-bucket verification sweep.

--- a/docs/BDD-ITERATION-LOG-2026-04-19.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-19.md
@@ -210,5 +210,17 @@ This log is append-amended each loop: plan review -> implementation -> verificat
 - Retrospective amendments:
   - Drift guard now has both local and PR-time enforcement.
 
+## Iteration 21
+- Focus: add one-command representative per-bucket verification sweep.
+- Delivered:
+  - `scripts/run-bdd-bucket-sweep.sh`
+  - npm command: `test:bdd:sweep`
+  - FEATURE-INDEX updated with sweep command section
+- Verified:
+  - `npm run test:bdd:sweep` -> all representative bucket suites green
+  - Aggregate observed in run output: 19 suites, 80/80 tests passing
+- Retrospective amendments:
+  - Per-bucket confidence checks are now runnable from a single command.
+
 ## Next loop candidates
-1. Add a single command/script to run a representative per-bucket verification sweep.
+1. Add CI/manual-dispatch workflow for `test:bdd:sweep` (non-blocking confidence lane).

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -29,7 +29,7 @@ Lanes:
 | A2.3 | On-chain `attest_quality` succeeds | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` (+ integration/manual) | route-unit/integration |
 | A2.4 | Audit trail persisted | ✅ | `lib/__tests__/onboarding-routes-support.test.ts` | route-unit |
 | A2.5 | Missing operator signer fails explicitly | ✅ | `lib/__tests__/operator-key-rotation.test.ts` | route-unit |
-| A2.6 | Confirm/dispute flow completes | ✅ | onboarding Step 7 + planner settlement | e2e-ui/route-unit |
+| A2.6 | Confirm/dispute flow completes | ✅ | onboarding Step 7 + planner settlement + `onboarding-routes-wrappers.test.ts` | e2e-ui/route-unit |
 
 ## Bucket B — Discovery + Capability Index
 
@@ -127,3 +127,4 @@ Lanes:
 8. Sweep lane now produces structured artifacts per run (`artifacts/bdd-sweep/<timestamp>/SUMMARY.md`, log, steps table).
 9. Latest sweep quick-status command is available: `npm run test:bdd:status`.
 10. Sweep CI workflow now prints quick status in logs after each run (`bdd-bucket-sweep-confidence.yml`).
+11. Remaining substantive gap emphasis is E1 deterministic reliability contracts (offline/online transition + remediation guidance assertions).

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -123,3 +123,4 @@ Lanes:
 4. Index drift guard command is available: `npm run test:bdd:index`.
 5. PR-time CI enforcement for drift guard is wired: `.github/workflows/bdd-index-guard.yml`.
 6. One-command representative bucket confidence sweep is available: `npm run test:bdd:sweep`.
+7. CI/manual-dispatch confidence lane is wired: `.github/workflows/bdd-bucket-sweep-confidence.yml`.

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -19,14 +19,14 @@ Lanes:
 | A1.1 | Consent denied blocks endpoint exposure + registration | ✅ | `app/onboarding/page.tsx`, `e2e/onboarding.spec.ts` | e2e-ui |
 | A1.2 | Runtime bootstrap succeeds | ✅ | `app/api/onboarding/runtime/route.ts` | route-unit/manual |
 | A1.3 | Token-gated proxy + tunnel setup succeeds | ✅ | `lib/onboarding/endpoint-manager.ts` | route-unit |
-| A1.4 | Wallet existing path completes | ✅ | `app/api/onboarding/wallet/route.ts` | route-unit |
-| A1.5 | Wallet bootstrap path enforces encrypted key + backup | ✅ | `lib/onboarding/wallet-sponsorship.ts` | route-unit |
-| A1.6 | Sponsorship cap enforced | ✅ | `lib/onboarding/wallet-sponsorship.ts` | route-unit |
+| A1.4 | Wallet existing path completes | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
+| A1.5 | Wallet bootstrap path enforces encrypted key + backup | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
+| A1.6 | Sponsorship cap enforced | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
 | A1.7 | Register tx preflight shown before signing | ✅ | `app/onboarding/page.tsx` | e2e-ui/manual |
 | A1.8 | Register tx succeeds on-chain | ✅ | `app/onboarding/page.tsx` | integration/manual |
-| A2.1 | Healthcheck fail blocks attestation | ✅ | `app/api/onboarding/attestation/route.ts` | route-unit |
-| A2.2 | Healthcheck pass includes runtime/public probe | ✅ | `app/api/onboarding/healthcheck/route.ts` | route-unit |
-| A2.3 | On-chain `attest_quality` succeeds | ✅ | `lib/onboarding/onchain-attestation.ts` | integration/manual |
+| A2.1 | Healthcheck fail blocks attestation | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
+| A2.2 | Healthcheck pass includes runtime/public probe | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
+| A2.3 | On-chain `attest_quality` succeeds | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` (+ integration/manual) | route-unit/integration |
 | A2.4 | Audit trail persisted | ✅ | `app/api/onboarding/audit/route.ts` | route-unit |
 | A2.5 | Missing operator signer fails explicitly | ✅ | `lib/__tests__/operator-key-rotation.test.ts` | route-unit |
 | A2.6 | Confirm/dispute flow completes | ✅ | onboarding Step 7 + planner settlement | e2e-ui/route-unit |

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -120,3 +120,4 @@ Lanes:
 1. Integration lane is telemetry-backed (including probe-vs-selected model mismatch), but infra availability remains environment-dependent (expected for runtime-backed lane).
 2. Scenario map promotion to executable Gherkin now spans all active buckets (`docs/bdd/features/bucket-a-onboarding.feature`, `docs/bdd/features/bucket-b-discovery.feature`, `docs/bdd/features/bucket-c-planner-consumption.feature`, `docs/bdd/features/bucket-d-e-reliability.feature`, `docs/bdd/features/bucket-f-jupiter-settlement.feature`, `docs/bdd/features/bucket-g-torque-retention.feature`, `docs/bdd/features/bucket-h-consumer-orchestrator.feature`).
 3. Operational verification index is now available at `docs/bdd/FEATURE-INDEX.md`.
+4. Index drift guard command is available: `npm run test:bdd:index`.

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -17,8 +17,8 @@ Lanes:
 | ID | Scenario | Status | Evidence | Lane |
 |---|---|---|---|---|
 | A1.1 | Consent denied blocks endpoint exposure + registration | ✅ | `app/onboarding/page.tsx`, `e2e/onboarding.spec.ts` | e2e-ui |
-| A1.2 | Runtime bootstrap succeeds | ✅ | `app/api/onboarding/runtime/route.ts` | route-unit/manual |
-| A1.3 | Token-gated proxy + tunnel setup succeeds | ✅ | `lib/onboarding/endpoint-manager.ts` | route-unit |
+| A1.2 | Runtime bootstrap succeeds | ✅ | `lib/__tests__/onboarding-routes-support.test.ts` | route-unit |
+| A1.3 | Token-gated proxy + tunnel setup succeeds | ✅ | `lib/__tests__/onboarding-routes-support.test.ts` | route-unit |
 | A1.4 | Wallet existing path completes | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
 | A1.5 | Wallet bootstrap path enforces encrypted key + backup | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
 | A1.6 | Sponsorship cap enforced | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
@@ -27,7 +27,7 @@ Lanes:
 | A2.1 | Healthcheck fail blocks attestation | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
 | A2.2 | Healthcheck pass includes runtime/public probe | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` | route-unit |
 | A2.3 | On-chain `attest_quality` succeeds | ✅ | `lib/__tests__/onboarding-routes-core.test.ts` (+ integration/manual) | route-unit/integration |
-| A2.4 | Audit trail persisted | ✅ | `app/api/onboarding/audit/route.ts` | route-unit |
+| A2.4 | Audit trail persisted | ✅ | `lib/__tests__/onboarding-routes-support.test.ts` | route-unit |
 | A2.5 | Missing operator signer fails explicitly | ✅ | `lib/__tests__/operator-key-rotation.test.ts` | route-unit |
 | A2.6 | Confirm/dispute flow completes | ✅ | onboarding Step 7 + planner settlement | e2e-ui/route-unit |
 

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -127,4 +127,4 @@ Lanes:
 8. Sweep lane now produces structured artifacts per run (`artifacts/bdd-sweep/<timestamp>/SUMMARY.md`, log, steps table).
 9. Latest sweep quick-status command is available: `npm run test:bdd:status`.
 10. Sweep CI workflow now prints quick status in logs after each run (`bdd-bucket-sweep-confidence.yml`).
-11. Remaining substantive gap emphasis is E1 deterministic reliability contracts (offline/online transition + remediation guidance assertions).
+11. E1 deterministic reliability contracts are now directly covered (`endpoint-manager-reliability.test.ts`); remaining focus has shifted to reporting polish (`$GITHUB_STEP_SUMMARY` for sweep CI).

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -119,3 +119,4 @@ Lanes:
 ## Current Gaps (from map)
 1. Integration lane is telemetry-backed (including probe-vs-selected model mismatch), but infra availability remains environment-dependent (expected for runtime-backed lane).
 2. Scenario map promotion to executable Gherkin now spans all active buckets (`docs/bdd/features/bucket-a-onboarding.feature`, `docs/bdd/features/bucket-b-discovery.feature`, `docs/bdd/features/bucket-c-planner-consumption.feature`, `docs/bdd/features/bucket-d-e-reliability.feature`, `docs/bdd/features/bucket-f-jupiter-settlement.feature`, `docs/bdd/features/bucket-g-torque-retention.feature`, `docs/bdd/features/bucket-h-consumer-orchestrator.feature`).
+3. Operational verification index is now available at `docs/bdd/FEATURE-INDEX.md`.

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -129,3 +129,4 @@ Lanes:
 10. Sweep CI workflow now prints quick status in logs after each run (`bdd-bucket-sweep-confidence.yml`).
 11. E1 deterministic reliability contracts are now directly covered (`endpoint-manager-reliability.test.ts`).
 12. Sweep CI reporting polish is complete: workflow now writes `$GITHUB_STEP_SUMMARY` with quick status + summary artifact path.
+13. Closure snapshot published: `docs/BDD-GAP-CLOSURE-SNAPSHOT-2026-04-19.md` (includes residual-risk register + maintain-mode recommendation).

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -1,0 +1,121 @@
+# BDD Scenario ID Map (A-H)
+
+_Last updated: 2026-04-19 AEST_
+
+Purpose: single source-of-truth mapping from BDD scenario ID -> implementation evidence -> test evidence -> lane.
+
+Lanes:
+- `route-unit` = Jest route/unit contracts (`lib/__tests__/*`)
+- `e2e-ui` = Playwright UI flow (`e2e/*.spec.ts`)
+- `integration` = infra-backed Playwright integration lane (`e2e/integration.spec.ts`)
+- `manual` = currently documented/manual verification only
+
+---
+
+## Bucket A — Specialist Onboarding
+
+| ID | Scenario | Status | Evidence | Lane |
+|---|---|---|---|---|
+| A1.1 | Consent denied blocks endpoint exposure + registration | ✅ | `app/onboarding/page.tsx`, `e2e/onboarding.spec.ts` | e2e-ui |
+| A1.2 | Runtime bootstrap succeeds | ✅ | `app/api/onboarding/runtime/route.ts` | route-unit/manual |
+| A1.3 | Token-gated proxy + tunnel setup succeeds | ✅ | `lib/onboarding/endpoint-manager.ts` | route-unit |
+| A1.4 | Wallet existing path completes | ✅ | `app/api/onboarding/wallet/route.ts` | route-unit |
+| A1.5 | Wallet bootstrap path enforces encrypted key + backup | ✅ | `lib/onboarding/wallet-sponsorship.ts` | route-unit |
+| A1.6 | Sponsorship cap enforced | ✅ | `lib/onboarding/wallet-sponsorship.ts` | route-unit |
+| A1.7 | Register tx preflight shown before signing | ✅ | `app/onboarding/page.tsx` | e2e-ui/manual |
+| A1.8 | Register tx succeeds on-chain | ✅ | `app/onboarding/page.tsx` | integration/manual |
+| A2.1 | Healthcheck fail blocks attestation | ✅ | `app/api/onboarding/attestation/route.ts` | route-unit |
+| A2.2 | Healthcheck pass includes runtime/public probe | ✅ | `app/api/onboarding/healthcheck/route.ts` | route-unit |
+| A2.3 | On-chain `attest_quality` succeeds | ✅ | `lib/onboarding/onchain-attestation.ts` | integration/manual |
+| A2.4 | Audit trail persisted | ✅ | `app/api/onboarding/audit/route.ts` | route-unit |
+| A2.5 | Missing operator signer fails explicitly | ✅ | `lib/__tests__/operator-key-rotation.test.ts` | route-unit |
+| A2.6 | Confirm/dispute flow completes | ✅ | onboarding Step 7 + planner settlement | e2e-ui/route-unit |
+
+## Bucket B — Discovery + Capability Index
+
+| ID | Scenario | Status | Evidence | Lane |
+|---|---|---|---|---|
+| B1.1 | Capability schema validates | ✅ | `app/api/onboarding/capabilities/route.ts` | route-unit |
+| B1.2 | Specialist profile linked to on-chain identity | ✅ | `lib/registry/bridge.ts` | route-unit/manual |
+| B1.3 | Invalid schema rejected with actionable errors | ✅ | capabilities route validation | route-unit |
+| B2.1 | Filter by capability tags | ✅ | `lib/__tests__/registry-route.test.ts` (`tag`, `tags` csv) | route-unit |
+| B2.2 | Filter by attestation + health | ✅ | `lib/__tests__/registry-route.test.ts` | route-unit |
+| B2.3 | Sort by fit/reputation/cost/latency | ✅ | `registry-route.test.ts` + ranking tie-break policy (freshness then cost-latency proxy) | route-unit |
+
+## Bucket C — Planner-Native Specialist Consumption
+
+| ID | Scenario | Status | Evidence | Lane |
+|---|---|---|---|---|
+| C1.1 | Planner policy includes budget/min-rep/privacy | ✅ | planner policy + resolve route | route-unit |
+| C1.2 | Discovery returns candidate set | ✅ | `planner-resolve-route.test.ts` | route-unit |
+| C1.3 | Deterministic candidate selection + reasons | ✅ | `app/api/planner/tools/resolve/route.ts` | route-unit |
+| C2.1 | x402 challenge/retry/payment succeeds | ✅ | x402 settlement + package tests | route-unit/integration |
+| C2.2 | Escrow/payment fallback handles private rail failure | ✅ | x402 settlement fallback logic | route-unit |
+| C2.3 | Receipt + trace captured | ✅ | planner run records | route-unit |
+| C3.1 | Feedback captured and linked to call | ✅ | `planner-signal-route.test.ts` | route-unit |
+| C3.2 | Feedback contributes to routing/reputation | ✅ | planner signal + registry feedback | route-unit |
+| C4.1 | REPUTATION_EVENT mint emitted | ✅ | `reputation-signal.ts` | route-unit |
+| C4.2 | REPUTATION_EVENT reveal emitted | ✅ | reveal route/tests | route-unit |
+| C4.3 | Log includes job_id/wallet/score/tx | ✅ | reputation event payload tests | route-unit |
+
+## Bucket D — x402 + Endpoint Security Compatibility
+
+| ID | Scenario | Status | Evidence | Lane |
+|---|---|---|---|---|
+| D1.1 | `/v1/*`,`/x402/*`,`/healthz` bypass token gate | ✅ | `endpoint-security-compat.test.ts` | route-unit |
+| D1.2 | Non-public/control paths require token | ✅ | `endpoint-security-compat.test.ts` | route-unit |
+| D1.3 | Misconfigured global gate detected by healthcheck | ✅ | healthcheck + compat tests | route-unit |
+
+## Bucket E — Operational Reliability
+
+| ID | Scenario | Status | Evidence | Lane |
+|---|---|---|---|---|
+| E1.1 | Tunnel/proxy failure marks specialist offline | ✅ | endpoint/profile/heartbeat paths | route-unit/manual |
+| E1.2 | Quick-fix commands surfaced in UI | ✅ | onboarding endpoint responses | e2e-ui/manual |
+| E1.3 | Heartbeat restore flips online | ✅ | `/api/heartbeat` | route-unit/manual |
+| E2.1 | Missing operator env gives recovery guidance | ✅ | operator key status checks | route-unit |
+| E2.2 | Operator rotation procedure documented/tested | ✅ | runbook + `operator-key-rotation.test.ts` | route-unit |
+| E3.1 | RPC env override respected | ✅ | `program-rpc-config.test.ts` | route-unit |
+| E3.2 | Devnet fallback when unset | ✅ | `program-rpc-config.test.ts` | route-unit |
+| E3.3 | RPC endpoint usage consistency | ✅ | `program-rpc-config.test.ts` | route-unit |
+
+## Bucket F — Cross-Token Settlement (Jupiter)
+
+| ID | Scenario | Status | Evidence | Lane |
+|---|---|---|---|---|
+| F1.1 | Auto-swap needed on token mismatch | ✅ | payment tests | route-unit |
+| F1.2 | sendPayment executes Jupiter swap | ✅ | payment tests | route-unit |
+| F1.3 | Fails fast without swap client | ✅ | payment tests | route-unit |
+| F1.4 | Swap receipt included in payment receipt | ✅ | payment tests | route-unit |
+| F1.5 | getJupiterClient null without API key | ✅ | jupiter-client tests | route-unit |
+| F1.6 | getJupiterClient singleton with key | ✅ | jupiter-client tests | route-unit |
+| F1.7 | Planner invoke passes swap client | ✅ | planner invoke tests | route-unit |
+
+## Bucket G — Torque Retention
+
+| ID | Scenario | Status | Evidence | Lane |
+|---|---|---|---|---|
+| G1.1-G1.5 | Torque client enablement/no-op/failure behavior | ✅ | `torque-client.test.ts` | route-unit |
+| G1.6 | SPECIALIST_JOB_COMPLETED emitted after release | ✅ | x402 settlement integration | route-unit |
+| G1.7 | CONSUMER_QUERY_RUN emitted after planner invoke | ✅ | onboarding/planner event wiring | route-unit |
+| G1.8 | RATING_SUBMITTED emitted after commit | ✅ | reputation signal path | route-unit |
+| G2.1-G2.2 | leaderboard empty/failure behavior | ✅ | leaderboard route tests | route-unit |
+| G2.3-G2.6 | leaderboard UI + attribution/no token leak | ✅ | `e2e/leaderboard.spec.ts` | e2e-ui |
+
+## Bucket H — Consumer Orchestrator Lifecycle
+
+| ID | Scenario | Status | Evidence | Lane |
+|---|---|---|---|---|
+| H1.1-H1.3 | register_consumer valid/idempotent/invalid | ✅ | `planner-register-consumer-route.test.ts` | route-unit |
+| H1.4 | tools manifest includes consumer tools | ✅ | `planner-tools-manifest-route.test.ts` | route-unit |
+| H2.1 | resolve_specialist deterministic candidate | ✅ | `planner-resolve-route.test.ts` | route-unit |
+| H2.2-H2.3 | resolve_attestor + no-candidate path | ✅ | `planner-resolve-attestor-route.test.ts` | route-unit |
+| H3.1-H3.5 | invoke + settlement lifecycle + guards | ✅ | invoke/release route tests | route-unit |
+| H4.1-H4.2 | quality signal persisted + commit trigger | ✅ | signal route tests | route-unit |
+| H4.3 | settlement + rating independently auditable | ✅ | `planner-auditability.test.ts` | route-unit |
+
+---
+
+## Current Gaps (from map)
+1. Integration lane is telemetry-backed (including probe-vs-selected model mismatch), but infra availability remains environment-dependent (expected for runtime-backed lane).
+2. Scenario map promotion to executable Gherkin now spans all active buckets (`docs/bdd/features/bucket-a-onboarding.feature`, `docs/bdd/features/bucket-b-discovery.feature`, `docs/bdd/features/bucket-c-planner-consumption.feature`, `docs/bdd/features/bucket-d-e-reliability.feature`, `docs/bdd/features/bucket-f-jupiter-settlement.feature`, `docs/bdd/features/bucket-g-torque-retention.feature`, `docs/bdd/features/bucket-h-consumer-orchestrator.feature`).

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -121,3 +121,4 @@ Lanes:
 2. Scenario map promotion to executable Gherkin now spans all active buckets (`docs/bdd/features/bucket-a-onboarding.feature`, `docs/bdd/features/bucket-b-discovery.feature`, `docs/bdd/features/bucket-c-planner-consumption.feature`, `docs/bdd/features/bucket-d-e-reliability.feature`, `docs/bdd/features/bucket-f-jupiter-settlement.feature`, `docs/bdd/features/bucket-g-torque-retention.feature`, `docs/bdd/features/bucket-h-consumer-orchestrator.feature`).
 3. Operational verification index is now available at `docs/bdd/FEATURE-INDEX.md`.
 4. Index drift guard command is available: `npm run test:bdd:index`.
+5. PR-time CI enforcement for drift guard is wired: `.github/workflows/bdd-index-guard.yml`.

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -70,9 +70,9 @@ Lanes:
 
 | ID | Scenario | Status | Evidence | Lane |
 |---|---|---|---|---|
-| E1.1 | Tunnel/proxy failure marks specialist offline | ✅ | endpoint/profile/heartbeat paths | route-unit/manual |
-| E1.2 | Quick-fix commands surfaced in UI | ✅ | onboarding endpoint responses | e2e-ui/manual |
-| E1.3 | Heartbeat restore flips online | ✅ | `/api/heartbeat` | route-unit/manual |
+| E1.1 | Tunnel/proxy failure marks specialist offline | ✅ | `lib/__tests__/endpoint-manager-reliability.test.ts` | route-unit |
+| E1.2 | Quick-fix commands surfaced in UI | ✅ | `lib/__tests__/endpoint-manager-reliability.test.ts` (remediation notes) | route-unit/manual |
+| E1.3 | Heartbeat restore flips online | ✅ | `lib/__tests__/endpoint-manager-reliability.test.ts` | route-unit |
 | E2.1 | Missing operator env gives recovery guidance | ✅ | operator key status checks | route-unit |
 | E2.2 | Operator rotation procedure documented/tested | ✅ | runbook + `operator-key-rotation.test.ts` | route-unit |
 | E3.1 | RPC env override respected | ✅ | `program-rpc-config.test.ts` | route-unit |

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -125,3 +125,4 @@ Lanes:
 6. One-command representative bucket confidence sweep is available: `npm run test:bdd:sweep`.
 7. CI/manual-dispatch confidence lane is wired: `.github/workflows/bdd-bucket-sweep-confidence.yml`.
 8. Sweep lane now produces structured artifacts per run (`artifacts/bdd-sweep/<timestamp>/SUMMARY.md`, log, steps table).
+9. Latest sweep quick-status command is available: `npm run test:bdd:status`.

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -127,4 +127,5 @@ Lanes:
 8. Sweep lane now produces structured artifacts per run (`artifacts/bdd-sweep/<timestamp>/SUMMARY.md`, log, steps table).
 9. Latest sweep quick-status command is available: `npm run test:bdd:status`.
 10. Sweep CI workflow now prints quick status in logs after each run (`bdd-bucket-sweep-confidence.yml`).
-11. E1 deterministic reliability contracts are now directly covered (`endpoint-manager-reliability.test.ts`); remaining focus has shifted to reporting polish (`$GITHUB_STEP_SUMMARY` for sweep CI).
+11. E1 deterministic reliability contracts are now directly covered (`endpoint-manager-reliability.test.ts`).
+12. Sweep CI reporting polish is complete: workflow now writes `$GITHUB_STEP_SUMMARY` with quick status + summary artifact path.

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -130,3 +130,4 @@ Lanes:
 11. E1 deterministic reliability contracts are now directly covered (`endpoint-manager-reliability.test.ts`).
 12. Sweep CI reporting polish is complete: workflow now writes `$GITHUB_STEP_SUMMARY` with quick status + summary artifact path.
 13. Closure snapshot published: `docs/BDD-GAP-CLOSURE-SNAPSHOT-2026-04-19.md` (includes residual-risk register + maintain-mode recommendation).
+14. Post-closure scope delivered (without changing one-agent-per-wallet): authenticated devnet banner + owner dashboards (`/dashboard`, `/specialist`, `/attestation`, `/consumer`) backed by onboarding stats routes.

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -122,3 +122,4 @@ Lanes:
 3. Operational verification index is now available at `docs/bdd/FEATURE-INDEX.md`.
 4. Index drift guard command is available: `npm run test:bdd:index`.
 5. PR-time CI enforcement for drift guard is wired: `.github/workflows/bdd-index-guard.yml`.
+6. One-command representative bucket confidence sweep is available: `npm run test:bdd:sweep`.

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -124,3 +124,4 @@ Lanes:
 5. PR-time CI enforcement for drift guard is wired: `.github/workflows/bdd-index-guard.yml`.
 6. One-command representative bucket confidence sweep is available: `npm run test:bdd:sweep`.
 7. CI/manual-dispatch confidence lane is wired: `.github/workflows/bdd-bucket-sweep-confidence.yml`.
+8. Sweep lane now produces structured artifacts per run (`artifacts/bdd-sweep/<timestamp>/SUMMARY.md`, log, steps table).

--- a/docs/BDD-SCENARIO-ID-MAP.md
+++ b/docs/BDD-SCENARIO-ID-MAP.md
@@ -126,3 +126,4 @@ Lanes:
 7. CI/manual-dispatch confidence lane is wired: `.github/workflows/bdd-bucket-sweep-confidence.yml`.
 8. Sweep lane now produces structured artifacts per run (`artifacts/bdd-sweep/<timestamp>/SUMMARY.md`, log, steps table).
 9. Latest sweep quick-status command is available: `npm run test:bdd:status`.
+10. Sweep CI workflow now prints quick status in logs after each run (`bdd-bucket-sweep-confidence.yml`).

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -45,6 +45,11 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Verify:
   - `npx jest lib/__tests__/planner-register-consumer-route.test.ts lib/__tests__/planner-tools-manifest-route.test.ts lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-resolve-attestor-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-release-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/planner-auditability.test.ts --runInBand`
 
+## Drift guard
+- Validate index coverage against feature files:
+  - `npm run test:bdd:index`
+  - (script: `scripts/check-bdd-feature-index.sh`)
+
 ## Suggested cadence
 - Per iteration: run only affected bucket commands.
 - End-of-day confidence sweep: run representative command per bucket.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -9,7 +9,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket A — Onboarding
 - Feature: `docs/bdd/features/bucket-a-onboarding.feature`
 - Verify:
-  - `npx jest lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand`
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand`
   - `npx playwright test e2e/onboarding.spec.ts --grep "consent gates|next button advances|back button returns|step 2 runtime — next is disabled|run button disabled when prompt is empty"`
 
 ### Bucket B — Discovery + Capability Index

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -9,7 +9,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket A — Onboarding
 - Feature: `docs/bdd/features/bucket-a-onboarding.feature`
 - Verify:
-  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand`
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand`
   - `npx playwright test e2e/onboarding.spec.ts --grep "consent gates|next button advances|back button returns|step 2 runtime — next is disabled|run button disabled when prompt is empty"`
 
 ### Bucket B — Discovery + Capability Index

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -54,6 +54,9 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Run representative verification across all active buckets:
   - `npm run test:bdd:sweep`
   - (script: `scripts/run-bdd-bucket-sweep.sh`)
+- Output artifacts per run:
+  - `artifacts/bdd-sweep/<timestamp>/SUMMARY.md`
+  - `artifacts/bdd-sweep/<timestamp>/bdd-sweep.log`
 
 ## Suggested cadence
 - Per iteration: run only affected bucket commands.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -9,7 +9,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket A — Onboarding
 - Feature: `docs/bdd/features/bucket-a-onboarding.feature`
 - Verify:
-  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand`
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/onboarding-routes-wrappers.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand`
   - `npx playwright test e2e/onboarding.spec.ts --grep "consent gates|next button advances|back button returns|step 2 runtime — next is disabled|run button disabled when prompt is empty"`
 
 ### Bucket B — Discovery + Capability Index

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -1,0 +1,51 @@
+# BDD Feature Index
+
+_Last updated: 2026-04-19 AEST_
+
+Purpose: single lookup from BDD feature file -> bucket -> executable verification command(s).
+
+## Features and mapped verification commands
+
+### Bucket A — Onboarding
+- Feature: `docs/bdd/features/bucket-a-onboarding.feature`
+- Verify:
+  - `npx jest lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand`
+  - `npx playwright test e2e/onboarding.spec.ts --grep "consent gates|next button advances|back button returns|step 2 runtime — next is disabled|run button disabled when prompt is empty"`
+
+### Bucket B — Discovery + Capability Index
+- Feature: `docs/bdd/features/bucket-b-discovery.feature`
+- Verify:
+  - `npx jest lib/__tests__/registry-route.test.ts lib/__tests__/registry-bridge-sort.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
+
+### Bucket C — Planner-Native Consumption
+- Feature: `docs/bdd/features/bucket-c-planner-consumption.feature`
+- Verify:
+  - `npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-client.test.ts --runInBand`
+
+### Bucket D/E — Security + Reliability
+- Feature: `docs/bdd/features/bucket-d-e-reliability.feature`
+- Verify:
+  - `npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts lib/__tests__/program-rpc-config.test.ts --runInBand`
+  - `npm run test:e2e:integration-lane`
+
+### Bucket F — Jupiter Cross-Token Settlement
+- Feature: `docs/bdd/features/bucket-f-jupiter-settlement.feature`
+- Verify:
+  - `npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts --runInBand`
+  - `cd packages/x402-solana && npm test -- --runInBand tests/payment.test.ts`
+
+### Bucket G — Torque Retention
+- Feature: `docs/bdd/features/bucket-g-torque-retention.feature`
+- Verify:
+  - `npx jest lib/__tests__/torque-client.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-leaderboard-route.test.ts lib/__tests__/torque-onboarding-event.test.ts --runInBand`
+  - `npx playwright test e2e/leaderboard.spec.ts`
+
+### Bucket H — Consumer Orchestrator Lifecycle
+- Feature: `docs/bdd/features/bucket-h-consumer-orchestrator.feature`
+- Verify:
+  - `npx jest lib/__tests__/planner-register-consumer-route.test.ts lib/__tests__/planner-tools-manifest-route.test.ts lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-resolve-attestor-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-release-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/planner-auditability.test.ts --runInBand`
+
+## Suggested cadence
+- Per iteration: run only affected bucket commands.
+- End-of-day confidence sweep: run representative command per bucket.
+- Nightly: rely on CI integration-lane workflow artifact uploads.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -57,6 +57,9 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Output artifacts per run:
   - `artifacts/bdd-sweep/<timestamp>/SUMMARY.md`
   - `artifacts/bdd-sweep/<timestamp>/bdd-sweep.log`
+- One-line latest status helper:
+  - `npm run test:bdd:status`
+  - (script: `scripts/bdd-sweep-latest-status.sh`)
 
 ## Suggested cadence
 - Per iteration: run only affected bucket commands.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -50,6 +50,11 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
   - `npm run test:bdd:index`
   - (script: `scripts/check-bdd-feature-index.sh`)
 
+## One-command representative sweep
+- Run representative verification across all active buckets:
+  - `npm run test:bdd:sweep`
+  - (script: `scripts/run-bdd-bucket-sweep.sh`)
+
 ## Suggested cadence
 - Per iteration: run only affected bucket commands.
 - End-of-day confidence sweep: run representative command per bucket.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -25,7 +25,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket D/E — Security + Reliability
 - Feature: `docs/bdd/features/bucket-d-e-reliability.feature`
 - Verify:
-  - `npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts lib/__tests__/program-rpc-config.test.ts --runInBand`
+  - `npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/endpoint-manager-reliability.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts lib/__tests__/program-rpc-config.test.ts --runInBand`
   - `npm run test:e2e:integration-lane`
 
 ### Bucket F — Jupiter Cross-Token Settlement

--- a/docs/bdd/features/bucket-f-jupiter-settlement.feature
+++ b/docs/bdd/features/bucket-f-jupiter-settlement.feature
@@ -1,0 +1,28 @@
+Feature: Bucket F Cross-Token Settlement (Jupiter)
+  As a payer using different tokens
+  I want automatic swap-aware settlement behavior
+  So that specialist payments can still complete safely
+
+  Background:
+    Given Jupiter swap support is available in x402 settlement paths
+
+  @F1.1 @F1.2 @F1.3 @F1.4 @route-unit
+  Scenario: Auto-swap behavior and swap-required guardrails are enforced
+    When payment flow evaluates token mismatch with and without swap client
+    Then mismatch detection triggers swap path when enabled
+    And swap-required without client fails fast explicitly
+    And swap receipt metadata is persisted in payment receipt
+    And the behavior is covered by package payment tests
+
+  @F1.5 @F1.6 @route-unit
+  Scenario: Jupiter client bootstrap respects API key configuration
+    When Jupiter client factory is called with and without API key
+    Then null is returned when key is missing
+    And singleton client is returned when key is present
+    And the behavior is covered by "lib/__tests__/jupiter-client.test.ts"
+
+  @F1.7 @route-unit
+  Scenario: Planner invoke wiring passes swap client to execution path
+    When planner invoke route executes settlement path
+    Then swap client wiring remains connected for cross-token calls
+    And the behavior is covered by "lib/__tests__/planner-invoke-route.test.ts"

--- a/docs/bdd/features/bucket-g-torque-retention.feature
+++ b/docs/bdd/features/bucket-g-torque-retention.feature
@@ -1,0 +1,32 @@
+Feature: Bucket G Torque Retention Layer
+  As a product operator
+  I want retention and leaderboard telemetry to be reliable and non-breaking
+  So that growth loops remain observable without blocking core flows
+
+  Background:
+    Given Torque client and route integrations are configured
+
+  @G1.1 @G1.2 @G1.3 @G1.4 @G1.5 @route-unit
+  Scenario: Torque client handles enabled, disabled, and failure modes safely
+    When Torque client emits events with varied config/network conditions
+    Then enabled paths send expected payload contracts
+    And missing token paths no-op safely
+    And network failures do not break caller flow
+    And the behavior is covered by "lib/__tests__/torque-client.test.ts"
+
+  @G1.6 @G1.7 @G1.8 @route-unit
+  Scenario: Event route accepts and validates onboarding/planner retention events
+    When event payloads are posted to /api/torque/event
+    Then accepted event types and shapes return expected responses
+    And event pipeline contracts remain stable for onboarding/planner/reputation flows
+    And the behavior is covered by "lib/__tests__/torque-event-route.test.ts" and "lib/__tests__/torque-onboarding-event.test.ts"
+
+  @G2.1 @G2.2 @G2.3 @G2.4 @G2.5 @G2.6 @route-unit @e2e-ui
+  Scenario: Leaderboard route and UI remain safe under empty and live states
+    When leaderboard API and page are exercised
+    Then empty/failure states are handled gracefully
+    And UI renders table or empty state with attribution
+    And sensitive token data is not exposed
+    And the behavior is covered by:
+      | lib/__tests__/torque-leaderboard-route.test.ts |
+      | e2e/leaderboard.spec.ts |

--- a/docs/playbooks/BDD-GAP-CLOSURE-LOOP.md
+++ b/docs/playbooks/BDD-GAP-CLOSURE-LOOP.md
@@ -1,0 +1,26 @@
+# Playbook — BDD Gap Closure Loop
+
+## Loop (every iteration)
+1. Review current plan + highest-priority open gap.
+2. Implement one bounded slice.
+3. Verify with explicit test commands.
+4. Retrospective updates:
+   - plan doc
+   - iteration log
+   - scenario map / feature index (if affected)
+   - project status
+   - daily memory
+5. Commit with a scoped intelligent message.
+
+## Commit style
+- `test(bdd): ...`
+- `docs(bdd): ...`
+- `ci(bdd): ...`
+- `feat(bdd): ...`
+
+## Definition of done (per iteration)
+- Slice implemented
+- Tests executed and results captured
+- Retrospective docs updated
+- Memory appended
+- Commit created

--- a/lib/__tests__/endpoint-manager-reliability.test.ts
+++ b/lib/__tests__/endpoint-manager-reliability.test.ts
@@ -49,6 +49,27 @@ describe("endpoint manager reliability contracts (E1)", () => {
     expect(hb.note).toMatch(/reachable through scoped token-gated proxy/i);
   });
 
+  it("heartbeat reports tunnel remediation when runtime/proxy are up but remote is down", async () => {
+    global.fetch = jest.fn(async () => ({ ok: true, status: 200 })) as unknown as typeof fetch;
+    await createOrRotateEndpoint({
+      consentExposeEndpoint: true,
+      port: 11434,
+      endpointUrl: "https://agent.example",
+    });
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 }) // local runtime
+      .mockResolvedValueOnce({ ok: true, status: 200 }) // local proxy
+      .mockRejectedValueOnce(new Error("remote offline")); // remote endpoint
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const hb = await heartbeatEndpoint({});
+    expect(hb.status).toBe("offline");
+    expect(hb.heartbeatOk).toBe(false);
+    expect(hb.note).toMatch(/Re-open tunnel/i);
+  });
+
   it("heartbeat reports proxy remediation when runtime is up but proxy/remote are down", async () => {
     global.fetch = jest.fn(async () => ({ ok: true, status: 200 })) as unknown as typeof fetch;
     await createOrRotateEndpoint({

--- a/lib/__tests__/endpoint-manager-reliability.test.ts
+++ b/lib/__tests__/endpoint-manager-reliability.test.ts
@@ -1,0 +1,72 @@
+import { existsSync, unlinkSync } from "fs";
+import { join } from "path";
+import { createOrRotateEndpoint, heartbeatEndpoint } from "@/lib/onboarding/endpoint-manager";
+
+describe("endpoint manager reliability contracts (E1)", () => {
+  const profilePath = join(process.cwd(), "data", "onboarding", "specialist-profile.json");
+
+  beforeEach(() => {
+    if (existsSync(profilePath)) unlinkSync(profilePath);
+    (global.fetch as jest.Mock | undefined)?.mockReset?.();
+  });
+
+  it("returns offline with runtime remediation note when local runtime is unreachable", async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    const result = await createOrRotateEndpoint({
+      consentExposeEndpoint: true,
+      port: 11434,
+      endpointUrl: "https://agent.example",
+    });
+
+    expect(result.status).toBe("offline");
+    expect(result.heartbeatOk).toBe(false);
+    expect(result.note).toMatch(/Local Ollama runtime is unreachable/i);
+  });
+
+  it("heartbeat can recover to online when remote endpoint responds", async () => {
+    // Seed profile as online first.
+    global.fetch = jest.fn(async () => ({ ok: true, status: 200 })) as unknown as typeof fetch;
+    await createOrRotateEndpoint({
+      consentExposeEndpoint: true,
+      port: 11434,
+      endpointUrl: "https://agent.example",
+    });
+
+    // Transition case: local runtime up, local proxy down, remote endpoint up.
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 }) // local runtime
+      .mockRejectedValueOnce(new Error("proxy offline")) // local proxy
+      .mockResolvedValueOnce({ ok: false, status: 200 }); // remote HEAD success (<500)
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const hb = await heartbeatEndpoint({});
+    expect(hb.status).toBe("online");
+    expect(hb.heartbeatOk).toBe(true);
+    expect(hb.note).toMatch(/reachable through scoped token-gated proxy/i);
+  });
+
+  it("heartbeat reports proxy remediation when runtime is up but proxy/remote are down", async () => {
+    global.fetch = jest.fn(async () => ({ ok: true, status: 200 })) as unknown as typeof fetch;
+    await createOrRotateEndpoint({
+      consentExposeEndpoint: true,
+      port: 11434,
+      endpointUrl: "https://agent.example",
+    });
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 }) // local runtime
+      .mockRejectedValueOnce(new Error("proxy offline")) // local proxy
+      .mockRejectedValueOnce(new Error("remote offline")); // remote endpoint
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const hb = await heartbeatEndpoint({});
+    expect(hb.status).toBe("offline");
+    expect(hb.heartbeatOk).toBe(false);
+    expect(hb.note).toMatch(/Token-gated proxy is offline/i);
+  });
+});

--- a/lib/__tests__/onboarding-consumers-route.test.ts
+++ b/lib/__tests__/onboarding-consumers-route.test.ts
@@ -1,0 +1,38 @@
+jest.mock("@/lib/onboarding/consumer-registry", () => ({
+  listConsumers: jest.fn(),
+}));
+
+describe("GET /api/onboarding/consumers", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("returns consumer list on success", async () => {
+    const { listConsumers } = await import("@/lib/onboarding/consumer-registry");
+    (listConsumers as jest.Mock).mockReturnValue({ ok: true, results: [{ walletAddress: "w1" }] });
+
+    const { GET } = await import("@/app/api/onboarding/consumers/route");
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.result.results[0].walletAddress).toBe("w1");
+  });
+
+  it("returns 400 when consumer list read fails", async () => {
+    const { listConsumers } = await import("@/lib/onboarding/consumer-registry");
+    (listConsumers as jest.Mock).mockImplementation(() => {
+      throw new Error("read failed");
+    });
+
+    const { GET } = await import("@/app/api/onboarding/consumers/route");
+    const res = await GET();
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/read failed/i);
+  });
+});

--- a/lib/__tests__/onboarding-routes-core.test.ts
+++ b/lib/__tests__/onboarding-routes-core.test.ts
@@ -1,0 +1,158 @@
+jest.mock("@/lib/onboarding/wallet-sponsorship", () => ({
+  createLocalWallet: jest.fn(),
+  prepareSponsorship: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/healthcheck", () => ({
+  runSpecialistHealthcheck: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/specialist-index", () => ({
+  updateSpecialistHealthcheck: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/onchain-attestation", () => ({
+  submitOnchainOnboardingAttestation: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/attestation", () => ({
+  recordAttestation: jest.fn(),
+}));
+
+describe("onboarding core routes", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  describe("POST /api/onboarding/wallet", () => {
+    it("creates local wallet on default action", async () => {
+      const { createLocalWallet } = await import("@/lib/onboarding/wallet-sponsorship");
+      (createLocalWallet as jest.Mock).mockReturnValue({ walletAddress: "w1" });
+
+      const { POST } = await import("@/app/api/onboarding/wallet/route");
+      const req = new Request("http://localhost/api/onboarding/wallet", {
+        method: "POST",
+        body: JSON.stringify({ backupConfirmed: true, passphrase: "test-pass" }),
+        headers: { "content-type": "application/json" },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.result.walletAddress).toBe("w1");
+      expect(createLocalWallet).toHaveBeenCalledTimes(1);
+    });
+
+    it("runs sponsorship action when requested", async () => {
+      const { prepareSponsorship } = await import("@/lib/onboarding/wallet-sponsorship");
+      (prepareSponsorship as jest.Mock).mockReturnValue({ maxLamports: 10000 });
+
+      const { POST } = await import("@/app/api/onboarding/wallet/route");
+      const req = new Request("http://localhost/api/onboarding/wallet", {
+        method: "POST",
+        body: JSON.stringify({ action: "sponsorship", walletAddress: "abc" }),
+        headers: { "content-type": "application/json" },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(prepareSponsorship).toHaveBeenCalledWith("abc");
+    });
+  });
+
+  describe("POST /api/onboarding/healthcheck", () => {
+    it("writes PASS health status on successful probe", async () => {
+      const { runSpecialistHealthcheck } = await import("@/lib/onboarding/healthcheck");
+      const { updateSpecialistHealthcheck } = await import("@/lib/onboarding/specialist-index");
+      (runSpecialistHealthcheck as jest.Mock).mockResolvedValue({ status: "pass", checks: [] });
+
+      const { POST } = await import("@/app/api/onboarding/healthcheck/route");
+      const req = new Request("http://localhost/api/onboarding/healthcheck", {
+        method: "POST",
+        body: JSON.stringify({ walletAddress: "w1", endpointUrl: "https://example.com" }),
+        headers: { "content-type": "application/json" },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(updateSpecialistHealthcheck).toHaveBeenCalledWith("w1", {
+        endpointUrl: "https://example.com",
+        healthcheckStatus: "pass",
+      });
+    });
+
+    it("returns 400 when healthcheck throws", async () => {
+      const { runSpecialistHealthcheck } = await import("@/lib/onboarding/healthcheck");
+      (runSpecialistHealthcheck as jest.Mock).mockRejectedValue(new Error("probe failed"));
+
+      const { POST } = await import("@/app/api/onboarding/healthcheck/route");
+      const req = new Request("http://localhost/api/onboarding/healthcheck", {
+        method: "POST",
+        body: JSON.stringify({ walletAddress: "w1", endpointUrl: "bad" }),
+        headers: { "content-type": "application/json" },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error).toMatch(/probe failed/i);
+    });
+  });
+
+  describe("POST /api/onboarding/attestation", () => {
+    it("blocks attestation when healthcheck is not pass", async () => {
+      const { POST } = await import("@/app/api/onboarding/attestation/route");
+      const req = new Request("http://localhost/api/onboarding/attestation", {
+        method: "POST",
+        body: JSON.stringify({ walletAddress: "w1", healthcheckStatus: "fail" }),
+        headers: { "content-type": "application/json" },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error).toMatch(/blocked until healthcheck passes/i);
+    });
+
+    it("submits onchain attestation and records audit on pass", async () => {
+      const { submitOnchainOnboardingAttestation } = await import("@/lib/onboarding/onchain-attestation");
+      const { recordAttestation } = await import("@/lib/onboarding/attestation");
+
+      (submitOnchainOnboardingAttestation as jest.Mock).mockResolvedValue({
+        signature: "sig-123",
+        jobIdHex: "0xabc",
+        operator: "operator-pubkey-xyz",
+      });
+      (recordAttestation as jest.Mock).mockReturnValue({ stored: true });
+
+      const { POST } = await import("@/app/api/onboarding/attestation/route");
+      const req = new Request("http://localhost/api/onboarding/attestation", {
+        method: "POST",
+        body: JSON.stringify({
+          walletAddress: "w1",
+          endpointUrl: "https://example.com",
+          healthcheckStatus: "pass",
+          operator: "wizard-operator",
+          scores: [90, 90, 90, 90, 90],
+        }),
+        headers: { "content-type": "application/json" },
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(submitOnchainOnboardingAttestation).toHaveBeenCalledTimes(1);
+      expect(recordAttestation).toHaveBeenCalledTimes(1);
+      expect(body.result.onchain.signature).toBe("sig-123");
+    });
+  });
+});

--- a/lib/__tests__/onboarding-routes-support.test.ts
+++ b/lib/__tests__/onboarding-routes-support.test.ts
@@ -1,0 +1,211 @@
+jest.mock("@/lib/onboarding/runtime-bootstrap", () => ({
+  runRuntimeBootstrap: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/endpoint-manager", () => ({
+  createOrRotateEndpoint: jest.fn(),
+  heartbeatEndpoint: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/capabilities", () => ({
+  upsertCapabilities: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/specialist-index", () => ({
+  listSpecialistIndex: jest.fn(),
+  upsertSpecialistIndex: jest.fn(),
+}));
+
+jest.mock("fs", () => ({
+  readFileSync: jest.fn(),
+}));
+
+describe("onboarding support routes", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  describe("POST /api/onboarding/runtime", () => {
+    it("returns bootstrap result on success", async () => {
+      const { runRuntimeBootstrap } = await import("@/lib/onboarding/runtime-bootstrap");
+      (runRuntimeBootstrap as jest.Mock).mockResolvedValue({ ready: true });
+
+      const { POST } = await import("@/app/api/onboarding/runtime/route");
+      const req = new Request("http://localhost/api/onboarding/runtime", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          platform: "darwin",
+          port: 11434,
+          consentExposeEndpoint: true,
+          consentProtocolOps: true,
+          protocolDomain: "example.com",
+        }),
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(runRuntimeBootstrap).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns 400 on bootstrap failure", async () => {
+      const { runRuntimeBootstrap } = await import("@/lib/onboarding/runtime-bootstrap");
+      (runRuntimeBootstrap as jest.Mock).mockRejectedValue(new Error("bootstrap failed"));
+
+      const { POST } = await import("@/app/api/onboarding/runtime/route");
+      const req = new Request("http://localhost/api/onboarding/runtime", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ platform: "darwin", port: 11434 }),
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error).toMatch(/bootstrap failed/i);
+    });
+  });
+
+  describe("POST /api/onboarding/endpoint", () => {
+    it("runs create action by default", async () => {
+      const { createOrRotateEndpoint } = await import("@/lib/onboarding/endpoint-manager");
+      (createOrRotateEndpoint as jest.Mock).mockResolvedValue({ endpointUrl: "https://a.example" });
+
+      const { POST } = await import("@/app/api/onboarding/endpoint/route");
+      const req = new Request("http://localhost/api/onboarding/endpoint", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ consentExposeEndpoint: true, port: 3334 }),
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(createOrRotateEndpoint).toHaveBeenCalledTimes(1);
+    });
+
+    it("runs heartbeat action when requested", async () => {
+      const { heartbeatEndpoint } = await import("@/lib/onboarding/endpoint-manager");
+      (heartbeatEndpoint as jest.Mock).mockResolvedValue({ status: "online" });
+
+      const { POST } = await import("@/app/api/onboarding/endpoint/route");
+      const req = new Request("http://localhost/api/onboarding/endpoint", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action: "heartbeat", endpointUrl: "https://a.example" }),
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(heartbeatEndpoint).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("/api/onboarding/capabilities", () => {
+    it("GET returns specialist index list", async () => {
+      const { listSpecialistIndex } = await import("@/lib/onboarding/specialist-index");
+      (listSpecialistIndex as jest.Mock).mockReturnValue({ ok: true, results: [{ walletAddress: "w1" }] });
+
+      const { GET } = await import("@/app/api/onboarding/capabilities/route");
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.result.results[0].walletAddress).toBe("w1");
+    });
+
+    it("POST validates capabilities and upserts specialist index", async () => {
+      const { upsertCapabilities } = await import("@/lib/onboarding/capabilities");
+      const { upsertSpecialistIndex } = await import("@/lib/onboarding/specialist-index");
+
+      (upsertCapabilities as jest.Mock).mockReturnValue({
+        ok: true,
+        record: {
+          capabilities: {
+            taskTypes: ["summarize"],
+            inputModes: ["text"],
+            outputModes: ["text"],
+            pricing: { baseUsd: 1, perCallUsd: 2 },
+            privacyModes: ["public"],
+            tags: ["onboarding"],
+            context_requirements: [],
+            runtime_capabilities: ["web_search"],
+          },
+        },
+      });
+
+      const { POST } = await import("@/app/api/onboarding/capabilities/route");
+      const req = new Request("http://localhost/api/onboarding/capabilities", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          walletAddress: "w1",
+          taskTypes: ["summarize"],
+          inputModes: ["text"],
+          outputModes: ["text"],
+          pricing: { baseUsd: 1, perCallUsd: 2 },
+          privacyModes: ["public"],
+          tags: ["onboarding"],
+          context_requirements: [],
+          runtime_capabilities: ["web_search"],
+          endpointUrl: "https://a.example",
+          healthcheckStatus: "pass",
+          attested: true,
+        }),
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(upsertCapabilities).toHaveBeenCalledTimes(1);
+      expect(upsertSpecialistIndex).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("GET /api/onboarding/audit", () => {
+    it("returns attestations and heartbeat summaries", async () => {
+      const { readFileSync } = await import("fs");
+      (readFileSync as unknown as jest.Mock).mockImplementation((path: string) => {
+        if (path.includes("attestations.json")) {
+          return JSON.stringify([
+            {
+              recordedAt: "2026-04-19T00:00:00.000Z",
+              jobIdHex: "0xabc",
+              operatorPubkeySuffix: "1234abcd",
+              txSignature: "sig-1",
+              walletAddress: "w1",
+              endpointUrl: "https://a.example",
+            },
+          ]);
+        }
+        if (path.includes("heartbeat-poll.json")) {
+          return JSON.stringify([
+            {
+              polled_at: "2026-04-19T00:01:00.000Z",
+              specialists_checked: 1,
+              results: [{ wallet: "w1", status: "pass" }],
+            },
+          ]);
+        }
+        return JSON.stringify([]);
+      });
+
+      const { GET } = await import("@/app/api/onboarding/audit/route");
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.attestations.length).toBe(1);
+      expect(body.heartbeat_polls.length).toBe(1);
+      expect(body.heartbeat_polls[0].results_summary).toMatch(/w1: pass/i);
+    });
+  });
+});

--- a/lib/__tests__/onboarding-routes-wrappers.test.ts
+++ b/lib/__tests__/onboarding-routes-wrappers.test.ts
@@ -1,0 +1,138 @@
+jest.mock("@/lib/onboarding/wallet-recovery", () => ({
+  checkWalletBackupExists: jest.fn(),
+  getWalletRecoveryOptions: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/planner-execution", () => ({
+  executePlannerSpecialistCall: jest.fn(),
+  listPlannerRuns: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/planner-feedback", () => ({
+  listPlannerFeedback: jest.fn(),
+  recordPlannerFeedback: jest.fn(),
+}));
+
+jest.mock("@/lib/onboarding/reputation-signal", () => ({
+  listReputationCommits: jest.fn(),
+  revealReputationRating: jest.fn(),
+}));
+
+describe("onboarding wrapper routes", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.JUPITER_API_BASE;
+    delete process.env.JUPITER_SLIPPAGE_BPS;
+  });
+
+  it("GET /api/onboarding/wallet/recovery returns backup + options", async () => {
+    const { checkWalletBackupExists, getWalletRecoveryOptions } = await import("@/lib/onboarding/wallet-recovery");
+    (checkWalletBackupExists as jest.Mock).mockReturnValue(true);
+    (getWalletRecoveryOptions as jest.Mock).mockReturnValue([{ id: "seed" }]);
+
+    const { GET } = await import("@/app/api/onboarding/wallet/recovery/route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.backup_exists).toBe(true);
+    expect(body.recovery_options[0].id).toBe("seed");
+  });
+
+  it("GET /api/onboarding/settlement-config uses defaults and env overrides", async () => {
+    const { GET } = await import("@/app/api/onboarding/settlement-config/route");
+
+    const defRes = await GET();
+    const defBody = await defRes.json();
+    expect(defBody.api_base).toBe("https://api.jup.ag");
+    expect(defBody.slippage_bps).toBe(50);
+
+    process.env.JUPITER_API_BASE = "https://custom.jup";
+    process.env.JUPITER_SLIPPAGE_BPS = "80";
+    const overrideRes = await GET();
+    const overrideBody = await overrideRes.json();
+    expect(overrideBody.api_base).toBe("https://custom.jup");
+    expect(overrideBody.slippage_bps).toBe(80);
+  });
+
+  it("/api/onboarding/planner/execute GET lists runs and POST executes", async () => {
+    const { listPlannerRuns, executePlannerSpecialistCall } = await import("@/lib/onboarding/planner-execution");
+    (listPlannerRuns as jest.Mock).mockReturnValue({ ok: true, runs: [{ runId: "r1" }] });
+    (executePlannerSpecialistCall as jest.Mock).mockResolvedValue({ ok: true, runId: "r1" });
+
+    const route = await import("@/app/api/onboarding/planner/execute/route");
+
+    const getRes = await route.GET();
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json();
+    expect(getBody.ok).toBe(true);
+    expect(getBody.result.runs[0].runId).toBe("r1");
+
+    const postReq = new Request("http://localhost/api/onboarding/planner/execute", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt: "Hello", policy: { requiresAttested: true } }),
+    });
+    const postRes = await route.POST(postReq);
+    expect(postRes.status).toBe(200);
+    const postBody = await postRes.json();
+    expect(postBody.ok).toBe(true);
+    expect(executePlannerSpecialistCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("/api/onboarding/planner/feedback GET lists and POST records", async () => {
+    const { listPlannerFeedback, recordPlannerFeedback } = await import("@/lib/onboarding/planner-feedback");
+    (listPlannerFeedback as jest.Mock).mockReturnValue({ ok: true, entries: [{ runId: "r1" }] });
+    (recordPlannerFeedback as jest.Mock).mockResolvedValue({ ok: true, runId: "r1" });
+
+    const route = await import("@/app/api/onboarding/planner/feedback/route");
+
+    const getRes = await route.GET();
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json();
+    expect(getBody.ok).toBe(true);
+    expect(getBody.result.entries[0].runId).toBe("r1");
+
+    const postReq = new Request("http://localhost/api/onboarding/planner/feedback", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "r1", score: 95, agreesWithAttestation: true }),
+    });
+    const postRes = await route.POST(postReq);
+    expect(postRes.status).toBe(200);
+    const postBody = await postRes.json();
+    expect(postBody.ok).toBe(true);
+    expect(recordPlannerFeedback).toHaveBeenCalledTimes(1);
+  });
+
+  it("/api/onboarding/planner/reveal GET lists commits and POST validates runId", async () => {
+    const { listReputationCommits, revealReputationRating } = await import("@/lib/onboarding/reputation-signal");
+    (listReputationCommits as jest.Mock).mockReturnValue({ ok: true, commits: [{ runId: "r1" }] });
+    (revealReputationRating as jest.Mock).mockResolvedValue({ ok: true });
+
+    const route = await import("@/app/api/onboarding/planner/reveal/route");
+
+    const getRes = await route.GET();
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json();
+    expect(getBody.ok).toBe(true);
+
+    const badReq = new Request("http://localhost/api/onboarding/planner/reveal", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "" }),
+    });
+    const badRes = await route.POST(badReq);
+    expect(badRes.status).toBe(400);
+
+    const goodReq = new Request("http://localhost/api/onboarding/planner/reveal", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ runId: "r1" }),
+    });
+    const goodRes = await route.POST(goodReq);
+    expect(goodRes.status).toBe(200);
+    expect(revealReputationRating).toHaveBeenCalledWith("r1");
+  });
+});

--- a/lib/onboarding/endpoint-manager.ts
+++ b/lib/onboarding/endpoint-manager.ts
@@ -250,16 +250,18 @@ export async function createOrRotateEndpoint(input: EndpointActionInput): Promis
   const localOk = await checkLocalRuntime(input.port);
   const localProxyOk = await checkLocalTokenProxy(proxyPort, token);
   const remoteOk = await checkRemoteEndpoint(endpointUrl, token);
-  const heartbeatOk = localOk && (localProxyOk || remoteOk);
+  const heartbeatOk = localOk && remoteOk;
   const heartbeatCheckedAt = new Date().toISOString();
 
   const note = heartbeatOk
     ? "Endpoint reachable through scoped token-gated proxy (x402 public paths bypass token)."
     : !localOk
     ? "Local Ollama runtime is unreachable on the selected port. Restart runtime and retry."
-    : !localProxyOk
+    : !localProxyOk && !remoteOk
     ? `Token-gated proxy is not running. Start it first: ${proxyCommand}`
-    : `Tunnel appears down. Re-open tunnel: ${tunnelCommand}`;
+    : !remoteOk
+    ? `Tunnel appears down. Re-open tunnel: ${tunnelCommand}`
+    : `Endpoint check failed. Re-run endpoint onboarding.`;
 
   const profile: SpecialistProfile = {
     updatedAt: heartbeatCheckedAt,
@@ -328,15 +330,17 @@ export async function heartbeatEndpoint(input: {
   const localProxyOk = await checkLocalTokenProxy(proxyPort, token);
   const remoteOk = await checkRemoteEndpoint(endpointUrl, token);
 
-  const heartbeatOk = localOk && (localProxyOk || remoteOk);
+  const heartbeatOk = localOk && remoteOk;
   const heartbeatCheckedAt = new Date().toISOString();
   const note = heartbeatOk
     ? "Endpoint reachable through scoped token-gated proxy (x402 public paths bypass token)."
     : !localOk
     ? "Local runtime is offline. Re-run runtime bootstrap."
-    : !localProxyOk
+    : !localProxyOk && !remoteOk
     ? `Token-gated proxy is offline. Start it with: ${proxyCommand}`
-    : `Endpoint heartbeat failed. Re-open tunnel with: ${tunnelCommand}`;
+    : !remoteOk
+    ? `Endpoint heartbeat failed. Re-open tunnel with: ${tunnelCommand}`
+    : "Endpoint heartbeat failed. Re-run endpoint onboarding.";
 
   const profile: SpecialistProfile = {
     updatedAt: heartbeatCheckedAt,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:integration-lane": "./scripts/run-integration-lane.sh",
     "test:bdd:index": "./scripts/check-bdd-feature-index.sh",
-    "test:bdd:sweep": "./scripts/run-bdd-bucket-sweep.sh"
+    "test:bdd:sweep": "./scripts/run-bdd-bucket-sweep.sh",
+    "test:bdd:status": "./scripts/bdd-sweep-latest-status.sh"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:integration-lane": "./scripts/run-integration-lane.sh",
-    "test:bdd:index": "./scripts/check-bdd-feature-index.sh"
+    "test:bdd:index": "./scripts/check-bdd-feature-index.sh",
+    "test:bdd:sweep": "./scripts/run-bdd-bucket-sweep.sh"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:integration-lane": "./scripts/run-integration-lane.sh",
+    "test:bdd:index": "./scripts/check-bdd-feature-index.sh"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/bdd-sweep-latest-status.sh
+++ b/scripts/bdd-sweep-latest-status.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SWEEP_DIR="$ROOT_DIR/artifacts/bdd-sweep"
+
+if [ ! -d "$SWEEP_DIR" ]; then
+  echo "BDD_SWEEP_STATUS no_artifacts"
+  exit 0
+fi
+
+LATEST_DIR="$(find "$SWEEP_DIR" -mindepth 1 -maxdepth 1 -type d | sort | tail -1)"
+if [ -z "$LATEST_DIR" ]; then
+  echo "BDD_SWEEP_STATUS no_artifacts"
+  exit 0
+fi
+
+SUMMARY="$LATEST_DIR/SUMMARY.md"
+if [ ! -f "$SUMMARY" ]; then
+  echo "BDD_SWEEP_STATUS missing_summary dir=$(basename "$LATEST_DIR")"
+  exit 0
+fi
+
+TS="$(grep -E '^- Timestamp:' "$SUMMARY" | head -1 | sed -E 's/^- Timestamp:[[:space:]]*//')"
+PASS="$(grep -E '^- Steps passed:' "$SUMMARY" | head -1 | sed -E 's/^- Steps passed:[[:space:]]*//')"
+FAIL="$(grep -E '^- Steps failed:' "$SUMMARY" | head -1 | sed -E 's/^- Steps failed:[[:space:]]*//')"
+TOTAL="$(grep -E '^- Steps total:' "$SUMMARY" | head -1 | sed -E 's/^- Steps total:[[:space:]]*//')"
+
+TS="${TS:-unknown}"
+PASS="${PASS:-0}"
+FAIL="${FAIL:-0}"
+TOTAL="${TOTAL:-0}"
+
+if [ "$FAIL" = "0" ]; then
+  echo "BDD_SWEEP_STATUS ok ts=$TS passed=$PASS/$TOTAL failed=$FAIL summary=$SUMMARY"
+else
+  echo "BDD_SWEEP_STATUS fail ts=$TS passed=$PASS/$TOTAL failed=$FAIL summary=$SUMMARY"
+fi

--- a/scripts/check-bdd-feature-index.sh
+++ b/scripts/check-bdd-feature-index.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FEATURE_DIR="$ROOT_DIR/docs/bdd/features"
+INDEX_FILE="$ROOT_DIR/docs/bdd/FEATURE-INDEX.md"
+
+if [ ! -d "$FEATURE_DIR" ]; then
+  echo "[bdd-index-check] missing feature directory: $FEATURE_DIR"
+  exit 1
+fi
+
+if [ ! -f "$INDEX_FILE" ]; then
+  echo "[bdd-index-check] missing index file: $INDEX_FILE"
+  exit 1
+fi
+
+missing=0
+while IFS= read -r feature; do
+  rel="docs/bdd/features/$feature"
+  if ! grep -Fq "$rel" "$INDEX_FILE"; then
+    echo "[bdd-index-check] missing from index: $rel"
+    missing=1
+  fi
+done < <(find "$FEATURE_DIR" -maxdepth 1 -type f -name '*.feature' -print | xargs -n1 basename | sort)
+
+if [ "$missing" -ne 0 ]; then
+  echo "[bdd-index-check] FAILED"
+  exit 1
+fi
+
+echo "[bdd-index-check] OK: all feature files are indexed"

--- a/scripts/run-bdd-bucket-sweep.sh
+++ b/scripts/run-bdd-bucket-sweep.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[bdd-sweep] starting representative per-bucket verification"
+
+run_step() {
+  local label="$1"
+  shift
+  echo ""
+  echo "[bdd-sweep] >>> $label"
+  "$@"
+}
+
+run_step "Bucket A (onboarding/operator gates)" \
+  npx jest lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand
+
+run_step "Bucket B (discovery + ranking contracts)" \
+  npx jest lib/__tests__/registry-route.test.ts lib/__tests__/registry-bridge-sort.test.ts --runInBand
+
+run_step "Bucket C (planner consumption contracts)" \
+  npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-signal-route.test.ts --runInBand
+
+run_step "Bucket D/E (security + reliability contracts)" \
+  npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/program-rpc-config.test.ts --runInBand
+
+run_step "Bucket F (jupiter + payment contracts)" \
+  npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts --runInBand
+run_step "Bucket F package payment contracts" \
+  bash -lc 'cd packages/x402-solana && npm test -- --runInBand tests/payment.test.ts'
+
+run_step "Bucket G (torque retention contracts)" \
+  npx jest lib/__tests__/torque-client.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-leaderboard-route.test.ts lib/__tests__/torque-onboarding-event.test.ts --runInBand
+
+run_step "Bucket H (consumer orchestrator lifecycle contracts)" \
+  npx jest lib/__tests__/planner-register-consumer-route.test.ts lib/__tests__/planner-tools-manifest-route.test.ts lib/__tests__/planner-resolve-attestor-route.test.ts lib/__tests__/planner-release-route.test.ts lib/__tests__/planner-auditability.test.ts --runInBand
+
+echo ""
+echo "[bdd-sweep] complete: representative per-bucket suite is green"

--- a/scripts/run-bdd-bucket-sweep.sh
+++ b/scripts/run-bdd-bucket-sweep.sh
@@ -4,14 +4,36 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
+TS="$(date +%Y%m%d-%H%M%S)"
+OUT_DIR="$ROOT_DIR/artifacts/bdd-sweep/$TS"
+LOG_FILE="$OUT_DIR/bdd-sweep.log"
+STEPS_FILE="$OUT_DIR/steps.tsv"
+mkdir -p "$OUT_DIR"
+
 echo "[bdd-sweep] starting representative per-bucket verification"
+echo "[bdd-sweep] artifacts: $OUT_DIR"
+
+FAILED_STEPS=0
 
 run_step() {
   local label="$1"
   shift
-  echo ""
-  echo "[bdd-sweep] >>> $label"
-  "$@"
+
+  {
+    echo ""
+    echo "[bdd-sweep] >>> $label"
+    "$@"
+  } 2>&1 | tee -a "$LOG_FILE"
+
+  local code=${PIPESTATUS[0]}
+  if [ "$code" -eq 0 ]; then
+    printf "PASS\t%s\n" "$label" >> "$STEPS_FILE"
+  else
+    printf "FAIL\t%s\n" "$label" >> "$STEPS_FILE"
+    FAILED_STEPS=$((FAILED_STEPS + 1))
+  fi
+
+  return 0
 }
 
 run_step "Bucket A (onboarding/operator gates)" \
@@ -28,6 +50,7 @@ run_step "Bucket D/E (security + reliability contracts)" \
 
 run_step "Bucket F (jupiter + payment contracts)" \
   npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts --runInBand
+
 run_step "Bucket F package payment contracts" \
   bash -lc 'cd packages/x402-solana && npm test -- --runInBand tests/payment.test.ts'
 
@@ -37,5 +60,42 @@ run_step "Bucket G (torque retention contracts)" \
 run_step "Bucket H (consumer orchestrator lifecycle contracts)" \
   npx jest lib/__tests__/planner-register-consumer-route.test.ts lib/__tests__/planner-tools-manifest-route.test.ts lib/__tests__/planner-resolve-attestor-route.test.ts lib/__tests__/planner-release-route.test.ts lib/__tests__/planner-auditability.test.ts --runInBand
 
+PASS_COUNT=$(awk -F'\t' 'BEGIN{c=0} $1=="PASS"{c++} END{print c}' "$STEPS_FILE" 2>/dev/null || printf '0')
+FAIL_COUNT=$(awk -F'\t' 'BEGIN{c=0} $1=="FAIL"{c++} END{print c}' "$STEPS_FILE" 2>/dev/null || printf '0')
+TOTAL_COUNT=$((PASS_COUNT + FAIL_COUNT))
+
+{
+  echo "# BDD Bucket Sweep Summary"
+  echo ""
+  echo "- Timestamp: $TS"
+  echo "- Output dir: $OUT_DIR"
+  echo "- Steps passed: $PASS_COUNT"
+  echo "- Steps failed: $FAIL_COUNT"
+  echo "- Steps total: $TOTAL_COUNT"
+  echo ""
+  echo "## Step Results"
+  echo ""
+  echo "| Status | Step |"
+  echo "|---|---|"
+  if [ -f "$STEPS_FILE" ]; then
+    while IFS=$'\t' read -r status label; do
+      [ -n "$status" ] || continue
+      echo "| $status | $label |"
+    done < "$STEPS_FILE"
+  fi
+  echo ""
+  echo "## Artifacts"
+  echo "- Log: $LOG_FILE"
+  echo "- Step status table source: $STEPS_FILE"
+} > "$OUT_DIR/SUMMARY.md"
+
+if [ "$FAILED_STEPS" -gt 0 ]; then
+  echo ""
+  echo "[bdd-sweep] complete with failures ($FAILED_STEPS)"
+  echo "[bdd-sweep] summary: $OUT_DIR/SUMMARY.md"
+  exit 1
+fi
+
 echo ""
 echo "[bdd-sweep] complete: representative per-bucket suite is green"
+echo "[bdd-sweep] summary: $OUT_DIR/SUMMARY.md"


### PR DESCRIPTION
## Summary
This PR packages the recent BDD hardening and post-closure product updates:

- adds a global authenticated Devnet mode banner (`components/DevnetModeBanner.tsx`, wired in `app/layout.tsx`)
- adds/refreshes owner dashboard surfaces:
  - dashboard hub: `/dashboard`
  - specialist dashboard: `/specialist` (existing)
  - new attestation dashboard: `/attestation`
  - new consumer dashboard: `/consumer`
- adds consumer stats API route: `/api/onboarding/consumers`
- updates nav links to expose dashboard surfaces
- adds route-unit test coverage for consumer onboarding stats route

## BDD + reliability work included
- comprehensive BDD gap-closure docs and playbook
- onboarding route contract expansion (core/support/wrappers)
- endpoint reliability contracts (offline/online remediation)
- sweep/index guards + CI confidence/reporting polish
- closure snapshot documentation

## Explicit constraint
- One agent per wallet remains unchanged in this PR (as requested).

## Verification
- `npm run test:bdd:index` ✅
- `npm run test:bdd:sweep` ✅
  - latest artifact: `artifacts/bdd-sweep/20260419-223049/SUMMARY.md` (8/8 step passes)
- targeted onboarding/consumer route suites passing in prior iterations

## Notes
There are existing unrelated workspace changes tracked in this branch history from prior iteration workstreams; this PR is intended to merge the complete stabilized set.
