### PR TITLE
fix(build): unblock main after Playwright wallet merge

### DIFF
--- a/components/WalletProvider.tsx
+++ b/components/WalletProvider.tsx
@@ -9,6 +9,7 @@ import {
   PhantomWalletAdapter,
   SolflareWalletAdapter,
 } from "@solana/wallet-adapter-wallets";
+import type { WalletAdapter } from "@solana/wallet-adapter-base";
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import { PlaywrightWalletAdapter } from "@/lib/wallet/playwright-wallet-adapter";
 import "@solana/wallet-adapter-react-ui/styles.css";
@@ -23,7 +24,10 @@ const WalletProvider: FC<Props> = ({ children }) => {
   const enablePlaywrightWallet = process.env.NEXT_PUBLIC_ENABLE_PLAYWRIGHT_WALLET === "true";
 
   const wallets = useMemo(() => {
-    const adapters = [new PhantomWalletAdapter(), new SolflareWalletAdapter()];
+    const adapters: WalletAdapter[] = [
+      new PhantomWalletAdapter(),
+      new SolflareWalletAdapter(),
+    ];
     if (enablePlaywrightWallet) {
       adapters.unshift(new PlaywrightWalletAdapter());
     }

--- a/lib/wallet/playwright-wallet-adapter.ts
+++ b/lib/wallet/playwright-wallet-adapter.ts
@@ -1,14 +1,15 @@
 import {
   BaseMessageSignerWalletAdapter,
+  SendTransactionOptions,
   WalletName,
   WalletReadyState,
 } from "@solana/wallet-adapter-base";
 import {
   Connection,
   PublicKey,
-  SendTransactionOptions,
   Transaction,
   TransactionSignature,
+  TransactionVersion,
   VersionedTransaction,
 } from "@solana/web3.js";
 
@@ -23,9 +24,10 @@ export class PlaywrightWalletAdapter extends BaseMessageSignerWalletAdapter {
   icon =
     "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' rx='12' fill='%23111827'/%3E%3Cpath d='M18 46V18h14c8 0 14 6 14 14s-6 14-14 14H18zm8-8h6c3.3 0 6-2.7 6-6s-2.7-6-6-6h-6v12z' fill='%239945FF'/%3E%3C/svg%3E";
 
-  readonly supportedTransactionVersions = new Set(["legacy", 0]);
+  readonly supportedTransactionVersions: ReadonlySet<TransactionVersion> = new Set<TransactionVersion>(["legacy", 0]);
   private _publicKey: PublicKey | null = null;
   private _connected = false;
+  private _connecting = false;
 
   get publicKey() {
     return this._publicKey;
@@ -35,15 +37,24 @@ export class PlaywrightWalletAdapter extends BaseMessageSignerWalletAdapter {
     return this._connected;
   }
 
+  get connecting() {
+    return this._connecting;
+  }
+
   get readyState() {
     return WalletReadyState.Installed;
   }
 
   async connect(): Promise<void> {
     if (this._connected) return;
-    this._publicKey = PLAYWRIGHT_PUBLIC_KEY;
-    this._connected = true;
-    this.emit("connect", this._publicKey);
+    this._connecting = true;
+    try {
+      this._publicKey = PLAYWRIGHT_PUBLIC_KEY;
+      this._connected = true;
+      this.emit("connect", this._publicKey);
+    } finally {
+      this._connecting = false;
+    }
   }
 
   async disconnect(): Promise<void> {
@@ -73,4 +84,3 @@ export class PlaywrightWalletAdapter extends BaseMessageSignerWalletAdapter {
     return message;
   }
 }
-


### PR DESCRIPTION
## What broke
Main started failing TypeScript during production build after PR #51.

## Root causes
1. WalletProvider inferred a narrow adapter array union (Phantom|Solflare), so adding Playwright adapter failed type-check.
2. PlaywrightWalletAdapter types were not fully aligned with current wallet-adapter-base expectations (supportedTransactionVersions, connecting, and send options import source).

## Fix
- Type adapters as WalletAdapter[] in components/WalletProvider.tsx.
- In lib/wallet/playwright-wallet-adapter.ts:
  - import SendTransactionOptions from wallet-adapter-base
  - type supportedTransactionVersions as ReadonlySet<TransactionVersion>
  - implement connecting state/getter expected by base class

## Validation
- npm run build passes on latest main plus this patch.
