### PR TITLE
feat(nav): declutter header with More menu and mobile navigation

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import dynamic from "next/dynamic";
+import { useState } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
 
 const WalletMultiButton = dynamic(
@@ -26,12 +27,38 @@ const navLinks: { href: string; label: string; badge?: string }[] = [
   { href: "/attestation", label: "Attestation" },
   { href: "/consumer", label: "Consumer" },
   { href: "/audit", label: "Audit Trail" },
+  { href: "/dogfood", label: "Dogfood", badge: "New" },
   { href: "/orchestrator", label: "Settings" },
 ];
+
+const primaryLinks = navLinks.filter((l) => ["/agents", "/planner", "/runs"].includes(l.href));
+const secondaryLinks = navLinks.filter((l) => !["/agents", "/planner", "/runs"].includes(l.href));
 
 export default function NavBar() {
   const pathname = usePathname();
   const { publicKey, disconnect } = useWallet();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const walletControl = publicKey ? (
+    <button
+      onClick={() => disconnect()}
+      title={publicKey.toBase58()}
+      className="h-9 px-4 rounded-lg text-sm font-medium text-black transition-opacity hover:opacity-80"
+      style={{ background: "linear-gradient(135deg, #9945FF 0%, #14F195 100%)" }}
+    >
+      {abbrev(publicKey.toBase58())}
+    </button>
+  ) : (
+    <WalletMultiButton
+      style={{
+        background: "linear-gradient(135deg, #9945FF 0%, #14F195 100%)",
+        height: "36px",
+        fontSize: "13px",
+        borderRadius: "8px",
+        padding: "0 16px",
+      }}
+    />
+  );
 
   return (
     <nav className="sticky top-0 z-50 border-b border-border bg-page/90 backdrop-blur">
@@ -39,14 +66,14 @@ export default function NavBar() {
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <Link href="/" className="flex items-center gap-2">
-            <span className="font-display text-lg text-white">
+            <span className="font-display text-base sm:text-lg text-white">
               Reddi Agent Protocol
             </span>
           </Link>
 
-          {/* Nav links */}
-          <div className="hidden md:flex items-center gap-6">
-            {navLinks.map(({ href, label, badge }) => (
+          {/* Desktop nav */}
+          <div className="hidden md:flex items-center gap-5">
+            {primaryLinks.map(({ href, label, badge }) => (
               <Link
                 key={href}
                 href={href}
@@ -64,32 +91,70 @@ export default function NavBar() {
                 )}
               </Link>
             ))}
+
+            <details className="relative group">
+              <summary className="list-none cursor-pointer text-sm text-muted-foreground hover:text-white select-none">
+                More
+              </summary>
+              <div className="absolute right-0 mt-2 w-56 rounded-lg border border-white/10 bg-card/95 backdrop-blur p-2 shadow-xl z-50">
+                {secondaryLinks.map(({ href, label, badge }) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    className={`flex items-center justify-between rounded-md px-3 py-2 text-sm ${
+                      pathname === href ? "text-white bg-white/10" : "text-muted-foreground hover:text-white hover:bg-white/5"
+                    }`}
+                  >
+                    <span>{label}</span>
+                    {badge && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-accent-purple/20 text-accent-purple font-medium leading-none">
+                        {badge}
+                      </span>
+                    )}
+                  </Link>
+                ))}
+              </div>
+            </details>
           </div>
 
-          {/* Wallet button */}
-          <div className="flex items-center">
-            {publicKey ? (
-              <button
-                onClick={() => disconnect()}
-                title={publicKey.toBase58()}
-                className="h-9 px-4 rounded-lg text-sm font-medium text-black transition-opacity hover:opacity-80"
-                style={{ background: "linear-gradient(135deg, #9945FF 0%, #14F195 100%)" }}
-              >
-                {abbrev(publicKey.toBase58())}
-              </button>
-            ) : (
-              <WalletMultiButton
-                style={{
-                  background: "linear-gradient(135deg, #9945FF 0%, #14F195 100%)",
-                  height: "36px",
-                  fontSize: "13px",
-                  borderRadius: "8px",
-                  padding: "0 16px",
-                }}
-              />
-            )}
+          <div className="flex items-center gap-2">
+            <button
+              className="md:hidden h-9 px-3 rounded-lg border border-white/15 text-sm text-white"
+              onClick={() => setMobileOpen((v) => !v)}
+              aria-label="Toggle menu"
+            >
+              {mobileOpen ? "Close" : "Menu"}
+            </button>
+
+            <div className="hidden sm:flex items-center">{walletControl}</div>
           </div>
         </div>
+
+        {mobileOpen && (
+          <div className="md:hidden pb-4">
+            <div className="rounded-lg border border-white/10 bg-card/90 p-3 space-y-2">
+              <div className="sm:hidden pb-1">{walletControl}</div>
+
+              {[...primaryLinks, ...secondaryLinks].map(({ href, label, badge }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  onClick={() => setMobileOpen(false)}
+                  className={`flex items-center justify-between rounded-md px-3 py-2 text-sm ${
+                    pathname === href ? "text-white bg-white/10" : "text-muted-foreground hover:text-white hover:bg-white/5"
+                  }`}
+                >
+                  <span>{label}</span>
+                  {badge && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-accent-purple/20 text-accent-purple font-medium leading-none">
+                      {badge}
+                    </span>
+                  )}
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary\n- reduce desktop header clutter by keeping 3 primary links (Marketplace, Planner, History)\n- move secondary routes into a `More` dropdown\n- add mobile-friendly menu toggle with full link list\n- keep wallet connect/disconnect accessible (desktop and inside mobile panel)\n\n## UX impact\n- cleaner navbar on desktop\n- usable navigation on mobile browsers\n- preserves access to all existing routes\n\n## Validation\n- TypeScript check: `npx tsc --noEmit`