### PR TITLE
feat(source-adapter): source-aware routing policy + conformance matrix CI gate

### DIFF
--- a/.github/workflows/source-conformance-matrix.yml
+++ b/.github/workflows/source-conformance-matrix.yml
@@ -1,0 +1,52 @@
+name: Source Conformance Matrix
+
+on:
+  pull_request:
+    paths:
+      - "lib/integrations/source-adapter/**"
+      - "app/api/planner/tools/resolve/route.ts"
+      - "app/api/register/probe/route.ts"
+      - "lib/mcp/tools.ts"
+      - "docs/bdd/**"
+      - "scripts/run-source-conformance.sh"
+      - "scripts/run-source-conformance-matrix.sh"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+jobs:
+  source-conformance-matrix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run source conformance matrix
+        run: npm run test:source:matrix
+
+      - name: Upload matrix artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-conformance-matrix-${{ github.run_id }}
+          path: |
+            artifacts/source-conformance/
+            artifacts/source-conformance-matrix/
+          if-no-files-found: warn
+          retention-days: 14

--- a/app/api/planner/tools/resolve/route.ts
+++ b/app/api/planner/tools/resolve/route.ts
@@ -9,6 +9,7 @@ import { fetchSpecialistListings } from "@/lib/registry/bridge";
 import { readPolicy } from "@/lib/orchestrator/policy";
 import type { ResolveInput, ResolveOutput } from "@/lib/mcp/tools";
 import { isValidRuntimeCapability } from "@/lib/capabilities/taxonomy";
+import { evaluateSourceRoutingDecision } from "@/lib/integrations/source-adapter/routing-policy";
 
 export const runtime = "nodejs";
 
