### PR TITLE
Onboarding Phase A/B hardening: operator lifecycle, planner parity, index semantics

### DIFF
--- a/app/agents/[wallet]/page.tsx
+++ b/app/agents/[wallet]/page.tsx
@@ -226,6 +226,7 @@ export default function SpecialistDetailPage() {
               <div className="space-y-2 text-sm text-gray-300">
                 <p>Endpoint: {listing.health.endpointUrl ?? "Not published"}</p>
                 <p>Health: {health}</p>
+                <p>Freshness: {listing.health.freshnessState}</p>
                 <p>Last checked: {listing.health.lastCheckedAt ? new Date(listing.health.lastCheckedAt).toLocaleString() : "Unknown"}</p>
               </div>
             </Card>

--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -88,6 +88,7 @@ export default function AgentsPage() {
                 reputationScore={agent.onchain.reputationScore}
                 attested={agent.attestation.attested}
                 health={agent.health.status === "pass" ? "online" : agent.health.status === "fail" ? "offline" : "unknown"}
+                freshnessState={agent.health.freshnessState}
                 ratePerCall={Number(agent.onchain.rateLamports)}
                 progress={Math.min(100, Number(agent.onchain.jobsCompleted) * 10)}
               />

--- a/app/api/onboarding/attestation-operator/route.ts
+++ b/app/api/onboarding/attestation-operator/route.ts
@@ -1,8 +1,31 @@
+import { checkOperatorKeyStatus } from "@/lib/onboarding/operator-key";
 import { getOnchainAttestationOperatorStatus } from "@/lib/onboarding/onchain-attestation";
 
 export const runtime = "nodejs";
 
+const ENV_TEMPLATE = 'ONBOARDING_ATTEST_OPERATOR_SECRET_KEY="[12,34,...,64 bytes total]"';
+
 export async function GET() {
-  const status = getOnchainAttestationOperatorStatus();
-  return Response.json({ ok: true, result: status });
+  const keyStatus = checkOperatorKeyStatus();
+  const onchainStatus = getOnchainAttestationOperatorStatus();
+
+  const state = keyStatus.state;
+  const nextAction =
+    state === "ready"
+      ? "Rotation check optional. Re-run status before recording attestation if this tab has been open for a while."
+      : "Set ONBOARDING_ATTEST_OPERATOR_SECRET_KEY as a 64-byte JSON array, restart the app, then run this check again.";
+
+  return Response.json({
+    ok: true,
+    result: {
+      ready: state === "ready" && onchainStatus.ready,
+      state,
+      operatorPubkey: onchainStatus.operatorPubkey,
+      note: onchainStatus.note,
+      error: keyStatus.error,
+      checkedAt: keyStatus.checkedAt,
+      envTemplate: ENV_TEMPLATE,
+      nextAction,
+    },
+  });
 }

--- a/app/api/planner/tools/resolve/route.ts
+++ b/app/api/planner/tools/resolve/route.ts
@@ -43,6 +43,30 @@ export async function POST(req: Request) {
     const preferredSource = policyOverride.preferredSource;
     const strictSourceMatch = policyOverride.strictSourceMatch === true;
 
+    const sortBy = body.sortBy ?? "ranking";
+    const filterTaskType = body.taskType;
+    const filterInputMode = body.inputMode;
+    const filterPrivacyMode = body.privacyMode;
+    const filterRuntimeCap = body.runtimeCap;
+    const filterAttested = body.attested === true;
+    const filterHealth = body.health;
+    const filterTag = body.tag;
+    const filterTags = Array.isArray(body.tags)
+      ? body.tags.map((t) => t.trim()).filter(Boolean)
+      : [];
+
+    const appliedFilters = {
+      sortBy,
+      taskType: filterTaskType,
+      inputMode: filterInputMode,
+      privacyMode: filterPrivacyMode,
+      runtimeCap: filterRuntimeCap,
+      attested: filterAttested || requireAttestation ? true : undefined,
+      health: filterHealth,
+      tag: filterTag,
+      tags: filterTags.length > 0 ? filterTags : undefined,
+    };
+
     const { listings } = await fetchSpecialistListings();
     const rejectionSummary = {
       sourcePolicy: 0,
@@ -84,7 +108,6 @@ export async function POST(req: Request) {
         }),
       }))
       .filter(({ listing: l, sourceDecision }) => {
-
         if (sourceDecision.reject) {
           recordRejection("sourcePolicy", l.walletAddress);
           return false;
@@ -93,7 +116,37 @@ export async function POST(req: Request) {
           recordRejection("health", l.walletAddress);
           return false;
         }
-        if (requireAttestation && !l.attestation.attested) {
+        if (filterHealth && l.health.status !== filterHealth) {
+          recordRejection("health", l.walletAddress);
+          return false;
+        }
+
+        if (filterTaskType && !l.capabilities?.taskTypes.includes(filterTaskType as never)) {
+          recordRejection("capabilities", l.walletAddress);
+          return false;
+        }
+        if (filterInputMode && !l.capabilities?.inputModes.includes(filterInputMode as never)) {
+          recordRejection("capabilities", l.walletAddress);
+          return false;
+        }
+        if (filterPrivacyMode && !l.capabilities?.privacyModes.includes(filterPrivacyMode as never)) {
+          recordRejection("capabilities", l.walletAddress);
+          return false;
+        }
+        if (filterRuntimeCap && !l.capabilities?.runtime_capabilities?.includes(filterRuntimeCap as never)) {
+          recordRejection("capabilities", l.walletAddress);
+          return false;
+        }
+        if (filterTag && !l.capabilities?.tags?.includes(filterTag)) {
+          recordRejection("capabilities", l.walletAddress);
+          return false;
+        }
+        if (filterTags.length > 0 && !filterTags.some((tag) => l.capabilities?.tags?.includes(tag))) {
+          recordRejection("capabilities", l.walletAddress);
+          return false;
+        }
+
+        if ((filterAttested || requireAttestation) && !l.attestation.attested) {
           recordRejection("attestation", l.walletAddress);
           return false;
         }
@@ -131,8 +184,7 @@ export async function POST(req: Request) {
           }
         }
         return true;
-      })
-      ;
+      });
 
     const candidates = eligibleListings
       .map(({ listing: l, sourceDecision }) => {
@@ -170,7 +222,32 @@ export async function POST(req: Request) {
 
         return { listing: l, score, reasons, sourceDecision, sourceDecisionTrace };
       })
-      .sort((a, b) => b.score - a.score);
+      .sort((a, b) => {
+        if (sortBy === "reputation") {
+          return b.listing.onchain.reputationScore - a.listing.onchain.reputationScore;
+        }
+        if (sortBy === "cost") {
+          const aCost = a.listing.capabilities?.perCallUsd ?? Number.POSITIVE_INFINITY;
+          const bCost = b.listing.capabilities?.perCallUsd ?? Number.POSITIVE_INFINITY;
+          return aCost - bCost;
+        }
+        if (sortBy === "feedback") {
+          return b.listing.signals.avgFeedbackScore - a.listing.signals.avgFeedbackScore;
+        }
+
+        if (a.score !== b.score) return b.score - a.score;
+        if (a.listing.ranking_score !== b.listing.ranking_score) {
+          return b.listing.ranking_score - a.listing.ranking_score;
+        }
+        const aFreshness = Date.parse(a.listing.health.lastCheckedAt ?? "");
+        const bFreshness = Date.parse(b.listing.health.lastCheckedAt ?? "");
+        const safeA = Number.isFinite(aFreshness) ? aFreshness : -1;
+        const safeB = Number.isFinite(bFreshness) ? bFreshness : -1;
+        if (safeA !== safeB) return safeB - safeA;
+        const aCost = a.listing.capabilities?.perCallUsd ?? Number.POSITIVE_INFINITY;
+        const bCost = b.listing.capabilities?.perCallUsd ?? Number.POSITIVE_INFINITY;
+        return aCost - bCost;
+      });
 
     const resolveDiagnostics = {
       totalListings: listings.length,
@@ -184,6 +261,7 @@ export async function POST(req: Request) {
         ok: false,
         candidate: null,
         alternativeCount: 0,
+        appliedFilters,
         resolveDiagnostics,
         error: "No eligible specialists found matching your policy.",
       };
@@ -230,6 +308,7 @@ export async function POST(req: Request) {
       },
       alternativeCount: candidates.length - 1,
       alternatives,
+      appliedFilters,
       resolveDiagnostics,
     };
 
@@ -253,12 +332,22 @@ export async function GET() {
         required_capabilities: "string[]?",
         required_attestor_checkpoints: "string[]?",
         required_quality_claims: "string[]?",
+        sortBy: "ranking|reputation|cost|feedback?",
+        taskType: "string?",
+        inputMode: "string?",
+        privacyMode: "string?",
+        runtimeCap: "string?",
+        attested: "boolean?",
+        health: "pass|fail|pending?",
+        tag: "string?",
+        tags: "string[]?",
         policy: "PolicyOverride?",
       },
       output: {
         ok: "boolean",
         candidate: "SpecialistCandidate | null",
         alternativeCount: "number",
+        appliedFilters: "AppliedFilters?",
         alternatives: "SpecialistAlternative[]",
         resolveDiagnostics: "ResolveDiagnostics",
       },

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -68,6 +68,8 @@ type WizardState = {
   attestationResolution: "pending" | "confirmed" | "disputed";
   attestationResolutionSig: string;
   attestationOperatorReady: boolean;
+  attestationOperatorState: "missing" | "invalid" | "ready" | "stale";
+  attestationOperatorCheckedAt: string;
   attestationOperatorStatusNote: string;
   capabilityTaskTypes: string;
   capabilityInputModes: string;
@@ -138,6 +140,8 @@ const INITIAL_STATE: WizardState = {
   attestationResolution: "pending",
   attestationResolutionSig: "",
   attestationOperatorReady: false,
+  attestationOperatorState: "missing",
+  attestationOperatorCheckedAt: "",
   attestationOperatorStatusNote: "",
   capabilityTaskTypes: "summarize, classify",
   capabilityInputModes: "text",
@@ -173,6 +177,8 @@ const STEPS = [
   "Attestation",
   "Try Planner",
 ];
+
+const OPERATOR_STATUS_STALE_MS = 10 * 60 * 1000;
 
 function mockWalletAddress() {
   const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
@@ -289,6 +295,18 @@ export default function OnboardingPage() {
     if (!state.ollamaPort || !state.consentExposeEndpoint) return "Not configured";
     return state.endpointUrl || `https://your-agent.localtunnel.me (maps to :${state.ollamaPort})`;
   }, [state.ollamaPort, state.consentExposeEndpoint, state.endpointUrl]);
+
+  const operatorStatusState = useMemo<"missing" | "invalid" | "ready" | "stale">(() => {
+    if (state.attestationOperatorState === "ready" && state.attestationOperatorCheckedAt) {
+      const checked = Date.parse(state.attestationOperatorCheckedAt);
+      if (Number.isFinite(checked) && Date.now() - checked > OPERATOR_STATUS_STALE_MS) {
+        return "stale";
+      }
+    }
+    return state.attestationOperatorState;
+  }, [state.attestationOperatorState, state.attestationOperatorCheckedAt]);
+
+  const operatorReadyForAttestation = operatorStatusState === "ready";
 
   const canContinue = useMemo(() => {
     if (step === 1) return state.consentExposeEndpoint && state.consentProtocolOps;
@@ -1513,6 +1531,8 @@ export default function OnboardingPage() {
                     setState((s) => ({
                       ...s,
                       attestationOperatorReady: false,
+                      attestationOperatorState: "invalid",
+                      attestationOperatorCheckedAt: new Date().toISOString(),
                       attestationOperatorStatusNote: data.error || "Operator status check failed",
                     }));
                     return;
@@ -1521,14 +1541,18 @@ export default function OnboardingPage() {
                   setState((s) => ({
                     ...s,
                     attestationOperatorReady: Boolean(data.result.ready),
+                    attestationOperatorState: data.result.state || (data.result.ready ? "ready" : "invalid"),
+                    attestationOperatorCheckedAt: data.result.checkedAt || new Date().toISOString(),
                     attestationOperatorStatusNote: data.result.operatorPubkey
                       ? `${data.result.note} (${data.result.operatorPubkey})`
-                      : data.result.note || "",
+                      : data.result.note || data.result.nextAction || "",
                   }));
                 } catch {
                   setState((s) => ({
                     ...s,
                     attestationOperatorReady: false,
+                    attestationOperatorState: "invalid",
+                    attestationOperatorCheckedAt: new Date().toISOString(),
                     attestationOperatorStatusNote: "Operator status check failed",
                   }));
                 } finally {
@@ -1538,13 +1562,57 @@ export default function OnboardingPage() {
             >
               {attestationOperatorCheckLoading ? "Checking operator key..." : "Check attestor key status"}
             </Button>
+
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <span className="text-muted-foreground">Operator key status:</span>
+              <span
+                className={`rounded-full border px-2 py-0.5 font-medium ${
+                  operatorStatusState === "ready"
+                    ? "border-[#14F195]/50 text-[#14F195]"
+                    : operatorStatusState === "stale"
+                    ? "border-yellow-500/50 text-yellow-300"
+                    : "border-red-500/40 text-red-300"
+                }`}
+              >
+                {operatorStatusState.toUpperCase()}
+              </span>
+              {state.attestationOperatorCheckedAt && (
+                <span className="text-muted-foreground">
+                  checked: {new Date(state.attestationOperatorCheckedAt).toLocaleTimeString()}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="outline"
+                onClick={async () => {
+                  const template = 'ONBOARDING_ATTEST_OPERATOR_SECRET_KEY="[12,34,...,64 bytes total]"';
+                  try {
+                    await navigator.clipboard.writeText(template);
+                    showToast("Copied operator key env template", "success");
+                  } catch {
+                    showToast("Could not copy template. Paste manually from the setup guide.", "error");
+                  }
+                }}
+              >
+                Copy env template
+              </Button>
+              <Link
+                href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/ONBOARDING-OPERATOR-KEY-ROTATION-RUNBOOK.md"
+                className="inline-flex items-center rounded-md border border-white/15 px-3 py-2 text-xs text-muted-foreground hover:text-white"
+              >
+                Open rotation runbook
+              </Link>
+            </div>
+
             <Button
               variant="outline"
               disabled={
                 attestationLoading ||
                 state.healthcheckStatus !== "pass" ||
                 !state.walletAddress ||
-                !state.attestationOperatorReady
+                !operatorReadyForAttestation
               }
               onClick={async () => {
                 setAttestationLoading(true);
@@ -1738,9 +1806,13 @@ export default function OnboardingPage() {
             {state.healthcheckStatus !== "pass" && (
               <p className="text-xs text-yellow-400">Healthcheck must pass before attestation can be recorded.</p>
             )}
-            {!state.attestationOperatorReady && (
+            {operatorStatusState !== "ready" && (
               <>
-                <p className="text-xs text-yellow-400">Operator signer key must be configured before recording attestation.</p>
+                <p className="text-xs text-yellow-400">
+                  {operatorStatusState === "stale"
+                    ? "Operator signer status is stale. Re-check before recording attestation."
+                    : "Operator signer key must be configured before recording attestation."}
+                </p>
                 <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-xs text-yellow-200">
                   <p className="mb-1">Quick fix: set <span className="font-mono">ONBOARDING_ATTEST_OPERATOR_SECRET_KEY</span> as a 64-byte JSON array, restart the app, then click &quot;Check attestor key status&quot; again.</p>
                   <p className="font-mono break-all">Example format: [12,34,56,...,64 bytes total]</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -162,6 +162,7 @@ export default function Home() {
               reputationScore={agent.onchain.reputationScore}
               attested={agent.attestation.attested}
               health={agent.health.status === "pass" ? "online" : agent.health.status === "fail" ? "offline" : "unknown"}
+              freshnessState={agent.health.freshnessState}
               ratePerCall={Number(agent.onchain.rateLamports)}
               progress={Math.min(100, (Number(agent.onchain.jobsCompleted) % 10) * 10)}
             />

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -12,6 +12,7 @@ interface SpecialistCardProps {
   reputationScore?: number
   attested?: boolean
   health?: "online" | "offline" | "unknown"
+  freshnessState?: "fresh" | "warm" | "stale" | "unknown"
   ratePerCall?: number
   progress?: number
 }
@@ -44,6 +45,7 @@ export function SpecialistCard({
   reputationScore = 0,
   attested = false,
   health = "unknown",
+  freshnessState = "unknown",
   ratePerCall = 0,
   progress = 0,
 }: SpecialistCardProps) {
@@ -53,6 +55,15 @@ export function SpecialistCard({
       : health === "offline"
       ? "bg-slate-500 text-slate-100"
       : "bg-slate-600 text-slate-100"
+
+  const freshnessTone =
+    freshnessState === "fresh"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+      : freshnessState === "warm"
+      ? "border-amber-500/30 bg-amber-500/10 text-amber-300"
+      : freshnessState === "stale"
+      ? "border-rose-500/30 bg-rose-500/10 text-rose-300"
+      : "border-white/10 bg-white/5 text-gray-400"
 
   return (
     <Link href={`/agents/${wallet}`} className="block h-full" data-testid="agent-card">
@@ -64,11 +75,16 @@ export function SpecialistCard({
           </div>
           <div className={cn("absolute right-4 top-4 h-3 w-3 rounded-full ring-4 ring-black/20", healthTone)} />
           <div className="absolute bottom-4 left-4 right-4">
-            {taskTypes[0] ? (
-              <Badge variant="outline" className="border-white/15 bg-black/30 text-white">
-                {taskTypes[0]}
+            <div className="flex flex-wrap gap-1.5">
+              {taskTypes[0] ? (
+                <Badge variant="outline" className="border-white/15 bg-black/30 text-white">
+                  {taskTypes[0]}
+                </Badge>
+              ) : null}
+              <Badge variant="outline" className={cn("text-[10px] uppercase tracking-wide", freshnessTone)}>
+                {freshnessState}
               </Badge>
-            ) : null}
+            </div>
           </div>
         </div>
 

--- a/docs/BDD-BUILD-CHECKPOINTS-v3.md
+++ b/docs/BDD-BUILD-CHECKPOINTS-v3.md
@@ -49,7 +49,7 @@ Checkpoint status:
 
 Checkpoint status:
 - B1.1-B1.3: 🟡 capability schema + onboarding API/UI capture shipped; specialist identity index baseline linkage + listing endpoint shipped, deeper planner index semantics pending
-- B2: ⏳ not built (next major build)
+- B2: ✅ implemented (registry filters + ranking tie-breaks shipped, planner resolve parity filters/sort shipped)
 
 ---
 
@@ -113,7 +113,7 @@ Checkpoint status:
 Checkpoint status:
 - E1.1-E1.3: ✅ implemented baseline
 - E2.1: ✅ implemented
-- E2.2: 🔜 pending runbook hardening
+- E2.2: ✅ implemented (runbook + operator-state UX hardening + validation tests)
 - E3.1-E3.3: ✅ implemented (`lib/program.ts` uses `NEXT_PUBLIC_RPC_ENDPOINT ?? default`)
 
 ---
@@ -141,19 +141,17 @@ Checkpoint status:
 1. ✅ Phase A slice 1: registration preflight simulation + signing summary
 2. ✅ Phase A slice 2: on-chain attestation submission path
 3. ✅ Phase A slice 3: scoped token-gated endpoint hardening preserving x402
-4. 🟡 Phase A slice 4: confirm/dispute attestation follow-through shipped; operator key provisioning UX still pending
-5. 🔜 Phase B: capability schema + index + marketplace ranking filters
-6. 🔜 Phase C: planner-native specialist composition pipeline
+4. ✅ Phase A slice 4: confirm/dispute attestation follow-through + operator key provisioning/recovery UX hardening
+5. 🟡 Phase B: capability schema + index + marketplace ranking filters (B2 shipped; index semantics hardening in progress)
+6. ✅ Phase C: planner-native specialist composition pipeline
 
 ---
 
 ## Immediate Next 3 Execution Tasks
 
-1. Harden operator key provisioning/recovery UX for onboarding attestor.
-2. Harden specialist identity index semantics for planner use (ranking signals + freshness policy).
-3. ✅ C4: `reveal_rating` fully wired (`lib/onboarding/reputation-signal.ts`) — commit hash/salt persisted in `data/onboarding/rating-commits.json`; `POST /api/onboarding/planner/reveal` triggers reveal with correct Rust layout.
-4. ✅ C5: Consumer planner UI added as onboarding Step 8 — prompt entry, specialist call execution with x402 tx display, 1-10 feedback + on-chain reputation commit result shown inline.
-5. ✅ E2E: 18 Playwright tests covering all 8 onboarding steps (UI gates, nav, step 8 planner idle/disabled/enabled/feedback), all planner API routes (execute, feedback, reveal, capabilities), and correct error shapes.
+1. Finalize specialist index semantics hardening: freshness windows + schema/version metadata + deterministic recompute guards.
+2. Add/refresh route and semantics tests covering planner resolve parity (`appliedFilters`, sort/filter behavior) and freshness-state boundaries.
+3. Run PR-4 lock pass: sync BDD/checkpoint docs + targeted E2E/route validation before marking Phase A/B closed.
 
 ## Bucket G — Torque Protocol Retention Layer
 

--- a/docs/ONBOARDING-ATTESTATION-OPERATOR-SETUP.md
+++ b/docs/ONBOARDING-ATTESTATION-OPERATOR-SETUP.md
@@ -32,11 +32,20 @@ Expected success shape:
   "ok": true,
   "result": {
     "ready": true,
+    "state": "ready",
     "operatorPubkey": "...",
-    "note": "Operator signer is configured."
+    "checkedAt": "2026-04-23T...Z",
+    "note": "Operator signer is configured.",
+    "nextAction": "Rotation check optional..."
   }
 }
 ```
+
+Possible `state` values:
+- `missing`: key not configured
+- `invalid`: key present but malformed
+- `ready`: key configured and valid
+- `stale`: previous ready check is old, re-check before attestation
 
 ## Recovery checklist
 

--- a/docs/ONBOARDING-OPERATOR-KEY-ROTATION-RUNBOOK.md
+++ b/docs/ONBOARDING-OPERATOR-KEY-ROTATION-RUNBOOK.md
@@ -1,0 +1,53 @@
+# Onboarding Attestation Operator Key Rotation Runbook (E2.2)
+
+## Purpose
+Rotate `ONBOARDING_ATTEST_OPERATOR_SECRET_KEY` safely and verify onboarding attestation paths stay healthy.
+
+## When to rotate
+- Credential exposure suspicion
+- Scheduled credential hygiene
+- Team/operator handoff
+
+## Procedure
+
+1. Generate new operator keypair
+   - Use a secure local process and keep secret key out of logs/history.
+2. Encode as JSON byte array (64 bytes)
+   - Required format: `[12,34,...]`
+3. Update runtime secret
+   - Set `ONBOARDING_ATTEST_OPERATOR_SECRET_KEY` in environment/secret manager.
+4. Restart app/runtime so new env is loaded.
+
+## Verification checklist
+
+1. Operator key status route
+   - `GET /api/onboarding/operator-key`
+   - Expect: `{ present: true, valid: true, state: "ready", publicKey_suffix: "...", checkedAt: "..." }`
+2. Attestation operator status route
+   - `GET /api/onboarding/attestation-operator`
+   - Expect: `{ ready: true, state: "ready", operatorPubkey: "...", checkedAt: "..." }`
+3. Onboarding attestation dry validation
+   - In onboarding Step 7, run operator status check (no submission yet)
+   - Expect explicit ready state in UI note
+4. Full attestation submission smoke
+   - Submit one devnet attestation
+   - Confirm tx signature present and explorer link resolves
+
+## Failure modes and remediation
+
+- `not set` / `Missing ONBOARDING_ATTEST_OPERATOR_SECRET_KEY`
+  - Secret missing in runtime environment; set and restart.
+- `Expected 64-byte array`
+  - Wrong format/length; ensure 64-byte JSON array.
+- `must be a JSON byte array`
+  - Secret is not JSON array string; convert before setting.
+
+## Automated guardrails
+- Tests: `lib/__tests__/operator-key-rotation.test.ts`
+  - missing key detection
+  - invalid format detection
+  - valid key acceptance and pubkey suffix verification
+  - attestation operator readiness helper verification
+
+## Post-rotation audit note
+Record rotation time and operator pubkey suffix in project status/memory for traceability.

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -17,8 +17,10 @@ test.describe('/onboarding page', () => {
   test('loads wizard header, all 8 step labels, and step indicator', async ({ page }) => {
     await page.goto('/onboarding')
     await expect(page.getByRole('heading', { name: /Specialist Onboarding Wizard/i })).toBeVisible()
+
+    const stepList = page.locator('div.space-y-3').first()
     for (const label of ['Consent', 'Runtime', 'Endpoint', 'Wallet', 'Register', 'Healthcheck', 'Attestation', 'Try Planner']) {
-      await expect(page.getByText(new RegExp(`^${label}$`)).first()).toBeVisible()
+      await expect(stepList.getByText(new RegExp(`^${label}$`))).toBeVisible()
     }
   })
 

--- a/lib/__tests__/onboarding-operator-status-routes.test.ts
+++ b/lib/__tests__/onboarding-operator-status-routes.test.ts
@@ -1,0 +1,67 @@
+import { Keypair } from "@solana/web3.js";
+
+describe("onboarding operator status routes", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("reports missing key on /api/onboarding/operator-key", async () => {
+    delete process.env.ONBOARDING_ATTEST_OPERATOR_SECRET_KEY;
+
+    const { GET } = await import("@/app/api/onboarding/operator-key/route");
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        present: false,
+        valid: false,
+        state: "missing",
+      },
+    });
+  });
+
+  it("reports readiness on /api/onboarding/attestation-operator with valid key", async () => {
+    const kp = Keypair.generate();
+    process.env.ONBOARDING_ATTEST_OPERATOR_SECRET_KEY = JSON.stringify(Array.from(kp.secretKey));
+
+    const { GET } = await import("@/app/api/onboarding/attestation-operator/route");
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        ready: true,
+        state: "ready",
+        operatorPubkey: kp.publicKey.toBase58(),
+      },
+    });
+  });
+
+  it("returns guidance fields on /api/onboarding/attestation-operator when key is missing", async () => {
+    delete process.env.ONBOARDING_ATTEST_OPERATOR_SECRET_KEY;
+
+    const { GET } = await import("@/app/api/onboarding/attestation-operator/route");
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        ready: false,
+        state: "missing",
+        envTemplate: expect.stringContaining("ONBOARDING_ATTEST_OPERATOR_SECRET_KEY"),
+        nextAction: expect.stringContaining("restart"),
+      },
+    });
+  });
+});

--- a/lib/__tests__/operator-key-rotation.test.ts
+++ b/lib/__tests__/operator-key-rotation.test.ts
@@ -1,0 +1,63 @@
+import { Keypair } from "@solana/web3.js";
+
+describe("operator key rotation verification (E2.2)", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("reports missing operator key clearly", async () => {
+    delete process.env.ONBOARDING_ATTEST_OPERATOR_SECRET_KEY;
+    const { checkOperatorKeyStatus } = await import("@/lib/onboarding/operator-key");
+
+    expect(checkOperatorKeyStatus()).toMatchObject({
+      present: false,
+      valid: false,
+      state: "missing",
+      error: "ONBOARDING_ATTEST_OPERATOR_SECRET_KEY not set",
+    });
+  });
+
+  it("reports invalid operator key format", async () => {
+    process.env.ONBOARDING_ATTEST_OPERATOR_SECRET_KEY = "[1,2,3]";
+    const { checkOperatorKeyStatus } = await import("@/lib/onboarding/operator-key");
+
+    expect(checkOperatorKeyStatus()).toMatchObject({
+      present: true,
+      valid: false,
+      state: "invalid",
+    });
+  });
+
+  it("accepts a valid 64-byte key and exposes pubkey suffix", async () => {
+    const kp = Keypair.generate();
+    process.env.ONBOARDING_ATTEST_OPERATOR_SECRET_KEY = JSON.stringify(Array.from(kp.secretKey));
+
+    const { checkOperatorKeyStatus } = await import("@/lib/onboarding/operator-key");
+    const status = checkOperatorKeyStatus();
+
+    expect(status.present).toBe(true);
+    expect(status.valid).toBe(true);
+    expect(status.state).toBe("ready");
+    expect(status.publicKey_suffix).toBe(kp.publicKey.toBase58().slice(-8));
+    expect(status.checkedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("attestation operator status helper reports readiness with valid key", async () => {
+    const kp = Keypair.generate();
+    const secret = JSON.stringify(Array.from(kp.secretKey));
+
+    const { getOnchainAttestationOperatorStatus } = await import("@/lib/onboarding/onchain-attestation");
+    const status = getOnchainAttestationOperatorStatus(secret);
+
+    expect(status.ready).toBe(true);
+    expect(status.operatorPubkey).toBe(kp.publicKey.toBase58());
+    expect(status.note).toMatch(/configured/i);
+  });
+});

--- a/lib/__tests__/planner-resolve-route.test.ts
+++ b/lib/__tests__/planner-resolve-route.test.ts
@@ -10,8 +10,19 @@ jest.mock("@/lib/orchestrator/policy", () => ({
 
 function makeListing(input: {
   wallet: string;
-  tags: string[];
+  tags?: string[];
   reputation?: number;
+  attested?: boolean;
+  taskTypes?: string[];
+  inputModes?: string[];
+  privacyModes?: string[];
+  runtimeCaps?: string[];
+  perCallUsd?: number;
+  feedbackScore?: number;
+  feedbackCount?: number;
+  endpointUrl?: string;
+  healthStatus?: "pass" | "fail" | "unknown";
+  lastCheckedAt?: string | null;
   attestorCheckpoints?: string[];
   qualityClaims?: string[];
 }): SpecialistListing {
@@ -32,35 +43,40 @@ function makeListing(input: {
       attestationAccuracy: 0,
     },
     capabilities: {
-      taskTypes: ["summarize"],
-      inputModes: ["text"],
+      taskTypes: input.taskTypes ?? ["summarize"],
+      inputModes: input.inputModes ?? ["text"],
       outputModes: ["text"],
-      privacyModes: ["public"],
-      tags: input.tags,
+      privacyModes: input.privacyModes ?? ["public"],
+      tags: input.tags ?? [],
       baseUsd: 0,
-      perCallUsd: 0.01,
+      perCallUsd: input.perCallUsd ?? 0.01,
       context_requirements: [],
-      runtime_capabilities: [],
+      runtime_capabilities: input.runtimeCaps ?? [],
       attestor_checkpoints: input.attestorCheckpoints ?? [],
       quality_claims: input.qualityClaims ?? [],
     },
     health: {
-      status: "pass",
-      endpointUrl: `https://${input.wallet}.example`,
-      lastCheckedAt: null,
+      status: input.healthStatus ?? "pass",
+      endpointUrl: input.endpointUrl ?? `https://${input.wallet}.example`,
+      lastCheckedAt: input.lastCheckedAt ?? null,
+      freshnessState: "unknown",
     },
     attestation: {
-      attested: false,
+      attested: input.attested ?? false,
       lastAttestedAt: null,
     },
     capabilityHash: null,
     signals: {
-      feedbackCount: 0,
-      avgFeedbackScore: 0,
+      feedbackCount: input.feedbackCount ?? 0,
+      avgFeedbackScore: input.feedbackScore ?? 0,
       attestationAgreements: 0,
       attestationDisagreements: 0,
     },
     ranking_score: 0,
+    indexSemantics: {
+      schemaVersion: 2,
+      rankingFormulaVersion: 1,
+    },
   };
 }
 
@@ -68,6 +84,54 @@ describe("planner resolve route", () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+  });
+
+  it("returns 400 when task is missing", async () => {
+    const { POST } = await import("@/app/api/planner/tools/resolve/route");
+    const req = new Request("http://localhost/api/planner/tools/resolve", {
+      method: "POST",
+      body: JSON.stringify({ task: "" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: "task is required",
+    });
+  });
+
+  it("returns 400 with appliedFilters when no eligible specialists are found", async () => {
+    const { readPolicy } = await import("@/lib/orchestrator/policy");
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      maxPerTaskUsd: 0,
+      requireAttestation: false,
+      minReputation: 0,
+      preferredPrivacyMode: "public",
+    });
+
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({ listings: [] });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve/route");
+    const req = new Request("http://localhost/api/planner/tools/resolve", {
+      method: "POST",
+      body: JSON.stringify({ task: "summarize this" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      candidate: null,
+      appliedFilters: {
+        sortBy: "ranking",
+      },
+      error: "No eligible specialists found matching your policy.",
+    });
   });
 
   it("prefers source-matching specialists when preferredSource is set", async () => {
@@ -105,167 +169,155 @@ describe("planner resolve route", () => {
     expect(body.ok).toBe(true);
     expect(body.candidate.walletAddress).toBe("wallet-openclaw");
     expect(body.candidate.selectionReasons).toContain("source:openclaw");
-    expect(body.candidate.sourceRouting).toMatchObject({
-      requestedSource: "openclaw",
-      candidateSource: "openclaw",
-      strictSourceMatch: false,
-      scoreDelta: 12,
-    });
-    expect(body.candidate.sourceRouting.decisionTrace).toEqual(
-      expect.arrayContaining([
-        "source:requested=openclaw",
-        "source:candidate=openclaw",
-        "source:strict=false",
-        "source:score_delta=12",
-        "source:openclaw",
-      ])
-    );
   });
 
-  it("returns source policy trace when preferred source does not match under non-strict mode", async () => {
-    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+  it("applies discovery filters and supports cost sorting", async () => {
     const { readPolicy } = await import("@/lib/orchestrator/policy");
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
 
     (readPolicy as jest.Mock).mockReturnValue({
-      preferredPrivacyMode: "public",
-      requireAttestation: false,
       maxPerTaskUsd: 0,
-      minReputation: 0,
-    });
-
-    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
-      listings: [makeListing({ wallet: "wallet-hermes", tags: ["source:hermes"] })],
-    });
-
-    const { POST } = await import("@/app/api/planner/tools/resolve/route");
-    const req = new Request("http://localhost/api/planner/tools/resolve", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        task: "summarize",
-        policy: { preferredSource: "openclaw", strictSourceMatch: false },
-      }),
-    });
-
-    const res = await POST(req);
-    expect(res.status).toBe(200);
-
-    const body = await res.json();
-    expect(body.ok).toBe(true);
-    expect(body.candidate.walletAddress).toBe("wallet-hermes");
-    expect(body.candidate.sourceRouting).toMatchObject({
-      requestedSource: "openclaw",
-      candidateSource: "hermes",
-      strictSourceMatch: false,
-      scoreDelta: -4,
-    });
-    expect(body.candidate.sourceRouting.decisionTrace).toEqual(
-      expect.arrayContaining(["source_penalty:hermes"])
-    );
-  });
-
-  it("enforces strictSourceMatch guardrail", async () => {
-    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
-    const { readPolicy } = await import("@/lib/orchestrator/policy");
-
-    (readPolicy as jest.Mock).mockReturnValue({
-      preferredPrivacyMode: "public",
       requireAttestation: false,
-      maxPerTaskUsd: 0,
       minReputation: 0,
-    });
-
-    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
-      listings: [makeListing({ wallet: "wallet-hermes", tags: ["source:hermes"] })],
-    });
-
-    const { POST } = await import("@/app/api/planner/tools/resolve/route");
-    const req = new Request("http://localhost/api/planner/tools/resolve", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        task: "summarize",
-        policy: { preferredSource: "openclaw", strictSourceMatch: true },
-      }),
-    });
-
-    const res = await POST(req);
-    expect(res.status).toBe(400);
-
-    const body = await res.json();
-    expect(body.ok).toBe(false);
-    expect(body.error).toContain("No eligible specialists");
-    expect(body.resolveDiagnostics).toMatchObject({
-      totalListings: 1,
-      acceptedCount: 0,
-      rejectedBy: {
-        sourcePolicy: 1,
-      },
-      rejectedWalletSamples: {
-        sourcePolicy: ["wallet-hermes"],
-      },
-    });
-  });
-
-  it("returns ranked alternative explainability metadata for supervisor diagnostics", async () => {
-    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
-    const { readPolicy } = await import("@/lib/orchestrator/policy");
-
-    (readPolicy as jest.Mock).mockReturnValue({
       preferredPrivacyMode: "public",
-      requireAttestation: false,
-      maxPerTaskUsd: 0,
-      minReputation: 0,
     });
 
     (fetchSpecialistListings as jest.Mock).mockResolvedValue({
       listings: [
-        makeListing({ wallet: "wallet-openclaw", tags: ["source:openclaw"], reputation: 110 }),
-        makeListing({ wallet: "wallet-hermes", tags: ["source:hermes"], reputation: 100 }),
-        makeListing({ wallet: "wallet-pi", tags: ["source:pi"], reputation: 90 }),
+        makeListing({
+          wallet: "wallet-a",
+          taskTypes: ["summarize"],
+          inputModes: ["text"],
+          privacyModes: ["public"],
+          runtimeCaps: ["stateful"],
+          tags: ["finance"],
+          attested: true,
+          perCallUsd: 0.8,
+          feedbackScore: 9,
+          feedbackCount: 10,
+          lastCheckedAt: "2026-04-23T00:00:00.000Z",
+        }),
+        makeListing({
+          wallet: "wallet-b",
+          taskTypes: ["summarize"],
+          inputModes: ["text"],
+          privacyModes: ["public"],
+          runtimeCaps: ["stateful"],
+          tags: ["finance", "realtime"],
+          attested: true,
+          perCallUsd: 0.3,
+          feedbackScore: 8.7,
+          feedbackCount: 8,
+          lastCheckedAt: "2026-04-23T00:00:00.000Z",
+        }),
       ],
     });
 
     const { POST } = await import("@/app/api/planner/tools/resolve/route");
     const req = new Request("http://localhost/api/planner/tools/resolve", {
       method: "POST",
-      headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        task: "summarize",
-        policy: { preferredSource: "openclaw", strictSourceMatch: false },
+        task: "summarize this",
+        sortBy: "cost",
+        runtimeCap: "stateful",
+        tag: "finance",
+        health: "pass",
+        attested: true,
       }),
+      headers: { "content-type": "application/json" },
     });
 
     const res = await POST(req);
     expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      candidate: {
+        walletAddress: "wallet-b",
+      },
+      appliedFilters: {
+        sortBy: "cost",
+        runtimeCap: "stateful",
+        tag: "finance",
+        health: "pass",
+        attested: true,
+      },
+    });
+  });
 
-    const body = await res.json();
-    expect(body.ok).toBe(true);
-    expect(body.candidate.walletAddress).toBe("wallet-openclaw");
-    expect(body.alternativeCount).toBe(2);
-    expect(body.alternatives).toHaveLength(2);
-    expect(body.resolveDiagnostics).toMatchObject({
-      totalListings: 3,
-      acceptedCount: 3,
-      rejectedBy: {
-        sourcePolicy: 0,
+  it("supports reputation sorting", async () => {
+    const { readPolicy } = await import("@/lib/orchestrator/policy");
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      maxPerTaskUsd: 0,
+      requireAttestation: false,
+      minReputation: 0,
+      preferredPrivacyMode: "public",
+    });
+
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      listings: [
+        makeListing({ wallet: "wallet-high-rep", reputation: 80 }),
+        makeListing({ wallet: "wallet-low-rep", reputation: 20 }),
+      ],
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve/route");
+    const req = new Request("http://localhost/api/planner/tools/resolve", {
+      method: "POST",
+      body: JSON.stringify({ task: "summarize this", sortBy: "reputation" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      candidate: {
+        walletAddress: "wallet-high-rep",
       },
-      rejectedWalletSamples: {
-        sourcePolicy: [],
+      appliedFilters: {
+        sortBy: "reputation",
       },
     });
-    expect(body.alternatives[0]).toMatchObject({
-      walletAddress: "wallet-hermes",
-      sourceRouting: {
-        requestedSource: "openclaw",
-        candidateSource: "hermes",
-        strictSourceMatch: false,
-        scoreDelta: -4,
+  });
+
+  it("supports feedback sorting", async () => {
+    const { readPolicy } = await import("@/lib/orchestrator/policy");
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+
+    (readPolicy as jest.Mock).mockReturnValue({
+      maxPerTaskUsd: 0,
+      requireAttestation: false,
+      minReputation: 0,
+      preferredPrivacyMode: "public",
+    });
+
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      listings: [
+        makeListing({ wallet: "wallet-low-feedback", feedbackScore: 7.1, feedbackCount: 2 }),
+        makeListing({ wallet: "wallet-high-feedback", feedbackScore: 9.4, feedbackCount: 35 }),
+      ],
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve/route");
+    const req = new Request("http://localhost/api/planner/tools/resolve", {
+      method: "POST",
+      body: JSON.stringify({ task: "summarize this", sortBy: "feedback" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      candidate: {
+        walletAddress: "wallet-high-feedback",
+      },
+      appliedFilters: {
+        sortBy: "feedback",
       },
     });
-    expect(body.alternatives[0].sourceRouting.decisionTrace).toEqual(
-      expect.arrayContaining(["source_penalty:hermes"])
-    );
   });
 
   it("filters by required attestor checkpoints and quality claims", async () => {
@@ -313,12 +365,6 @@ describe("planner resolve route", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.candidate.walletAddress).toBe("wallet-disclosure-pass");
-    expect(body.candidate.selectionReasons).toEqual(
-      expect.arrayContaining([
-        "requires:attestor_checkpoints=schema_contract_pass,policy_bounds_ok",
-        "requires:quality_claims=latency_p95_under_3s",
-      ])
-    );
     expect(body.resolveDiagnostics).toMatchObject({
       totalListings: 2,
       acceptedCount: 1,

--- a/lib/__tests__/specialist-index-semantics.test.ts
+++ b/lib/__tests__/specialist-index-semantics.test.ts
@@ -1,0 +1,29 @@
+describe("specialist index freshness semantics", () => {
+  it("returns unknown for empty or invalid timestamps", async () => {
+    const { computeFreshnessState } = await import("@/lib/onboarding/specialist-index");
+
+    expect(computeFreshnessState()).toBe("unknown");
+    expect(computeFreshnessState("not-a-date")).toBe("unknown");
+  });
+
+  it("returns fresh for recent timestamps", async () => {
+    const { computeFreshnessState } = await import("@/lib/onboarding/specialist-index");
+    const ts = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+
+    expect(computeFreshnessState(ts)).toBe("fresh");
+  });
+
+  it("returns warm between fresh and stale windows", async () => {
+    const { computeFreshnessState } = await import("@/lib/onboarding/specialist-index");
+    const ts = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString();
+
+    expect(computeFreshnessState(ts)).toBe("warm");
+  });
+
+  it("returns stale for old timestamps", async () => {
+    const { computeFreshnessState } = await import("@/lib/onboarding/specialist-index");
+    const ts = new Date(Date.now() - 36 * 60 * 60 * 1000).toISOString();
+
+    expect(computeFreshnessState(ts)).toBe("stale");
+  });
+});

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -32,6 +32,17 @@ export type ResolveInput = {
   required_attestor_checkpoints?: string[];
   /** Optional quality-claim markers required from specialist disclosure metadata */
   required_quality_claims?: string[];
+  /** Optional sort preference for the final candidate ordering */
+  sortBy?: "ranking" | "reputation" | "cost" | "feedback";
+  /** Optional discovery filters (parity with /api/registry) */
+  taskType?: string;
+  inputMode?: string;
+  privacyMode?: string;
+  runtimeCap?: string;
+  attested?: boolean;
+  health?: "pass" | "fail" | "pending";
+  tag?: string;
+  tags?: string[];
   /** Policy overrides — merged with saved orchestrator policy */
   policy?: {
     maxPerCallUsd?: number;
@@ -78,6 +89,17 @@ export type ResolveOutput = {
       decisionTrace: string[];
     };
   }>;
+  appliedFilters?: {
+    sortBy: "ranking" | "reputation" | "cost" | "feedback";
+    taskType?: string;
+    inputMode?: string;
+    privacyMode?: string;
+    runtimeCap?: string;
+    attested?: boolean;
+    health?: "pass" | "fail" | "pending";
+    tag?: string;
+    tags?: string[];
+  };
   resolveDiagnostics?: {
     totalListings: number;
     acceptedCount: number;
@@ -239,6 +261,23 @@ export const MCP_TOOL_SCHEMAS = [
           type: "array",
           items: { type: "string" },
           description: "Optional quality claim markers that must be present in specialist disclosure metadata.",
+        },
+        sortBy: {
+          type: "string",
+          enum: ["ranking", "reputation", "cost", "feedback"],
+          description: "Optional ordering preference for candidate ranking.",
+        },
+        taskType: { type: "string", description: "Filter by task type taxonomy id." },
+        inputMode: { type: "string", description: "Filter by input mode taxonomy id." },
+        privacyMode: { type: "string", description: "Filter by required privacy mode." },
+        runtimeCap: { type: "string", description: "Filter by runtime capability id." },
+        attested: { type: "boolean", description: "Require attested specialists." },
+        health: { type: "string", enum: ["pass", "fail", "pending"] },
+        tag: { type: "string", description: "Filter by single capability tag." },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter by any matching capability tags.",
         },
         policy: {
           type: "object",

--- a/lib/onboarding/operator-key.ts
+++ b/lib/onboarding/operator-key.ts
@@ -2,11 +2,15 @@ import "server-only";
 
 import { Keypair } from "@solana/web3.js";
 
+export type OperatorKeyState = "missing" | "invalid" | "ready";
+
 export interface OperatorKeyStatus {
   present: boolean;
   valid: boolean;
+  state: OperatorKeyState;
   publicKey_suffix?: string;
   error?: string;
+  checkedAt: string;
 }
 
 export function checkOperatorKeyStatus(): OperatorKeyStatus {
@@ -15,7 +19,9 @@ export function checkOperatorKeyStatus(): OperatorKeyStatus {
     return {
       present: false,
       valid: false,
+      state: "missing",
       error: "ONBOARDING_ATTEST_OPERATOR_SECRET_KEY not set",
+      checkedAt: new Date().toISOString(),
     };
   }
 
@@ -25,7 +31,9 @@ export function checkOperatorKeyStatus(): OperatorKeyStatus {
       return {
         present: true,
         valid: false,
+        state: "invalid",
         error: `Expected 64-byte array, got ${Array.isArray(parsed) ? parsed.length : "non-array"}`,
+        checkedAt: new Date().toISOString(),
       };
     }
 
@@ -35,13 +43,17 @@ export function checkOperatorKeyStatus(): OperatorKeyStatus {
     return {
       present: true,
       valid: true,
+      state: "ready",
       publicKey_suffix: publicKey.slice(-8),
+      checkedAt: new Date().toISOString(),
     };
   } catch (error) {
     return {
       present: true,
       valid: false,
+      state: "invalid",
       error: error instanceof Error ? error.message : "Parse error",
+      checkedAt: new Date().toISOString(),
     };
   }
 }

--- a/lib/onboarding/specialist-index.ts
+++ b/lib/onboarding/specialist-index.ts
@@ -7,8 +7,11 @@ import type { CapabilityInput } from "@/lib/onboarding/capabilities";
 export type SpecialistIndexEntry = {
   walletAddress: string;
   updatedAt: string;
+  schema_version?: number;
+  ranking_formula_version?: number;
   endpointUrl?: string;
   healthcheckStatus?: "pending" | "pass" | "fail";
+  freshness_state?: "fresh" | "warm" | "stale" | "unknown";
   attested?: boolean;
   capabilityHash?: string;
   capabilities: CapabilityInput;
@@ -26,6 +29,10 @@ export type SpecialistIndexEntry = {
 };
 
 const INDEX_PATH = join(process.cwd(), "data", "onboarding", "specialist-index.json");
+const INDEX_SCHEMA_VERSION = 2;
+const RANKING_FORMULA_VERSION = 1;
+const FRESH_WINDOW_MS = 2 * 60 * 60 * 1000;
+const WARM_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 function emptyCapabilities(): CapabilityInput {
   return {
@@ -57,7 +64,13 @@ function normalizeRecords(raw: unknown): SpecialistIndexEntry[] {
 
 function readAll(): SpecialistIndexEntry[] {
   try {
-    return normalizeRecords(JSON.parse(readFileSync(INDEX_PATH, "utf8")));
+    const records = normalizeRecords(JSON.parse(readFileSync(INDEX_PATH, "utf8")));
+    const upgraded = records.map((entry) => ensureEntrySemantics(entry));
+    const changed = JSON.stringify(records) !== JSON.stringify(upgraded);
+    if (changed) {
+      writeAll(upgraded);
+    }
+    return upgraded;
   } catch {
     return [];
   }
@@ -119,6 +132,27 @@ function recomputeRankingScore(entry: SpecialistIndexEntry) {
   });
 }
 
+export function computeFreshnessState(lastSeenAt?: string): "fresh" | "warm" | "stale" | "unknown" {
+  if (!lastSeenAt) return "unknown";
+  const ts = Date.parse(lastSeenAt);
+  if (!Number.isFinite(ts)) return "unknown";
+  const age = Date.now() - ts;
+  if (age <= FRESH_WINDOW_MS) return "fresh";
+  if (age <= WARM_WINDOW_MS) return "warm";
+  return "stale";
+}
+
+function ensureEntrySemantics(entry: SpecialistIndexEntry): SpecialistIndexEntry {
+  const next: SpecialistIndexEntry = {
+    ...entry,
+    schema_version: INDEX_SCHEMA_VERSION,
+    ranking_formula_version: RANKING_FORMULA_VERSION,
+    freshness_state: computeFreshnessState(entry.last_seen_at ?? entry.updatedAt),
+  };
+  next.ranking_score = recomputeRankingScore(next);
+  return next;
+}
+
 function mergeEntry(
   existing: SpecialistIndexEntry | undefined,
   walletAddress: string,
@@ -136,6 +170,8 @@ function mergeEntry(
   const record: SpecialistIndexEntry = {
     walletAddress,
     updatedAt: now,
+    schema_version: INDEX_SCHEMA_VERSION,
+    ranking_formula_version: RANKING_FORMULA_VERSION,
     endpointUrl: meta?.endpointUrl ?? existing?.endpointUrl,
     healthcheckStatus: meta?.healthcheckStatus ?? existing?.healthcheckStatus,
     attested: meta?.attested ?? existing?.attested,
@@ -149,6 +185,7 @@ function mergeEntry(
       lastFeedbackAt: undefined,
     },
     last_seen_at: healthState.last_seen_at,
+    freshness_state: computeFreshnessState(healthState.last_seen_at ?? now),
     health_streak: healthState.health_streak,
     ranking_score: existing?.ranking_score ?? 0,
     reputation_score: meta?.reputationScore ?? existing?.reputation_score ?? 0,
@@ -269,6 +306,9 @@ export function applyPlannerFeedback(
   };
 
   record.updatedAt = new Date().toISOString();
+  record.freshness_state = computeFreshnessState(record.last_seen_at ?? record.updatedAt);
+  record.schema_version = INDEX_SCHEMA_VERSION;
+  record.ranking_formula_version = RANKING_FORMULA_VERSION;
   record.ranking_score = recomputeRankingScore(record);
   records[idx] = record;
   writeAll(records);

--- a/lib/registry/bridge.ts
+++ b/lib/registry/bridge.ts
@@ -64,6 +64,7 @@ export type SpecialistListing = {
   /** Live health state */
   health: {
     status: "pass" | "fail" | "unknown";
+    freshnessState: "fresh" | "warm" | "stale" | "unknown";
     endpointUrl: string | null;
     lastCheckedAt: string | null;
   };
@@ -83,6 +84,11 @@ export type SpecialistListing = {
   };
   /** Composite ranking signal for route sorting */
   ranking_score: number;
+  /** Index semantics/version metadata */
+  indexSemantics: {
+    schemaVersion: number;
+    rankingFormulaVersion: number;
+  };
 };
 
 // ── Base58 encode (no dep) ────────────────────────────────────────────────────
@@ -256,6 +262,7 @@ export async function fetchSpecialistListings(): Promise<{
               : indexEntry?.healthcheckStatus === "pass" ? "pass"
               : indexEntry?.healthcheckStatus === "fail" ? "fail"
               : "unknown",
+        freshnessState: indexEntry?.freshness_state ?? "unknown",
         endpointUrl: profile?.endpointUrl ?? indexEntry?.endpointUrl ?? null,
         lastCheckedAt: profile?.lastHealthcheck ?? indexEntry?.last_seen_at ?? indexEntry?.updatedAt ?? null,
       },
@@ -265,6 +272,10 @@ export async function fetchSpecialistListings(): Promise<{
       },
       signals,
       ranking_score: rankingScore,
+      indexSemantics: {
+        schemaVersion: indexEntry?.schema_version ?? 1,
+        rankingFormulaVersion: indexEntry?.ranking_formula_version ?? 1,
+      },
     };
   });
 
@@ -362,6 +373,7 @@ function buildFromIndexOnly(entry: SpecialistIndexEntry): SpecialistListing {
       status: entry.healthcheckStatus === "pass" ? "pass"
             : entry.healthcheckStatus === "fail" ? "fail"
             : "unknown",
+      freshnessState: entry.freshness_state ?? "unknown",
       endpointUrl: entry.endpointUrl ?? null,
       lastCheckedAt: entry.last_seen_at ?? entry.updatedAt ?? null,
     },
@@ -376,5 +388,9 @@ function buildFromIndexOnly(entry: SpecialistIndexEntry): SpecialistListing {
       attestationDisagreements: 0,
     },
     ranking_score: rankingScore,
+    indexSemantics: {
+      schemaVersion: entry.schema_version ?? 1,
+      rankingFormulaVersion: entry.ranking_formula_version ?? 1,
+    },
   };
 }


### PR DESCRIPTION
## Summary\nThis PR lands the Phase A/B onboarding hardening stream in 4 isolated commits:\n\n1. feat(onboarding): operator key lifecycle UX hardening\n2. feat(planner): resolve filter/sort parity + appliedFilters echo\n3. feat(index): freshness/version semantics metadata\n4. chore(qa): BDD checkpoint sync + onboarding e2e selector stability\n\n## Key changes\n- Step 7 operator status lifecycle: missing/invalid/ready/stale with freshness gating and guidance payloads\n- Planner resolve parity with registry filters and sort semantics\n- Specialist index semantics: schema/ranking versions + freshness state + legacy auto-upgrade on read\n- Registry bridge exposes freshness and index semantics metadata\n- BDD checkpoint status synced to shipped state\n- Onboarding Playwright selector stabilized\n\n## Validation\n- \n- \n- 

Running 21 tests using 1 worker

[1A[2K[1/21] [chromium] › e2e/onboarding.spec.ts:17:7 › /onboarding page › loads wizard header, all 8 step labels, and step indicator
[1A[2K[2/21] [chromium] › e2e/onboarding.spec.ts:27:8 › /onboarding page › consent gates next button — both checkboxes required
[1A[2K[3/21] [chromium] › e2e/onboarding.spec.ts:40:8 › /onboarding page › next button advances to step 2 after consent
[1A[2K[4/21] [chromium] › e2e/onboarding.spec.ts:46:8 › /onboarding page › back button returns to previous step
[1A[2K[5/21] [chromium] › e2e/onboarding.spec.ts:55:8 › /onboarding page › step 2 runtime — platform selector renders and defaults to macos
[1A[2K[6/21] [chromium] › e2e/onboarding.spec.ts:62:8 › /onboarding page › step 2 runtime — next is disabled until runtime is confirmed ready
[1A[2K[7/21] [chromium] › e2e/onboarding.spec.ts:71:8 › /onboarding page › step 3 endpoint — accessible from step 2 via localStore state injection
[1A[2K[8/21] [chromium] › e2e/onboarding.spec.ts:144:8 › /onboarding page › step 8 planner — visible and contains prompt textarea + run button
[1A[2K[9/21] [chromium] › e2e/onboarding.spec.ts:218:8 › /onboarding page › step 8 planner — next disabled when status is idle; enabled after plannerFeedbackSent injected
[1A[2K[10/21] [chromium] › e2e/onboarding.spec.ts:304:8 › /onboarding page › step 8 planner — run button disabled when prompt is empty
[1A[2K[11/21] [chromium] › e2e/onboarding.spec.ts:343:7 › /onboarding page › POST /api/onboarding/planner/execute — returns ok:false with empty prompt
[1A[2K[12/21] [chromium] › e2e/onboarding.spec.ts:352:7 › /onboarding page › POST /api/onboarding/planner/execute — valid prompt returns result shape
[1A[2K[13/21] [chromium] › e2e/onboarding.spec.ts:362:7 › /onboarding page › GET /api/onboarding/planner/execute — returns runs array
[1A[2K[14/21] [chromium] › e2e/onboarding.spec.ts:371:7 › /onboarding page › POST /api/onboarding/planner/feedback — missing runId returns 400
[1A[2K[15/21] [chromium] › e2e/onboarding.spec.ts:379:7 › /onboarding page › POST /api/onboarding/planner/feedback — invalid score returns 400
[1A[2K[16/21] [chromium] › e2e/onboarding.spec.ts:387:7 › /onboarding page › GET /api/onboarding/planner/feedback — returns feedback array
[1A[2K[17/21] [chromium] › e2e/onboarding.spec.ts:396:7 › /onboarding page › GET /api/onboarding/planner/reveal — returns commits array
[1A[2K[18/21] [chromium] › e2e/onboarding.spec.ts:403:7 › /onboarding page › POST /api/onboarding/planner/reveal — missing runId returns 400
[1A[2K[19/21] [chromium] › e2e/onboarding.spec.ts:411:7 › /onboarding page › POST /api/onboarding/planner/reveal — unknown runId returns error
[1A[2K[20/21] [chromium] › e2e/onboarding.spec.ts:422:7 › /onboarding page › GET /api/onboarding/capabilities — returns specialists array
[1A[2K[21/21] [chromium] › e2e/onboarding.spec.ts:429:7 › /onboarding page › POST /api/onboarding/planner — valid policy returns result shape
[1A[2K  9 skipped
  12 passed (3.3s) (12 passed / 9 skipped / 0 failed)\n