### PR TITLE
feat: add capability disclosure schema for marketplace + attestor checkpoints

### DIFF
--- a/app/api/onboarding/capabilities/route.ts
+++ b/app/api/onboarding/capabilities/route.ts
@@ -47,6 +47,22 @@ export async function POST(req: Request) {
       runtime_capabilities: Array.isArray(body.runtime_capabilities)
         ? body.runtime_capabilities.map(String) as Array<"code_execution" | "file_read" | "file_write" | "web_search" | "stateful" | "long_running" | "multimodal" | "streaming">
         : [],
+      agent_composition: body.agent_composition && typeof body.agent_composition === "object"
+        ? {
+            llm: typeof body.agent_composition.llm === "string" ? body.agent_composition.llm : undefined,
+            control_loop:
+              typeof body.agent_composition.control_loop === "string"
+                ? body.agent_composition.control_loop
+                : undefined,
+            tools: Array.isArray(body.agent_composition.tools) ? body.agent_composition.tools.map(String) : [],
+            memory: Array.isArray(body.agent_composition.memory) ? body.agent_composition.memory.map(String) : [],
+            goals: Array.isArray(body.agent_composition.goals) ? body.agent_composition.goals.map(String) : [],
+          }
+        : undefined,
+      quality_claims: Array.isArray(body.quality_claims) ? body.quality_claims.map(String) : [],
+      attestor_checkpoints: Array.isArray(body.attestor_checkpoints)
+        ? body.attestor_checkpoints.map(String)
+        : [],
     });
 
     upsertSpecialistIndex(walletAddress, result.record.capabilities, {

--- a/lib/__tests__/capabilities-disclosure.test.ts
+++ b/lib/__tests__/capabilities-disclosure.test.ts
@@ -1,0 +1,74 @@
+import { computeCapabilityHash, validateCapabilities } from "@/lib/onboarding/capabilities";
+
+describe("capabilities disclosure schema", () => {
+  it("normalizes optional disclosure metadata", () => {
+    const normalized = validateCapabilities({
+      taskTypes: ["summarize"],
+      inputModes: ["text"],
+      outputModes: ["text"],
+      pricing: { baseUsd: 0.1, perCallUsd: 0.2 },
+      privacyModes: ["public"],
+      tags: [" openclaw ", "openclaw"],
+      agent_composition: {
+        llm: " qwen2.5:7b ",
+        control_loop: " reflect-revise ",
+        tools: ["web_search", "web_search"],
+        memory: ["session"],
+        goals: ["accuracy", "accuracy", "latency"],
+      },
+      quality_claims: ["schema pass", "schema pass"],
+      attestor_checkpoints: ["schema_contract", "schema_contract", "policy_bounds"],
+    });
+
+    expect(normalized.agent_composition).toEqual({
+      llm: "qwen2.5:7b",
+      control_loop: "reflect-revise",
+      tools: ["web_search"],
+      memory: ["session"],
+      goals: ["accuracy", "latency"],
+    });
+    expect(normalized.quality_claims).toEqual(["schema pass"]);
+    expect(normalized.attestor_checkpoints).toEqual(["schema_contract", "policy_bounds"]);
+  });
+
+  it("includes disclosure metadata in capability hash", () => {
+    const base = validateCapabilities({
+      taskTypes: ["summarize"],
+      inputModes: ["text"],
+      outputModes: ["text"],
+      pricing: { baseUsd: 0.1, perCallUsd: 0.2 },
+      privacyModes: ["public"],
+      agent_composition: {
+        llm: "qwen2.5:7b",
+        control_loop: "reflect-revise",
+        tools: ["web_search"],
+        memory: ["session"],
+        goals: ["accuracy"],
+      },
+      quality_claims: ["schema pass"],
+      attestor_checkpoints: ["schema_contract"],
+    });
+
+    const changed = validateCapabilities({
+      taskTypes: ["summarize"],
+      inputModes: ["text"],
+      outputModes: ["text"],
+      pricing: { baseUsd: 0.1, perCallUsd: 0.2 },
+      privacyModes: ["public"],
+      agent_composition: {
+        llm: "qwen2.5:7b",
+        control_loop: "reflect-revise",
+        tools: ["web_search"],
+        memory: ["session"],
+        goals: ["accuracy"],
+      },
+      quality_claims: ["schema pass", "latency p95 < 3s"],
+      attestor_checkpoints: ["schema_contract"],
+    });
+
+    const baseHash = computeCapabilityHash("wallet-1", base);
+    const changedHash = computeCapabilityHash("wallet-1", changed);
+
+    expect(baseHash).not.toBe(changedHash);
+  });
+});

--- a/lib/__tests__/onboarding-routes-support.test.ts
+++ b/lib/__tests__/onboarding-routes-support.test.ts
@@ -155,6 +155,15 @@ describe("onboarding support routes", () => {
           tags: ["onboarding"],
           context_requirements: [],
           runtime_capabilities: ["web_search"],
+          agent_composition: {
+            llm: "qwen2.5:7b",
+            control_loop: "plan-execute-review",
+            tools: ["web_search"],
+            memory: ["session"],
+            goals: ["accuracy", "latency"],
+          },
+          quality_claims: ["95% schema compliance"],
+          attestor_checkpoints: ["schema_contract_pass"],
           endpointUrl: "https://a.example",
           healthcheckStatus: "pass",
           attested: true,
@@ -166,6 +175,20 @@ describe("onboarding support routes", () => {
       const body = await res.json();
       expect(body.ok).toBe(true);
       expect(upsertCapabilities).toHaveBeenCalledTimes(1);
+      expect(upsertCapabilities).toHaveBeenCalledWith(
+        "w1",
+        expect.objectContaining({
+          agent_composition: {
+            llm: "qwen2.5:7b",
+            control_loop: "plan-execute-review",
+            tools: ["web_search"],
+            memory: ["session"],
+            goals: ["accuracy", "latency"],
+          },
+          quality_claims: ["95% schema compliance"],
+          attestor_checkpoints: ["schema_contract_pass"],
+        })
+      );
       expect(upsertSpecialistIndex).toHaveBeenCalledTimes(1);
     });
   });

--- a/lib/onboarding/capabilities.ts
+++ b/lib/onboarding/capabilities.ts
@@ -18,6 +18,15 @@ export type CapabilityInput = {
   tags?: string[];
   context_requirements?: ContextRequirement[];
   runtime_capabilities?: RuntimeCapability[];
+  agent_composition?: {
+    llm?: string;
+    control_loop?: string;
+    tools?: string[];
+    memory?: string[];
+    goals?: string[];
+  };
+  quality_claims?: string[];
+  attestor_checkpoints?: string[];
 };
 
 export type CapabilityRecord = {
@@ -34,11 +43,22 @@ export type CapabilityRecord = {
  */
 export function computeCapabilityHash(walletAddress: string, caps: ReturnType<typeof validateCapabilities>): string {
   const canonical = {
+    agent_composition: caps.agent_composition
+      ? {
+          llm: caps.agent_composition.llm,
+          control_loop: caps.agent_composition.control_loop,
+          tools: [...(caps.agent_composition.tools ?? [])].sort(),
+          memory: [...(caps.agent_composition.memory ?? [])].sort(),
+          goals: [...(caps.agent_composition.goals ?? [])].sort(),
+        }
+      : undefined,
+    attestor_checkpoints: [...(caps.attestor_checkpoints ?? [])].sort(),
     context_requirements: normalizeContextRequirements(caps.context_requirements ?? []),
     inputModes: [...caps.inputModes].sort(),
     outputModes: [...caps.outputModes].sort(),
     pricing: { baseUsd: caps.pricing.baseUsd, perCallUsd: caps.pricing.perCallUsd ?? 0 },
     privacyModes: [...caps.privacyModes].sort(),
+    quality_claims: [...(caps.quality_claims ?? [])].sort(),
     runtime_capabilities: [...(caps.runtime_capabilities ?? [])].sort(),
     tags: [...(caps.tags ?? [])].sort(),
     taskTypes: [...caps.taskTypes].sort(),
@@ -52,6 +72,10 @@ const CAPABILITY_PATH = join(process.cwd(), "data", "onboarding", "specialist-ca
 
 function normalizeList(values: string[]) {
   return Array.from(new Set(values.map((v) => v.trim()).filter(Boolean)));
+}
+
+function normalizeOptionalList(values: string[] | undefined, maxItems: number) {
+  return normalizeList(values ?? []).slice(0, maxItems);
 }
 
 function normalizeContextRequirements(values: ContextRequirement[]) {
@@ -88,6 +112,20 @@ export function validateCapabilities(input: CapabilityInput) {
   const privacyModes = Array.from(new Set((input.privacyModes || []).filter(Boolean)));
   const runtimeCapabilities = Array.from(new Set((input.runtime_capabilities || []).filter(Boolean)));
   const contextRequirements = Array.isArray(input.context_requirements) ? input.context_requirements : [];
+  const qualityClaims = normalizeOptionalList(input.quality_claims, 12);
+  const attestorCheckpoints = normalizeOptionalList(input.attestor_checkpoints, 12);
+  const agentComposition = input.agent_composition
+    ? {
+        llm: typeof input.agent_composition.llm === "string" ? input.agent_composition.llm.trim() : undefined,
+        control_loop:
+          typeof input.agent_composition.control_loop === "string"
+            ? input.agent_composition.control_loop.trim()
+            : undefined,
+        tools: normalizeOptionalList(input.agent_composition.tools, 12),
+        memory: normalizeOptionalList(input.agent_composition.memory, 12),
+        goals: normalizeOptionalList(input.agent_composition.goals, 12),
+      }
+    : undefined;
 
   if (taskTypes.length === 0) throw new Error("At least one task type is required.");
   if (inputModes.length === 0) throw new Error("At least one input mode is required.");
@@ -131,6 +169,8 @@ export function validateCapabilities(input: CapabilityInput) {
   }
 
   return {
+    agent_composition: agentComposition,
+    attestor_checkpoints: attestorCheckpoints,
     taskTypes,
     inputModes,
     outputModes,
@@ -140,6 +180,7 @@ export function validateCapabilities(input: CapabilityInput) {
       baseUsd,
       perCallUsd,
     },
+    quality_claims: qualityClaims,
     context_requirements: normalizeContextRequirements(contextRequirements),
     runtime_capabilities: runtimeCapabilities as RuntimeCapability[],
   };

--- a/lib/registry/bridge.ts
+++ b/lib/registry/bridge.ts
@@ -51,6 +51,15 @@ export type SpecialistListing = {
     perCallUsd: number;
     context_requirements: ContextRequirement[];
     runtime_capabilities: RuntimeCapability[];
+    agent_composition?: {
+      llm?: string;
+      control_loop?: string;
+      tools?: string[];
+      memory?: string[];
+      goals?: string[];
+    };
+    quality_claims?: string[];
+    attestor_checkpoints?: string[];
   } | null;
   /** Live health state */
   health: {
@@ -211,6 +220,20 @@ export async function fetchSpecialistListings(): Promise<{
           perCallUsd: typeof cap.pricing === "object" ? (cap.pricing?.perCallUsd ?? 0) : 0,
           context_requirements: Array.isArray(cap.context_requirements) ? cap.context_requirements : [],
           runtime_capabilities: Array.isArray(cap.runtime_capabilities) ? normalizeArray<RuntimeCapability>(cap.runtime_capabilities) : [],
+          agent_composition: cap.agent_composition
+            ? {
+                llm: typeof cap.agent_composition.llm === "string" ? cap.agent_composition.llm : undefined,
+                control_loop:
+                  typeof cap.agent_composition.control_loop === "string"
+                    ? cap.agent_composition.control_loop
+                    : undefined,
+                tools: normalizeArray<string>(cap.agent_composition.tools ?? []),
+                memory: normalizeArray<string>(cap.agent_composition.memory ?? []),
+                goals: normalizeArray<string>(cap.agent_composition.goals ?? []),
+              }
+            : undefined,
+          quality_claims: normalizeArray<string>(cap.quality_claims ?? []),
+          attestor_checkpoints: normalizeArray<string>(cap.attestor_checkpoints ?? []),
         }
       : null;
 
@@ -319,6 +342,20 @@ function buildFromIndexOnly(entry: SpecialistIndexEntry): SpecialistListing {
           perCallUsd: typeof cap.pricing === "object" ? (cap.pricing?.perCallUsd ?? 0) : 0,
           context_requirements: Array.isArray(cap.context_requirements) ? cap.context_requirements : [],
           runtime_capabilities: Array.isArray(cap.runtime_capabilities) ? normalizeArray<RuntimeCapability>(cap.runtime_capabilities) : [],
+          agent_composition: cap.agent_composition
+            ? {
+                llm: typeof cap.agent_composition.llm === "string" ? cap.agent_composition.llm : undefined,
+                control_loop:
+                  typeof cap.agent_composition.control_loop === "string"
+                    ? cap.agent_composition.control_loop
+                    : undefined,
+                tools: normalizeArray<string>(cap.agent_composition.tools ?? []),
+                memory: normalizeArray<string>(cap.agent_composition.memory ?? []),
+                goals: normalizeArray<string>(cap.agent_composition.goals ?? []),
+              }
+            : undefined,
+          quality_claims: normalizeArray<string>(cap.quality_claims ?? []),
+          attestor_checkpoints: normalizeArray<string>(cap.attestor_checkpoints ?? []),
         }
       : null,
     health: {


### PR DESCRIPTION
## Summary
- extend onboarding capability schema with optional marketplace disclosure metadata:
  - `agent_composition` (`llm`, `control_loop`, `tools[]`, `memory[]`, `goals[]`)
  - `quality_claims[]`
  - `attestor_checkpoints[]`
- plumb new fields through `POST /api/onboarding/capabilities`
- expose disclosure metadata via registry bridge listing capabilities for marketplace consumption
- include disclosure metadata in capability hash canonicalization (integrity linkage)
- add tests for normalization/hash sensitivity and onboarding route pass-through

## Why
This operationalizes the design rule:

> Agent = LLM + control loop + tools + memory + goals

It lets specialist profiles disclose value-driving composition and verifier checkpoints without exposing private payloads, and gives attestors explicit settlement-relevant checkpoints in the x402 flow.

## Validation
- `npx jest lib/__tests__/capabilities-disclosure.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
- `npm run build`
