### PR TITLE
fix(register): build-safe devnet/surfpool validation package

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -321,11 +321,7 @@ function RegisterInner() {
       tx.add(ix);
 
       try {
-        const sim = await conn.simulateTransaction(tx, {
-          commitment: "processed",
-          replaceRecentBlockhash: true,
-          sigVerify: false,
-        });
+        const sim = await conn.simulateTransaction(tx);
 
         if (sim.value.err) {
           throw new Error(formatSimulationError(sim.value.err, sim.value.logs));

--- a/lib/wallet/playwright-wallet-adapter.ts
+++ b/lib/wallet/playwright-wallet-adapter.ts
@@ -7,7 +7,7 @@ import {
   Connection,
   Keypair,
   PublicKey,
-  SendTransactionOptions,
+  SendOptions,
   Transaction,
   TransactionSignature,
   VersionedTransaction,
@@ -38,9 +38,10 @@ export class PlaywrightWalletAdapter extends BaseMessageSignerWalletAdapter {
   icon =
     "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' rx='12' fill='%23111827'/%3E%3Cpath d='M18 46V18h14c8 0 14 6 14 14s-6 14-14 14H18zm8-8h6c3.3 0 6-2.7 6-6s-2.7-6-6-6h-6v12z' fill='%239945FF'/%3E%3C/svg%3E";
 
-  readonly supportedTransactionVersions = new Set(["legacy", 0]);
+  readonly supportedTransactionVersions = new Set(["legacy", 0] as const);
   private _publicKey: PublicKey | null = null;
   private _connected = false;
+  private _connecting = false;
 
   get publicKey() {
     return this._publicKey;
@@ -50,14 +51,20 @@ export class PlaywrightWalletAdapter extends BaseMessageSignerWalletAdapter {
     return this._connected;
   }
 
+  get connecting() {
+    return this._connecting;
+  }
+
   get readyState() {
     return WalletReadyState.Installed;
   }
 
   async connect(): Promise<void> {
     if (this._connected) return;
+    this._connecting = true;
     this._publicKey = PLAYWRIGHT_PUBLIC_KEY;
     this._connected = true;
+    this._connecting = false;
     this.emit("connect", this._publicKey);
   }
 
@@ -71,7 +78,7 @@ export class PlaywrightWalletAdapter extends BaseMessageSignerWalletAdapter {
   async sendTransaction(
     transaction: Transaction | VersionedTransaction,
     connection: Connection,
-    options?: SendTransactionOptions
+    options?: SendOptions
   ): Promise<TransactionSignature> {
     if (PLAYWRIGHT_SIGNER) {
       if (transaction instanceof VersionedTransaction) {


### PR DESCRIPTION
## Summary
This PR supersedes #68 with build-safe fixes.

- keeps all register hardening from #68:
  - localhost probe guards and clearer hosted/local messaging
  - `/register` error surfacing improvements
  - Playwright adapter optional signed-tx path (`NEXT_PUBLIC_PLAYWRIGHT_WALLET_SECRET_KEY`)
  - focused E2E specs for local sim/failure + local success capture
- fixes Vercel/Next TypeScript build blockers:
  - use `conn.simulateTransaction(tx)` legacy signature for typed compatibility
  - fix wallet adapter transaction options type (`SendOptions`)
  - add required `connecting` implementation on adapter
  - narrow `supportedTransactionVersions` typing via `as const`

## Validation
- `npm run build` ✅
- `npx eslint app/api/register/local-check/route.ts app/api/register/probe/route.ts app/register/page.tsx lib/wallet/playwright-wallet-adapter.ts e2e/helpers/wallet.ts e2e/register-local-sim.spec.ts e2e/register-local-success.spec.ts` ✅
- `npx playwright test e2e/register-local-sim.spec.ts` ✅

## Notes
- The peer dependency warnings in Vercel logs are non-fatal and unrelated to this failure.
- The failing build root cause was TypeScript incompatibility in the new register/playwright code path; this PR addresses that directly.
