### PR TITLE
PR-A (I1): runtime-agnostic endpoint probe foundation

### DIFF
--- a/app/api/register/probe/route.ts
+++ b/app/api/register/probe/route.ts
@@ -1,61 +1,38 @@
 import { NextResponse } from "next/server";
+import { probeRuntimeEndpoint, type RuntimeTarget } from "@/lib/onboarding/runtime-probe";
 
 export const runtime = "nodejs";
-
-function normalizeEndpoint(endpoint: string) {
-  const raw = endpoint.trim();
-  if (!raw) throw new Error("Endpoint URL is required.");
-  try {
-    return raw.startsWith("http://") || raw.startsWith("https://")
-      ? new URL(raw)
-      : new URL(`https://${raw}`);
-  } catch {
-    throw new Error("Invalid endpoint URL.");
-  }
-}
 
 export async function POST(req: Request) {
   const body = await req.json().catch(() => null);
   const endpoint = body?.endpoint;
+  const runtimeTarget = (body?.runtimeTarget ?? "auto") as RuntimeTarget;
 
   if (!endpoint || typeof endpoint !== "string") {
     return NextResponse.json({ ok: false, status: "invalid_url" }, { status: 400 });
   }
 
-  try {
-    const url = normalizeEndpoint(endpoint);
+  const result = await probeRuntimeEndpoint(endpoint, runtimeTarget);
 
-    const tagsRes = await fetch(`${url.origin}/api/tags`, {
-      signal: AbortSignal.timeout(5000),
-    });
+  const legacyStatus =
+    result.status === "runtime_detected" && result.detectedRuntime === "ollama"
+      ? "ollama_detected"
+      : result.status === "runtime_detected"
+        ? "reachable"
+        : result.status;
 
-    if (tagsRes.ok) {
-      const body = await tagsRes.json().catch(() => null);
-      const hasModels = body?.models && Array.isArray(body.models);
-      return NextResponse.json({
-        ok: true,
-        status: hasModels ? "ollama_detected" : "reachable",
-        models: hasModels ? body.models.map((m: { name?: string }) => m.name).filter(Boolean) : [],
-      });
-    }
-
-    const healthRes = await fetch(`${url.origin}/healthz`, {
-      signal: AbortSignal.timeout(5000),
-    });
-
-    return NextResponse.json({
-      ok: healthRes.ok,
-      status: healthRes.ok ? "reachable" : "unhealthy",
-      models: [],
-    });
-  } catch (error: unknown) {
-    return NextResponse.json(
-      {
-        ok: false,
-        status: "unreachable",
-        error: error instanceof Error ? error.message : "Connection failed",
-      },
-      { status: 200 }
-    );
-  }
+  return NextResponse.json(
+    {
+      ok: result.ok,
+      // legacy compatibility for existing UI surfaces
+      status: legacyStatus,
+      // normalized runtime-aware fields
+      runtimeStatus: result.status,
+      detectedRuntime: result.detectedRuntime,
+      models: result.models,
+      hints: result.hints,
+      error: result.error,
+    },
+    { status: result.status === "invalid_url" ? 400 : 200 }
+  );
 }

--- a/lib/__tests__/register-probe-route.test.ts
+++ b/lib/__tests__/register-probe-route.test.ts
@@ -1,0 +1,84 @@
+jest.mock("@/lib/onboarding/runtime-probe", () => ({
+  probeRuntimeEndpoint: jest.fn(),
+}));
+
+describe("POST /api/register/probe runtime normalization", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("returns legacy ollama_detected status for compatibility", async () => {
+    const { probeRuntimeEndpoint } = await import("@/lib/onboarding/runtime-probe");
+    (probeRuntimeEndpoint as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: "runtime_detected",
+      detectedRuntime: "ollama",
+      models: ["qwen3:8b"],
+      hints: [],
+    });
+
+    const { POST } = await import("@/app/api/register/probe/route");
+    const req = new Request("http://localhost/api/register/probe", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ endpoint: "https://example.com" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ollama_detected");
+    expect(body.runtimeStatus).toBe("runtime_detected");
+    expect(body.detectedRuntime).toBe("ollama");
+  });
+
+  it("maps non-ollama runtime_detected to reachable for legacy UI", async () => {
+    const { probeRuntimeEndpoint } = await import("@/lib/onboarding/runtime-probe");
+    (probeRuntimeEndpoint as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: "runtime_detected",
+      detectedRuntime: "openai_compatible",
+      models: ["llama3.1"],
+      hints: [],
+    });
+
+    const { POST } = await import("@/app/api/register/probe/route");
+    const req = new Request("http://localhost/api/register/probe", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ endpoint: "https://example.com" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("reachable");
+    expect(body.runtimeStatus).toBe("runtime_detected");
+    expect(body.detectedRuntime).toBe("openai_compatible");
+  });
+
+  it("returns 400 for invalid URL status", async () => {
+    const { probeRuntimeEndpoint } = await import("@/lib/onboarding/runtime-probe");
+    (probeRuntimeEndpoint as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: "invalid_url",
+      detectedRuntime: "unknown",
+      models: [],
+      hints: [],
+      error: "Invalid endpoint URL.",
+    });
+
+    const { POST } = await import("@/app/api/register/probe/route");
+    const req = new Request("http://localhost/api/register/probe", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ endpoint: "bad url" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.status).toBe("invalid_url");
+  });
+});