@@ -33,12 +34,20 @@ export async function POST(req: Request) {
       policyOverride.minReputation ?? savedPolicy.minReputation ?? 0;
     const preferredPrivacyMode =
       policyOverride.preferredPrivacyMode ?? savedPolicy.preferredPrivacyMode ?? "public";
+    const preferredSource = policyOverride.preferredSource;
+    const strictSourceMatch = policyOverride.strictSourceMatch ?? false;
 
     const { listings } = await fetchSpecialistListings();
 
     // Filter and score candidates
     const candidates = listings
       .filter((l) => {
+        const sourceDecision = evaluateSourceRoutingDecision(l, {
+          preferredSource,
+          strictSourceMatch,
+        });
+
+        if (sourceDecision.reject) return false;
         if (l.health.status === "fail") return false;
         if (requireAttestation && !l.attestation.attested) return false;
         if (minReputation > 0 && l.onchain.reputationScore < minReputation) return false;
@@ -51,6 +60,10 @@ export async function POST(req: Request) {
         return true;
       })
       .map((l) => {
+        const sourceDecision = evaluateSourceRoutingDecision(l, {
+          preferredSource,
+          strictSourceMatch,
+        });
         const reasons: string[] = [];
         if (l.attestation.attested) reasons.push("attested");
         if (l.health.status === "pass") reasons.push("online");
@@ -61,12 +74,14 @@ export async function POST(req: Request) {
         if (requiredCapabilities.length > 0) {
           reasons.push(`requires:${requiredCapabilities.join(",")}`);
         }
+        reasons.push(...sourceDecision.reasons);
         const score =
           (l.attestation.attested ? 30 : 0) +
           (l.health.status === "pass" ? 20 : 0) +
           Math.min(l.signals.avgFeedbackScore * 5, 25) +
           Math.min(l.onchain.reputationScore * 0.1, 15) +
-          (l.capabilities?.privacyModes.includes(preferredPrivacyMode as never) ? 10 : 0);
+          (l.capabilities?.privacyModes.includes(preferredPrivacyMode as never) ? 10 : 0) +
+          sourceDecision.scoreDelta;
 
         return { listing: l, score, reasons };
       })

--- a/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md
+++ b/docs/BDD-COMPREHENSIVE-REVIEW-AND-GAP-PLAN-2026-04-22-source-adapters.md
@@ -41,7 +41,7 @@ Implement source ecosystem onboarding (OpenClaw, Hermes, pi.dev) with infrastruc
 5. Commit scoped change.
 
 ## Active iteration target
-- Iteration 6: source-aware routing preference policy + CI gating for cross-source matrix artifacts.
+- Iteration 7: source-aware ranking explainability in resolve output + supervisor diagnostics.
 
 ## Re-ranking board
 
@@ -63,6 +63,6 @@ Implement source ecosystem onboarding (OpenClaw, Hermes, pi.dev) with infrastruc
 9. ✅ Add pi source profile + canonical extension-bundle compatibility checks.
 10. ✅ Add cross-source conformance matrix output across openclaw/hermes/pi smoke runs.
 
-### P4 (active)
-11. Add source-aware routing preference policy hooks (selection defaults + guardrails).
-12. Wire matrix verification into CI so artifact regressions fail fast.
+### P4 (complete)
+11. ✅ Add source-aware routing preference policy hooks (selection defaults + guardrails).
+12. ✅ Wire matrix verification into CI so artifact regressions fail fast.

--- a/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
@@ -110,3 +110,41 @@ This log follows `playbooks/bdd-gap-closure-loop/PLAYBOOK.md` and is updated eve
   - All three sources now have baseline profile coverage with deterministic parity checks.
   - Next iteration should focus on promotion policy wiring for source-aware routing preferences and CI lane gating for matrix artifacts.
 
+## Iteration 6
+- Focus: P4 source-aware routing preference policy hooks + CI lane gating for matrix artifacts.
+- Delivered:
+  - Added source-routing policy evaluator:
+    - `lib/integrations/source-adapter/routing-policy.ts`
+    - supports `preferredSource` + `strictSourceMatch` guardrails with deterministic scoring/rejection reasons.
+  - Wired source-aware routing into resolve tool route:
+    - `app/api/planner/tools/resolve/route.ts`
+    - applies source policy in candidate filter + score phases.
+  - Added OpenClaw source default routing hook:
+    - `lib/integrations/source-adapter/openclaw/connector.ts`
+    - resolve calls now default `policy.preferredSource = "openclaw"` when not provided.
+  - Extended MCP resolve tool schema:
+    - `lib/mcp/tools.ts`
+    - adds `policy.preferredSource` and `policy.strictSourceMatch`.
+  - Added tests:
+    - `lib/__tests__/source-adapter-routing-policy.test.ts`
+    - `lib/__tests__/planner-resolve-route.test.ts`
+    - updated `lib/__tests__/source-adapter-openclaw-connector.test.ts` for default source-policy assertions.
+  - Added CI gating workflow:
+    - `.github/workflows/source-conformance-matrix.yml`
+    - runs `npm run test:source:matrix` and uploads source+matrix artifacts.
+  - Updated Bucket-S BDD docs:
+    - `docs/bdd/features/bucket-s-source-adapters.feature` (`@S2.2`, `@S5.4`)
+    - `docs/bdd/FEATURE-INDEX.md` with new routing policy verification lanes.
+- Verified:
+  - `npx jest lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts --runInBand` -> 3 suites, 7/7 tests passing.
+  - `npm run test:bdd:index` -> PASS.
+  - `npm run test:source:matrix` -> PASS.
+  - Artifact evidence:
+    - `artifacts/source-conformance/20260423-054949-openclaw-smoke/SUMMARY.md`
+    - `artifacts/source-conformance/20260423-054958-hermes-smoke/SUMMARY.md`
+    - `artifacts/source-conformance/20260423-055006-pi-smoke/SUMMARY.md`
+    - `artifacts/source-conformance-matrix/20260423-054949/SUMMARY.md`.
+- Retrospective:
+  - Source-aware routing defaults are now wired with strict guardrails and deterministic reasons.
+  - Matrix regressions are CI-gated with retained artifacts for fast diagnosis.
+  - Next iteration should add source-aware ranking explainability in API output metadata (per-candidate source match summary) for external supervisor debugging.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -49,7 +49,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket S — Source Adapter Onboarding
 - Feature: `docs/bdd/features/bucket-s-source-adapters.feature`
 - Verify:
-  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts --runInBand`
+  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
   - `npm run test:source:conformance`
   - `./scripts/run-source-conformance.sh --source hermes --mode smoke`
   - `./scripts/run-source-conformance.sh --source pi --mode smoke`

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -62,3 +62,15 @@ Feature: Bucket S Source Adapter Onboarding
     When the matrix runner executes source conformance for all supported sources
     Then matrix summary includes rows for openclaw hermes and pi
     And each row contains pass fail and artifact summary path fields
+
+  @S2.2 @supervisor @routing-policy
+  Scenario: Source-aware routing applies preferred source defaults with strict guardrails
+    When resolve policy includes preferredSource and strictSourceMatch options
+    Then source-matching specialists receive deterministic routing preference
+    And strict mode rejects non-matching source candidates
+
+  @S5.4 @conformance @ci-gating
+  Scenario: CI matrix lane uploads source conformance artifacts for regressions
+    When source-conformance-matrix workflow runs on source adapter changes
+    Then matrix execution must pass before merge
+    And source and matrix artifact directories are uploaded for inspection

--- a/lib/__tests__/planner-resolve-route.test.ts
+++ b/lib/__tests__/planner-resolve-route.test.ts
@@ -1,0 +1,138 @@
+import type { SpecialistListing } from "@/lib/registry/bridge";
+
+jest.mock("@/lib/registry/bridge", () => ({
+  fetchSpecialistListings: jest.fn(),
+}));
+
+jest.mock("@/lib/orchestrator/policy", () => ({
+  readPolicy: jest.fn(),
+}));
+
+function makeListing(input: {
+  wallet: string;
+  tags: string[];
+  reputation?: number;
+}): SpecialistListing {
+  return {
+    pda: `pda-${input.wallet}`,
+    walletAddress: input.wallet,
+    onchain: {
+      owner: input.wallet,
+      agentType: "Primary",
+      model: "model",
+      rateLamports: 0n,
+      minReputation: 0,
+      reputationScore: input.reputation ?? 100,
+      jobsCompleted: 0n,
+      jobsFailed: 0n,
+      createdAt: 0n,
+      active: true,
+      attestationAccuracy: 0,
+    },
+    capabilities: {
+      taskTypes: ["summarize"],
+      inputModes: ["text"],
+      outputModes: ["text"],
+      privacyModes: ["public"],
+      tags: input.tags,
+      baseUsd: 0,
+      perCallUsd: 0.01,
+      context_requirements: [],
+      runtime_capabilities: [],
+    },
+    health: {
+      status: "pass",
+      endpointUrl: `https://${input.wallet}.example`,
+      lastCheckedAt: null,
+    },
+    attestation: {
+      attested: false,
+      lastAttestedAt: null,
+    },
+    capabilityHash: null,
+    signals: {
+      feedbackCount: 0,
+      avgFeedbackScore: 0,
+      attestationAgreements: 0,
+      attestationDisagreements: 0,
+    },
+    ranking_score: 0,
+  };
+}
+
+describe("planner resolve route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("prefers source-matching specialists when preferredSource is set", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    const { readPolicy } = await import("@/lib/orchestrator/policy");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      preferredPrivacyMode: "public",
+      requireAttestation: false,
+      maxPerTaskUsd: 0,
+      minReputation: 0,
+    });
+
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      listings: [
+        makeListing({ wallet: "wallet-hermes", tags: ["source:hermes"] }),
+        makeListing({ wallet: "wallet-openclaw", tags: ["source:openclaw"] }),
+      ],
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve/route");
+    const req = new Request("http://localhost/api/planner/tools/resolve", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        task: "summarize",
+        policy: { preferredSource: "openclaw" },
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.candidate.walletAddress).toBe("wallet-openclaw");
+    expect(body.candidate.selectionReasons).toContain("source:openclaw");
+  });
+
+  it("enforces strictSourceMatch guardrail", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    const { readPolicy } = await import("@/lib/orchestrator/policy");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      preferredPrivacyMode: "public",
+      requireAttestation: false,
+      maxPerTaskUsd: 0,
+      minReputation: 0,
+    });
+
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      listings: [makeListing({ wallet: "wallet-hermes", tags: ["source:hermes"] })],
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve/route");
+    const req = new Request("http://localhost/api/planner/tools/resolve", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        task: "summarize",
+        policy: { preferredSource: "openclaw", strictSourceMatch: true },
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("No eligible specialists");
+  });
+});

