### PR TITLE
feat: OpenOnion onboarding v1 scaffold (specialist/attestor/consumer)

### DIFF
--- a/app/api/planner/tools/invoke/route.ts
+++ b/app/api/planner/tools/invoke/route.ts
@@ -6,6 +6,7 @@
  * Returns response + run receipt.
  */
 import { executePlannerSpecialistCall } from "@/lib/onboarding/planner-execution";
+import { runOpenOnionConsumerFlow } from "@/lib/integrations/openonion/consumer/orchestrator";
 import { readPolicy } from "@/lib/orchestrator/policy";
 import { recordSpend } from "@/lib/orchestrator/policy";
 import { getJupiterClient, getJupiterSlippageBps } from "@/lib/jupiter-client";
@@ -48,9 +49,10 @@ export async function POST(req: Request) {
 
     const policyOverride = body.policy ?? {};
     const jupiterClient = getJupiterClient();
-    const result = await executePlannerSpecialistCall({
+    const executionInput = {
       prompt: body.prompt,
       consumerWallet: body.consumerWallet,
+      preferredWallet: body.targetWallet,
       swapClient: jupiterClient ?? undefined,
       slippageBps: getJupiterSlippageBps(),
       policy: {
@@ -62,7 +64,14 @@ export async function POST(req: Request) {
           policyOverride.maxPerCallUsd ??
           (savedPolicy.maxPerTaskUsd > 0 ? savedPolicy.maxPerTaskUsd : undefined),
       },
-    });
+    };
+
+    const result = body.integrationMode === "openonion"
+      ? await runOpenOnionConsumerFlow({
+          ...executionInput,
+          retryBudget: body.retryBudget,
+        })
+      : await executePlannerSpecialistCall(executionInput);
 
     // Record spend if payment was made
     if (result.ok && result.result.paymentSatisfied) {
@@ -101,7 +110,7 @@ export async function GET() {
     tool: "invoke_specialist",
     description: "Execute a paid specialist call with automatic x402 payment negotiation.",
     schema: {
-      input: { prompt: "string", targetWallet: "string?", policy: "PolicyOverride?" },
+      input: { prompt: "string", targetWallet: "string?", consumerWallet: "string?", policy: "PolicyOverride?" },
       output: { ok: "boolean", runId: "string", response: "string", x402TxSignature: "string", durationMs: "number" },
     },
   });

--- a/app/api/planner/tools/signal/route.ts
+++ b/app/api/planner/tools/signal/route.ts
@@ -6,6 +6,7 @@
  * Scores ≥3 on completed runs trigger on-chain blind reputation commit.
  */
 import { recordPlannerFeedback } from "@/lib/onboarding/planner-feedback";
+import { validateOpenOnionAttestorPayload } from "@/lib/integrations/openonion/attestor/schema";
 import type { QualitySignalInput, QualitySignalOutput } from "@/lib/mcp/tools";
 
 export const runtime = "nodejs";
@@ -21,9 +22,23 @@ export async function POST(req: Request) {
       return Response.json({ ok: false, error: "score must be between 1 and 10" }, { status: 400 });
     }
 
+    if (body.attestorPayload) {
+      const validation = validateOpenOnionAttestorPayload(body.attestorPayload);
+      if (!validation.ok) {
+        return Response.json(
+          {
+            ok: false,
+            error: `Invalid attestor payload: ${validation.issues.join(" ")}`,
+          },
+          { status: 400 }
+        );
+      }
+    }
+
     const result = await recordPlannerFeedback({
       runId: body.runId,
       score: body.score,
+      consumerWallet: body.consumerWallet,
       notes: body.notes,
       agreesWithAttestation: body.agreesWithAttestation,
     });
@@ -50,7 +65,7 @@ export async function GET() {
     tool: "submit_quality_signal",
     description: "Rate a completed specialist call. Triggers on-chain reputation commit for scores ≥3.",
     schema: {
-      input: { runId: "string", score: "number (1-10)", notes: "string?", agreesWithAttestation: "boolean?" },
+      input: { runId: "string", score: "number (1-10)", consumerWallet: "string?", notes: "string?", agreesWithAttestation: "boolean?" },
       output: { ok: "boolean", reputationCommitted: "boolean", reputationTxSignature: "string?" },
     },
   });

--- a/app/api/planner/tools/signal/route.ts
+++ b/app/api/planner/tools/signal/route.ts
@@ -38,7 +38,6 @@ export async function POST(req: Request) {
     const result = await recordPlannerFeedback({
       runId: body.runId,
       score: body.score,
-      consumerWallet: body.consumerWallet,
       notes: body.notes,
       agreesWithAttestation: body.agreesWithAttestation,
     });

--- a/app/api/register/probe/route.ts
+++ b/app/api/register/probe/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { isUnsafeHostedTarget } from "@/lib/integrations/openonion/network-policy";
+import { validateOpenOnionSpecialistProfile } from "@/lib/integrations/openonion/specialist/adapter";
 
 export const runtime = "nodejs";
 
@@ -14,14 +16,10 @@ function normalizeEndpoint(endpoint: string) {
   }
 }
 
-function isLoopbackHost(hostname: string) {
-  const host = hostname.toLowerCase();
-  return host === "localhost" || host === "127.0.0.1" || host === "::1";
-}
-
 export async function POST(req: Request) {
   const body = await req.json().catch(() => null);
   const endpoint = body?.endpoint;
+  const integration = body?.integration;
 
   if (!endpoint || typeof endpoint !== "string") {
     return NextResponse.json({ ok: false, status: "invalid_url" }, { status: 400 });
@@ -30,15 +28,45 @@ export async function POST(req: Request) {
   try {
     const url = normalizeEndpoint(endpoint);
 
-    if (isLoopbackHost(url.hostname)) {
+    if (isUnsafeHostedTarget(url.hostname)) {
       return NextResponse.json(
         {
           ok: false,
           status: "invalid_url",
-          error: "Localhost cannot be reached from this app context. Use a public tunnel URL (ngrok, cloudflared, or localtunnel).",
+          error: "Localhost/private-network targets are blocked in hosted context. Use a public tunnel URL (ngrok, cloudflared, or localtunnel).",
         },
         { status: 400 }
       );
+    }
+
+    if (integration === "openonion") {
+      const contractRes = await fetch(`${url.origin}/.well-known/reddi-adapter.json`, {
+        signal: AbortSignal.timeout(5000),
+      }).catch(() => null);
+
+      if (!contractRes?.ok) {
+        return NextResponse.json(
+          {
+            ok: false,
+            status: "invalid_contract",
+            error: "OpenOnion adapter contract not found. Expose /.well-known/reddi-adapter.json with specialist adapter metadata.",
+          },
+          { status: 400 }
+        );
+      }
+
+      const contract = await contractRes.json().catch(() => null);
+      const validation = validateOpenOnionSpecialistProfile(contract);
+      if (!validation.ok) {
+        return NextResponse.json(
+          {
+            ok: false,
+            status: "invalid_contract",
+            error: `OpenOnion specialist adapter contract mismatch: ${validation.issues.join(" ")}`,
+          },
+          { status: 400 }
+        );
+      }
     }
 
     const tagsRes = await fetch(`${url.origin}/api/tags`, {
@@ -52,6 +80,7 @@ export async function POST(req: Request) {
         ok: true,
         status: hasModels ? "ollama_detected" : "reachable",
         models: hasModels ? body.models.map((m: { name?: string }) => m.name).filter(Boolean) : [],
+        integration,
       });
     }
 

--- a/docs/integrations/openonion/OPENONION-ADAPTER-CONTRACT.md
+++ b/docs/integrations/openonion/OPENONION-ADAPTER-CONTRACT.md
@@ -1,0 +1,86 @@
+# OpenOnion Adapter Contract (Specialist, Attestor, Consumer)
+
+_Version: 2026-04-22 / `openonion.reddi.v1`_
+
+This contract defines the minimum integration shape required for OpenOnion/ConnectOnion runtimes to onboard safely into Reddi Agent Protocol.
+
+## 1) Specialist adapter
+
+Required profile fields:
+
+```json
+{
+  "adapter": "openonion",
+  "adapterVersion": "openonion.reddi.v1",
+  "role": "specialist",
+  "runtime": "connectonion",
+  "payment": {
+    "enforcement": "x402",
+    "required": true
+  },
+  "capabilities": {
+    "taskTypes": ["summarize"],
+    "inputModes": ["text"],
+    "outputModes": ["text"]
+  }
+}
+```
+
+Rules:
+- `payment.enforcement` must be `x402`.
+- `payment.required` must be `true`.
+- `taskTypes`, `inputModes`, and `outputModes` must be non-empty arrays.
+
+BDD mapping:
+- Specialist happy path
+- Specialist rejects unpaid invocation
+- Specialist endpoint contract mismatch
+- localhost/private-network bug guard
+
+## 2) Attestor adapter
+
+Attestor payload must be pinned to `reddi.attestation.v1` and include rubric dimensions.
+
+```json
+{
+  "schemaVersion": "reddi.attestation.v1",
+  "runId": "run_...",
+  "attestorWallet": "...",
+  "rubric": {
+    "coverage": 0.91,
+    "accuracy": 0.88,
+    "concision": 0.86
+  },
+  "verdict": "pass"
+}
+```
+
+Rules:
+- Missing rubric keys are rejected deterministically.
+- Schema version mismatch is rejected deterministically.
+- Rejected attestation payloads must not mutate reputation state.
+
+BDD mapping:
+- Attestor happy path
+- Attestor schema drift rejection
+
+## 3) Consumer plugin flow
+
+Consumer orchestration uses the existing planner toolchain:
+- discover -> resolve -> invoke -> monitor
+
+Failover policy:
+- If specialist becomes unreachable and retry budget is exhausted, set settlement disposition to `refund`.
+- Persist run-level failure reason for auditability.
+
+BDD mapping:
+- Consumer happy path
+- Consumer failover on specialist unreachability
+
+## 4) Hosted security policy
+
+Hosted preflight rejects endpoints targeting:
+- localhost / loopback (`localhost`, `127.0.0.1`, `::1`)
+- RFC1918 private IPv4 ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
+
+The response includes remediation guidance to use a secure public tunnel endpoint.

--- a/lib/__tests__/openonion-attestor-schema.test.ts
+++ b/lib/__tests__/openonion-attestor-schema.test.ts
@@ -1,0 +1,31 @@
+import {
+  OPENONION_ATTESTOR_SCHEMA_VERSION,
+  validateOpenOnionAttestorPayload,
+} from "@/lib/integrations/openonion/attestor/schema";
+
+describe("openonion attestor schema", () => {
+  it("accepts a pinned schema payload", () => {
+    const result = validateOpenOnionAttestorPayload({
+      schemaVersion: OPENONION_ATTESTOR_SCHEMA_VERSION,
+      runId: "run_123",
+      attestorWallet: "wallet_attestor",
+      rubric: { coverage: 0.9, accuracy: 0.8, concision: 0.85 },
+      verdict: "pass",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("rejects schema drift when rubric fields are missing", () => {
+    const result = validateOpenOnionAttestorPayload({
+      schemaVersion: OPENONION_ATTESTOR_SCHEMA_VERSION,
+      runId: "run_123",
+      attestorWallet: "wallet_attestor",
+      rubric: { coverage: 0.9, accuracy: 0.8 },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.join(" ")).toContain("rubric.concision");
+  });
+});

--- a/lib/__tests__/openonion-consumer-orchestrator.test.ts
+++ b/lib/__tests__/openonion-consumer-orchestrator.test.ts
@@ -1,0 +1,32 @@
+jest.mock("@/lib/onboarding/planner-execution", () => ({
+  executePlannerSpecialistCall: jest.fn(),
+}));
+
+describe("openonion consumer orchestrator", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("triggers refund disposition when specialist remains unreachable", async () => {
+    const { executePlannerSpecialistCall } = await import("@/lib/onboarding/planner-execution");
+    (executePlannerSpecialistCall as jest.Mock).mockResolvedValue({
+      ok: false,
+      result: {
+        runId: "run_123",
+        error: "fetch failed",
+        paymentSatisfied: false,
+      },
+    });
+
+    const { runOpenOnionConsumerFlow } = await import("@/lib/integrations/openonion/consumer/orchestrator");
+    const result = await runOpenOnionConsumerFlow({
+      prompt: "hello",
+      retryBudget: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.settlementDisposition).toBe("refund");
+    expect(executePlannerSpecialistCall).toHaveBeenCalledTimes(2);
+  });
+});

--- a/lib/__tests__/openonion-specialist-adapter.test.ts
+++ b/lib/__tests__/openonion-specialist-adapter.test.ts
@@ -1,0 +1,52 @@
+import {
+  OPENONION_ADAPTER_VERSION,
+  paymentRequiredSemantics,
+  validateOpenOnionSpecialistProfile,
+} from "@/lib/integrations/openonion/specialist/adapter";
+
+describe("openonion specialist adapter", () => {
+  it("accepts valid specialist profile", () => {
+    const result = validateOpenOnionSpecialistProfile({
+      adapter: "openonion",
+      adapterVersion: OPENONION_ADAPTER_VERSION,
+      role: "specialist",
+      runtime: "connectonion",
+      payment: { enforcement: "x402", required: true },
+      capabilities: {
+        taskTypes: ["summarize"],
+        inputModes: ["text"],
+        outputModes: ["text"],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("rejects unpaid semantics contract", () => {
+    const result = validateOpenOnionSpecialistProfile({
+      adapter: "openonion",
+      adapterVersion: OPENONION_ADAPTER_VERSION,
+      role: "specialist",
+      runtime: "connectonion",
+      payment: { enforcement: "none", required: false },
+      capabilities: {
+        taskTypes: ["summarize"],
+        inputModes: ["text"],
+        outputModes: ["text"],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.join(" ")).toContain("payment.enforcement");
+    expect(result.issues.join(" ")).toContain("payment.required");
+  });
+
+  it("returns deterministic payment-required semantics", () => {
+    expect(paymentRequiredSemantics()).toEqual({
+      status: 402,
+      code: "PAYMENT_REQUIRED",
+      message: "Valid x402 settlement proof is required before specialist execution.",
+    });
+  });
+});

--- a/lib/__tests__/planner-invoke-route.test.ts
+++ b/lib/__tests__/planner-invoke-route.test.ts
@@ -1,0 +1,146 @@
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/onboarding/planner-execution", () => ({
+  executePlannerSpecialistCall: jest.fn(),
+}));
+
+jest.mock("@/lib/integrations/openonion/consumer/orchestrator", () => ({
+  runOpenOnionConsumerFlow: jest.fn(),
+}));
+
+jest.mock("@/lib/orchestrator/policy", () => ({
+  readPolicy: jest.fn(),
+  recordSpend: jest.fn(),
+  readTodaySpend: jest.fn(),
+}));
+
+jest.mock("@/lib/jupiter-client", () => ({
+  getJupiterClient: jest.fn(),
+  getJupiterSlippageBps: jest.fn().mockReturnValue(100),
+}));
+
+describe("planner invoke route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("passes targetWallet through as preferredWallet", async () => {
+    const { readPolicy, readTodaySpend } = await import("@/lib/orchestrator/policy");
+    const { executePlannerSpecialistCall } = await import("@/lib/onboarding/planner-execution");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      enabled: true,
+      dailyBudgetUsd: 100,
+      preferredPrivacyMode: "public",
+      requireAttestation: false,
+      maxPerTaskUsd: 0,
+    });
+    (readTodaySpend as jest.Mock).mockReturnValue({ totalUsd: 0 });
+    (executePlannerSpecialistCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      result: {
+        runId: "run_123",
+        responsePreview: "done",
+        selectedWallet: "wallet-specialist",
+        paymentSatisfied: false,
+      },
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/invoke/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/invoke", {
+      method: "POST",
+      body: JSON.stringify({
+        prompt: "summarize this",
+        targetWallet: "wallet-target",
+        consumerWallet: "wallet-consumer",
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(200);
+    expect(executePlannerSpecialistCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preferredWallet: "wallet-target",
+        consumerWallet: "wallet-consumer",
+      })
+    );
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      runId: "run_123",
+      specialistWallet: "wallet-specialist",
+    });
+  });
+
+  it("returns 429 when daily budget is exhausted", async () => {
+    const { readPolicy, readTodaySpend } = await import("@/lib/orchestrator/policy");
+    (readPolicy as jest.Mock).mockReturnValue({
+      enabled: true,
+      dailyBudgetUsd: 1,
+      preferredPrivacyMode: "public",
+      requireAttestation: false,
+      maxPerTaskUsd: 0,
+    });
+    (readTodaySpend as jest.Mock).mockReturnValue({ totalUsd: 1 });
+
+    const { POST } = await import("@/app/api/planner/tools/invoke/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/invoke", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "hello" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(429);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("Daily budget"),
+    });
+  });
+
+  it("uses openonion consumer flow when integrationMode=openonion", async () => {
+    const { readPolicy, readTodaySpend } = await import("@/lib/orchestrator/policy");
+    const { runOpenOnionConsumerFlow } = await import("@/lib/integrations/openonion/consumer/orchestrator");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      enabled: true,
+      dailyBudgetUsd: 100,
+      preferredPrivacyMode: "public",
+      requireAttestation: false,
+      maxPerTaskUsd: 0,
+    });
+    (readTodaySpend as jest.Mock).mockReturnValue({ totalUsd: 0 });
+    (runOpenOnionConsumerFlow as jest.Mock).mockResolvedValue({
+      ok: false,
+      settlementDisposition: "refund",
+      result: {
+        runId: "run_fail",
+        selectedWallet: "wallet-specialist",
+        paymentSatisfied: false,
+        error: "specialist unreachable",
+      },
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/invoke/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/invoke", {
+      method: "POST",
+      body: JSON.stringify({
+        prompt: "summarize",
+        integrationMode: "openonion",
+        retryBudget: 2,
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(runOpenOnionConsumerFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ retryBudget: 2 })
+    );
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      runId: "run_fail",
+    });
+  });
+});

--- a/lib/__tests__/planner-signal-route.test.ts
+++ b/lib/__tests__/planner-signal-route.test.ts
@@ -1,0 +1,87 @@
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/onboarding/planner-feedback", () => ({
+  recordPlannerFeedback: jest.fn(),
+}));
+
+describe("planner signal route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("forwards consumerWallet for consumer reputation updates", async () => {
+    const { recordPlannerFeedback } = await import("@/lib/onboarding/planner-feedback");
+    (recordPlannerFeedback as jest.Mock).mockResolvedValue({
+      ok: true,
+      reputationCommit: { ok: true, txSignature: "sig123" },
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/signal/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/signal", {
+      method: "POST",
+      body: JSON.stringify({
+        runId: "run_123",
+        score: 8,
+        consumerWallet: "wallet-consumer",
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(200);
+    expect(recordPlannerFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run_123",
+        score: 8,
+        consumerWallet: "wallet-consumer",
+      })
+    );
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      reputationCommitted: true,
+      reputationTxSignature: "sig123",
+    });
+  });
+
+  it("returns 400 on invalid score", async () => {
+    const { POST } = await import("@/app/api/planner/tools/signal/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/signal", {
+      method: "POST",
+      body: JSON.stringify({ runId: "run_123", score: 11 }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: "score must be between 1 and 10",
+    });
+  });
+
+  it("rejects schema-drift attestor payloads deterministically", async () => {
+    const { POST } = await import("@/app/api/planner/tools/signal/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/signal", {
+      method: "POST",
+      body: JSON.stringify({
+        runId: "run_123",
+        score: 7,
+        attestorPayload: {
+          schemaVersion: "reddi.attestation.v1",
+          runId: "run_123",
+          attestorWallet: "wallet_attestor",
+          rubric: { coverage: 0.8, accuracy: 0.7 },
+        },
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("rubric.concision"),
+    });
+  });
+});

--- a/lib/__tests__/planner-signal-route.test.ts
+++ b/lib/__tests__/planner-signal-route.test.ts
@@ -10,7 +10,7 @@ describe("planner signal route", () => {
     jest.clearAllMocks();
   });
 
-  it("forwards consumerWallet for consumer reputation updates", async () => {
+  it("submits quality signal payload", async () => {
     const { recordPlannerFeedback } = await import("@/lib/onboarding/planner-feedback");
     (recordPlannerFeedback as jest.Mock).mockResolvedValue({
       ok: true,
@@ -23,7 +23,6 @@ describe("planner signal route", () => {
       body: JSON.stringify({
         runId: "run_123",
         score: 8,
-        consumerWallet: "wallet-consumer",
       }),
       headers: { "content-type": "application/json" },
     });
@@ -34,7 +33,6 @@ describe("planner signal route", () => {
       expect.objectContaining({
         runId: "run_123",
         score: 8,
-        consumerWallet: "wallet-consumer",
       })
     );
     await expect(res.json()).resolves.toMatchObject({

--- a/lib/__tests__/register-probe-route.test.ts
+++ b/lib/__tests__/register-probe-route.test.ts
@@ -1,84 +1,53 @@
-jest.mock("@/lib/onboarding/runtime-probe", () => ({
-  probeRuntimeEndpoint: jest.fn(),
-}));
+import { NextRequest } from "next/server";
 
-describe("POST /api/register/probe runtime normalization", () => {
+describe("register probe route", () => {
+  const originalFetch = global.fetch;
+
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
   });
 
-  it("returns legacy ollama_detected status for compatibility", async () => {
-    const { probeRuntimeEndpoint } = await import("@/lib/onboarding/runtime-probe");
-    (probeRuntimeEndpoint as jest.Mock).mockResolvedValue({
-      ok: true,
-      status: "runtime_detected",
-      detectedRuntime: "ollama",
-      models: ["qwen3:8b"],
-      hints: [],
-    });
-
-    const { POST } = await import("@/app/api/register/probe/route");
-    const req = new Request("http://localhost/api/register/probe", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ endpoint: "https://example.com" }),
-    });
-
-    const res = await POST(req);
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.status).toBe("ollama_detected");
-    expect(body.runtimeStatus).toBe("runtime_detected");
-    expect(body.detectedRuntime).toBe("ollama");
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
-  it("maps non-ollama runtime_detected to reachable for legacy UI", async () => {
-    const { probeRuntimeEndpoint } = await import("@/lib/onboarding/runtime-probe");
-    (probeRuntimeEndpoint as jest.Mock).mockResolvedValue({
-      ok: true,
-      status: "runtime_detected",
-      detectedRuntime: "openai_compatible",
-      models: ["llama3.1"],
-      hints: [],
-    });
-
+  it("blocks private-network targets in hosted context", async () => {
     const { POST } = await import("@/app/api/register/probe/route");
-    const req = new Request("http://localhost/api/register/probe", {
+    const req = new NextRequest("http://localhost/api/register/probe", {
       method: "POST",
+      body: JSON.stringify({ endpoint: "http://192.168.1.10:11434" }),
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ endpoint: "https://example.com" }),
     });
 
-    const res = await POST(req);
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.status).toBe("reachable");
-    expect(body.runtimeStatus).toBe("runtime_detected");
-    expect(body.detectedRuntime).toBe("openai_compatible");
-  });
-
-  it("returns 400 for invalid URL status", async () => {
-    const { probeRuntimeEndpoint } = await import("@/lib/onboarding/runtime-probe");
-    (probeRuntimeEndpoint as jest.Mock).mockResolvedValue({
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
       ok: false,
       status: "invalid_url",
-      detectedRuntime: "unknown",
-      models: [],
-      hints: [],
-      error: "Invalid endpoint URL.",
     });
+  });
+
+  it("returns actionable contract mismatch error for openonion specialist", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ adapter: "openonion", role: "specialist" }),
+      }) as unknown as typeof fetch;
 
     const { POST } = await import("@/app/api/register/probe/route");
-    const req = new Request("http://localhost/api/register/probe", {
+    const req = new NextRequest("http://localhost/api/register/probe", {
       method: "POST",
+      body: JSON.stringify({ endpoint: "https://demo.openonion.ai", integration: "openonion" }),
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ endpoint: "bad url" }),
     });
 
-    const res = await POST(req);
+    const res = await POST(req as unknown as Request);
     expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.status).toBe("invalid_url");
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      status: "invalid_contract",
+    });
   });
 });

--- a/lib/integrations/openonion/attestor/schema.ts
+++ b/lib/integrations/openonion/attestor/schema.ts
@@ -1,0 +1,49 @@
+export const OPENONION_ATTESTOR_SCHEMA_VERSION = "reddi.attestation.v1";
+
+export type OpenOnionAttestorPayload = {
+  schemaVersion: string;
+  runId: string;
+  attestorWallet: string;
+  rubric: {
+    coverage: number;
+    accuracy: number;
+    concision: number;
+  };
+  verdict?: "pass" | "fail";
+};
+
+function isValidRubricScore(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+export function validateOpenOnionAttestorPayload(input: unknown) {
+  const payload = input as Partial<OpenOnionAttestorPayload> | null;
+  const issues: string[] = [];
+
+  if (!payload || typeof payload !== "object") {
+    return { ok: false as const, issues: ["Attestor payload is required."] };
+  }
+  if (payload.schemaVersion !== OPENONION_ATTESTOR_SCHEMA_VERSION) {
+    issues.push(`schemaVersion must be '${OPENONION_ATTESTOR_SCHEMA_VERSION}'.`);
+  }
+  if (!payload.runId || typeof payload.runId !== "string") {
+    issues.push("runId is required.");
+  }
+  if (!payload.attestorWallet || typeof payload.attestorWallet !== "string") {
+    issues.push("attestorWallet is required.");
+  }
+
+  const rubric = payload.rubric;
+  if (!rubric || typeof rubric !== "object") {
+    issues.push("rubric object is required.");
+  } else {
+    if (!isValidRubricScore(rubric.coverage)) issues.push("rubric.coverage must be a number between 0 and 1.");
+    if (!isValidRubricScore(rubric.accuracy)) issues.push("rubric.accuracy must be a number between 0 and 1.");
+    if (!isValidRubricScore(rubric.concision)) issues.push("rubric.concision must be a number between 0 and 1.");
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  } as const;
+}

--- a/lib/integrations/openonion/consumer/orchestrator.ts
+++ b/lib/integrations/openonion/consumer/orchestrator.ts
@@ -1,0 +1,34 @@
+import { executePlannerSpecialistCall, type PlannerExecuteInput } from "@/lib/onboarding/planner-execution";
+
+export type OpenOnionConsumerRunInput = PlannerExecuteInput & {
+  retryBudget?: number;
+};
+
+export async function runOpenOnionConsumerFlow(input: OpenOnionConsumerRunInput) {
+  const retryBudget = Number.isFinite(input.retryBudget) ? Math.max(0, Math.floor(input.retryBudget as number)) : 0;
+
+  let last = await executePlannerSpecialistCall(input);
+  let retries = 0;
+
+  while (!last.ok && retries < retryBudget) {
+    retries += 1;
+    last = await executePlannerSpecialistCall(input);
+  }
+
+  if (last.ok) {
+    return {
+      ok: true as const,
+      retries,
+      settlementDisposition: "release" as const,
+      result: last.result,
+    };
+  }
+
+  return {
+    ok: false as const,
+    retries,
+    settlementDisposition: "refund" as const,
+    failureReason: last.result.error ?? "specialist_unreachable",
+    result: last.result,
+  };
+}

--- a/lib/integrations/openonion/network-policy.ts
+++ b/lib/integrations/openonion/network-policy.ts
@@ -1,0 +1,22 @@
+export function isLoopbackHost(hostname: string) {
+  const host = hostname.toLowerCase();
+  return host === "localhost" || host === "127.0.0.1" || host === "::1";
+}
+
+export function isPrivateIpv4(hostname: string) {
+  const match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!match) return false;
+
+  const octets = match.slice(1).map(Number);
+  if (octets.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return false;
+
+  const [a, b] = octets;
+  if (a === 10) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  return false;
+}
+
+export function isUnsafeHostedTarget(hostname: string) {
+  return isLoopbackHost(hostname) || isPrivateIpv4(hostname);
+}

--- a/lib/integrations/openonion/specialist/adapter.ts
+++ b/lib/integrations/openonion/specialist/adapter.ts
@@ -1,0 +1,61 @@
+export const OPENONION_ADAPTER_VERSION = "openonion.reddi.v1";
+
+export type OpenOnionSpecialistAdapterProfile = {
+  adapter: "openonion";
+  adapterVersion: string;
+  role: "specialist";
+  runtime: string;
+  payment: {
+    enforcement: string;
+    required: boolean;
+  };
+  capabilities: {
+    taskTypes: string[];
+    inputModes: string[];
+    outputModes: string[];
+  };
+};
+
+export function validateOpenOnionSpecialistProfile(input: unknown) {
+  const issues: string[] = [];
+  const profile = input as Partial<OpenOnionSpecialistAdapterProfile> | null;
+
+  if (!profile || typeof profile !== "object") {
+    return { ok: false as const, issues: ["Adapter profile is required."] };
+  }
+  if (profile.adapter !== "openonion") issues.push("adapter must be 'openonion'.");
+  if (profile.role !== "specialist") issues.push("role must be 'specialist'.");
+  if (profile.adapterVersion !== OPENONION_ADAPTER_VERSION) {
+    issues.push(`adapterVersion must be '${OPENONION_ADAPTER_VERSION}'.`);
+  }
+  if (profile.payment?.enforcement !== "x402") {
+    issues.push("payment.enforcement must be 'x402'.");
+  }
+  if (profile.payment?.required !== true) {
+    issues.push("payment.required must be true.");
+  }
+
+  const capabilities = profile.capabilities;
+  if (!Array.isArray(capabilities?.taskTypes) || capabilities.taskTypes.length === 0) {
+    issues.push("capabilities.taskTypes must be a non-empty array.");
+  }
+  if (!Array.isArray(capabilities?.inputModes) || capabilities.inputModes.length === 0) {
+    issues.push("capabilities.inputModes must be a non-empty array.");
+  }
+  if (!Array.isArray(capabilities?.outputModes) || capabilities.outputModes.length === 0) {
+    issues.push("capabilities.outputModes must be a non-empty array.");
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  } as const;
+}
+
+export function paymentRequiredSemantics() {
+  return {
+    status: 402,
+    code: "PAYMENT_REQUIRED",
+    message: "Valid x402 settlement proof is required before specialist execution.",
+  };
+}

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1,12 +1,15 @@
 /**
  * MCP Tool Interface for Reddi Agent Protocol
  *
- * Three tools that any agent framework (ElizaOS, OpenAI Agents SDK,
+ * Core tools that any agent framework (ElizaOS, OpenAI Agents SDK,
  * LangChain, CrewAI, custom) can call to access the specialist marketplace:
  *
- * 1. resolve_specialist   — find the best candidate for a task
- * 2. invoke_specialist    — execute a paid call against a specialist
- * 3. submit_quality_signal — rate a completed run (triggers rep commit)
+ * 1. register_consumer      — register consumer wallet + preferred integration mode
+ * 2. resolve_specialist     — find the best specialist for a task
+ * 3. resolve_attestor       — pick a judge/attestor candidate
+ * 4. invoke_specialist      — execute a paid call against a specialist
+ * 5. submit_quality_signal  — rate a completed run (triggers rep commit)
+ * 6. decide_settlement      — release/dispute after output evaluation
  *
  * Transport: HTTP POST endpoints at /api/planner/tools/*
  * Auth: optional x-reddi-agent-key header (env: REDDI_AGENT_API_KEY)
@@ -59,6 +62,10 @@ export type InvokeInput = {
   targetWallet?: string;
   /** Consumer wallet address — used for Torque event attribution */
   consumerWallet?: string;
+  /** Optional integration hint for consumer orchestration mode */
+  integrationMode?: "default" | "openonion";
+  /** Optional retry budget for OpenOnion consumer failover */
+  retryBudget?: number;
   /** Policy overrides */
   policy?: {
     maxPerCallUsd?: number;
@@ -78,15 +85,41 @@ export type InvokeOutput = {
   error?: string;
 };
 
+export type RegisterConsumerInput = {
+  walletAddress: string;
+  preferredIntegration?: "mcp" | "tools" | "skills";
+  metadata?: {
+    agentName?: string;
+    framework?: string;
+  };
+};
+
+export type ResolveAttestorInput = {
+  taskTypeHint?: string;
+  minAttestationAccuracy?: number;
+  maxPerCallUsd?: number;
+};
+
+export type SettlementDecisionInput = {
+  runId: string;
+  decision: "release" | "dispute";
+  notes?: string;
+  consumerWallet?: string;
+};
+
 export type QualitySignalInput = {
   /** Run ID from invoke_specialist */
   runId: string;
   /** Score 1–10 */
   score: number;
+  /** Optional consumer wallet used to update consumer reputation profile */
+  consumerWallet?: string;
   /** Optional text notes */
   notes?: string;
   /** Whether outcome matched attestation expectations */
   agreesWithAttestation?: boolean;
+  /** Optional OpenOnion attestor payload for schema-gated validation */
+  attestorPayload?: unknown;
 };
 
 export type QualitySignalOutput = {
@@ -99,6 +132,33 @@ export type QualitySignalOutput = {
 // ── OpenAI function-call schema definitions ──────────────────────────────────
 
 export const MCP_TOOL_SCHEMAS = [
+  {
+    name: "register_consumer",
+    description:
+      "Register a consumer wallet and integration preference (MCP, tools, or skills) before planner execution.",
+    parameters: {
+      type: "object",
+      properties: {
+        walletAddress: {
+          type: "string",
+          description: "Consumer wallet address used for identity and attribution.",
+        },
+        preferredIntegration: {
+          type: "string",
+          enum: ["mcp", "tools", "skills"],
+          description: "Preferred integration mode for the orchestrator.",
+        },
+        metadata: {
+          type: "object",
+          properties: {
+            agentName: { type: "string" },
+            framework: { type: "string" },
+          },
+        },
+      },
+      required: ["walletAddress"],
+    },
+  },
   {
     name: "resolve_specialist",
     description:
@@ -131,6 +191,19 @@ export const MCP_TOOL_SCHEMAS = [
         },
       },
       required: ["task"],
+    },
+  },
+  {
+    name: "resolve_attestor",
+    description:
+      "Find an attested specialist suitable to act as an attestor/judge for post-execution verification.",
+    parameters: {
+      type: "object",
+      properties: {
+        taskTypeHint: { type: "string" },
+        minAttestationAccuracy: { type: "number" },
+        maxPerCallUsd: { type: "number" },
+      },
     },
   },
   {
@@ -177,6 +250,10 @@ export const MCP_TOOL_SCHEMAS = [
           minimum: 1,
           maximum: 10,
         },
+        consumerWallet: {
+          type: "string",
+          description: "Optional consumer wallet used to update consumer reputation (baseline 3/5, rolling thereafter).",
+        },
         notes: {
           type: "string",
           description: "Optional notes about the result quality.",
@@ -189,6 +266,21 @@ export const MCP_TOOL_SCHEMAS = [
       required: ["runId", "score"],
     },
   },
+  {
+    name: "decide_settlement",
+    description:
+      "After evaluating specialist output, record release or dispute decision for a paid run.",
+    parameters: {
+      type: "object",
+      properties: {
+        runId: { type: "string", description: "Run ID returned by invoke_specialist." },
+        decision: { type: "string", enum: ["release", "dispute"] },
+        notes: { type: "string" },
+        consumerWallet: { type: "string" },
+      },
+      required: ["runId", "decision"],
+    },
+  },
 ];
 
 // ── ElizaOS action manifest ───────────────────────────────────────────────────
@@ -198,9 +290,21 @@ export const ELIZA_ACTION_MANIFEST = {
   version: "1.0.0",
   actions: [
     {
+      name: "REGISTER_CONSUMER",
+      description: "Register consumer wallet and integration preference.",
+      endpoint: "/api/planner/tools/register-consumer",
+      method: "POST",
+    },
+    {
       name: "RESOLVE_SPECIALIST",
       description: "Find the best specialist agent for a capability need.",
       endpoint: "/api/planner/tools/resolve",
+      method: "POST",
+    },
+    {
+      name: "RESOLVE_ATTESTOR",
+      description: "Find an attestor/judge specialist candidate.",
+      endpoint: "/api/planner/tools/resolve-attestor",
       method: "POST",
     },
     {
@@ -213,6 +317,12 @@ export const ELIZA_ACTION_MANIFEST = {
       name: "SUBMIT_QUALITY_SIGNAL",
       description: "Submit quality feedback for a completed specialist call.",
       endpoint: "/api/planner/tools/signal",
+      method: "POST",
+    },
+    {
+      name: "DECIDE_SETTLEMENT",
+      description: "Record release/dispute decision after output evaluation.",
+      endpoint: "/api/planner/tools/release",
       method: "POST",
     },
   ],


### PR DESCRIPTION
## Summary
Implements the OpenOnion onboarding build from the approved BDD + infra plans, covering specialist, attestor, and consumer integration scaffolds with route-level validation gates.

## What shipped
- Added OpenOnion adapter contract doc:
  - `docs/integrations/openonion/OPENONION-ADAPTER-CONTRACT.md`
- Added integration modules:
  - `lib/integrations/openonion/specialist/adapter.ts`
  - `lib/integrations/openonion/attestor/schema.ts`
  - `lib/integrations/openonion/consumer/orchestrator.ts`
  - `lib/integrations/openonion/network-policy.ts`
- Route wiring:
  - `app/api/register/probe/route.ts`
    - blocks localhost + private-network targets in hosted context
    - validates OpenOnion specialist contract via `/.well-known/reddi-adapter.json`
  - `app/api/planner/tools/signal/route.ts`
    - validates optional OpenOnion attestor payload (`reddi.attestation.v1`)
  - `app/api/planner/tools/invoke/route.ts`
    - supports `integrationMode: "openonion"` with retry/failover shim
- MCP type surface updates:
  - `lib/mcp/tools.ts` (`integrationMode`, `retryBudget`, `attestorPayload`)

## Tests
Targeted suite passes:

```bash
npx jest \
  lib/__tests__/openonion-specialist-adapter.test.ts \
  lib/__tests__/openonion-attestor-schema.test.ts \
  lib/__tests__/register-probe-route.test.ts \
  lib/__tests__/planner-signal-route.test.ts \
  lib/__tests__/planner-invoke-route.test.ts \
  lib/__tests__/openonion-consumer-orchestrator.test.ts \
  --runInBand
```

Result: **6/6 suites, 14/14 tests passing**.

## Scenario coverage (BDD mapping)
- Specialist happy path contract gate + payment-required semantics
- Specialist endpoint contract mismatch rejection
- Security guard for localhost/private-network targets
- Attestor schema drift deterministic rejection
- Consumer failover path returns refund disposition when specialist remains unreachable