--- a/lib/__tests__/runtime-probe.test.ts
+++ b/lib/__tests__/runtime-probe.test.ts
@@ -1,0 +1,72 @@
+import { probeRuntimeEndpoint } from "@/lib/onboarding/runtime-probe";
+
+describe("runtime probe foundation (I1)", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    global.fetch = jest.fn() as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("detects OpenAI-compatible runtime via /v1/models", async () => {
+    (global.fetch as unknown as jest.Mock).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ data: [{ id: "Qwen/Qwen2.5-7B-Instruct" }] }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    const out = await probeRuntimeEndpoint("https://example.com");
+
+    expect(out.ok).toBe(true);
+    expect(out.status).toBe("runtime_detected");
+    expect(out.detectedRuntime).toBe("openai_compatible");
+    expect(out.models).toEqual(["Qwen/Qwen2.5-7B-Instruct"]);
+    expect((global.fetch as unknown as jest.Mock).mock.calls[0][0]).toContain("/v1/models");
+  });
+
+  it("falls back to Ollama detection via /api/tags", async () => {
+    (global.fetch as unknown as jest.Mock)
+      .mockResolvedValueOnce(new Response("", { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ models: [{ name: "qwen3:8b" }] }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      );
+
+    const out = await probeRuntimeEndpoint("https://example.com");
+
+    expect(out.ok).toBe(true);
+    expect(out.status).toBe("runtime_detected");
+    expect(out.detectedRuntime).toBe("ollama");
+    expect(out.models).toEqual(["qwen3:8b"]);
+    expect((global.fetch as unknown as jest.Mock).mock.calls[1][0]).toContain("/api/tags");
+  });
+
+  it("returns reachable when only /healthz works", async () => {
+    (global.fetch as unknown as jest.Mock)
+      .mockResolvedValueOnce(new Response("", { status: 404 }))
+      .mockResolvedValueOnce(new Response("", { status: 404 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const out = await probeRuntimeEndpoint("https://example.com");
+
+    expect(out.ok).toBe(true);
+    expect(out.status).toBe("reachable");
+    expect(out.detectedRuntime).toBe("unknown");
+    expect(out.models).toEqual([]);
+  });
+
+  it("returns invalid_url for malformed endpoint", async () => {
+    const out = await probeRuntimeEndpoint("::not-a-url::");
+
+    expect(out.ok).toBe(false);
+    expect(out.status).toBe("invalid_url");
+  });
+});

--- a/lib/onboarding/runtime-probe.ts
+++ b/lib/onboarding/runtime-probe.ts
@@ -1,0 +1,144 @@
+export type RuntimeTarget = "auto" | "ollama" | "llama_cpp" | "vllm" | "lm_studio";
+export type RuntimeDetected = "unknown" | "ollama" | "openai_compatible";
+export type RuntimeProbeStatus = "runtime_detected" | "reachable" | "unreachable" | "invalid_url";
+
+export type RuntimeProbeResult = {
+  ok: boolean;
+  status: RuntimeProbeStatus;
+  detectedRuntime: RuntimeDetected;
+  models: string[];
+  hints: string[];
+  error?: string;
+};
+
+function normalizeEndpoint(endpoint: string) {
+  const raw = endpoint.trim();
+  if (!raw) throw new Error("Endpoint URL is required.");
+  try {
+    return raw.startsWith("http://") || raw.startsWith("https://")
+      ? new URL(raw)
+      : new URL(`https://${raw}`);
+  } catch {
+    throw new Error("Invalid endpoint URL.");
+  }
+}
+
+function modelHints(runtime: RuntimeDetected) {
+  if (runtime === "ollama") return ["Detected Ollama-compatible endpoint (/api/tags)."];
+  if (runtime === "openai_compatible") {
+    return ["Detected OpenAI-compatible endpoint (/v1/models).", "Works for llama.cpp, vLLM, and LM Studio local server modes."];
+  }
+  return ["Endpoint is reachable, but runtime API shape was not detected."];
+}
+
+async function probeOpenAI(origin: string) {
+  const res = await fetch(`${origin}/v1/models`, {
+    signal: AbortSignal.timeout(5000),
+  });
+
+  if (!res.ok) return null;
+
+  const body = (await res.json().catch(() => null)) as
+    | { data?: Array<{ id?: string }> }
+    | null;
+
+  const models = Array.isArray(body?.data)
+    ? body.data.map((m) => m?.id).filter((id): id is string => Boolean(id))
+    : [];
+
+  return {
+    runtime: "openai_compatible" as const,
+    models,
+  };
+}
+
+async function probeOllama(origin: string) {
+  const res = await fetch(`${origin}/api/tags`, {
+    signal: AbortSignal.timeout(5000),
+  });
+
+  if (!res.ok) return null;
+
+  const body = (await res.json().catch(() => null)) as
+    | { models?: Array<{ name?: string }> }
+    | null;
+
+  const models = Array.isArray(body?.models)
+    ? body.models.map((m) => m?.name).filter((name): name is string => Boolean(name))
+    : [];
+
+  return {
+    runtime: "ollama" as const,
+    models,
+  };
+}
+
+export async function probeRuntimeEndpoint(endpoint: string, target: RuntimeTarget = "auto"): Promise<RuntimeProbeResult> {
+  try {
+    const url = normalizeEndpoint(endpoint);
+    const origin = url.origin;
+
+    const shouldTryOpenAI = target === "auto" || target === "llama_cpp" || target === "vllm" || target === "lm_studio";
+    const shouldTryOllama = target === "auto" || target === "ollama";
+
+    if (shouldTryOpenAI) {
+      const openai = await probeOpenAI(origin);
+      if (openai) {
+        return {
+          ok: true,
+          status: "runtime_detected",
+          detectedRuntime: openai.runtime,
+          models: openai.models,
+          hints: modelHints(openai.runtime),
+        };
+      }
+    }
+
+    if (shouldTryOllama) {
+      const ollama = await probeOllama(origin);
+      if (ollama) {
+        return {
+          ok: true,
+          status: "runtime_detected",
+          detectedRuntime: ollama.runtime,
+          models: ollama.models,
+          hints: modelHints(ollama.runtime),
+        };
+      }
+    }
+
+    const healthRes = await fetch(`${origin}/healthz`, {
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (healthRes.ok) {
+      return {
+        ok: true,
+        status: "reachable",
+        detectedRuntime: "unknown",
+        models: [],
+        hints: modelHints("unknown"),
+      };
+    }
+
+    return {
+      ok: false,
+      status: "unreachable",
+      detectedRuntime: "unknown",
+      models: [],
+      hints: ["Check URL, tunnel process, and port mapping."],
+      error: "Endpoint is not reachable.",
+    };
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : "Connection failed";
+    const status: RuntimeProbeStatus = /invalid endpoint url|required/i.test(msg) ? "invalid_url" : "unreachable";
+    return {
+      ok: false,
+      status,
+      detectedRuntime: "unknown",
+      models: [],
+      hints: ["Check URL format and that the server is publicly reachable."],
+      error: msg,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Implements Phase I1 foundation from the runtime-diverse onboarding infrastructure plan.

## What changed
- Added runtime probe core: `lib/onboarding/runtime-probe.ts`
  - supports target hints (`auto|ollama|llama_cpp|vllm|lm_studio`)
  - probes in normalized order:
    - OpenAI-compatible: `GET /v1/models`
    - Ollama-compatible: `GET /api/tags`
    - health fallback: `GET /healthz`
  - returns normalized contract (`runtimeStatus`, `detectedRuntime`, `models`, `hints`)
- Updated `POST /api/register/probe` to use the new probe core
- Preserved legacy UI compatibility:
  - keeps `status=ollama_detected` for Ollama runtime detection
  - maps non-Ollama runtime detection to legacy `status=reachable`
  - exposes normalized fields for new runtime-aware UI work

## Tests
Added:
- `lib/__tests__/runtime-probe.test.ts`
- `lib/__tests__/register-probe-route.test.ts`

Run:
```bash
npx jest lib/__tests__/runtime-probe.test.ts lib/__tests__/register-probe-route.test.ts --runInBand
```

Result:
- 2 suites passed
- 7 tests passed

## Phase checkpoint
This is **PR-A (I1 foundation)** in the phased runtime-onboarding plan.
