### PR TITLE
Finalize runtime-diverse onboarding to main (I3 + I4)

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -33,6 +33,7 @@ const WalletMultiButton = dynamic(
 type WizardState = {
   consentExposeEndpoint: boolean;
   consentProtocolOps: boolean;
+  runtimeType: "ollama" | "openai_local";
   platform: "macos" | "ubuntu" | "windows";
   ollamaPort: string;
   protocolDomain: string;
@@ -102,6 +103,7 @@ const STORAGE_KEY = "reddi-onboarding-wizard-v1";
 const INITIAL_STATE: WizardState = {
   consentExposeEndpoint: false,
   consentProtocolOps: false,
+  runtimeType: "ollama",
   platform: "macos",
   ollamaPort: "11434",
   protocolDomain: "https://reddi.tech",
@@ -290,7 +292,10 @@ export default function OnboardingPage() {
 
   const canContinue = useMemo(() => {
     if (step === 1) return state.consentExposeEndpoint && state.consentProtocolOps;
-    if (step === 2) return Number(state.ollamaPort) > 0 && state.runtimeReady;
+    if (step === 2) {
+      if (state.runtimeType === "ollama") return Number(state.ollamaPort) > 0 && state.runtimeReady;
+      return state.runtimeReady;
+    }
     if (step === 3) return state.endpointStatus === "online";
     if (step === 4) {
       const walletOk = state.walletAddress.length > 0;
@@ -455,7 +460,7 @@ export default function OnboardingPage() {
                 onChange={(e) => setState((s) => ({ ...s, consentExposeEndpoint: e.target.checked }))}
                 className="mt-1 accent-[#9945FF]"
               />
-              <span>I consent to exposing my local Ollama API through a tunnel endpoint.</span>
+              <span>I consent to exposing my local runtime API through a tunnel endpoint.</span>
             </label>
             <label className="flex items-start gap-3 text-sm cursor-pointer">
               <input
@@ -472,8 +477,26 @@ export default function OnboardingPage() {
         {step === 2 && (
           <div className="space-y-4">
             <h2 className="text-lg font-semibold">2. Runtime setup</h2>
-            <p className="text-sm text-muted-foreground">Wizard checks/install steps for Ollama by platform.</p>
+            <p className="text-sm text-muted-foreground">Wizard checks/install steps for Ollama or OpenAI-compatible local runtimes.</p>
             <div className="grid sm:grid-cols-2 gap-4">
+              <div>
+                <Label className="mb-1 block">Runtime type</Label>
+                <select
+                  value={state.runtimeType}
+                  onChange={(e) =>
+                    setState((s) => ({
+                      ...s,
+                      runtimeType: e.target.value as WizardState["runtimeType"],
+                      runtimeReady: false,
+                      runtimeNote: "",
+                    }))
+                  }
+                  className="w-full bg-background border border-white/10 rounded-md px-3 py-2 text-sm"
+                >
+                  <option value="ollama">Ollama</option>
+                  <option value="openai_local">OpenAI-compatible local server (llama.cpp / vLLM / LM Studio)</option>
+                </select>
+              </div>
               <div>
                 <Label className="mb-1 block">Platform</Label>
                 <select
@@ -489,7 +512,7 @@ export default function OnboardingPage() {
                 </select>
               </div>
               <div>
-                <Label className="mb-1 block">Ollama API port</Label>
+                <Label className="mb-1 block">Local runtime API port</Label>
                 <Input
                   value={state.ollamaPort}
                   onChange={(e) =>
@@ -509,66 +532,83 @@ export default function OnboardingPage() {
                 placeholder="https://reddi.tech"
               />
             </div>
-            <Button
-              variant="outline"
-              disabled={
-                runtimeLoading ||
-                !state.consentExposeEndpoint ||
-                !state.consentProtocolOps ||
-                Number(state.ollamaPort) <= 0
-              }
-              onClick={async () => {
-                setRuntimeLoading(true);
-                try {
-                  const res = await fetch("/api/onboarding/runtime", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                      platform: state.platform,
-                      port: Number(state.ollamaPort),
-                      protocolDomain: state.protocolDomain,
-                      consentExposeEndpoint: state.consentExposeEndpoint,
-                      consentProtocolOps: state.consentProtocolOps,
-                    }),
-                  });
-                  const data = await res.json();
-                  if (!res.ok || !data.ok) {
+            {state.runtimeType === "ollama" ? (
+              <Button
+                variant="outline"
+                disabled={
+                  runtimeLoading ||
+                  !state.consentExposeEndpoint ||
+                  !state.consentProtocolOps ||
+                  Number(state.ollamaPort) <= 0
+                }
+                onClick={async () => {
+                  setRuntimeLoading(true);
+                  try {
+                    const res = await fetch("/api/onboarding/runtime", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({
+                        platform: state.platform,
+                        port: Number(state.ollamaPort),
+                        protocolDomain: state.protocolDomain,
+                        consentExposeEndpoint: state.consentExposeEndpoint,
+                        consentProtocolOps: state.consentProtocolOps,
+                      }),
+                    });
+                    const data = await res.json();
+                    if (!res.ok || !data.ok) {
+                      setState((s) => ({
+                        ...s,
+                        runtimeReady: false,
+                        runtimeTokenStored: false,
+                        runtimeNote: data.error || "Runtime bootstrap failed",
+                      }));
+                      return;
+                    }
+
+                    const noteParts = [
+                      data.result.ollama.running ? "Ollama running" : "Ollama not running",
+                      data.result.token.storedInKeychain ? "token stored in keychain" : "token not stored in keychain",
+                      data.result.installHint ? `hint: ${data.result.installHint}` : null,
+                      data.result.token.note || null,
+                    ].filter(Boolean);
+
+                    setState((s) => ({
+                      ...s,
+                      runtimeReady: Boolean(data.result.ready),
+                      runtimeTokenStored: Boolean(data.result.token.storedInKeychain),
+                      runtimeNote: noteParts.join(" · "),
+                    }));
+                  } catch {
                     setState((s) => ({
                       ...s,
                       runtimeReady: false,
                       runtimeTokenStored: false,
-                      runtimeNote: data.error || "Runtime bootstrap failed",
+                      runtimeNote: "Runtime bootstrap failed",
                     }));
-                    return;
+                  } finally {
+                    setRuntimeLoading(false);
                   }
-
-                  const noteParts = [
-                    data.result.ollama.running ? "Ollama running" : "Ollama not running",
-                    data.result.token.storedInKeychain ? "token stored in keychain" : "token not stored in keychain",
-                    data.result.installHint ? `hint: ${data.result.installHint}` : null,
-                    data.result.token.note || null,
-                  ].filter(Boolean);
-
+                }}
+              >
+                {runtimeLoading ? "Bootstrapping runtime..." : "Run runtime bootstrap"}
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                onClick={() =>
                   setState((s) => ({
                     ...s,
-                    runtimeReady: Boolean(data.result.ready),
-                    runtimeTokenStored: Boolean(data.result.token.storedInKeychain),
-                    runtimeNote: noteParts.join(" · "),
-                  }));
-                } catch {
-                  setState((s) => ({
-                    ...s,
-                    runtimeReady: false,
+                    runtimeReady: true,
                     runtimeTokenStored: false,
-                    runtimeNote: "Runtime bootstrap failed",
-                  }));
-                } finally {
-                  setRuntimeLoading(false);
+                    runtimeNote:
+                      "Manual runtime mode enabled for OpenAI-compatible local server (llama.cpp/vLLM/LM Studio).",
+                  }))
                 }
-              }}
-            >
-              {runtimeLoading ? "Bootstrapping runtime..." : "Run runtime bootstrap"}
-            </Button>
+              >
+                Mark runtime ready (manual)
+              </Button>
+            )}
 
             {state.runtimeNote && (
               <div className="rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-muted-foreground">
@@ -587,7 +627,7 @@ export default function OnboardingPage() {
         {step === 3 && (
           <div className="space-y-4">
             <h2 className="text-lg font-semibold">3. Endpoint setup</h2>
-            <p className="text-sm text-muted-foreground">Configure token-gated proxy + tunnel endpoint mapped to your local Ollama port.</p>
+            <p className="text-sm text-muted-foreground">Configure token-gated proxy + tunnel endpoint mapped to your local runtime port.</p>
             <div>
               <Label className="mb-1 block">Tunnel endpoint (optional override)</Label>
               <Input
@@ -717,6 +757,22 @@ export default function OnboardingPage() {
               >
                 {endpointHeartbeatLoading ? "Checking heartbeat..." : "Run endpoint heartbeat"}
               </Button>
+
+              {state.runtimeType === "openai_local" && state.endpointUrl && (
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    setState((s) => ({
+                      ...s,
+                      endpointStatus: "online",
+                      endpointNote:
+                        "Manual endpoint mode enabled for OpenAI-compatible runtime. Proceeding without Ollama-specific endpoint bootstrap.",
+                    }))
+                  }
+                >
+                  Mark endpoint online (manual)
+                </Button>
+              )}
             </div>
 
             <div className="rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-muted-foreground">

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useWallet, useConnection } from "@solana/wallet-adapter-react";
 import {
   Connection,
@@ -57,7 +57,8 @@ const WalletMultiButton = dynamic(
 type Step = 1 | 2 | 3;
 type AgentType = "primary" | "attestation" | "both";
 type PrivacyTier = "local" | "tee" | "cloud";
-type EndpointProbeStatus = "idle" | "checking" | "reachable" | "no_ollama" | "unreachable";
+type EndpointProbeStatus = "idle" | "checking" | "reachable" | "runtime_not_detected" | "unreachable";
+type RuntimeTarget = "auto" | "ollama" | "llama_cpp" | "vllm" | "lm_studio";
 type HelpItem = { text: string; href?: string; code?: string };
 type HelpStep = { title: string; items: HelpItem[] };
 
@@ -91,18 +92,19 @@ const REGISTRATION_FEE_SOL = 0.01;
 const RENT_SOL = 0.00057;
 const ENDPOINT_HELP_STEPS: HelpStep[] = [
   {
-    title: "Install and start Ollama",
+    title: "Start a local runtime",
     items: [
-      { text: "Download Ollama", href: "https://ollama.com/download" },
-      { text: "Pull a model", code: "ollama pull qwen2.5:7b" },
-      { text: "Ollama runs at http://localhost:11434 by default" },
+      { text: "Ollama", code: "ollama serve  # default http://localhost:11434" },
+      { text: "llama.cpp", code: "./llama-server -m /path/to/model.gguf --port 8080" },
+      { text: "vLLM", code: "python -m vllm.entrypoints.openai.api_server --model /path/to/model" },
+      { text: "LM Studio: open Local Server tab, select model, Start Server" },
     ],
   },
   {
     title: "Expose it with localtunnel",
     items: [
       { text: "Install", code: "npm install -g localtunnel" },
-      { text: "Run", code: "lt --port 11434 --subdomain my-agent" },
+      { text: "Run", code: "lt --port <runtime-port> --subdomain my-agent" },
       { text: "Your endpoint will be", code: "https://my-agent.loca.lt" },
       { text: "Note: localtunnel URLs expire when the process stops" },
     ],
@@ -111,13 +113,13 @@ const ENDPOINT_HELP_STEPS: HelpStep[] = [
     title: "Or use ngrok (more stable)",
     items: [
       { text: "Install", href: "https://ngrok.com/download" },
-      { text: "Run", code: "ngrok http 11434" },
+      { text: "Run", code: "ngrok http <runtime-port>" },
       { text: "Copy the https:// forwarding URL" },
     ],
   },
   {
     title: "Paste the public URL below",
-    items: [{ text: "Then probe it to confirm the endpoint is reachable." }],
+    items: [{ text: "Choose Runtime Type, then probe to confirm the endpoint and API shape." }],
   },
 ];
 
@@ -132,13 +134,14 @@ function RegisterInner() {
   const [txSig, setTxSig] = useState<string | null>(null);
   const [txError, setTxError] = useState<string | null>(null);
   const [setupModalOpen, setSetupModalOpen] = useState(false);
+  const [runtimeTarget, setRuntimeTarget] = useState<RuntimeTarget>("auto");
   const [endpointProbeStatus, setEndpointProbeStatus] = useState<EndpointProbeStatus>("idle");
   const [endpointProbeMessage, setEndpointProbeMessage] = useState("");
   const [endpointProbeModels, setEndpointProbeModels] = useState<string[]>([]);
   const endpointProbeTimeoutRef = useRef<number | null>(null);
   const endpointProbeRequestRef = useRef(0);
 
-  const runEndpointProbe = async (rawEndpoint: string) => {
+  const runEndpointProbe = useCallback(async (rawEndpoint: string, runtime: RuntimeTarget = runtimeTarget) => {
     const endpoint = rawEndpoint.trim();
     if (!endpoint) {
       setEndpointProbeStatus("idle");
@@ -156,7 +159,7 @@ function RegisterInner() {
       const res = await fetch("/api/register/probe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ endpoint }),
+        body: JSON.stringify({ endpoint, runtimeTarget: runtime }),
       });
       const data = await res.json().catch(() => null);
       if (requestId !== endpointProbeRequestRef.current) return;
@@ -167,20 +170,33 @@ function RegisterInner() {
         return;
       }
 
-      if (data.status === "ollama_detected") {
+      if (data.runtimeStatus === "runtime_detected" || data.status === "ollama_detected") {
+        const detectedRuntime =
+          data.detectedRuntime === "ollama"
+            ? "Ollama"
+            : data.detectedRuntime === "openai_compatible"
+              ? "OpenAI-compatible runtime"
+              : "Runtime";
+        const probedModels = Array.isArray(data.models) ? data.models : [];
+
         setEndpointProbeStatus("reachable");
-        setEndpointProbeModels(Array.isArray(data.models) ? data.models : []);
+        setEndpointProbeModels(probedModels);
         setEndpointProbeMessage(
-          Array.isArray(data.models) && data.models.length > 0
-            ? `Ollama detected, models: ${data.models.slice(0, 3).join(", ")}`
-            : "Endpoint reachable."
+          probedModels.length > 0
+            ? `${detectedRuntime} detected, models: ${probedModels.slice(0, 3).join(", ")}`
+            : `${detectedRuntime} detected.`
         );
+
+        setForm((prev) => {
+          if (prev.model.trim() || probedModels.length === 0) return prev;
+          return { ...prev, model: probedModels[0] };
+        });
         return;
       }
 
       if (data.status === "reachable") {
-        setEndpointProbeStatus("no_ollama");
-        setEndpointProbeMessage("Endpoint responded, but /api/tags did not look like Ollama.");
+        setEndpointProbeStatus("runtime_not_detected");
+        setEndpointProbeMessage("Endpoint responded, but runtime API shape was not detected yet.");
         return;
       }
 
@@ -191,7 +207,7 @@ function RegisterInner() {
       setEndpointProbeStatus("unreachable");
       setEndpointProbeMessage("Check the URL and ensure it is publicly accessible.");
     }
-  };
+  }, [runtimeTarget]);
 
   useEffect(() => {
     const endpoint = searchParams.get("endpoint")?.trim();
@@ -245,7 +261,7 @@ function RegisterInner() {
         window.clearTimeout(endpointProbeTimeoutRef.current);
       }
     };
-  }, [form.endpoint]);
+  }, [form.endpoint, runtimeTarget, runEndpointProbe]);
 
   const isJudge = form.agentType === "attestation" || form.agentType === "both";
 
@@ -591,6 +607,35 @@ function RegisterInner() {
 
             {/* Endpoint */}
             <div className="space-y-1.5">
+              <div className="space-y-1.5">
+                <Label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block">
+                  Runtime Type
+                </Label>
+                <Select
+                  value={runtimeTarget}
+                  onValueChange={(value) => {
+                    setRuntimeTarget(value as RuntimeTarget);
+                    setEndpointProbeStatus("idle");
+                    setEndpointProbeMessage("");
+                    setEndpointProbeModels([]);
+                  }}
+                >
+                  <SelectTrigger className="!w-full !min-w-[180px] !rounded-lg !border !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-gray-900 !px-3 !py-2 !text-sm focus:!ring-2 focus:!ring-blue-500 focus:!outline-none">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent className="min-w-[240px] rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg">
+                    <SelectItem value="auto">Auto detect</SelectItem>
+                    <SelectItem value="ollama">Ollama</SelectItem>
+                    <SelectItem value="llama_cpp">llama.cpp</SelectItem>
+                    <SelectItem value="vllm">vLLM</SelectItem>
+                    <SelectItem value="lm_studio">LM Studio</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Pick your local runtime for more accurate endpoint validation.
+                </p>
+              </div>
+
               <div className="flex items-center justify-between gap-3">
                 <Label htmlFor="endpoint" className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block">
                   Service Endpoint URL
@@ -619,14 +664,14 @@ function RegisterInner() {
                   if (endpointProbeTimeoutRef.current) {
                     window.clearTimeout(endpointProbeTimeoutRef.current);
                   }
-                  void runEndpointProbe(form.endpoint);
+                  void runEndpointProbe(form.endpoint, runtimeTarget);
                 }}
                 className={`!w-full !rounded-lg !border !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-gray-900 !px-3 !py-2 !text-sm focus:!ring-2 focus:!ring-blue-500 focus:!outline-none ${
                   endpointProbeStatus === "checking"
                     ? "!border-blue-400"
                     : endpointProbeStatus === "reachable"
                       ? "!border-green-400"
-                      : endpointProbeStatus === "no_ollama"
+                      : endpointProbeStatus === "runtime_not_detected"
                         ? "!border-yellow-400"
                         : endpointProbeStatus === "unreachable"
                           ? "!border-red-400"
@@ -643,7 +688,7 @@ function RegisterInner() {
                       ? "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/20 dark:text-blue-200"
                       : endpointProbeStatus === "reachable"
                         ? "border-green-200 bg-green-50 text-green-700 dark:border-green-900/40 dark:bg-green-950/20 dark:text-green-200"
-                        : endpointProbeStatus === "no_ollama"
+                        : endpointProbeStatus === "runtime_not_detected"
                           ? "border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-900/40 dark:bg-yellow-950/20 dark:text-yellow-200"
                           : "border-red-200 bg-red-50 text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-200"
                   }`}
@@ -652,7 +697,7 @@ function RegisterInner() {
                     <Loader2 className="mt-0.5 h-4 w-4 animate-spin" />
                   ) : endpointProbeStatus === "reachable" ? (
                     <CheckCircle2 className="mt-0.5 h-4 w-4" />
-                  ) : endpointProbeStatus === "no_ollama" ? (
+                  ) : endpointProbeStatus === "runtime_not_detected" ? (
                     <AlertTriangle className="mt-0.5 h-4 w-4" />
                   ) : (
                     <XCircle className="mt-0.5 h-4 w-4" />
@@ -663,8 +708,8 @@ function RegisterInner() {
                         ? "Checking…"
                         : endpointProbeStatus === "reachable"
                           ? "Endpoint reachable"
-                          : endpointProbeStatus === "no_ollama"
-                            ? "Reachable, but no Ollama detected"
+                          : endpointProbeStatus === "runtime_not_detected"
+                            ? "Reachable, but runtime not detected"
                             : "Unreachable"}
                     </p>
                     {endpointProbeMessage && <p className="mt-0.5 text-[11px] font-normal">{endpointProbeMessage}</p>}


### PR DESCRIPTION
## Summary
Brings the remaining runtime-diverse onboarding phases into `main`.

This PR includes:
- **I3 / PR-C equivalent**: runtime-aware register endpoint validation and messaging
- **I4 / PR-D equivalent**: onboarding wizard runtime parity for non-Ollama local runtimes

## Why this PR exists
PR #63 and PR #64 were merged in a stacked flow, but not directly into `main`. This PR ports those changes onto `main` cleanly.

## Changes included
- Register page:
  - runtime selector (`auto`, `ollama`, `llama_cpp`, `vllm`, `lm_studio`)
  - sends `runtimeTarget` to probe route
  - runtime-neutral status text and model auto-prefill
- Onboarding wizard:
  - runtime type selection (`ollama` vs `openai_local`)
  - manual runtime-ready path for non-Ollama local servers
  - manual endpoint-online path for non-Ollama local servers
  - copy updates from Ollama-only wording to runtime-neutral wording

## Verification
- `npx jest lib/__tests__/runtime-probe.test.ts lib/__tests__/register-probe-route.test.ts --runInBand` ✅
- `npm run build` ✅

## Cherry-picks
- `5609ab31` (register runtime-aware validation)
- `e872f6f6` (onboarding runtime parity)
