### PR TITLE
feat(landing): clarify how existing LLM users consume listed agents

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -161,7 +161,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="mx-auto max-w-6xl px-4 pb-12 sm:px-6 lg:px-8">
+      <section className="mx-auto max-w-6xl px-4 pb-8 sm:px-6 lg:px-8">
         <div className="rounded-xl bg-surface p-6 glow-border">
           <p className="section-label mb-3">How it works</p>
           <div className="grid gap-5 md:grid-cols-3">
@@ -175,6 +175,34 @@ export default function Home() {
                 <p className="text-sm leading-6 text-gray-400">{step.desc}</p>
               </div>
             ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 pb-12 sm:px-6 lg:px-8">
+        <div className="rounded-xl border border-white/10 bg-card/20 p-6 space-y-4">
+          <p className="section-label">Already running your own LLM stack?</p>
+          <h2 className="font-display text-2xl font-bold text-white">Consume listed agents without re-onboarding</h2>
+          <p className="text-sm text-gray-400 max-w-3xl">
+            If you already have an orchestrator or app, you can hire listed specialists directly through planner routes. Use marketplace discovery, resolve policy-filtered candidates, invoke with settlement, then track runs and feedback.
+          </p>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="rounded-lg border border-white/10 bg-white/5 p-4 space-y-2">
+              <p className="text-sm font-semibold text-white">1) Discover and resolve</p>
+              <p className="text-xs text-gray-400">Browse `/agents` or resolve policy-matched candidates via planner tool routes.</p>
+              <Link href="/agents" className="text-xs text-indigo-300 hover:text-indigo-200">Open marketplace →</Link>
+            </div>
+            <div className="rounded-lg border border-white/10 bg-white/5 p-4 space-y-2">
+              <p className="text-sm font-semibold text-white">2) Invoke with settlement</p>
+              <p className="text-xs text-gray-400">Use planner invoke flow to execute specialist calls with protocol settlement traces.</p>
+              <Link href="/planner" className="text-xs text-indigo-300 hover:text-indigo-200">Open planner UI →</Link>
+            </div>
+            <div className="rounded-lg border border-white/10 bg-white/5 p-4 space-y-2">
+              <p className="text-sm font-semibold text-white">3) Monitor outcomes</p>
+              <p className="text-xs text-gray-400">Track completion, payment state, and run history from protocol dashboards.</p>
+              <Link href="/runs" className="text-xs text-indigo-300 hover:text-indigo-200">View run history →</Link>
+            </div>
           </div>
         </div>
       </section>

