### PR TITLE
feat(bdd): source-adapter.v1 preflight contract (iteration 1)

### DIFF
--- a/app/api/register/probe/route.ts
+++ b/app/api/register/probe/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { isUnsafeHostedTarget } from "@/lib/integrations/openonion/network-policy";
 import { validateOpenOnionSpecialistProfile } from "@/lib/integrations/openonion/specialist/adapter";
+import { validateSourceAdapterManifest } from "@/lib/integrations/source-adapter/schema";
 
 export const runtime = "nodejs";
 
@@ -19,7 +20,8 @@ function normalizeEndpoint(endpoint: string) {
 export async function POST(req: Request) {
   const body = await req.json().catch(() => null);
   const endpoint = body?.endpoint;
-  const integration = body?.integration;
+  const sourceAdapter = body?.sourceAdapter;
+  const integration = body?.integration ?? sourceAdapter?.source;
 
   if (!endpoint || typeof endpoint !== "string") {
     return NextResponse.json({ ok: false, status: "invalid_url" }, { status: 400 });
@@ -27,6 +29,20 @@ export async function POST(req: Request) {
 
   try {
     const url = normalizeEndpoint(endpoint);
+
+    if (sourceAdapter !== undefined) {
+      const sourceValidation = validateSourceAdapterManifest(sourceAdapter);
+      if (!sourceValidation.ok) {
+        return NextResponse.json(
+          {
+            ok: false,
+            status: "invalid_source_adapter",
+            error: `sourceAdapter manifest mismatch: ${sourceValidation.issues.join(" ")}`,
+          },
+          { status: 400 }
+        );
+      }
+    }
 
     if (isUnsafeHostedTarget(url.hostname)) {
       return NextResponse.json(

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md
@@ -1,0 +1,64 @@
+# BDD Comprehensive Review + Gap Plan (2026-04-22, Source Adapters)
+
+## Objective
+Implement source ecosystem onboarding (OpenClaw, Hermes, pi.dev) with infrastructure-first controls, then close BDD gaps iteratively with explicit verification and retrospectives each loop.
+
+## Inputs
+- `playbooks/bdd-gap-closure-loop/PLAYBOOK.md`
+- `docs/BDD-SCENARIO-ID-MAP.md`
+- `docs/bdd/FEATURE-INDEX.md`
+- `docs/bdd/features/*.feature`
+- `projects/reddi-agent-protocol/SOURCE-INTEGRATION-INFRA-FIRST-BDD-PLAYBOOK.md`
+
+## Infra-first phases (must run in order)
+
+### P0 — Contract + preflight
+- Define `source-adapter.v1` schema and validation helpers.
+- Enforce schema in register probe/preflight path.
+- Preserve existing hosted safety controls and OpenOnion contract checks.
+
+### P1 — Conformance harness
+- Add repeatable source conformance script + CI hook.
+- Add baseline checks: schema integrity, settlement-safe failover, attestor strictness.
+
+### P2 — Source connectors
+- OpenClaw connector first.
+- Hermes connector second.
+- pi.dev connector third.
+
+### P3 — BDD parity buckets
+- S1 source registration safety
+- S2 supervisor orchestration reliability
+- S3 attestor schema integrity
+- S4 consumer settlement guarantees
+- S5 cross-source parity
+
+## Iteration contract (mandatory every loop)
+1. Review this plan and pick one small slice.
+2. Implement slice.
+3. Run explicit verification commands and record pass/fail.
+4. Update plan + iteration log + STATUS + daily memory.
+5. Commit scoped change.
+
+## Active iteration target
+- Iteration 2: P0.2 conformance harness skeleton (`scripts/run-source-conformance.sh`) + artifact conventions + first smoke invocation path.
+
+## Re-ranking board
+
+### P0 (active)
+1. ✅ Add source-adapter schema helper (`source`, `role`, `runtime`, `capabilities`, `paymentPolicy`, optional `failurePolicy`/`attestationSchema`).
+2. ✅ Enforce schema when `sourceAdapter` payload is supplied to `/api/register/probe`.
+3. ✅ Add actionable reject reasons and non-regression tests for OpenOnion and hosted target guards.
+4. Next: Add `scripts/run-source-conformance.sh` skeleton and artifact folder conventions.
+
+### P1
+5. Add OpenClaw source profile and initial connector wrappers.
+
+### P2
+6. Add Hermes source profile + strict attestor formatter checks.
+
+### P3
+7. Add pi source profile + canonical extension-bundle compatibility checks.
+
+### P4
+8. Add new feature file `docs/bdd/features/bucket-s-source-adapters.feature` with S1-S5 tags.

--- a/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
@@ -1,0 +1,19 @@
+# BDD Iteration Log — 2026-04-22 (Source Adapters)
+
+This log follows `playbooks/bdd-gap-closure-loop/PLAYBOOK.md` and is updated every iteration.
+
+## Iteration 1
+- Focus: P0 source-adapter contract validation + probe preflight enforcement.
+- Delivered:
+  - Added `lib/integrations/source-adapter/schema.ts` with `source-adapter.v1` validator.
+  - Updated `/api/register/probe` to validate optional `sourceAdapter` payload and return deterministic `invalid_source_adapter` errors.
+  - Added tests:
+    - `lib/__tests__/source-adapter-schema.test.ts`
+    - expanded `lib/__tests__/register-probe-route.test.ts` for valid/invalid sourceAdapter paths and OpenOnion non-regression.
+- Verified:
+  - `npx jest lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-schema.test.ts --runInBand` -> 2 suites, 6/6 tests passing.
+  - `pnpm build` -> PASS.
+- Retrospective:
+  - P0.1 schema + probe validation is now implemented and test-backed.
+  - Next iteration should start P0.2 by wiring a first `run-source-conformance.sh` harness skeleton and artifact output conventions.
+

--- a/lib/__tests__/register-probe-route.test.ts
+++ b/lib/__tests__/register-probe-route.test.ts
@@ -28,6 +28,67 @@ describe("register probe route", () => {
     });
   });
 
+  it("rejects malformed sourceAdapter manifests with actionable errors", async () => {
+    const { POST } = await import("@/app/api/register/probe/route");
+    const req = new NextRequest("http://localhost/api/register/probe", {
+      method: "POST",
+      body: JSON.stringify({
+        endpoint: "https://demo.reddi.tech",
+        sourceAdapter: {
+          version: "source-adapter.v1",
+          source: "openclaw",
+          role: "attestor",
+          runtime: "ollama",
+          capabilities: { taskTypes: ["judge"] },
+          paymentPolicy: "x402_required",
+        },
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      status: "invalid_source_adapter",
+    });
+  });
+
+  it("accepts valid sourceAdapter manifests and continues endpoint probe", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ models: [{ name: "qwen3:8b" }] }),
+      }) as unknown as typeof fetch;
+
+    const { POST } = await import("@/app/api/register/probe/route");
+    const req = new NextRequest("http://localhost/api/register/probe", {
+      method: "POST",
+      body: JSON.stringify({
+        endpoint: "https://demo.reddi.tech",
+        sourceAdapter: {
+          version: "source-adapter.v1",
+          source: "openclaw",
+          role: "consumer",
+          runtime: "ollama",
+          capabilities: { taskTypes: ["resolve", "invoke"], inputModes: ["text"], outputModes: ["text"] },
+          paymentPolicy: "x402_required",
+          failurePolicy: { maxRetries: 2, refundOnFailure: true },
+        },
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      status: "ollama_detected",
+      integration: "openclaw",
+    });
+  });
+
   it("returns actionable contract mismatch error for openonion specialist", async () => {
     global.fetch = jest
       .fn()

--- a/lib/__tests__/source-adapter-schema.test.ts
+++ b/lib/__tests__/source-adapter-schema.test.ts
@@ -1,0 +1,38 @@
+import { validateSourceAdapterManifest } from "@/lib/integrations/source-adapter/schema";
+
+describe("source adapter schema", () => {
+  it("accepts a valid consumer manifest", () => {
+    const result = validateSourceAdapterManifest({
+      version: "source-adapter.v1",
+      source: "openclaw",
+      role: "consumer",
+      runtime: "ollama",
+      capabilities: {
+        taskTypes: ["resolve", "invoke"],
+        inputModes: ["text"],
+        outputModes: ["text"],
+      },
+      paymentPolicy: "x402_required",
+      failurePolicy: {
+        maxRetries: 2,
+        refundOnFailure: true,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("requires attestationSchema for attestor role", () => {
+    const result = validateSourceAdapterManifest({
+      version: "source-adapter.v1",
+      source: "hermes",
+      role: "attestor",
+      runtime: "vllm",
+      capabilities: { taskTypes: ["judge"] },
+      paymentPolicy: "x402_required",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.join(" ")).toContain("attestationSchema is required");
+  });
+});

--- a/lib/integrations/source-adapter/schema.ts
+++ b/lib/integrations/source-adapter/schema.ts
@@ -1,0 +1,98 @@
+export const SOURCE_ADAPTER_VERSION = "source-adapter.v1";
+
+export type SourceAdapterRole = "supervisor" | "specialist" | "attestor" | "consumer";
+export type SourcePaymentPolicy = "x402_required" | "simulation_only";
+
+export type SourceAdapterManifest = {
+  version: string;
+  source: string;
+  role: SourceAdapterRole;
+  runtime: string;
+  capabilities: {
+    taskTypes: string[];
+    inputModes?: string[];
+    outputModes?: string[];
+  };
+  paymentPolicy: SourcePaymentPolicy;
+  attestationSchema?: string;
+  failurePolicy?: {
+    maxRetries?: number;
+    refundOnFailure?: boolean;
+  };
+};
+
+const ROLE_SET: SourceAdapterRole[] = ["supervisor", "specialist", "attestor", "consumer"];
+const PAYMENT_POLICY_SET: SourcePaymentPolicy[] = ["x402_required", "simulation_only"];
+
+function hasNonEmptyStringArray(value: unknown) {
+  return Array.isArray(value) && value.length > 0 && value.every((x) => typeof x === "string" && x.trim().length > 0);
+}
+
+export function validateSourceAdapterManifest(input: unknown) {
+  const issues: string[] = [];
+  const manifest = input as Partial<SourceAdapterManifest> | null;
+
+  if (!manifest || typeof manifest !== "object") {
+    return { ok: false as const, issues: ["sourceAdapter manifest object is required."] };
+  }
+
+  if (manifest.version !== SOURCE_ADAPTER_VERSION) {
+    issues.push(`version must be '${SOURCE_ADAPTER_VERSION}'.`);
+  }
+
+  if (!manifest.source || typeof manifest.source !== "string") {
+    issues.push("source is required.");
+  }
+
+  if (!manifest.runtime || typeof manifest.runtime !== "string") {
+    issues.push("runtime is required.");
+  }
+
+  if (!manifest.role || !ROLE_SET.includes(manifest.role)) {
+    issues.push("role must be one of: supervisor, specialist, attestor, consumer.");
+  }
+
+  if (!manifest.paymentPolicy || !PAYMENT_POLICY_SET.includes(manifest.paymentPolicy)) {
+    issues.push("paymentPolicy must be one of: x402_required, simulation_only.");
+  }
+
+  const capabilities = manifest.capabilities;
+  if (!capabilities || typeof capabilities !== "object") {
+    issues.push("capabilities object is required.");
+  } else {
+    if (!hasNonEmptyStringArray(capabilities.taskTypes)) {
+      issues.push("capabilities.taskTypes must be a non-empty string array.");
+    }
+
+    if (capabilities.inputModes && !hasNonEmptyStringArray(capabilities.inputModes)) {
+      issues.push("capabilities.inputModes must be a non-empty string array when provided.");
+    }
+
+    if (capabilities.outputModes && !hasNonEmptyStringArray(capabilities.outputModes)) {
+      issues.push("capabilities.outputModes must be a non-empty string array when provided.");
+    }
+  }
+
+  if (manifest.role === "attestor") {
+    if (!manifest.attestationSchema || typeof manifest.attestationSchema !== "string" || !manifest.attestationSchema.trim()) {
+      issues.push("attestationSchema is required when role=attestor.");
+    }
+  }
+
+  if (manifest.failurePolicy && typeof manifest.failurePolicy === "object") {
+    const maxRetries = manifest.failurePolicy.maxRetries;
+    if (maxRetries !== undefined && (!Number.isInteger(maxRetries) || maxRetries < 0 || maxRetries > 10)) {
+      issues.push("failurePolicy.maxRetries must be an integer between 0 and 10 when provided.");
+    }
+
+    const refundOnFailure = manifest.failurePolicy.refundOnFailure;
+    if (refundOnFailure !== undefined && typeof refundOnFailure !== "boolean") {
+      issues.push("failurePolicy.refundOnFailure must be a boolean when provided.");
+    }
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+  } as const;
+}


### PR DESCRIPTION
## Summary
Starts the infra-first source integration track with Iteration 1 from the new BDD loop.

This PR delivers P0 contract enforcement:
- Adds `source-adapter.v1` validation helper
- Enforces optional `sourceAdapter` payload checks in `/api/register/probe`
- Returns deterministic actionable `invalid_source_adapter` errors
- Preserves hosted target safety + OpenOnion contract checks

## BDD loop artifacts (persisted first)
- `docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md`
- `docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md`

## Verification
- `npx jest lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-schema.test.ts --runInBand`
  - 2 suites, 6/6 tests passing
- `pnpm build`
  - PASS

## Iteration retrospective
Iteration 1 closed P0.1 (schema + preflight validation). Next target is P0.2 conformance harness skeleton and artifact conventions.