--- a/lib/__tests__/source-adapter-openclaw-connector.test.ts
+++ b/lib/__tests__/source-adapter-openclaw-connector.test.ts
@@ -34,6 +34,9 @@ describe("openclaw source connector", () => {
         headers: expect.objectContaining({ "x-reddi-agent-key": "secret" }),
       })
     );
+
+    const payload = JSON.parse(((global.fetch as jest.Mock).mock.calls[0]?.[1]?.body ?? "{}") as string);
+    expect(payload.policy?.preferredSource).toBe("openclaw");
   });
 
   it("runs supervisor resolve->invoke flow", async () => {

--- a/lib/__tests__/source-adapter-routing-policy.test.ts
+++ b/lib/__tests__/source-adapter-routing-policy.test.ts
@@ -1,0 +1,77 @@
+import { detectListingSource, evaluateSourceRoutingDecision } from "@/lib/integrations/source-adapter/routing-policy";
+import type { SpecialistListing } from "@/lib/registry/bridge";
+
+function makeListing(tags: string[]): SpecialistListing {
+  return {
+    pda: "pda-1",
+    walletAddress: "wallet-1",
+    onchain: {
+      owner: "wallet-1",
+      agentType: "Primary",
+      model: "model",
+      rateLamports: 0n,
+      minReputation: 0,
+      reputationScore: 80,
+      jobsCompleted: 0n,
+      jobsFailed: 0n,
+      createdAt: 0n,
+      active: true,
+      attestationAccuracy: 0,
+    },
+    capabilities: {
+      taskTypes: ["summarize"],
+      inputModes: ["text"],
+      outputModes: ["text"],
+      privacyModes: ["public"],
+      tags,
+      baseUsd: 0,
+      perCallUsd: 0,
+      context_requirements: [],
+      runtime_capabilities: [],
+    },
+    health: {
+      status: "pass",
+      endpointUrl: "https://spec.example",
+      lastCheckedAt: null,
+    },
+    attestation: {
+      attested: false,
+      lastAttestedAt: null,
+    },
+    capabilityHash: null,
+    signals: {
+      feedbackCount: 0,
+      avgFeedbackScore: 0,
+      attestationAgreements: 0,
+      attestationDisagreements: 0,
+    },
+    ranking_score: 0,
+  };
+}
+
+describe("source adapter routing policy", () => {
+  it("detects source tags from specialist listing metadata", () => {
+    expect(detectListingSource(makeListing(["source:openclaw", "foo"]))).toBe("openclaw");
+    expect(detectListingSource(makeListing(["source=hermes"]))).toBe("hermes");
+    expect(detectListingSource(makeListing(["source:unknown"]))).toBeNull();
+  });
+
+  it("adds preference bonus for source match and rejects strict mismatches", () => {
+    const openclawListing = makeListing(["source:openclaw"]);
+    const hermesListing = makeListing(["source:hermes"]);
+
+    const match = evaluateSourceRoutingDecision(openclawListing, {
+      preferredSource: "openclaw",
+      strictSourceMatch: false,
+    });
+    expect(match.scoreDelta).toBe(12);
+    expect(match.reject).toBe(false);
+
+    const strictMismatch = evaluateSourceRoutingDecision(hermesListing, {
+      preferredSource: "openclaw",
+      strictSourceMatch: true,
+    });
+    expect(strictMismatch.reject).toBe(true);
+    expect(strictMismatch.reasons).toContain("source_mismatch:openclaw");
+  });
+});

--- a/lib/integrations/source-adapter/openclaw/connector.ts
+++ b/lib/integrations/source-adapter/openclaw/connector.ts
@@ -1,4 +1,5 @@
 import type { InvokeInput, InvokeOutput, QualitySignalInput, QualitySignalOutput, ResolveInput, ResolveOutput } from "@/lib/mcp/tools";
+import { OPENCLAW_SOURCE_ID } from "@/lib/integrations/source-adapter/profiles/openclaw";
 
 export type OpenClawConnectorConfig = {
   baseUrl: string;
@@ -42,7 +43,13 @@ async function postJson<T>(cfg: OpenClawConnectorConfig, path: string, payload: 
 }
 
 export async function openClawResolveSpecialist(cfg: OpenClawConnectorConfig, input: ResolveInput) {
-  return postJson<ResolveOutput>(cfg, "/api/planner/tools/resolve", input);
+  return postJson<ResolveOutput>(cfg, "/api/planner/tools/resolve", {
+    ...input,
+    policy: {
+      ...input.policy,
+      preferredSource: input.policy?.preferredSource ?? OPENCLAW_SOURCE_ID,
+    },
+  });
 }
 
 export async function openClawInvokeSpecialist(cfg: OpenClawConnectorConfig, input: InvokeInput) {

--- a/lib/integrations/source-adapter/routing-policy.ts
+++ b/lib/integrations/source-adapter/routing-policy.ts
@@ -1,0 +1,97 @@
+import type { SpecialistListing } from "@/lib/registry/bridge";
+import { getSourceProfile, type SourceProfileId } from "@/lib/integrations/source-adapter/profiles";
+
+export type SourceRoutingPolicyInput = {
+  preferredSource?: string;
+  strictSourceMatch?: boolean;
+};
+
+export type SourceRoutingDecision = {
+  requestedSource: SourceProfileId | null;
+  listingSource: SourceProfileId | null;
+  scoreDelta: number;
+  reject: boolean;
+  reasons: string[];
+};
+
+function normalizeRequestedSource(source?: string): SourceProfileId | null {
+  if (!source) return null;
+  return getSourceProfile(source) ? (source as SourceProfileId) : null;
+}
+
+export function detectListingSource(listing: SpecialistListing): SourceProfileId | null {
+  const tags = listing.capabilities?.tags ?? [];
+
+  for (const tag of tags) {
+    if (!tag || typeof tag !== "string") continue;
+
+    const [prefix, value] = tag.includes(":")
+      ? tag.split(":", 2)
+      : tag.split("=", 2);
+
+    if (prefix !== "source" || !value) continue;
+    if (getSourceProfile(value)) {
+      return value as SourceProfileId;
+    }
+  }
+
+  return null;
+}
+
+export function evaluateSourceRoutingDecision(
+  listing: SpecialistListing,
+  policy: SourceRoutingPolicyInput
+): SourceRoutingDecision {
+  const requestedSource = normalizeRequestedSource(policy.preferredSource);
+  const listingSource = detectListingSource(listing);
+
+  if (!requestedSource) {
+    return {
+      requestedSource: null,
+      listingSource,
+      scoreDelta: 0,
+      reject: false,
+      reasons: [],
+    };
+  }
+
+  const strict = policy.strictSourceMatch === true;
+
+  if (listingSource === requestedSource) {
+    return {
+      requestedSource,
+      listingSource,
+      scoreDelta: 12,
+      reject: false,
+      reasons: [`source:${requestedSource}`],
+    };
+  }
+
+  if (strict) {
+    return {
+      requestedSource,
+      listingSource,
+      scoreDelta: 0,
+      reject: true,
+      reasons: [`source_mismatch:${requestedSource}`],
+    };
+  }
+
+  if (listingSource) {
+    return {
+      requestedSource,
+      listingSource,
+      scoreDelta: -4,
+      reject: false,
+      reasons: [`source_penalty:${listingSource}`],
+    };
+  }
+
+  return {
+    requestedSource,
+    listingSource,
+    scoreDelta: 0,
+    reject: false,
+    reasons: [`source_unknown:${requestedSource}`],
+  };
+}

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -34,6 +34,8 @@ export type ResolveInput = {
     requireAttestation?: boolean;
     preferredPrivacyMode?: "public" | "per" | "vanish";
     minReputation?: number;
+    preferredSource?: "openclaw" | "hermes" | "pi";
+    strictSourceMatch?: boolean;
   };
 };
 
@@ -187,6 +189,15 @@ export const MCP_TOOL_SCHEMAS = [
             requireAttestation: { type: "boolean", description: "Only use attested specialists." },
             preferredPrivacyMode: { type: "string", enum: ["public","per","vanish"] },
             minReputation: { type: "number", description: "Minimum on-chain reputation score." },
+            preferredSource: {
+              type: "string",
+              enum: ["openclaw", "hermes", "pi"],
+              description: "Optional source-ecosystem preference for candidate routing.",
+            },
+            strictSourceMatch: {
+              type: "boolean",
+              description: "When true, only candidates tagged to preferredSource are eligible.",
+            },
           },
         },
       },


### PR DESCRIPTION
## Summary
- add source-aware routing policy evaluator for planner resolve (`preferredSource`, `strictSourceMatch`)
- wire resolve route scoring/filter guardrails and OpenClaw default source preference hook
- extend MCP resolve schema with source policy fields
- add Bucket-S BDD/docs updates for routing policy + CI gating scenarios
- add dedicated `source-conformance-matrix` GitHub Actions workflow with artifact upload

## Verification
- `npx jest lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts --runInBand`
- `npm run test:bdd:index`
- `npm run test:source:matrix`

## Notes
- source matrix run artifacts were generated locally under `artifacts/source-conformance*/` for this iteration but are intentionally not committed.
