### PR TITLE
feat(bdd): OpenClaw source profile + connector stubs (iteration 3)

### DIFF
--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md
@@ -41,7 +41,7 @@ Implement source ecosystem onboarding (OpenClaw, Hermes, pi.dev) with infrastruc
 5. Commit scoped change.
 
 ## Active iteration target
-- Iteration 3: P1 OpenClaw source profile + connector wrapper stubs + initial Bucket-S BDD feature scaffold.
+- Iteration 4: P2 Hermes source profile + strict attestor formatter checks + Bucket-S parity expansion.
 
 ## Re-ranking board
 
@@ -51,12 +51,14 @@ Implement source ecosystem onboarding (OpenClaw, Hermes, pi.dev) with infrastruc
 3. ✅ Add actionable reject reasons and non-regression tests for OpenOnion and hosted target guards.
 4. ✅ Add `scripts/run-source-conformance.sh` harness skeleton and artifact folder conventions.
 
-### P1 (active)
-5. Add OpenClaw source profile and initial connector wrappers.
-6. Add `docs/bdd/features/bucket-s-source-adapters.feature` with S1-S5 tags for source onboarding flow.
+### P1 (complete)
+5. ✅ Add OpenClaw source profile and initial connector wrappers.
+6. ✅ Add `docs/bdd/features/bucket-s-source-adapters.feature` with S1-S5 tags for source onboarding flow.
 
-### P2
+### P2 (active)
 7. Add Hermes source profile + strict attestor formatter checks.
+8. Extend Bucket-S scenarios with Hermes parity checks + verification commands.
 
 ### P3
-8. Add pi source profile + canonical extension-bundle compatibility checks.
+9. Add pi source profile + canonical extension-bundle compatibility checks.
+10. Add cross-source conformance matrix output across openclaw/hermes/pi smoke runs.

--- a/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
@@ -35,3 +35,28 @@ This log follows `playbooks/bdd-gap-closure-loop/PLAYBOOK.md` and is updated eve
   - P0.2 baseline is now implemented and executable.
   - Next iteration should begin P1 by adding OpenClaw source profile + connector wrapper stubs and corresponding BDD scenario file for Bucket S (`S1-S5`).
 
