### PR TITLE
feat: require disclosure checkpoints during specialist resolve

### DIFF
--- a/app/api/planner/tools/resolve/route.ts
+++ b/app/api/planner/tools/resolve/route.ts
@@ -25,6 +25,12 @@ export async function POST(req: Request) {
     const requiredCapabilities = Array.isArray(body.required_capabilities)
       ? body.required_capabilities.filter(isValidRuntimeCapability)
       : [];
+    const requiredAttestorCheckpoints = Array.isArray(body.required_attestor_checkpoints)
+      ? body.required_attestor_checkpoints.map(String).map((value) => value.trim()).filter(Boolean)
+      : [];
+    const requiredQualityClaims = Array.isArray(body.required_quality_claims)
+      ? body.required_quality_claims.map(String).map((value) => value.trim()).filter(Boolean)
+      : [];
 
     const maxPerCallUsd =
       policyOverride.maxPerCallUsd ?? savedPolicy.maxPerTaskUsd ?? 0;
@@ -46,6 +52,7 @@ export async function POST(req: Request) {
       cost: 0,
       capabilities: 0,
       endpoint: 0,
+      disclosure: 0,
     };
     const rejectedWalletSamples: Record<keyof typeof rejectionSummary, string[]> = {
       sourcePolicy: [],
@@ -55,6 +62,7 @@ export async function POST(req: Request) {
       cost: [],
       capabilities: [],
       endpoint: [],
+      disclosure: [],
     };
     const rejectionSampleLimit = 3;
 
@@ -108,6 +116,20 @@ export async function POST(req: Request) {
           recordRejection("endpoint", l.walletAddress);
           return false;
         }
+        if (requiredAttestorCheckpoints.length > 0) {
+          const checkpoints = l.capabilities?.attestor_checkpoints ?? [];
+          if (!requiredAttestorCheckpoints.every((checkpoint) => checkpoints.includes(checkpoint))) {
+            recordRejection("disclosure", l.walletAddress);
+            return false;
+          }
+        }
+        if (requiredQualityClaims.length > 0) {
+          const qualityClaims = l.capabilities?.quality_claims ?? [];
+          if (!requiredQualityClaims.every((claim) => qualityClaims.includes(claim))) {
+            recordRejection("disclosure", l.walletAddress);
+            return false;
+          }
+        }
         return true;
       })
       ;
@@ -130,6 +152,12 @@ export async function POST(req: Request) {
         }
         if (requiredCapabilities.length > 0) {
           reasons.push(`requires:${requiredCapabilities.join(",")}`);
+        }
+        if (requiredAttestorCheckpoints.length > 0) {
+          reasons.push(`requires:attestor_checkpoints=${requiredAttestorCheckpoints.join(",")}`);
+        }
+        if (requiredQualityClaims.length > 0) {
+          reasons.push(`requires:quality_claims=${requiredQualityClaims.join(",")}`);
         }
         reasons.push(...sourceDecision.reasons);
         const score =
