### PR TITLE
feat(testing): simulate Solana wallet in Playwright for gated flows

### DIFF
--- a/components/WalletProvider.tsx
+++ b/components/WalletProvider.tsx
@@ -10,6 +10,7 @@ import {
   SolflareWalletAdapter,
 } from "@solana/wallet-adapter-wallets";
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
+import { PlaywrightWalletAdapter } from "@/lib/wallet/playwright-wallet-adapter";
 import "@solana/wallet-adapter-react-ui/styles.css";
 
 interface Props {
@@ -19,18 +20,19 @@ interface Props {
 const WalletProvider: FC<Props> = ({ children }) => {
   const endpoint =
     process.env.NEXT_PUBLIC_RPC_URL || "https://api.devnet.solana.com";
+  const enablePlaywrightWallet = process.env.NEXT_PUBLIC_ENABLE_PLAYWRIGHT_WALLET === "true";
 
   const wallets = useMemo(() => {
-    const adapters = [
-      new PhantomWalletAdapter(),
-      new SolflareWalletAdapter(),
-    ];
+    const adapters = [new PhantomWalletAdapter(), new SolflareWalletAdapter()];
+    if (enablePlaywrightWallet) {
+      adapters.unshift(new PlaywrightWalletAdapter());
+    }
     return adapters;
-  }, []);
+  }, [enablePlaywrightWallet]);
 
   return (
     <ConnectionProvider endpoint={endpoint}>
-      <SolanaWalletProvider wallets={wallets} autoConnect={false}>
+      <SolanaWalletProvider wallets={wallets} autoConnect={enablePlaywrightWallet}>
         <WalletModalProvider>{children}</WalletModalProvider>
       </SolanaWalletProvider>
     </ConnectionProvider>

--- a/docs/WALLET-MOCK-PLAYWRIGHT.md
+++ b/docs/WALLET-MOCK-PLAYWRIGHT.md
@@ -1,0 +1,50 @@
+# Playwright Solana Wallet Simulation
+
+Use this for wallet-gated UX tests and screenshot capture without a browser extension.
+
+## How it works
+
+- A test-only adapter (`Playwright Wallet`) is injected in `WalletProvider` when:
+  - `NEXT_PUBLIC_ENABLE_PLAYWRIGHT_WALLET=true`
+- Tests connect through wallet modal selection (no extension needed), exposing a deterministic public key:
+  - `11111111111111111111111111111111`
+
+## Files
+
+- Adapter: `lib/wallet/playwright-wallet-adapter.ts`
+- Provider wiring: `components/WalletProvider.tsx`
+- Playwright helper: `e2e/helpers/wallet.ts`
+- Example spec: `e2e/wallet-mock.spec.ts`
+
+## Commands
+
+Run wallet simulation tests:
+
+```bash
+npm run test:e2e:wallet
+```
+
+Run full e2e with wallet simulation enabled in web server:
+
+```bash
+npm run test:e2e
+```
+
+## Screenshot capture usage
+
+In any Playwright spec:
+
+```ts
+import { connectMockWallet, enableMockWallet } from "./helpers/wallet";
+
+await enableMockWallet(page);
+await page.goto("/planner");
+await connectMockWallet(page);
+await page.screenshot({ path: "artifacts/playwright-wallet/planner-wallet.png", fullPage: true });
+```
+
+## Safety
+
+- This mode is disabled by default.
+- It only activates when `NEXT_PUBLIC_ENABLE_PLAYWRIGHT_WALLET=true`.
+- Do not set that flag in production deployment environments.

--- a/e2e/helpers/wallet.ts
+++ b/e2e/helpers/wallet.ts
@@ -1,0 +1,13 @@
+import { expect, type Page } from "@playwright/test";
+
+export const PLAYWRIGHT_WALLET_NAME = "Playwright Wallet";
+
+export async function enableMockWallet(page: Page) {
+  await page.addInitScript((walletName) => {
+    window.localStorage.setItem("walletName", JSON.stringify(walletName));
+  }, PLAYWRIGHT_WALLET_NAME);
+}
+
+export async function connectMockWallet(page: Page) {
+  await expect(page.getByRole("button", { name: "1111...1111" })).toBeVisible({ timeout: 15000 });
+}

--- a/e2e/wallet-mock.spec.ts
+++ b/e2e/wallet-mock.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+import { connectMockWallet, enableMockWallet } from "./helpers/wallet";
+
+test.describe("playwright wallet simulation", () => {
+  test("shows connected wallet state for wallet-gated routes", async ({ page }) => {
+    await enableMockWallet(page);
+    await page.goto("/planner");
+    await connectMockWallet(page);
+
+    await expect(page.getByText(/connect your wallet/i)).toHaveCount(0);
+  });
+
+  test("can capture wallet-gated onboarding screen without manual extension", async ({ page }) => {
+    await enableMockWallet(page);
+    await page.goto("/onboarding");
+    await connectMockWallet(page);
+
+    await expect(page.getByRole("heading", { name: /Specialist Onboarding Wizard/i })).toBeVisible();
+
+    await page.screenshot({
+      path: "artifacts/playwright-wallet/onboarding-wallet-mock.png",
+      fullPage: true,
+    });
+  });
+});

--- a/lib/wallet/playwright-wallet-adapter.ts
+++ b/lib/wallet/playwright-wallet-adapter.ts
@@ -1,0 +1,76 @@
+import {
+  BaseMessageSignerWalletAdapter,
+  WalletName,
+  WalletReadyState,
+} from "@solana/wallet-adapter-base";
+import {
+  Connection,
+  PublicKey,
+  SendTransactionOptions,
+  Transaction,
+  TransactionSignature,
+  VersionedTransaction,
+} from "@solana/web3.js";
+
+export const PLAYWRIGHT_WALLET_NAME = "Playwright Wallet" as WalletName<"Playwright Wallet">;
+const PLAYWRIGHT_PUBLIC_KEY = new PublicKey(
+  process.env.NEXT_PUBLIC_PLAYWRIGHT_WALLET_PUBLIC_KEY ?? "11111111111111111111111111111111"
+);
+
+export class PlaywrightWalletAdapter extends BaseMessageSignerWalletAdapter {
+  name = PLAYWRIGHT_WALLET_NAME;
+  url = "https://agent-protocol.reddi.tech";
+  icon =
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' rx='12' fill='%23111827'/%3E%3Cpath d='M18 46V18h14c8 0 14 6 14 14s-6 14-14 14H18zm8-8h6c3.3 0 6-2.7 6-6s-2.7-6-6-6h-6v12z' fill='%239945FF'/%3E%3C/svg%3E";
+
+  readonly supportedTransactionVersions = new Set(["legacy", 0]);
+  private _publicKey: PublicKey | null = null;
+  private _connected = false;
+
+  get publicKey() {
+    return this._publicKey;
+  }
+
+  get connected() {
+    return this._connected;
+  }
+
+  get readyState() {
+    return WalletReadyState.Installed;
+  }
+
+  async connect(): Promise<void> {
+    if (this._connected) return;
+    this._publicKey = PLAYWRIGHT_PUBLIC_KEY;
+    this._connected = true;
+    this.emit("connect", this._publicKey);
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this._connected) return;
+    this._connected = false;
+    this._publicKey = null;
+    this.emit("disconnect");
+  }
+
+  async sendTransaction(
+    _transaction: Transaction | VersionedTransaction,
+    _connection: Connection,
+    _options?: SendTransactionOptions
+  ): Promise<TransactionSignature> {
+    return "playwright-mock-signature";
+  }
+
+  async signTransaction<T extends Transaction | VersionedTransaction>(transaction: T): Promise<T> {
+    return transaction;
+  }
+
+  async signAllTransactions<T extends Transaction | VersionedTransaction>(transactions: T[]): Promise<T[]> {
+    return transactions;
+  }
+
+  async signMessage(message: Uint8Array): Promise<Uint8Array> {
+    return message;
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "test:e2e": "playwright test",
     "test:e2e:dogfood": "playwright test e2e/dogfood.spec.ts",
+    "test:e2e:wallet": "playwright test e2e/wallet-mock.spec.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "demo:dogfood:capture": "./scripts/run-dogfood-demo-capture.sh",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } }
   ],
   webServer: {
-    command: 'node node_modules/next/dist/bin/next dev --port 3010',
+    command: 'NEXT_PUBLIC_ENABLE_PLAYWRIGHT_WALLET=true node node_modules/next/dist/bin/next dev --port 3010',
     url: 'http://127.0.0.1:3010',
     reuseExistingServer: true,
     timeout: 60_000,


### PR DESCRIPTION
## Summary\n- add a Playwright-only Solana wallet adapter for deterministic browser tests\n- wire adapter into WalletProvider behind \n- add wallet mock helper + e2e spec for planner/setup gated flows\n- add docs + npm script () for repeatable screenshot/user-flow capture\n\n## Validation\n- 
> web@0.1.0 test:e2e:wallet
> playwright test e2e/wallet-mock.spec.ts


Running 2 tests using 1 worker

  ✓  1 [chromium] › e2e/wallet-mock.spec.ts:5:7 › playwright wallet simulation › shows connected wallet state for wallet-gated routes (1.1s)
  ✓  2 [chromium] › e2e/wallet-mock.spec.ts:13:7 › playwright wallet simulation › can capture wallet-gated onboarding screen without manual extension (1.1s)

  2 passed (6.4s)\n