+## Iteration 3
+- Focus: P1 OpenClaw source profile + connector wrapper stubs + Bucket-S BDD scaffold.
+- Delivered:
+  - Added OpenClaw source profile + registry access:
+    - `lib/integrations/source-adapter/profiles/openclaw.ts`
+    - `lib/integrations/source-adapter/profiles/index.ts`
+  - Added OpenClaw connector wrappers for planner routes:
+    - `lib/integrations/source-adapter/openclaw/connector.ts`
+    - resolve/invoke/signal wrappers + supervisor resolve→invoke orchestrator helper
+  - Added tests:
+    - `lib/__tests__/source-adapter-openclaw-profile.test.ts`
+    - `lib/__tests__/source-adapter-openclaw-connector.test.ts`
+  - Added Bucket-S feature scaffold:
+    - `docs/bdd/features/bucket-s-source-adapters.feature` (`@S1.1`..`@S5.1`)
+  - Updated BDD feature index:
+    - `docs/bdd/FEATURE-INDEX.md` now maps Bucket-S verification commands.
+- Verified:
+  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts --runInBand` -> 4 suites, 11/11 tests passing.
+  - `npm run test:bdd:index` -> PASS.
+  - `npm run test:source:conformance` -> PASS.
+  - Artifact evidence: `artifacts/source-conformance/20260422-213317-openclaw-smoke/SUMMARY.md`.
+- Retrospective:
+  - OpenClaw path now has profile + wrapper baseline with BDD scenario scaffold in place.
+  - Next iteration should start Hermes profile + strict attestor formatter checks, then extend Bucket-S parity scenarios.
+

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -1,6 +1,6 @@
 # BDD Feature Index
 
-_Last updated: 2026-04-19 AEST_
+_Last updated: 2026-04-22 AEST_
 
 Purpose: single lookup from BDD feature file -> bucket -> executable verification command(s).
 
@@ -45,6 +45,12 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Verify:
   - `npx jest lib/__tests__/planner-register-consumer-route.test.ts lib/__tests__/planner-tools-manifest-route.test.ts lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-resolve-attestor-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-release-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/planner-auditability.test.ts lib/__tests__/dogfood-testing-specialist-route.test.ts lib/__tests__/dogfood-testing-attestor-route.test.ts lib/__tests__/dogfood-consumer-run-route.test.ts --runInBand`
   - `npx playwright test e2e/dogfood.spec.ts`
+
+### Bucket S — Source Adapter Onboarding
+- Feature: `docs/bdd/features/bucket-s-source-adapters.feature`
+- Verify:
+  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts --runInBand`
+  - `npm run test:source:conformance`
 
 ## Drift guard
 - Validate index coverage against feature files:

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -1,0 +1,42 @@
+Feature: Bucket S Source Adapter Onboarding
+  As a protocol operator
+  I want source ecosystems to onboard through a shared contract and conformance harness
+  So that supervisor, attestor, and consumer roles remain settlement-safe and auditable
+
+  Background:
+    Given source-adapter manifests are validated before runtime integration
+
+  @S1.1 @source-adapter @registration-safety
+  Scenario: Source adapter manifest must validate before probe succeeds
+    When a source submits an invalid sourceAdapter manifest
+    Then `/api/register/probe` rejects with `invalid_source_adapter`
+    And the response includes actionable mismatch reasons
+
+  @S1.2 @source-adapter @registration-safety
+  Scenario: Hosted unsafe target protections remain active with source adapters
+    When a source probe targets localhost or private-network endpoints
+    Then probe is rejected with `invalid_url`
+
+  @S2.1 @supervisor @orchestration
+  Scenario: OpenClaw supervisor orchestration resolves then invokes deterministically
+    When the supervisor wrapper executes a task
+    Then it calls resolve before invoke
+    And returns phase metadata for auditability
+
+  @S3.1 @attestor @schema-integrity
+  Scenario: OpenClaw attestor manifest includes strict attestation schema
+    When an attestor manifest is built from OpenClaw source profile defaults
+    Then `attestationSchema` is pinned to `reddi.attestation.v1`
+    And schema validation succeeds
+
+  @S4.1 @consumer @settlement-safety
+  Scenario: Connector surfaces invoke errors explicitly
+    When invoke endpoint returns a non-OK status
+    Then the connector throws a deterministic error
+    And no implicit success path is returned
+
+  @S5.1 @conformance @cross-source-parity
+  Scenario: Source conformance harness emits reusable artifact summaries
+    When conformance script runs in smoke mode
+    Then summary artifacts are written under `artifacts/source-conformance/...`
+    And step pass/fail counts are captured for retrospective updates

--- a/lib/__tests__/source-adapter-openclaw-connector.test.ts
+++ b/lib/__tests__/source-adapter-openclaw-connector.test.ts
@@ -1,0 +1,79 @@
+import {
+  openClawInvokeSpecialist,
+  openClawResolveSpecialist,
+  openClawSupervisorOrchestrate,
+} from "@/lib/integrations/source-adapter/openclaw/connector";
+
+describe("openclaw source connector", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("calls planner resolve endpoint with configured api key", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, candidate: { walletAddress: "abc", endpointUrl: "https://x" }, alternativeCount: 0 }),
+    }) as unknown as typeof fetch;
+
+    const out = await openClawResolveSpecialist(
+      { baseUrl: "https://agent-protocol.reddi.tech", apiKey: "secret" },
+      { task: "summarize" }
+    );
+
+    expect(out.ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://agent-protocol.reddi.tech/api/planner/tools/resolve",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "x-reddi-agent-key": "secret" }),
+      })
+    );
+  });
+
+  it("runs supervisor resolve->invoke flow", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          candidate: { walletAddress: "wallet_1", endpointUrl: "https://spec.example" },
+          alternativeCount: 0,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, runId: "run_1", specialistWallet: "wallet_1", paymentSatisfied: true }),
+      }) as unknown as typeof fetch;
+
+    const out = await openClawSupervisorOrchestrate(
+      { baseUrl: "https://agent-protocol.reddi.tech" },
+      { task: "summarize docs", prompt: "summarize this", consumerWallet: "consumer_1" }
+    );
+
+    expect(out.ok).toBe(true);
+    expect(out.phase).toBe("invoke");
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces route errors from invoke endpoint", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "bad invoke" }),
+    }) as unknown as typeof fetch;
+
+    await expect(
+      openClawInvokeSpecialist(
+        { baseUrl: "https://agent-protocol.reddi.tech" },
+        { prompt: "ping" }
+      )
+    ).rejects.toThrow("bad invoke");
+  });
+});

