### PR TITLE
feat: add ranked alternatives explainability to resolve output

### DIFF
--- a/app/api/planner/tools/resolve/route.ts
+++ b/app/api/planner/tools/resolve/route.ts
@@ -106,6 +106,19 @@ export async function POST(req: Request) {
     const best = candidates[0];
     const l = best.listing;
     const endpointUrl = l.health.endpointUrl ?? "";
+    const alternatives = candidates.slice(1, 4).map((candidate) => ({
+      walletAddress: candidate.listing.walletAddress,
+      endpointUrl: candidate.listing.health.endpointUrl ?? "",
+      score: candidate.score,
+      selectionReasons: candidate.reasons,
+      sourceRouting: {
+        requestedSource: candidate.sourceDecision.requestedSource,
+        candidateSource: candidate.sourceDecision.listingSource,
+        strictSourceMatch,
+        scoreDelta: candidate.sourceDecision.scoreDelta,
+        decisionTrace: candidate.sourceDecisionTrace,
+      },
+    }));
 
     const output: ResolveOutput = {
       ok: true,
@@ -129,6 +142,7 @@ export async function POST(req: Request) {
         },
       },
       alternativeCount: candidates.length - 1,
+      alternatives,
     };
 
     return Response.json(output);
@@ -146,7 +160,12 @@ export async function GET() {
     description: "Find the best specialist candidate for a task.",
     schema: {
       input: { task: "string", taskTypeHint: "string?", required_capabilities: "string[]?", policy: "PolicyOverride?" },
-      output: { ok: "boolean", candidate: "SpecialistCandidate | null", alternativeCount: "number" },
+      output: {
+        ok: "boolean",
+        candidate: "SpecialistCandidate | null",
+        alternativeCount: "number",
+        alternatives: "SpecialistAlternative[]",
+      },
     },
   });
 }

--- a/lib/__tests__/planner-resolve-route.test.ts
+++ b/lib/__tests__/planner-resolve-route.test.ts
@@ -192,4 +192,55 @@ describe("planner resolve route", () => {
     expect(body.ok).toBe(false);
     expect(body.error).toContain("No eligible specialists");
   });
+
+  it("returns ranked alternative explainability metadata for supervisor diagnostics", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    const { readPolicy } = await import("@/lib/orchestrator/policy");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      preferredPrivacyMode: "public",
+      requireAttestation: false,
+      maxPerTaskUsd: 0,
+      minReputation: 0,
+    });
+
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      listings: [
+        makeListing({ wallet: "wallet-openclaw", tags: ["source:openclaw"], reputation: 110 }),
+        makeListing({ wallet: "wallet-hermes", tags: ["source:hermes"], reputation: 100 }),
+        makeListing({ wallet: "wallet-pi", tags: ["source:pi"], reputation: 90 }),
+      ],
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve/route");
+    const req = new Request("http://localhost/api/planner/tools/resolve", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        task: "summarize",
+        policy: { preferredSource: "openclaw", strictSourceMatch: false },
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.candidate.walletAddress).toBe("wallet-openclaw");
+    expect(body.alternativeCount).toBe(2);
+    expect(body.alternatives).toHaveLength(2);
+    expect(body.alternatives[0]).toMatchObject({
+      walletAddress: "wallet-hermes",
+      sourceRouting: {
+        requestedSource: "openclaw",
+        candidateSource: "hermes",
+        strictSourceMatch: false,
+        scoreDelta: -4,
+      },
+    });
+    expect(body.alternatives[0].sourceRouting.decisionTrace).toEqual(
+      expect.arrayContaining(["source_penalty:hermes"])
+    );
+  });
 });

--- a/lib/integrations/source-adapter/profiles/hermes.ts
+++ b/lib/integrations/source-adapter/profiles/hermes.ts
@@ -1,6 +1,6 @@
 import { SOURCE_ADAPTER_VERSION, type SourceAdapterManifest, type SourceAdapterRole } from "@/lib/integrations/source-adapter/schema";
 
-export const HERMES_SOURCE_ID = "hermes";
+export const HERMES_SOURCE_ID = "hermes" as const;
 
 export const HERMES_SOURCE_PROFILE = {
   source: HERMES_SOURCE_ID,

--- a/lib/integrations/source-adapter/profiles/openclaw.ts
+++ b/lib/integrations/source-adapter/profiles/openclaw.ts
@@ -1,6 +1,6 @@
 import { SOURCE_ADAPTER_VERSION, type SourceAdapterManifest, type SourceAdapterRole } from "@/lib/integrations/source-adapter/schema";
 
-export const OPENCLAW_SOURCE_ID = "openclaw";
+export const OPENCLAW_SOURCE_ID = "openclaw" as const;
 
 export const OPENCLAW_SOURCE_PROFILE = {
   source: OPENCLAW_SOURCE_ID,

--- a/lib/integrations/source-adapter/profiles/pi.ts
+++ b/lib/integrations/source-adapter/profiles/pi.ts
@@ -1,6 +1,6 @@
 import { SOURCE_ADAPTER_VERSION, type SourceAdapterManifest, type SourceAdapterRole } from "@/lib/integrations/source-adapter/schema";
 
-export const PI_SOURCE_ID = "pi";
+export const PI_SOURCE_ID = "pi" as const;
 
 export const PI_SOURCE_PROFILE = {
   source: PI_SOURCE_ID,

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -61,6 +61,19 @@ export type ResolveOutput = {
     };
   } | null;
   alternativeCount: number;
+  alternatives?: Array<{
+    walletAddress: string;
+    endpointUrl: string;
+    score: number;
+    selectionReasons: string[];
+    sourceRouting?: {
+      requestedSource: "openclaw" | "hermes" | "pi" | null;
+      candidateSource: "openclaw" | "hermes" | "pi" | null;
+      strictSourceMatch: boolean;
+      scoreDelta: number;
+      decisionTrace: string[];
+    };
+  }>;
   error?: string;
 };
 


### PR DESCRIPTION
## Summary
- extend `resolve_specialist` output with ranked `alternatives` payload (top 3) for supervisor diagnostics
- include per-alternative source-routing explainability (`requestedSource`, `candidateSource`, strict mode, score delta, decision trace)
- update resolve route schema metadata + TypeScript contract to document alternatives payload
- add route tests validating alternative ranking + source trace fields

## Why
After Iteration 7 exposed source-routing explainability for the selected candidate, supervisors still lacked structured context for *why* non-selected candidates lost. This closes that gap with deterministic alternative diagnostics.

## Validation
- `npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts --runInBand`