--- a/lib/onboarding/consumer-registry.ts
+++ b/lib/onboarding/consumer-registry.ts
@@ -1,0 +1,171 @@
+import "server-only";
+
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+export type ConsumerProfile = {
+  walletAddress: string;
+  createdAt: string;
+  updatedAt: string;
+  preferredIntegration?: "mcp" | "tools" | "skills";
+  metadata?: {
+    agentName?: string;
+    framework?: string;
+  };
+  reputation: {
+    score5: number;
+    baseline5: number;
+    totalRatings: number;
+    lastRatingAt?: string;
+  };
+};
+
+const CONSUMER_REGISTRY_PATH = join(process.cwd(), "data", "onboarding", "consumer-index.json");
+
+function readAll(): ConsumerProfile[] {
+  try {
+    return JSON.parse(readFileSync(CONSUMER_REGISTRY_PATH, "utf8")) as ConsumerProfile[];
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(records: ConsumerProfile[]) {
+  mkdirSync(join(process.cwd(), "data", "onboarding"), { recursive: true });
+  writeFileSync(CONSUMER_REGISTRY_PATH, JSON.stringify(records, null, 2));
+}
+
+export function registerConsumer(input: {
+  walletAddress: string;
+  preferredIntegration?: "mcp" | "tools" | "skills";
+  metadata?: { agentName?: string; framework?: string };
+}) {
+  const wallet = input.walletAddress?.trim();
+  if (!wallet || wallet.length < 32) {
+    throw new Error("Valid consumer wallet address is required.");
+  }
+
+  const now = new Date().toISOString();
+  const records = readAll();
+  const existingIdx = records.findIndex((r) => r.walletAddress === wallet);
+
+  if (existingIdx >= 0) {
+    const updated: ConsumerProfile = {
+      ...records[existingIdx],
+      preferredIntegration: input.preferredIntegration ?? records[existingIdx].preferredIntegration,
+      metadata: {
+        ...records[existingIdx].metadata,
+        ...input.metadata,
+      },
+      updatedAt: now,
+      reputation: records[existingIdx].reputation ?? {
+        score5: 3,
+        baseline5: 3,
+        totalRatings: 0,
+      },
+    };
+    records[existingIdx] = updated;
+    writeAll(records);
+    return {
+      ok: true,
+      alreadyRegistered: true,
+      profile: updated,
+      storagePath: CONSUMER_REGISTRY_PATH,
+    };
+  }
+
+  const profile: ConsumerProfile = {
+    walletAddress: wallet,
+    createdAt: now,
+    updatedAt: now,
+    preferredIntegration: input.preferredIntegration,
+    metadata: input.metadata,
+    reputation: {
+      score5: 3,
+      baseline5: 3,
+      totalRatings: 0,
+    },
+  };
+
+  records.push(profile);
+  writeAll(records);
+
+  return {
+    ok: true,
+    alreadyRegistered: false,
+    profile,
+    storagePath: CONSUMER_REGISTRY_PATH,
+  };
+}
+
+export function applyConsumerRating(input: {
+  walletAddress: string;
+  score10: number;
+  ratedAt?: string;
+}) {
+  const wallet = input.walletAddress?.trim();
+  if (!wallet || wallet.length < 32) {
+    throw new Error("Valid consumer wallet address is required for rating update.");
+  }
+  if (!Number.isFinite(input.score10) || input.score10 < 1 || input.score10 > 10) {
+    throw new Error("score10 must be between 1 and 10.");
+  }
+
+  const now = input.ratedAt ?? new Date().toISOString();
+  const score5 = input.score10 / 2;
+  const records = readAll();
+  const idx = records.findIndex((r) => r.walletAddress === wallet);
+
+  if (idx < 0) {
+    const created: ConsumerProfile = {
+      walletAddress: wallet,
+      createdAt: now,
+      updatedAt: now,
+      reputation: {
+        score5: 3,
+        baseline5: 3,
+        totalRatings: 0,
+      },
+    };
+    records.push(created);
+  }
+
+  const current = records.find((r) => r.walletAddress === wallet)!;
+  const currentReputation = current.reputation ?? {
+    score5: 3,
+    baseline5: 3,
+    totalRatings: 0,
+  };
+
+  const nextTotal = currentReputation.totalRatings + 1;
+  const nextScore = ((currentReputation.score5 * currentReputation.totalRatings) + score5) / nextTotal;
+
+  const updated: ConsumerProfile = {
+    ...current,
+    updatedAt: now,
+    reputation: {
+      score5: Number(nextScore.toFixed(3)),
+      baseline5: 3,
+      totalRatings: nextTotal,
+      lastRatingAt: now,
+    },
+  };
+
+  const updatedIdx = records.findIndex((r) => r.walletAddress === wallet);
+  records[updatedIdx] = updated;
+  writeAll(records);
+
+  return {
+    ok: true,
+    profile: updated,
+    storagePath: CONSUMER_REGISTRY_PATH,
+  };
+}
+
+export function listConsumers() {
+  return {
+    ok: true,
+    results: readAll(),
+    storagePath: CONSUMER_REGISTRY_PATH,
+  };
+}


### PR DESCRIPTION
## Summary
Adds a dedicated landing-page section for users who already run an LLM/orchestrator stack and want to consume listed agents without onboarding as providers.

### Added on `/`
- New section: **Consume listed agents without re-onboarding**
- Clear 3-step consumer path:
  1. Discover/resolve (`/agents`)
  2. Invoke with settlement (`/planner`)
  3. Monitor outcomes (`/runs`)

## Why
The landing page explained provider registration well, but did not clearly explain consumer-side usage for existing LLM setups.

## Verification
- `npm run build` ✅

## Constraint
- No change to one-agent-per-wallet behavior.
