### PR TITLE
docs(whitepaper): phase-5 hardening with threat and benchmark appendices

### DIFF
--- a/app/whitepaper/page.tsx
+++ b/app/whitepaper/page.tsx
@@ -6,7 +6,7 @@ const phases = [
   { phase: "Phase 2", title: "Whitepaper draft", status: "Complete (v1 draft)" },
   { phase: "Phase 3", title: "Screenshot evidence", status: "Complete (initial pack)" },
   { phase: "Phase 4", title: "Web integration", status: "Complete (this page)" },
-  { phase: "Phase 5", title: "QA and publication", status: "Pending review" },
+  { phase: "Phase 5", title: "QA and publication", status: "In progress (threat + benchmark appendices added)" },
 ];
 
 const screenshots = [
@@ -31,6 +31,12 @@ export default function WhitepaperPage() {
           <div className="flex flex-wrap gap-3">
             <Link href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/whitepaper/WHITEPAPER-v1.md" className="rounded-lg bg-white text-black px-4 py-2 text-sm font-medium">
               Read whitepaper draft
+            </Link>
+            <Link href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/whitepaper/APPENDIX-THREAT-MODEL.md" className="rounded-lg border border-white/20 px-4 py-2 text-sm font-medium text-white/90">
+              Threat model appendix
+            </Link>
+            <Link href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/whitepaper/APPENDIX-BENCHMARK-METHODOLOGY.md" className="rounded-lg border border-white/20 px-4 py-2 text-sm font-medium text-white/90">
+              Benchmark appendix
             </Link>
             <Link href="https://github.com/nissan/reddi-agent-protocol/tree/main/docs/whitepaper" className="rounded-lg border border-white/20 px-4 py-2 text-sm font-medium text-white/90">
               Open docs folder
@@ -72,8 +78,8 @@ export default function WhitepaperPage() {
           <h2 className="font-display text-2xl font-semibold">What is next</h2>
           <ul className="list-disc pl-5 text-sm text-gray-300 space-y-1">
             <li>Technical peer review of whitepaper claims against code and tests.</li>
-            <li>Add benchmark appendix and formal threat matrix.</li>
-            <li>Publish polished final whitepaper with versioning.</li>
+            <li>Add versioned benchmark results and threat-control residual risk ratings.</li>
+            <li>Publish final whitepaper v1.0 with changelog and review sign-off.</li>
           </ul>
         </section>
       </div>

--- a/docs/whitepaper/APPENDIX-BENCHMARK-METHODOLOGY.md
+++ b/docs/whitepaper/APPENDIX-BENCHMARK-METHODOLOGY.md
@@ -1,0 +1,89 @@
+# Appendix B — Benchmark Methodology and Reproducibility
+
+_Status: Phase 5 hardening draft_
+
+## Objective
+
+Provide a repeatable baseline for validating protocol behavior across:
+
+- specialist discovery and routing
+- paid invocation and settlement handling
+- attestation-gated release/refund decisions
+- end-to-end UI operator flows
+
+## Benchmark lanes
+
+### Lane 1 — Route/unit correctness
+
+Run dogfood and planner route-level tests:
+
+```bash
+npx jest \
+  lib/__tests__/dogfood-testing-specialist-route.test.ts \
+  lib/__tests__/dogfood-testing-attestor-route.test.ts \
+  lib/__tests__/dogfood-consumer-run-route.test.ts \
+  --runInBand
+```
+
+Expected outcome:
+- all suites pass
+- pass path resolves to `released`
+- fail path resolves to `refunded`
+
+### Lane 2 — BDD index integrity
+
+```bash
+npm run test:bdd:index
+```
+
+Expected outcome:
+- feature files and verification command map remain in sync
+
+### Lane 3 — Browser workflow lane
+
+```bash
+npx playwright test e2e/dogfood.spec.ts
+```
+
+Expected outcome:
+- `/dogfood` loads
+- forced pass run shows released escrow
+- forced fail run shows refunded escrow
+
+### Lane 4 — Demo artifact lane
+
+```bash
+npm run demo:dogfood:capture
+```
+
+Expected outcome:
+- timestamped artifacts under `artifacts/dogfood-demo/<timestamp>/`
+- logs and media traces available for review/demo editing
+
+## Environment notes
+
+- Node/Next versions should match repository lock constraints.
+- Local and CI should use consistent browser channel for Playwright where possible.
+- If using worktrees, ensure dependencies are available in that working directory.
+
+## Metrics to track over time
+
+- Test pass/fail rates per lane
+- Median `consumer-run` completion time (pass vs fail)
+- Rate of attestor disagreement events
+- Route regressions found before vs after PR merge
+
+## Reporting template
+
+For each benchmark run record:
+
+- git SHA
+- timestamp
+- lane commands executed
+- pass/fail summary
+- notable variance or flaky behavior
+
+## Caveats
+
+- Benchmark values are environment-sensitive and should be compared relative to baseline in the same environment.
+- Dogfood lane is intentionally synthetic for harness validation; it does not represent full marketplace complexity.

--- a/docs/whitepaper/APPENDIX-THREAT-MODEL.md
+++ b/docs/whitepaper/APPENDIX-THREAT-MODEL.md
@@ -1,0 +1,52 @@
+# Appendix A — Threat Model and Controls
+
+_Status: Phase 5 hardening draft_
+
+## Scope
+
+This appendix maps practical threats in agent commerce to protocol controls and known residual risks.
+
+## System boundary
+
+- Off-chain agent execution endpoints
+- Planner orchestration routes
+- Settlement decision paths
+- Reputation and attestation signals
+- On-chain state transitions and escrow lifecycle
+
+## Threat matrix
+
+| Threat | Attack pattern | Primary controls | Residual risk |
+|---|---|---|---|
+| Non-payment after delivery | Consumer receives output and withholds payout | Escrow/settlement state machine, explicit release/dispute path | Collusion or dishonest dispute signaling still requires arbitration policy evolution |
+| Payment without valid output | Specialist returns malformed/low-quality response after payment | Attestation gate, quality signaling, refund/dispute path | Attestor quality variance can cause false positives/negatives |
+| Replay of payment proof | Reuse of old payment header/receipt | Nonce-bound challenge/receipt semantics, challenge parsing checks | Misconfigured endpoint nonce persistence could weaken replay defense |
+| Attestation gaming | Friendly attestor passes bad output | Attestor selection scoring, agreement/disagreement telemetry, dispute path | Stronger cryptographic attestor signatures are still roadmap |
+| Reputation manipulation | Strategic rating behavior or retaliatory scoring | Commit-reveal pattern, rolling score model, multiple feedback signals | Sparse sample sizes early in lifecycle remain noisy |
+| Endpoint impersonation | Fake specialist endpoint presented in discovery | Registry + profile linkage + health check status | Off-chain DNS/TLS trust still external to protocol |
+| DoS on specialist endpoint | Flood requests to degrade service | Health checks + routing fallback to alternatives | No built-in rate-limiting standard enforced protocol-wide yet |
+| Config drift / broken route links | UI exposes paths not deployed on main | BDD route coverage + PR discipline + hotfix workflow | Human process error remains possible without automated deploy guards |
+
+## Existing controls in code/docs
+
+- Planner execution and settlement guards: `lib/onboarding/planner-execution.ts`, `lib/onboarding/planner-settlement.ts`
+- Attestor selection/routing: `lib/onboarding/attestor-resolver.ts`
+- Dogfood failure harness and attestor gate: `app/api/dogfood/*`, `lib/dogfood/*`
+- BDD behavior coverage map: `docs/bdd/FEATURE-INDEX.md`
+
+## Prioritized hardening roadmap
+
+1. **Attestor signed verdict binding**
+   - Sign `(runId, outputHash, verdict)` and verify before settlement finalization.
+2. **Output commit-reveal for specialists**
+   - Pre-commit output hash before reveal and attestation.
+3. **Dispute windows and penalties**
+   - Time-bounded challenge periods with explicit penalty policies.
+4. **Route-deploy guardrails**
+   - CI/deploy checks to block nav links to undeployed pages.
+
+## Practical guidance
+
+- Treat attestation as a weighted trust signal, not absolute truth.
+- Keep clear UX separation between `released`, `refunded`, and `disputed` outcomes.
+- Use evidence hashes and run IDs in all operator workflows and support playbooks.

--- a/docs/whitepaper/README.md
+++ b/docs/whitepaper/README.md
@@ -8,6 +8,8 @@ This folder contains the phased documentation program for publishing a protocol-
 - `RESEARCH-SOURCES.md` — internal/external references and claims ledger inputs
 - `WHITEPAPER-v1.md` — main whitepaper draft
 - `SCREENSHOT-EVIDENCE.md` — screenshot map and capture requirements
+- `APPENDIX-THREAT-MODEL.md` — threat matrix with controls and residual risks
+- `APPENDIX-BENCHMARK-METHODOLOGY.md` — reproducibility and benchmark lanes
 
 ## Publishing intent
 

--- a/docs/whitepaper/WHITEPAPER-v1.md
+++ b/docs/whitepaper/WHITEPAPER-v1.md
@@ -69,6 +69,8 @@ This harness demonstrates that acceptance logic can reject malformed outputs and
 
 ## 6. Security and anti-gaming posture
 
+See detailed control mapping in **Appendix A** (`APPENDIX-THREAT-MODEL.md`).
+
 Current controls include:
 
 - escrow-state gating of settlement transitions
@@ -92,6 +94,8 @@ Protocol economics are designed around successful completion, with explicit sepa
 - consumers for accurate post-run signaling.
 
 ## 8. Integration surfaces
+
+Benchmark and reproducibility guidance for these surfaces is documented in **Appendix B** (`APPENDIX-BENCHMARK-METHODOLOGY.md`).
 
 The protocol exposes planner-native tool routes for:
 
@@ -121,3 +125,8 @@ This supports framework-agnostic integration patterns (tool-calling orchestrator
 ## 10. Conclusion
 
 Reddi Agent Protocol treats agent commerce as a protocol problem, not just a UX problem. By giving payment, quality, and reputation their own verifiable lifecycle, the protocol makes agent markets more robust under adversarial behavior while staying composable for builders.
+
+## Appendices
+
+- Appendix A: `APPENDIX-THREAT-MODEL.md`
+- Appendix B: `APPENDIX-BENCHMARK-METHODOLOGY.md`


### PR DESCRIPTION
## Summary
Follow-up to merged whitepaper phase-pack PR #47.

### Added
- `docs/whitepaper/APPENDIX-THREAT-MODEL.md`
- `docs/whitepaper/APPENDIX-BENCHMARK-METHODOLOGY.md`

### Updated
- `docs/whitepaper/WHITEPAPER-v1.md` to reference appendices
- `docs/whitepaper/README.md` appendix index
- `/whitepaper` page to surface appendix links and updated phase status

## Why
You asked to continue after approvals and build documentation in proper phases. This PR executes Phase 5 hardening baseline with:
- explicit threat/control matrix
- reproducibility-oriented benchmark lanes
- clearer publication pathway in the web docs UI

## Validation note
Running `npx tsc --noEmit` in this branch still surfaces existing baseline errors in `lib/__tests__/torque-leaderboard-route.test.ts` unrelated to these docs changes.
