### PR TITLE
feat(bdd): pi source profile + conformance matrix (iteration 5)

### DIFF
--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md
@@ -41,7 +41,7 @@ Implement source ecosystem onboarding (OpenClaw, Hermes, pi.dev) with infrastruc
 5. Commit scoped change.
 
 ## Active iteration target
-- Iteration 5: P3 pi source profile + extension-bundle compatibility checks + cross-source conformance matrix output.
+- Iteration 6: source-aware routing preference policy + CI gating for cross-source matrix artifacts.
 
 ## Re-ranking board
 
@@ -59,6 +59,10 @@ Implement source ecosystem onboarding (OpenClaw, Hermes, pi.dev) with infrastruc
 7. ✅ Add Hermes source profile + strict attestor formatter checks.
 8. ✅ Extend Bucket-S scenarios with Hermes parity checks + verification commands.
 
-### P3 (active)
-9. Add pi source profile + canonical extension-bundle compatibility checks.
-10. Add cross-source conformance matrix output across openclaw/hermes/pi smoke runs.
+### P3 (complete)
+9. ✅ Add pi source profile + canonical extension-bundle compatibility checks.
+10. ✅ Add cross-source conformance matrix output across openclaw/hermes/pi smoke runs.
+
+### P4 (active)
+11. Add source-aware routing preference policy hooks (selection defaults + guardrails).
+12. Wire matrix verification into CI so artifact regressions fail fast.

--- a/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
@@ -82,3 +82,31 @@ This log follows `playbooks/bdd-gap-closure-loop/PLAYBOOK.md` and is updated eve
   - Hermes attestor strictness baseline is now implemented and tested.
   - Next iteration should start P3 pi source profile + extension-bundle compatibility checks and broaden cross-source conformance matrix output (openclaw + hermes + pi).
 
