### PR TITLE
feat(registry): add tag filters and deterministic ranking tie-breaks

### DIFF
--- a/app/api/registry/route.ts
+++ b/app/api/registry/route.ts
@@ -2,6 +2,20 @@ import { fetchSpecialistListings } from "@/lib/registry/bridge";
 
 export const runtime = "nodejs";
 
+function parseCsv(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+function asEpochMs(value: string | null): number {
+  if (!value) return -1;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? -1 : parsed;
+}
+
 /**
  * GET /api/registry
  * Returns merged on-chain + off-chain specialist listings.
@@ -12,6 +26,8 @@ export const runtime = "nodejs";
  *   runtimeCap — filter by runtime capability
  *   attested   — "true" to require attestation
  *   health     — "pass" to require health pass
+ *   tag       — filter by one capability tag
+ *   tags      — CSV filter by one or more capability tags
  *   sortBy    — "ranking" | "reputation" | "cost" | "feedback" (default: default bridge sort)
  */
 export async function GET(req: Request) {
@@ -23,6 +39,8 @@ export async function GET(req: Request) {
     const filterAttested = searchParams.get("attested") === "true";
     const filterHealth = searchParams.get("health");
     const filterRuntimeCap = searchParams.get("runtimeCap");
+    const filterTag = searchParams.get("tag");
+    const filterTags = parseCsv(searchParams.get("tags"));
     const sort = searchParams.get("sortBy") ?? searchParams.get("sort") ?? "default";
 
     const { ok, listings, onchainCount, indexedCount, error } =
@@ -56,9 +74,31 @@ export async function GET(req: Request) {
         l.capabilities?.runtime_capabilities?.includes(filterRuntimeCap as never)
       );
     }
+    if (filterTag) {
+      results = results.filter((l) => l.capabilities?.tags?.includes(filterTag));
+    }
+    if (filterTags.length > 0) {
+      results = results.filter((l) =>
+        filterTags.some((tag) => l.capabilities?.tags?.includes(tag))
+      );
+    }
 
     if (sort === "ranking") {
-      results = [...results].sort((a, b) => b.ranking_score - a.ranking_score);
+      results = [...results].sort((a, b) => {
+        if (a.ranking_score !== b.ranking_score) {
+          return b.ranking_score - a.ranking_score;
+        }
+
+        const aFreshness = asEpochMs(a.health.lastCheckedAt);
+        const bFreshness = asEpochMs(b.health.lastCheckedAt);
+        if (aFreshness !== bFreshness) {
+          return bFreshness - aFreshness;
+        }
+
+        const aCost = a.capabilities?.perCallUsd ?? Number.POSITIVE_INFINITY;
+        const bCost = b.capabilities?.perCallUsd ?? Number.POSITIVE_INFINITY;
+        return aCost - bCost;
+      });
     } else if (sort === "reputation") {
       results = [...results].sort(
         (a, b) => b.onchain.reputationScore - a.onchain.reputationScore

--- a/lib/__tests__/registry-route.test.ts
+++ b/lib/__tests__/registry-route.test.ts
@@ -1,0 +1,177 @@
+jest.mock("@/lib/registry/bridge", () => ({
+  fetchSpecialistListings: jest.fn(),
+}));
+
+type ListingLike = {
+  walletAddress: string;
+  ranking_score: number;
+  onchainReputation?: number;
+  perCallUsd?: number;
+  tags?: string[];
+  lastCheckedAt?: string | null;
+};
+
+function mkListing(input: ListingLike) {
+  return {
+    pda: "",
+    walletAddress: input.walletAddress,
+    onchain: {
+      owner: input.walletAddress,
+      agentType: "Primary",
+      model: "",
+      rateLamports: 0,
+      minReputation: 0,
+      reputationScore: input.onchainReputation ?? 0,
+      jobsCompleted: 0,
+      jobsFailed: 0,
+      createdAt: 0,
+      active: true,
+      attestationAccuracy: 0,
+    },
+    capabilities: {
+      taskTypes: [],
+      inputModes: [],
+      outputModes: [],
+      privacyModes: [],
+      tags: input.tags ?? [],
+      baseUsd: 0,
+      perCallUsd: input.perCallUsd ?? 0,
+      context_requirements: [],
+      runtime_capabilities: [],
+    },
+    health: {
+      status: "pass",
+      endpointUrl: null,
+      lastCheckedAt: input.lastCheckedAt ?? null,
+    },
+    attestation: {
+      attested: true,
+      lastAttestedAt: null,
+    },
+    capabilityHash: null,
+    signals: {
+      feedbackCount: 0,
+      avgFeedbackScore: 0,
+      attestationAgreements: 0,
+      attestationDisagreements: 0,
+    },
+    ranking_score: input.ranking_score,
+  };
+}
+
+describe("registry route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("filters by single tag", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      ok: true,
+      listings: [
+        mkListing({ walletAddress: "wallet-a", ranking_score: 1, tags: ["vision", "tooling"] }),
+        mkListing({ walletAddress: "wallet-b", ranking_score: 1, tags: ["finance"] }),
+      ],
+      onchainCount: 2,
+      indexedCount: 2,
+    });
+
+    const { GET } = await import("@/app/api/registry/route");
+    const res = await GET(new Request("http://localhost/api/registry?tag=vision"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.listings).toHaveLength(1);
+    expect(data.listings[0].walletAddress).toBe("wallet-a");
+  });
+
+  it("filters by tags CSV (any match)", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      ok: true,
+      listings: [
+        mkListing({ walletAddress: "wallet-a", ranking_score: 1, tags: ["vision"] }),
+        mkListing({ walletAddress: "wallet-b", ranking_score: 1, tags: ["finance"] }),
+        mkListing({ walletAddress: "wallet-c", ranking_score: 1, tags: ["tooling"] }),
+      ],
+      onchainCount: 3,
+      indexedCount: 3,
+    });
+
+    const { GET } = await import("@/app/api/registry/route");
+    const res = await GET(new Request("http://localhost/api/registry?tags=vision,finance"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.listings.map((l: { walletAddress: string }) => l.walletAddress)).toEqual([
+      "wallet-a",
+      "wallet-b",
+    ]);
+  });
+
+  it("applies ranking tie-breakers: freshness then cost", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      ok: true,
+      listings: [
+        mkListing({
+          walletAddress: "wallet-old-cheap",
+          ranking_score: 100,
+          lastCheckedAt: "2026-04-20T08:00:00.000Z",
+          perCallUsd: 0.1,
+        }),
+        mkListing({
+          walletAddress: "wallet-new-expensive",
+          ranking_score: 100,
+          lastCheckedAt: "2026-04-20T09:00:00.000Z",
+          perCallUsd: 0.5,
+        }),
+        mkListing({
+          walletAddress: "wallet-new-cheap",
+          ranking_score: 100,
+          lastCheckedAt: "2026-04-20T09:00:00.000Z",
+          perCallUsd: 0.2,
+        }),
+      ],
+      onchainCount: 3,
+      indexedCount: 3,
+    });
+
+    const { GET } = await import("@/app/api/registry/route");
+    const res = await GET(new Request("http://localhost/api/registry?sortBy=ranking"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.listings.map((l: { walletAddress: string }) => l.walletAddress)).toEqual([
+      "wallet-new-cheap",
+      "wallet-new-expensive",
+      "wallet-old-cheap",
+    ]);
+  });
+
+  it("keeps default bridge order when sortBy is unsupported", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      ok: true,
+      listings: [
+        mkListing({ walletAddress: "wallet-a", ranking_score: 2 }),
+        mkListing({ walletAddress: "wallet-b", ranking_score: 3 }),
+        mkListing({ walletAddress: "wallet-c", ranking_score: 1 }),
+      ],
+      onchainCount: 3,
+      indexedCount: 3,
+    });
+
+    const { GET } = await import("@/app/api/registry/route");
+    const res = await GET(new Request("http://localhost/api/registry?sortBy=unknown"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.listings.map((l: { walletAddress: string }) => l.walletAddress)).toEqual([
+      "wallet-a",
+      "wallet-b",
+      "wallet-c",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `tag` and `tags` (CSV) filters to `/api/registry`
- harden `sortBy=ranking` to use deterministic tie-breakers:
  1) `ranking_score` desc
  2) `health.lastCheckedAt` freshness desc
  3) `capabilities.perCallUsd` asc
- keep unsupported `sortBy` values non-breaking (preserve bridge order)
- add dedicated route tests in `lib/__tests__/registry-route.test.ts`

## Why
This closes the planner/discovery semantics gap by making ranking and filtering behavior explicit and test-backed.

## Validation
- `npx jest lib/__tests__/registry-route.test.ts --runInBand`
- `npm run build`
