### PR TITLE
UX polish: runtime onboarding clarity and helper guidance

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -522,6 +522,14 @@ export default function OnboardingPage() {
                 />
               </div>
             </div>
+            {state.runtimeType === "openai_local" && (
+              <div className="rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-muted-foreground space-y-1">
+                <p className="text-[#14F195]">Quick starts (OpenAI-compatible local server):</p>
+                <p className="font-mono">llama.cpp: ./llama-server -m /path/to/model.gguf --port 8080</p>
+                <p className="font-mono">vLLM: python -m vllm.entrypoints.openai.api_server --model /path/to/model</p>
+                <p>LM Studio: Local Server tab → select model → Start Server.</p>
+              </div>
+            )}
             <div>
               <Label className="mb-1 block">Protocol CORS allowlist domain</Label>
               <Input
@@ -1734,7 +1742,7 @@ export default function OnboardingPage() {
               <>
                 <p className="text-xs text-yellow-400">Operator signer key must be configured before recording attestation.</p>
                 <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-xs text-yellow-200">
-                  <p className="mb-1">Quick fix: set <span className="font-mono">ONBOARDING_ATTEST_OPERATOR_SECRET_KEY</span> as a 64-byte JSON array, restart the app, then click "Check attestor key status" again.</p>
+                  <p className="mb-1">Quick fix: set <span className="font-mono">ONBOARDING_ATTEST_OPERATOR_SECRET_KEY</span> as a 64-byte JSON array, restart the app, then click &quot;Check attestor key status&quot; again.</p>
                   <p className="font-mono break-all">Example format: [12,34,56,...,64 bytes total]</p>
                   <Link href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/ONBOARDING-ATTESTATION-OPERATOR-SETUP.md" className="mt-2 inline-block underline">
                     Operator setup and recovery guide →

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -728,10 +728,10 @@ function RegisterInner() {
                   Model Name
                 </Label>
                 <a
-                  href="https://ollama.com/library"
+                  href={runtimeTarget === "ollama" ? "https://ollama.com/library" : "https://github.com/ggerganov/llama.cpp/tree/master/tools/server"}
                   target="_blank"
                   rel="noopener noreferrer"
-                  title="Browse available Ollama models"
+                  title={runtimeTarget === "ollama" ? "Browse available Ollama models" : "Runtime model reference (OpenAI-compatible local servers)"}
                   className="inline-flex items-center text-gray-400 transition hover:text-gray-600 dark:hover:text-gray-200"
                 >
                   <CircleHelp className="h-4 w-4" />
@@ -744,6 +744,11 @@ function RegisterInner() {
                 onChange={(e) => setForm({ ...form, model: e.target.value })}
                 className="!w-full !rounded-lg !border !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-gray-900 !px-3 !py-2 !text-sm focus:!ring-2 focus:!ring-blue-500 focus:!outline-none"
               />
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {runtimeTarget === "ollama"
+                  ? "Use Ollama model names, for example qwen3:8b."
+                  : "Use the model id exposed by /v1/models for your local runtime."}
+              </p>
             </div>
 
             {/* Privacy Tier */}

--- a/components/GuidedSetupModal.tsx
+++ b/components/GuidedSetupModal.tsx
@@ -424,6 +424,11 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
                 onChange={(e) => setRuntimeBaseUrl(e.target.value)}
                 placeholder={runtimeConfig.defaultBaseUrl}
               />
+              <p className="text-xs text-muted-foreground">
+                {runtimeChoice === "ollama"
+                  ? "Expected probe path: /api/tags"
+                  : "Expected probe path: /v1/models"}
+              </p>
             </div>
 
             <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
Small UX polish pass for runtime-diverse onboarding flows.

## Changes
- Quick Setup (`GuidedSetupModal`)
  - added explicit expected probe path hint based on runtime:
    - Ollama → `/api/tags`
    - OpenAI-compatible local runtimes → `/v1/models`
- Register page
  - made model help link/title runtime-aware (not Ollama-only)
  - added model field helper text for runtime-specific model naming expectations
- Onboarding wizard
  - added quick-start guidance box for non-Ollama OpenAI-compatible local servers
  - fixed unescaped quote lint issue in attestor key helper copy

## Verification
- `npx eslint components/GuidedSetupModal.tsx app/register/page.tsx app/onboarding/page.tsx`
- `npm run build`
