### PR TITLE
Fix marketplace missing new agents (registry bigint serialization)

### DIFF
--- a/app/api/registry/route.ts
+++ b/app/api/registry/route.ts
@@ -1,6 +1,8 @@
 import { fetchSpecialistListings } from "@/lib/registry/bridge";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 function parseCsv(value: string | null): string[] {
   if (!value) return [];
@@ -14,6 +16,12 @@ function asEpochMs(value: string | null): number {
   if (!value) return -1;
   const parsed = Date.parse(value);
   return Number.isNaN(parsed) ? -1 : parsed;
+}
+
+function serializeForJson<T>(value: T): T {
+  return JSON.parse(
+    JSON.stringify(value, (_key, v) => (typeof v === "bigint" ? v.toString() : v))
+  ) as T;
 }
 
 /**
@@ -115,7 +123,7 @@ export async function GET(req: Request) {
 
     return Response.json({
       ok,
-      listings: results,
+      listings: serializeForJson(results),
       total: results.length,
       onchainCount,
       indexedCount,

--- a/lib/__tests__/registry-route.test.ts
+++ b/lib/__tests__/registry-route.test.ts
@@ -174,4 +174,34 @@ describe("registry route", () => {
       "wallet-c",
     ]);
   });
+
+  it("serializes bigint onchain fields without failing", async () => {
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    (fetchSpecialistListings as jest.Mock).mockResolvedValue({
+      ok: true,
+      listings: [
+        {
+          ...mkListing({ walletAddress: "wallet-bigint", ranking_score: 1 }),
+          onchain: {
+            ...mkListing({ walletAddress: "wallet-bigint", ranking_score: 1 }).onchain,
+            rateLamports: 1000000n,
+            jobsCompleted: 3n,
+            jobsFailed: 1n,
+            createdAt: 1713868800n,
+          },
+        },
+      ],
+      onchainCount: 1,
+      indexedCount: 1,
+    });
+
+    const { GET } = await import("@/app/api/registry/route");
+    const res = await GET(new Request("http://localhost/api/registry"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.listings).toHaveLength(1);
+    expect(data.listings[0].onchain.rateLamports).toBe("1000000");
+    expect(data.listings[0].onchain.jobsCompleted).toBe("3");
+  });
 });


### PR DESCRIPTION
## Problem
Newly registered agents were not showing in Marketplace.

## Root cause
`/api/registry` was returning 500 due JSON serialization failure on `bigint` fields from on-chain agent data:

- error: `Do not know how to serialize a BigInt`

When this happened, the client received no listings.

## Fix
1. Serialize BigInt fields safely in `/api/registry` before `Response.json`.
2. Mark registry route as dynamic (`force-dynamic`, `revalidate = 0`) to avoid stale marketplace responses.
3. Add regression test to ensure bigint-containing listings are returned successfully.

## Validation
- `npx jest lib/__tests__/registry-route.test.ts --runInBand` ✅ (5/5)
- `npm run build` ✅
