### PR TITLE
Fix register tx failure in browser (u64 encoding)

### DIFF
--- a/lib/program.ts
+++ b/lib/program.ts
@@ -131,6 +131,14 @@ export function buildRegisterAgentData(
   rateLamports: bigint,
   minReputation: number
 ): Buffer {
+  const writeU64LE = (target: Uint8Array, offset: number, value: bigint) => {
+    let v = value;
+    for (let i = 0; i < 8; i += 1) {
+      target[offset + i] = Number(v & 0xffn);
+      v >>= 8n;
+    }
+  };
+
   const modelBytes = Buffer.from(model, "utf-8");
   const buf = Buffer.alloc(8 + 1 + 4 + modelBytes.length + 8 + 1);
   let o = 0;
@@ -138,7 +146,7 @@ export function buildRegisterAgentData(
   buf.writeUInt8(agentType, o); o += 1;
   buf.writeUInt32LE(modelBytes.length, o); o += 4;
   modelBytes.copy(buf, o); o += modelBytes.length;
-  buf.writeBigUInt64LE(rateLamports, o); o += 8;
+  writeU64LE(buf, o, rateLamports); o += 8;
   buf.writeUInt8(minReputation, o);
   return buf;
 }


### PR DESCRIPTION
## Problem
Register flow fails at final on-chain submit with:
`o.writeBigUInt64LE is not a function`

## Root cause
`buildRegisterAgentData()` used `Buffer.writeBigUInt64LE(...)`. In browser bundling/runtime, this API can be missing or shimmed inconsistently.

## Fix
Replaced the single `writeBigUInt64LE` usage with a small runtime-safe little-endian u64 writer that writes 8 bytes directly to `Uint8Array`.

## Impact
- Fixes register transaction construction in browser wallets.
- No change to instruction layout or on-chain compatibility.

## Verification
- `npx eslint lib/program.ts`
- `npm run build` ✅