--- a/lib/__tests__/source-adapter-openclaw-profile.test.ts
+++ b/lib/__tests__/source-adapter-openclaw-profile.test.ts
@@ -1,0 +1,24 @@
+import { buildOpenClawSourceManifest, OPENCLAW_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/openclaw";
+import { getSourceProfile } from "@/lib/integrations/source-adapter/profiles";
+import { validateSourceAdapterManifest } from "@/lib/integrations/source-adapter/schema";
+
+describe("source adapter openclaw profile", () => {
+  it("is discoverable via source registry", () => {
+    const profile = getSourceProfile("openclaw");
+    expect(profile).toBeTruthy();
+    expect(profile?.source).toBe("openclaw");
+    expect(profile?.roles).toContain("supervisor");
+  });
+
+  it("builds a valid attestor manifest with default attestation schema", () => {
+    const manifest = buildOpenClawSourceManifest({
+      role: "attestor",
+      runtime: "ollama",
+      taskTypes: ["judge"],
+    });
+
+    const validation = validateSourceAdapterManifest(manifest);
+    expect(validation.ok).toBe(true);
+    expect(manifest.attestationSchema).toBe(OPENCLAW_SOURCE_PROFILE.defaultAttestationSchema);
+  });
+});

--- a/lib/integrations/source-adapter/openclaw/connector.ts
+++ b/lib/integrations/source-adapter/openclaw/connector.ts
@@ -1,0 +1,89 @@
+import type { InvokeInput, InvokeOutput, QualitySignalInput, QualitySignalOutput, ResolveInput, ResolveOutput } from "@/lib/mcp/tools";
+
+export type OpenClawConnectorConfig = {
+  baseUrl: string;
+  apiKey?: string;
+  timeoutMs?: number;
+};
+
+function normalizeBaseUrl(baseUrl: string) {
+  return baseUrl.replace(/\/$/, "");
+}
+
+async function postJson<T>(cfg: OpenClawConnectorConfig, path: string, payload: unknown): Promise<T> {
+  const endpoint = `${normalizeBaseUrl(cfg.baseUrl)}${path}`;
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+
+  if (cfg.apiKey) {
+    headers["x-reddi-agent-key"] = cfg.apiKey;
+  }
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 12000),
+  });
+
+  const body = (await res.json().catch(() => null)) as T | { error?: string } | null;
+
+  if (!res.ok) {
+    const err = (body as { error?: string } | null)?.error ?? `${path} failed with status ${res.status}`;
+    throw new Error(err);
+  }
+
+  if (!body) {
+    throw new Error(`${path} returned empty JSON response`);
+  }
+
+  return body as T;
+}
+
+export async function openClawResolveSpecialist(cfg: OpenClawConnectorConfig, input: ResolveInput) {
+  return postJson<ResolveOutput>(cfg, "/api/planner/tools/resolve", input);
+}
+
+export async function openClawInvokeSpecialist(cfg: OpenClawConnectorConfig, input: InvokeInput) {
+  return postJson<InvokeOutput>(cfg, "/api/planner/tools/invoke", input);
+}
+
+export async function openClawSubmitQualitySignal(cfg: OpenClawConnectorConfig, input: QualitySignalInput) {
+  return postJson<QualitySignalOutput>(cfg, "/api/planner/tools/signal", input);
+}
+
+export async function openClawSupervisorOrchestrate(cfg: OpenClawConnectorConfig, input: {
+  task: string;
+  prompt: string;
+  policy?: ResolveInput["policy"];
+  consumerWallet?: string;
+}) {
+  const resolved = await openClawResolveSpecialist(cfg, {
+    task: input.task,
+    policy: input.policy,
+  });
+
+  if (!resolved.ok || !resolved.candidate) {
+    return {
+      ok: false as const,
+      phase: "resolve" as const,
+      error: resolved.error ?? "No candidate available",
+      resolved,
+    };
+  }
+
+  const invoked = await openClawInvokeSpecialist(cfg, {
+    prompt: input.prompt,
+    targetWallet: resolved.candidate.walletAddress,
+    consumerWallet: input.consumerWallet,
+    policy: input.policy,
+  });
+
+  return {
+    ok: invoked.ok,
+    phase: invoked.ok ? ("invoke" as const) : ("invoke_failed" as const),
+    resolved,
+    invoked,
+  };
+}

