### PR TITLE
feat: expose source-routing explainability metadata in resolve output

### DIFF
--- a/app/api/planner/tools/resolve/route.ts
+++ b/app/api/planner/tools/resolve/route.ts
@@ -35,17 +35,20 @@ export async function POST(req: Request) {
     const preferredPrivacyMode =
       policyOverride.preferredPrivacyMode ?? savedPolicy.preferredPrivacyMode ?? "public";
     const preferredSource = policyOverride.preferredSource;
-    const strictSourceMatch = policyOverride.strictSourceMatch ?? false;
+    const strictSourceMatch = policyOverride.strictSourceMatch === true;
 
     const { listings } = await fetchSpecialistListings();
 
     // Filter and score candidates
     const candidates = listings
-      .filter((l) => {
-        const sourceDecision = evaluateSourceRoutingDecision(l, {
+      .map((l) => ({
+        listing: l,
+        sourceDecision: evaluateSourceRoutingDecision(l, {
           preferredSource,
           strictSourceMatch,
-        });
+        }),
+      }))
+      .filter(({ listing: l, sourceDecision }) => {
 
         if (sourceDecision.reject) return false;
         if (l.health.status === "fail") return false;
@@ -59,12 +62,15 @@ export async function POST(req: Request) {
         if (!l.health.endpointUrl) return false;
         return true;
       })
-      .map((l) => {
-        const sourceDecision = evaluateSourceRoutingDecision(l, {
-          preferredSource,
-          strictSourceMatch,
-        });
+      .map(({ listing: l, sourceDecision }) => {
         const reasons: string[] = [];
+        const sourceDecisionTrace = [
+          `source:requested=${sourceDecision.requestedSource ?? "none"}`,
+          `source:candidate=${sourceDecision.listingSource ?? "unknown"}`,
+          `source:strict=${strictSourceMatch}`,
+          `source:score_delta=${sourceDecision.scoreDelta}`,
+          ...sourceDecision.reasons,
+        ];
         if (l.attestation.attested) reasons.push("attested");
         if (l.health.status === "pass") reasons.push("online");
         if (l.signals.feedbackCount > 0) reasons.push(`feedback:${l.signals.avgFeedbackScore.toFixed(1)}`);
@@ -83,7 +89,7 @@ export async function POST(req: Request) {
           (l.capabilities?.privacyModes.includes(preferredPrivacyMode as never) ? 10 : 0) +
           sourceDecision.scoreDelta;
 
-        return { listing: l, score, reasons };
+        return { listing: l, score, reasons, sourceDecision, sourceDecisionTrace };
       })
       .sort((a, b) => b.score - a.score);
 
@@ -114,6 +120,13 @@ export async function POST(req: Request) {
         reputationScore: l.onchain.reputationScore,
         avgFeedbackScore: l.signals.avgFeedbackScore,
         selectionReasons: best.reasons,
+        sourceRouting: {
+          requestedSource: best.sourceDecision.requestedSource,
+          candidateSource: best.sourceDecision.listingSource,
+          strictSourceMatch,
+          scoreDelta: best.sourceDecision.scoreDelta,
+          decisionTrace: best.sourceDecisionTrace,
+        },
       },
       alternativeCount: candidates.length - 1,
     };

--- a/lib/__tests__/planner-resolve-route.test.ts
+++ b/lib/__tests__/planner-resolve-route.test.ts
@@ -101,6 +101,63 @@ describe("planner resolve route", () => {
     expect(body.ok).toBe(true);
     expect(body.candidate.walletAddress).toBe("wallet-openclaw");
     expect(body.candidate.selectionReasons).toContain("source:openclaw");
+    expect(body.candidate.sourceRouting).toMatchObject({
+      requestedSource: "openclaw",
+      candidateSource: "openclaw",
+      strictSourceMatch: false,
+      scoreDelta: 12,
+    });
+    expect(body.candidate.sourceRouting.decisionTrace).toEqual(
+      expect.arrayContaining([
+        "source:requested=openclaw",
+        "source:candidate=openclaw",
+        "source:strict=false",
+        "source:score_delta=12",
+        "source:openclaw",
+      ])
+    );
+  });
+
+  it("returns source policy trace when preferred source does not match under non-strict mode", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    const { readPolicy } = await import("@/lib/orchestrator/policy");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      preferredPrivacyMode: "public",
+      requireAttestation: false,
+      maxPerTaskUsd: 0,
+      minReputation: 0,
+    });
+
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      listings: [makeListing({ wallet: "wallet-hermes", tags: ["source:hermes"] })],
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve/route");
+    const req = new Request("http://localhost/api/planner/tools/resolve", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        task: "summarize",
+        policy: { preferredSource: "openclaw", strictSourceMatch: false },
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.candidate.walletAddress).toBe("wallet-hermes");
+    expect(body.candidate.sourceRouting).toMatchObject({
+      requestedSource: "openclaw",
+      candidateSource: "hermes",
+      strictSourceMatch: false,
+      scoreDelta: -4,
+    });
+    expect(body.candidate.sourceRouting.decisionTrace).toEqual(
+      expect.arrayContaining(["source_penalty:hermes"])
+    );
   });
 
   it("enforces strictSourceMatch guardrail", async () => {

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -52,6 +52,13 @@ export type ResolveOutput = {
     reputationScore: number;
     avgFeedbackScore: number;
     selectionReasons: string[];
+    sourceRouting?: {
+      requestedSource: "openclaw" | "hermes" | "pi" | null;
+      candidateSource: "openclaw" | "hermes" | "pi" | null;
+      strictSourceMatch: boolean;
+      scoreDelta: number;
+      decisionTrace: string[];
+    };
   } | null;
   alternativeCount: number;
   error?: string;


### PR DESCRIPTION
## Summary
- add source routing explainability metadata to `resolve_specialist` API output
- include candidate source, requested source, strict match mode, score delta, and decision trace
- extend route tests to verify source trace shape and mismatch penalty path

## Why
Iteration 7 requires source-match explainability for supervisor debugging and audit trails.

## Validation
- `npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts --runInBand`
