### PR TITLE
fix(nav): re-enable Dogfood link now that route is live

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -27,6 +27,7 @@ const navLinks: { href: string; label: string; badge?: string }[] = [
   { href: "/attestation", label: "Attestation" },
   { href: "/consumer", label: "Consumer" },
   { href: "/audit", label: "Audit Trail" },
+  { href: "/dogfood", label: "Dogfood", badge: "New" },
   { href: "/whitepaper", label: "Whitepaper", badge: "Docs" },
   { href: "/orchestrator", label: "Settings" },
 ];


### PR DESCRIPTION
## Summary
- re-add Dogfood nav link under the header menu
- this link was temporarily removed to avoid 404 before /dogfood shipped
- /dogfood is now on main (PR #46 merged), so link is safe to restore
