### PR TITLE
feat: include rejected wallet samples in resolve diagnostics

### DIFF
--- a/app/api/planner/tools/resolve/route.ts
+++ b/app/api/planner/tools/resolve/route.ts
@@ -47,6 +47,24 @@ export async function POST(req: Request) {
       capabilities: 0,
       endpoint: 0,
     };
+    const rejectedWalletSamples: Record<keyof typeof rejectionSummary, string[]> = {
+      sourcePolicy: [],
+      health: [],
+      attestation: [],
+      reputation: [],
+      cost: [],
+      capabilities: [],
+      endpoint: [],
+    };
+    const rejectionSampleLimit = 3;
+
+    const recordRejection = (reason: keyof typeof rejectionSummary, walletAddress: string) => {
+      rejectionSummary[reason] += 1;
+      const samples = rejectedWalletSamples[reason];
+      if (samples.length < rejectionSampleLimit) {
+        samples.push(walletAddress);
+      }
+    };
 
     // Filter and score candidates
     const eligibleListings = listings
@@ -60,34 +78,34 @@ export async function POST(req: Request) {
       .filter(({ listing: l, sourceDecision }) => {
 
         if (sourceDecision.reject) {
-          rejectionSummary.sourcePolicy += 1;
+          recordRejection("sourcePolicy", l.walletAddress);
           return false;
         }
         if (l.health.status === "fail") {
-          rejectionSummary.health += 1;
+          recordRejection("health", l.walletAddress);
           return false;
         }
         if (requireAttestation && !l.attestation.attested) {
-          rejectionSummary.attestation += 1;
+          recordRejection("attestation", l.walletAddress);
           return false;
         }
         if (minReputation > 0 && l.onchain.reputationScore < minReputation) {
-          rejectionSummary.reputation += 1;
+          recordRejection("reputation", l.walletAddress);
           return false;
         }
         if (maxPerCallUsd > 0 && l.capabilities && l.capabilities.perCallUsd > maxPerCallUsd) {
-          rejectionSummary.cost += 1;
+          recordRejection("cost", l.walletAddress);
           return false;
         }
         if (requiredCapabilities.length > 0) {
           const specialistCapabilities = l.capabilities?.runtime_capabilities ?? [];
           if (!requiredCapabilities.every((cap) => specialistCapabilities.includes(cap))) {
-            rejectionSummary.capabilities += 1;
+            recordRejection("capabilities", l.walletAddress);
             return false;
           }
         }
         if (!l.health.endpointUrl) {
-          rejectionSummary.endpoint += 1;
+          recordRejection("endpoint", l.walletAddress);
           return false;
         }
         return true;
@@ -130,6 +148,7 @@ export async function POST(req: Request) {
       totalListings: listings.length,
       acceptedCount: candidates.length,
       rejectedBy: rejectionSummary,
+      rejectedWalletSamples,
     };
 
     if (candidates.length === 0) {

--- a/lib/__tests__/planner-resolve-route.test.ts
+++ b/lib/__tests__/planner-resolve-route.test.ts
@@ -197,6 +197,9 @@ describe("planner resolve route", () => {
       rejectedBy: {
         sourcePolicy: 1,
       },
+      rejectedWalletSamples: {
+        sourcePolicy: ["wallet-hermes"],
+      },
     });
   });
 
@@ -242,6 +245,9 @@ describe("planner resolve route", () => {
       acceptedCount: 3,
       rejectedBy: {
         sourcePolicy: 0,
+      },
+      rejectedWalletSamples: {
+        sourcePolicy: [],
       },
     });
     expect(body.alternatives[0]).toMatchObject({

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -86,6 +86,15 @@ export type ResolveOutput = {
       capabilities: number;
       endpoint: number;
     };
+    rejectedWalletSamples: {
+      sourcePolicy: string[];
+      health: string[];
+      attestation: string[];
+      reputation: string[];
+      cost: string[];
+      capabilities: string[];
+      endpoint: string[];
+    };
   };
   error?: string;
 };


### PR DESCRIPTION
## Summary
- extend `resolveDiagnostics` with `rejectedWalletSamples` for each rejection bucket
- capture up to 3 wallet samples per bucket during filtering (`sourcePolicy`, `health`, `attestation`, `reputation`, `cost`, `capabilities`, `endpoint`)
- preserve existing deterministic rejection counters and add sample assertions in resolve route tests

## Why
Iteration 9 added aggregate rejection counters, but policy triage still needed a fast pointer to concrete affected candidates. This adds low-noise sample identities without dumping full candidate lists.

## Validation
- `npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts --runInBand`
- `npm run build`
