### PR TITLE
feat(onboarding): add attestation operator setup and recovery guidance

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1675,7 +1675,16 @@ export default function OnboardingPage() {
               <p className="text-xs text-yellow-400">Healthcheck must pass before attestation can be recorded.</p>
             )}
             {!state.attestationOperatorReady && (
-              <p className="text-xs text-yellow-400">Operator signer key must be configured before recording attestation.</p>
+              <>
+                <p className="text-xs text-yellow-400">Operator signer key must be configured before recording attestation.</p>
+                <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-xs text-yellow-200">
+                  <p className="mb-1">Quick fix: set <span className="font-mono">ONBOARDING_ATTEST_OPERATOR_SECRET_KEY</span> as a 64-byte JSON array, restart the app, then click "Check attestor key status" again.</p>
+                  <p className="font-mono break-all">Example format: [12,34,56,...,64 bytes total]</p>
+                  <Link href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/ONBOARDING-ATTESTATION-OPERATOR-SETUP.md" className="mt-2 inline-block underline">
+                    Operator setup and recovery guide →
+                  </Link>
+                </div>
+              </>
             )}
             {state.attestationOperatorStatusNote && (
               <div className="rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-muted-foreground">

--- a/docs/ONBOARDING-ATTESTATION-OPERATOR-SETUP.md
+++ b/docs/ONBOARDING-ATTESTATION-OPERATOR-SETUP.md
@@ -1,0 +1,54 @@
+# Onboarding Attestation Operator, Setup and Recovery
+
+This guide fixes Step 7 in `/onboarding` when attestation says the operator key is not configured.
+
+## Required env var
+
+Set:
+
+`ONBOARDING_ATTEST_OPERATOR_SECRET_KEY`
+
+Value format must be a JSON byte array with **64 numbers**.
+
+Example:
+
+`[12,34,56,...]`
+
+## Local setup
+
+1. Generate a dedicated devnet operator keypair (or reuse one).
+2. Put the secret key array into `ONBOARDING_ATTEST_OPERATOR_SECRET_KEY`.
+3. Restart the app server.
+4. In onboarding Step 7, click **Check attestor key status**.
+
+## Validation
+
+`GET /api/onboarding/attestation-operator`
+
+Expected success shape:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "ready": true,
+    "operatorPubkey": "...",
+    "note": "Operator signer is configured."
+  }
+}
+```
+
+## Recovery checklist
+
+If status is not ready:
+
+- Confirm env var is present in the same process that runs Next.js.
+- Confirm the value is valid JSON.
+- Confirm array length is exactly 64.
+- Restart the server after changes.
+- Re-run the status check.
+
+## Notes
+
+- This operator key only signs onboarding attestation transactions.
+- Use a dedicated key for onboarding, not your primary wallet.


### PR DESCRIPTION
## Summary
- add Step 7 UI guidance when attestation operator key is not ready
- include explicit secret-key format hint (64-byte JSON array)
- add runbook-style doc: 
- link onboarding UI directly to the operator setup/recovery guide

## Why
This closes the onboarding Phase A gap where operator-key provisioning/recovery feedback was too thin, and reduces confusion when attestation is blocked.

## Validation
- npm run build