@@ -219,7 +247,14 @@ export async function GET() {
     tool: "resolve_specialist",
     description: "Find the best specialist candidate for a task.",
     schema: {
-      input: { task: "string", taskTypeHint: "string?", required_capabilities: "string[]?", policy: "PolicyOverride?" },
+      input: {
+        task: "string",
+        taskTypeHint: "string?",
+        required_capabilities: "string[]?",
+        required_attestor_checkpoints: "string[]?",
+        required_quality_claims: "string[]?",
+        policy: "PolicyOverride?",
+      },
       output: {
         ok: "boolean",
         candidate: "SpecialistCandidate | null",

--- a/lib/__tests__/planner-resolve-route.test.ts
+++ b/lib/__tests__/planner-resolve-route.test.ts
@@ -12,6 +12,8 @@ function makeListing(input: {
   wallet: string;
   tags: string[];
   reputation?: number;
+  attestorCheckpoints?: string[];
+  qualityClaims?: string[];
 }): SpecialistListing {
   return {
     pda: `pda-${input.wallet}`,
@@ -39,6 +41,8 @@ function makeListing(input: {
       perCallUsd: 0.01,
       context_requirements: [],
       runtime_capabilities: [],
+      attestor_checkpoints: input.attestorCheckpoints ?? [],
+      quality_claims: input.qualityClaims ?? [],
     },
     health: {
       status: "pass",
@@ -262,5 +266,68 @@ describe("planner resolve route", () => {
     expect(body.alternatives[0].sourceRouting.decisionTrace).toEqual(
       expect.arrayContaining(["source_penalty:hermes"])
     );
+  });
+
+  it("filters by required attestor checkpoints and quality claims", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    const { readPolicy } = await import("@/lib/orchestrator/policy");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      preferredPrivacyMode: "public",
+      requireAttestation: false,
+      maxPerTaskUsd: 0,
+      minReputation: 0,
+    });
+
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      listings: [
+        makeListing({
+          wallet: "wallet-disclosure-pass",
+          tags: ["source:openclaw"],
+          attestorCheckpoints: ["schema_contract_pass", "policy_bounds_ok"],
+          qualityClaims: ["latency_p95_under_3s", "high_schema_compliance"],
+        }),
+        makeListing({
+          wallet: "wallet-disclosure-miss",
+          tags: ["source:openclaw"],
+          attestorCheckpoints: ["schema_contract_pass"],
+          qualityClaims: ["high_schema_compliance"],
+        }),
+      ],
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve/route");
+    const req = new Request("http://localhost/api/planner/tools/resolve", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        task: "summarize",
+        required_attestor_checkpoints: ["schema_contract_pass", "policy_bounds_ok"],
+        required_quality_claims: ["latency_p95_under_3s"],
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.candidate.walletAddress).toBe("wallet-disclosure-pass");
+    expect(body.candidate.selectionReasons).toEqual(
+      expect.arrayContaining([
+        "requires:attestor_checkpoints=schema_contract_pass,policy_bounds_ok",
+        "requires:quality_claims=latency_p95_under_3s",
+      ])
+    );
+    expect(body.resolveDiagnostics).toMatchObject({
+      totalListings: 2,
+      acceptedCount: 1,
+      rejectedBy: {
+        disclosure: 1,
+      },
+      rejectedWalletSamples: {
+        disclosure: ["wallet-disclosure-miss"],
+      },
+    });
   });
 });

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -28,6 +28,10 @@ export type ResolveInput = {
   taskTypeHint?: string;
   /** Explicit runtime capabilities required to fulfill the request */
   required_capabilities?: string[];
+  /** Optional attestor-verifiable checkpoints required from specialist disclosure metadata */
+  required_attestor_checkpoints?: string[];
+  /** Optional quality-claim markers required from specialist disclosure metadata */
+  required_quality_claims?: string[];
   /** Policy overrides — merged with saved orchestrator policy */
   policy?: {
     maxPerCallUsd?: number;
@@ -85,6 +89,7 @@ export type ResolveOutput = {
       cost: number;
       capabilities: number;
       endpoint: number;
+      disclosure: number;
     };
     rejectedWalletSamples: {
       sourcePolicy: string[];
@@ -94,6 +99,7 @@ export type ResolveOutput = {
       cost: string[];
       capabilities: string[];
       endpoint: string[];
+      disclosure: string[];
     };
   };
   error?: string;
@@ -223,6 +229,16 @@ export const MCP_TOOL_SCHEMAS = [
           type: "array",
           items: { type: "string" },
           description: "Runtime capabilities required from the specialist.",
+        },
+        required_attestor_checkpoints: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional attestor-verifiable checkpoints that must be disclosed by the specialist.",
+        },
+        required_quality_claims: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional quality claim markers that must be present in specialist disclosure metadata.",
         },
         policy: {
           type: "object",


### PR DESCRIPTION
## Summary
- extend `resolve_specialist` input schema with:
  - `required_attestor_checkpoints[]`
  - `required_quality_claims[]`
- enforce both constraints during candidate filtering in resolve route
- add `disclosure` bucket to `resolveDiagnostics.rejectedBy` and `rejectedWalletSamples`
- add selection-reason trace entries when disclosure requirements are applied
- update tests with a disclosure-gated routing scenario

## Why
Now that specialist capability profiles expose disclosure metadata, planner selection should be able to require specific attestor-verifiable checkpoints and quality claim markers for settlement-sensitive workflows.

## Validation
- `npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/capabilities-disclosure.test.ts --runInBand`
- `npm run build`