--- a/lib/integrations/source-adapter/profiles/index.ts
+++ b/lib/integrations/source-adapter/profiles/index.ts
@@ -1,0 +1,11 @@
+import { OPENCLAW_SOURCE_ID, OPENCLAW_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/openclaw";
+
+export const SOURCE_PROFILE_REGISTRY = {
+  [OPENCLAW_SOURCE_ID]: OPENCLAW_SOURCE_PROFILE,
+} as const;
+
+export type SourceProfileId = keyof typeof SOURCE_PROFILE_REGISTRY;
+
+export function getSourceProfile(source: string) {
+  return SOURCE_PROFILE_REGISTRY[source as SourceProfileId] ?? null;
+}

--- a/lib/integrations/source-adapter/profiles/openclaw.ts
+++ b/lib/integrations/source-adapter/profiles/openclaw.ts
@@ -1,0 +1,45 @@
+import { SOURCE_ADAPTER_VERSION, type SourceAdapterManifest, type SourceAdapterRole } from "@/lib/integrations/source-adapter/schema";
+
+export const OPENCLAW_SOURCE_ID = "openclaw";
+
+export const OPENCLAW_SOURCE_PROFILE = {
+  source: OPENCLAW_SOURCE_ID,
+  roles: ["supervisor", "consumer", "attestor"] as SourceAdapterRole[],
+  runtimes: ["ollama", "vllm", "hosted"],
+  defaultPaymentPolicy: "x402_required" as const,
+  defaultAttestationSchema: "reddi.attestation.v1",
+  capabilityHints: {
+    supervisor: ["resolve", "invoke", "monitor", "delegate"],
+    consumer: ["resolve", "invoke", "release", "signal"],
+    attestor: ["judge", "score", "audit"],
+  },
+};
+
+export function buildOpenClawSourceManifest(input: {
+  role: SourceAdapterRole;
+  runtime: "ollama" | "vllm" | "hosted";
+  taskTypes: string[];
+  inputModes?: string[];
+  outputModes?: string[];
+  failurePolicy?: { maxRetries?: number; refundOnFailure?: boolean };
+}): SourceAdapterManifest {
+  const manifest: SourceAdapterManifest = {
+    version: SOURCE_ADAPTER_VERSION,
+    source: OPENCLAW_SOURCE_ID,
+    role: input.role,
+    runtime: input.runtime,
+    capabilities: {
+      taskTypes: input.taskTypes,
+      inputModes: input.inputModes ?? ["text"],
+      outputModes: input.outputModes ?? ["text"],
+    },
+    paymentPolicy: OPENCLAW_SOURCE_PROFILE.defaultPaymentPolicy,
+    failurePolicy: input.failurePolicy,
+  };
+
+  if (input.role === "attestor") {
+    manifest.attestationSchema = OPENCLAW_SOURCE_PROFILE.defaultAttestationSchema;
+  }
+
+  return manifest;
+}


### PR DESCRIPTION
## Summary
Implements Iteration 3 (P1) of the infra-first source adapter BDD loop.

### Delivered
- OpenClaw source profile + registry
  - `lib/integrations/source-adapter/profiles/openclaw.ts`
  - `lib/integrations/source-adapter/profiles/index.ts`
- OpenClaw connector wrapper stubs
  - `lib/integrations/source-adapter/openclaw/connector.ts`
  - resolve/invoke/signal wrappers and a supervisor resolve→invoke orchestrator helper
- Tests
  - `lib/__tests__/source-adapter-openclaw-profile.test.ts`
  - `lib/__tests__/source-adapter-openclaw-connector.test.ts`
- BDD scaffold updates
  - Added `docs/bdd/features/bucket-s-source-adapters.feature`
  - Updated `docs/bdd/FEATURE-INDEX.md` with Bucket-S verification mapping
- Iteration retrospective updates
  - `docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md`
  - `docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md`

## Verification
- `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts --runInBand`
  - 4 suites, 11/11 tests passing
- `npm run test:bdd:index` ✅
- `npm run test:source:conformance` ✅
  - artifact: `artifacts/source-conformance/20260422-213317-openclaw-smoke/SUMMARY.md`

## Next iteration target
Iteration 4 / P2: Hermes source profile + strict attestor formatter checks + Bucket-S parity expansion.