+## Iteration 5
+- Focus: P3 pi source profile + canonical extension-bundle compatibility checks + cross-source conformance matrix output.
+- Delivered:
+  - Added pi source profile + manifest builder:
+    - `lib/integrations/source-adapter/profiles/pi.ts`
+    - registered pi in `lib/integrations/source-adapter/profiles/index.ts`
+  - Added pi extension-bundle compatibility validator:
+    - `lib/integrations/source-adapter/pi/extension-bundle.ts`
+  - Added tests:
+    - `lib/__tests__/source-adapter-pi-profile.test.ts`
+    - `lib/__tests__/source-adapter-pi-extension-bundle.test.ts`
+  - Expanded Bucket-S feature scenarios with pi parity tags (`@S3.3`, `@S5.3`).
+  - Enhanced conformance harness with source-specific contract checks per source.
+  - Added cross-source matrix runner:
+    - `scripts/run-source-conformance-matrix.sh`
+    - `npm run test:source:matrix`
+- Verified:
+  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts --runInBand` -> 8 suites, 19/19 tests passing.
+  - `npm run test:bdd:index` -> PASS.
+  - `./scripts/run-source-conformance.sh --source pi --mode smoke` -> PASS.
+  - `npm run test:source:matrix` -> PASS.
+  - Artifact evidence:
+    - `artifacts/source-conformance/20260422-230408-pi-smoke/SUMMARY.md`
+    - `artifacts/source-conformance-matrix/20260422-230418/SUMMARY.md`.
+- Retrospective:
+  - All three sources now have baseline profile coverage with deterministic parity checks.
+  - Next iteration should focus on promotion policy wiring for source-aware routing preferences and CI lane gating for matrix artifacts.
+

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -49,9 +49,11 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket S — Source Adapter Onboarding
 - Feature: `docs/bdd/features/bucket-s-source-adapters.feature`
 - Verify:
-  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts --runInBand`
+  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts --runInBand`
   - `npm run test:source:conformance`
   - `./scripts/run-source-conformance.sh --source hermes --mode smoke`
+  - `./scripts/run-source-conformance.sh --source pi --mode smoke`
+  - `npm run test:source:matrix`
 
 ## Drift guard
 - Validate index coverage against feature files:

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -51,3 +51,14 @@ Feature: Bucket S Source Adapter Onboarding
   Scenario: Hermes source profile resolves from registry
     When source profile lookup is called for `hermes`
     Then profile metadata is returned with supported roles and runtimes
+
+  @S3.3 @extension-bundle @pi @schema-integrity
+  Scenario: pi source extension bundle must include canonical required extensions
+    When a pi extension bundle omits a required extension
+    Then compatibility validation fails with deterministic missing-extension output
+
+  @S5.3 @conformance @cross-source-parity @pi
+  Scenario: Cross-source conformance matrix emits openclaw/hermes/pi smoke status in one report
+    When the matrix runner executes source conformance for all supported sources
+    Then matrix summary includes rows for openclaw hermes and pi
+    And each row contains pass fail and artifact summary path fields

--- a/lib/__tests__/source-adapter-pi-extension-bundle.test.ts
+++ b/lib/__tests__/source-adapter-pi-extension-bundle.test.ts
@@ -1,0 +1,26 @@
+import { validatePiExtensionBundle } from "@/lib/integrations/source-adapter/pi/extension-bundle";
+import { PI_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/pi";
+
+describe("source adapter pi extension bundle compatibility", () => {
+  it("accepts canonical pi extension bundle", () => {
+    const result = validatePiExtensionBundle({
+      version: PI_SOURCE_PROFILE.defaultExtensionBundleVersion,
+      source: "pi",
+      extensions: ["capability-index", "attestation", "settlement", "routing"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("rejects missing required extensions", () => {
+    const result = validatePiExtensionBundle({
+      version: PI_SOURCE_PROFILE.defaultExtensionBundleVersion,
+      source: "pi",
+      extensions: ["capability-index", "attestation"],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.join(" ")).toContain("missing required extension: settlement");
+  });
+});

--- a/lib/__tests__/source-adapter-pi-profile.test.ts
+++ b/lib/__tests__/source-adapter-pi-profile.test.ts
@@ -1,0 +1,24 @@
+import { getSourceProfile } from "@/lib/integrations/source-adapter/profiles";
+import { buildPiSourceManifest, PI_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/pi";
+import { validateSourceAdapterManifest } from "@/lib/integrations/source-adapter/schema";
+
+describe("source adapter pi profile", () => {
+  it("resolves from source profile registry", () => {
+    const profile = getSourceProfile("pi");
+    expect(profile).toBeTruthy();
+    expect(profile?.source).toBe("pi");
+    expect(profile?.runtimes).toContain("hosted");
+  });
+
+  it("builds valid manifest and pins attestation schema for attestors", () => {
+    const manifest = buildPiSourceManifest({
+      role: "attestor",
+      runtime: "hosted",
+      taskTypes: ["judge"],
+    });
+
+    const validation = validateSourceAdapterManifest(manifest);
+    expect(validation.ok).toBe(true);
+    expect(manifest.attestationSchema).toBe(PI_SOURCE_PROFILE.defaultAttestationSchema);
+  });
+});

--- a/lib/integrations/source-adapter/pi/extension-bundle.ts
+++ b/lib/integrations/source-adapter/pi/extension-bundle.ts
@@ -1,0 +1,39 @@
+import { PI_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/pi";
+
+export type PiExtensionBundle = {
+  version: string;
+  source: "pi";
+  extensions: string[];
+};
+
+const REQUIRED_PI_EXTENSIONS = ["capability-index", "attestation", "settlement"];
+
+export function validatePiExtensionBundle(bundle: unknown) {
+  const issues: string[] = [];
+  const value = bundle as Partial<PiExtensionBundle> | null;
+
+  if (!value || typeof value !== "object") {
+    return { ok: false as const, issues: ["bundle object is required."] };
+  }
+
+  if (value.version !== PI_SOURCE_PROFILE.defaultExtensionBundleVersion) {
+    issues.push(`version must be '${PI_SOURCE_PROFILE.defaultExtensionBundleVersion}'.`);
+  }
+
+  if (value.source !== "pi") {
+    issues.push("source must be 'pi'.");
+  }
+
+  if (!Array.isArray(value.extensions) || value.extensions.length === 0) {
+    issues.push("extensions must be a non-empty string array.");
+  } else {
+    const extSet = new Set(value.extensions.filter((x): x is string => typeof x === "string" && x.length > 0));
+    for (const req of REQUIRED_PI_EXTENSIONS) {
+      if (!extSet.has(req)) {
+        issues.push(`missing required extension: ${req}`);
+      }
+    }
+  }
+
+  return { ok: issues.length === 0, issues } as const;
+}

--- a/lib/integrations/source-adapter/profiles/index.ts
+++ b/lib/integrations/source-adapter/profiles/index.ts
@@ -1,9 +1,11 @@
 import { HERMES_SOURCE_ID, HERMES_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/hermes";
 import { OPENCLAW_SOURCE_ID, OPENCLAW_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/openclaw";
+import { PI_SOURCE_ID, PI_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/pi";
 
 export const SOURCE_PROFILE_REGISTRY = {
   [OPENCLAW_SOURCE_ID]: OPENCLAW_SOURCE_PROFILE,
   [HERMES_SOURCE_ID]: HERMES_SOURCE_PROFILE,
+  [PI_SOURCE_ID]: PI_SOURCE_PROFILE,
 } as const;
 
 export type SourceProfileId = keyof typeof SOURCE_PROFILE_REGISTRY;

--- a/lib/integrations/source-adapter/profiles/pi.ts
+++ b/lib/integrations/source-adapter/profiles/pi.ts
@@ -1,0 +1,46 @@
+import { SOURCE_ADAPTER_VERSION, type SourceAdapterManifest, type SourceAdapterRole } from "@/lib/integrations/source-adapter/schema";
+
+export const PI_SOURCE_ID = "pi";
+
+export const PI_SOURCE_PROFILE = {
+  source: PI_SOURCE_ID,
+  roles: ["supervisor", "consumer", "attestor"] as SourceAdapterRole[],
+  runtimes: ["hosted", "wasm"],
+  defaultPaymentPolicy: "x402_required" as const,
+  defaultAttestationSchema: "reddi.attestation.v1",
+  defaultExtensionBundleVersion: "pi.extension-bundle.v1",
+  capabilityHints: {
+    supervisor: ["resolve", "invoke", "monitor", "route"],
+    consumer: ["resolve", "invoke", "release", "signal"],
+    attestor: ["judge", "score", "audit"],
+  },
+};
+
+export function buildPiSourceManifest(input: {
+  role: SourceAdapterRole;
+  runtime: "hosted" | "wasm";
+  taskTypes: string[];
+  inputModes?: string[];
+  outputModes?: string[];
+  failurePolicy?: { maxRetries?: number; refundOnFailure?: boolean };
+}): SourceAdapterManifest {
+  const manifest: SourceAdapterManifest = {
+    version: SOURCE_ADAPTER_VERSION,
+    source: PI_SOURCE_ID,
+    role: input.role,
+    runtime: input.runtime,
+    capabilities: {
+      taskTypes: input.taskTypes,
+      inputModes: input.inputModes ?? ["text"],
+      outputModes: input.outputModes ?? ["text"],
+    },
+    paymentPolicy: PI_SOURCE_PROFILE.defaultPaymentPolicy,
+    failurePolicy: input.failurePolicy,
+  };
+
+  if (input.role === "attestor") {
+    manifest.attestationSchema = PI_SOURCE_PROFILE.defaultAttestationSchema;
+  }
+
+  return manifest;
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:bdd:index": "./scripts/check-bdd-feature-index.sh",
     "test:bdd:sweep": "./scripts/run-bdd-bucket-sweep.sh",
     "test:bdd:status": "./scripts/bdd-sweep-latest-status.sh",
-    "test:source:conformance": "./scripts/run-source-conformance.sh --source openclaw --mode smoke"
+    "test:source:conformance": "./scripts/run-source-conformance.sh --source openclaw --mode smoke",
+    "test:source:matrix": "./scripts/run-source-conformance-matrix.sh"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/run-source-conformance-matrix.sh
+++ b/scripts/run-source-conformance-matrix.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TS="$(date +%Y%m%d-%H%M%S)"
+OUT_DIR="$ROOT_DIR/artifacts/source-conformance-matrix/$TS"
+LOG_FILE="$OUT_DIR/matrix.log"
+SUMMARY="$OUT_DIR/SUMMARY.md"
+mkdir -p "$OUT_DIR"
+
+SOURCES=(openclaw hermes pi)
+
+run_source() {
+  local src="$1"
+
+  {
+    echo ""
+    echo "[source-matrix] >>> $src smoke"
+    ./scripts/run-source-conformance.sh --source "$src" --mode smoke
+  } 2>&1 | tee -a "$LOG_FILE"
+
+  local code=${PIPESTATUS[0]}
+  local latest_summary
+  latest_summary="$(find "$ROOT_DIR/artifacts/source-conformance" -maxdepth 1 -type d -name "*-${src}-smoke" | sort | tail -1)/SUMMARY.md"
+
+  if [ "$code" -eq 0 ]; then
+    printf "PASS\t%s\t%s\n" "$src" "$latest_summary" >> "$OUT_DIR/matrix.tsv"
+  else
+    printf "FAIL\t%s\t%s\n" "$src" "$latest_summary" >> "$OUT_DIR/matrix.tsv"
+  fi
+
+  return 0
+}
+
+for src in "${SOURCES[@]}"; do
+  run_source "$src"
+done
+
+PASS_COUNT=$(awk -F'\t' 'BEGIN{c=0} $1=="PASS"{c++} END{print c}' "$OUT_DIR/matrix.tsv" 2>/dev/null || printf '0')
+FAIL_COUNT=$(awk -F'\t' 'BEGIN{c=0} $1=="FAIL"{c++} END{print c}' "$OUT_DIR/matrix.tsv" 2>/dev/null || printf '0')
+TOTAL_COUNT=$((PASS_COUNT + FAIL_COUNT))
+
+{
+  echo "# Source Conformance Matrix"
+  echo ""
+  echo "- Timestamp: $TS"
+  echo "- Sources: openclaw, hermes, pi"
+  echo "- Rows passed: $PASS_COUNT"
+  echo "- Rows failed: $FAIL_COUNT"
+  echo "- Rows total: $TOTAL_COUNT"
+  echo ""
+  echo "| Status | Source | Summary |"
+  echo "|---|---|---|"
+  while IFS=$'\t' read -r status source summary; do
+    [ -n "$status" ] || continue
+    echo "| $status | $source | $summary |"
+  done < "$OUT_DIR/matrix.tsv"
+  echo ""
+  echo "- Log: $LOG_FILE"
+  echo "- Matrix table source: $OUT_DIR/matrix.tsv"
+} > "$SUMMARY"
+
+echo "[source-matrix] summary: $SUMMARY"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/run-source-conformance.sh
+++ b/scripts/run-source-conformance.sh
@@ -80,6 +80,21 @@ run_step "BDD feature index integrity" \
 run_step "Source adapter schema + probe contracts" \
   npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts --runInBand
 
+case "$SOURCE" in
+  openclaw)
+    run_step "OpenClaw profile + connector contracts" \
+      npx jest lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts --runInBand
+    ;;
+  hermes)
+    run_step "Hermes profile + attestor contracts" \
+      npx jest lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts --runInBand
+    ;;
+  pi)
+    run_step "pi profile + extension-bundle compatibility" \
+      npx jest lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts --runInBand
+    ;;
+esac
+
 if [ "$MODE" = "full" ]; then
   run_step "Representative BDD bucket sweep" \
     ./scripts/run-bdd-bucket-sweep.sh


### PR DESCRIPTION
## Summary
Implements Iteration 5 (P3) of the infra-first source-adapter BDD loop.

### Delivered
- pi source profile + registry wiring
  - `lib/integrations/source-adapter/profiles/pi.ts`
  - `lib/integrations/source-adapter/profiles/index.ts`
- Canonical pi extension-bundle compatibility validator
  - `lib/integrations/source-adapter/pi/extension-bundle.ts`
- Tests
  - `lib/__tests__/source-adapter-pi-profile.test.ts`
  - `lib/__tests__/source-adapter-pi-extension-bundle.test.ts`
- Conformance harness enhancement
  - `scripts/run-source-conformance.sh` now runs source-specific contract checks
  - new cross-source matrix runner: `scripts/run-source-conformance-matrix.sh`
  - new npm command: `npm run test:source:matrix`
- Bucket-S parity expansion and verification index updates
  - `docs/bdd/features/bucket-s-source-adapters.feature` (`@S3.3`, `@S5.3`)
  - `docs/bdd/FEATURE-INDEX.md`
- Iteration retrospective updates
  - `docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md`
  - `docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md`

## Verification
- `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts --runInBand`
  - 8 suites, 19/19 tests passing
- `npm run test:bdd:index` ✅
- `./scripts/run-source-conformance.sh --source pi --mode smoke` ✅
  - artifact: `artifacts/source-conformance/20260422-230408-pi-smoke/SUMMARY.md`
- `npm run test:source:matrix` ✅
  - artifact: `artifacts/source-conformance-matrix/20260422-230418/SUMMARY.md`

## Next iteration target
Iteration 6 / P4: source-aware routing preference policy hooks + CI gating for matrix artifacts.
