### PR TITLE
Batch 4: restore A-H traceability gates and planner lifecycle coverage

### DIFF
--- a/app/api/planner/tools/register-consumer/route.ts
+++ b/app/api/planner/tools/register-consumer/route.ts
@@ -1,0 +1,53 @@
+/**
+ * POST /api/planner/tools/register-consumer
+ *
+ * MCP tool: register_consumer
+ * Register or update a consumer wallet profile for planner marketplace usage.
+ */
+import { listConsumers, registerConsumer } from "@/lib/onboarding/consumer-registry";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const result = registerConsumer({
+      walletAddress: body.walletAddress,
+      preferredIntegration: body.preferredIntegration,
+      metadata: body.metadata,
+    });
+
+    return Response.json({
+      ok: true,
+      alreadyRegistered: result.alreadyRegistered,
+      profile: result.profile,
+      next: {
+        registerOnchain: "Connect wallet and submit free consumer registration tx",
+        selectIntegration: "Choose MCP, tools, or skills ingestion path",
+      },
+    });
+  } catch (error) {
+    return Response.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : "register_consumer failed",
+      },
+      { status: 400 }
+    );
+  }
+}
+
+export async function GET() {
+  return Response.json({
+    tool: "register_consumer",
+    description: "Register or update a consumer wallet profile for orchestrator usage.",
+    registry: listConsumers(),
+    schema: {
+      input: {
+        walletAddress: "string",
+        preferredIntegration: "mcp | tools | skills",
+        metadata: "{ agentName?: string, framework?: string }",
+      },
+    },
+  });
+}

--- a/app/api/planner/tools/release/route.ts
+++ b/app/api/planner/tools/release/route.ts
@@ -1,0 +1,58 @@
+/**
+ * POST /api/planner/tools/release
+ *
+ * MCP tool: decide_settlement
+ * Record consumer settlement decision after evaluating specialist output.
+ */
+import { decidePlannerSettlement } from "@/lib/onboarding/planner-settlement";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+
+    if (!body.runId?.trim()) {
+      return Response.json({ ok: false, error: "runId is required" }, { status: 400 });
+    }
+    if (body.decision !== "release" && body.decision !== "dispute") {
+      return Response.json({ ok: false, error: "decision must be release or dispute" }, { status: 400 });
+    }
+
+    const result = decidePlannerSettlement({
+      runId: body.runId,
+      decision: body.decision,
+      notes: body.notes,
+      consumerWallet: body.consumerWallet,
+    });
+
+    return Response.json({
+      ok: true,
+      run: result.run,
+      settlementState: result.run.settlementState,
+    });
+  } catch (error) {
+    return Response.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : "decide_settlement failed",
+      },
+      { status: 400 }
+    );
+  }
+}
+
+export async function GET() {
+  return Response.json({
+    tool: "decide_settlement",
+    description: "Record release/dispute decision for a paid planner run.",
+    schema: {
+      input: {
+        runId: "string",
+        decision: "release | dispute",
+        notes: "string?",
+        consumerWallet: "string?",
+      },
+    },
+  });
+}

--- a/app/api/planner/tools/resolve-attestor/route.ts
+++ b/app/api/planner/tools/resolve-attestor/route.ts
@@ -1,0 +1,47 @@
+/**
+ * POST /api/planner/tools/resolve-attestor
+ *
+ * MCP tool: resolve_attestor
+ * Find an attested specialist suitable to act as an attestor/judge.
+ */
+import { resolveAttestor } from "@/lib/onboarding/attestor-resolver";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const result = await resolveAttestor({
+      taskTypeHint: body.taskTypeHint,
+      minAttestationAccuracy: body.minAttestationAccuracy,
+      maxPerCallUsd: body.maxPerCallUsd,
+    });
+
+    return Response.json(result, { status: result.ok ? 200 : 400 });
+  } catch (error) {
+    return Response.json(
+      {
+        ok: false,
+        candidate: null,
+        alternatives: [],
+        count: 0,
+        error: error instanceof Error ? error.message : "resolve_attestor failed",
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET() {
+  return Response.json({
+    tool: "resolve_attestor",
+    description: "Find an attested specialist suitable for attestation/judge role.",
+    schema: {
+      input: {
+        taskTypeHint: "string?",
+        minAttestationAccuracy: "number?",
+        maxPerCallUsd: "number?",
+      },
+    },
+  });
+}

--- a/app/api/planner/tools/route.ts
+++ b/app/api/planner/tools/route.ts
@@ -21,15 +21,21 @@ export async function GET(req: Request) {
       openai_function_calls: MCP_TOOL_SCHEMAS,
       eliza_actions: ELIZA_ACTION_MANIFEST,
       endpoints: {
+        register_consumer: `${origin}/api/planner/tools/register-consumer`,
         resolve:  `${origin}/api/planner/tools/resolve`,
+        resolve_attestor: `${origin}/api/planner/tools/resolve-attestor`,
         invoke:   `${origin}/api/planner/tools/invoke`,
         signal:   `${origin}/api/planner/tools/signal`,
+        decide_settlement: `${origin}/api/planner/tools/release`,
       },
     },
     usage: {
+      register_consumer: "POST { walletAddress, preferredIntegration?, metadata? }",
       resolve:  "POST { task, taskTypeHint?, policy? }",
+      resolve_attestor: "POST { taskTypeHint?, minAttestationAccuracy?, maxPerCallUsd? }",
       invoke:   "POST { prompt, targetWallet?, policy? }",
       signal:   "POST { runId, score, notes?, agreesWithAttestation? }",
+      decide_settlement: "POST { runId, decision, notes?, consumerWallet? }",
     },
     docs: "https://github.com/nissan/reddi-agent-protocol",
   });

--- a/docs/USECASE-TRACEABILITY-MATRIX-2026-04-23.md
+++ b/docs/USECASE-TRACEABILITY-MATRIX-2026-04-23.md
@@ -1,0 +1,33 @@
+# Use-Case Traceability Matrix — 2026-04-23
+
+## Scope
+This matrix maps product use-cases to executable coverage lanes so regressions are caught before demo/release.
+
+## Buckets A-H
+
+| Bucket | Use-case | Primary coverage | Result |
+|---|---|---|---|
+| A | Onboarding/operator gates | `operator-key-rotation.test.ts`, `onboarding-operator-status-routes.test.ts` | ✅ |
+| B | Discovery/ranking | `registry-route.test.ts`, `registry-bridge-sort.test.ts` | ✅ |
+| C | Planner resolve/invoke/signal | `planner-resolve-route.test.ts`, `planner-invoke-route.test.ts`, `planner-signal-route.test.ts` | ✅ |
+| D/E | Endpoint security + reliability | `endpoint-security-compat.test.ts`, `program-rpc-config.test.ts` | ✅ |
+| F | Jupiter/x402 settlement | `jupiter-client.test.ts`, `packages/x402-solana/tests/payment.test.ts` | ✅ |
+| G | Torque retention layer | `torque-client.test.ts`, `torque-event-route.test.ts`, `torque-leaderboard-route.test.ts`, `torque-onboarding-event.test.ts` | ✅ |
+| H | Consumer lifecycle | `planner-register-consumer-route.test.ts`, `planner-tools-manifest-route.test.ts`, `planner-resolve-attestor-route.test.ts`, `planner-release-route.test.ts`, `planner-auditability.test.ts` | ✅ |
+
+## Gap closures included in this iteration
+- Restored missing executable coverage files referenced by the BDD sweep gate for Buckets B, D/E, and H.
+- Restored planner tool route surface for:
+  - `register_consumer`
+  - `resolve_attestor`
+  - `decide_settlement` (`/release` route)
+- Restored supporting onboarding helpers:
+  - `lib/onboarding/attestor-resolver.ts`
+  - `lib/onboarding/planner-settlement.ts`
+
+## Verification artifact
+- Representative sweep: `artifacts/bdd-sweep/20260423-232338/SUMMARY.md`
+- Command: `npm run test:bdd:sweep`
+
+## Next follow-up
+- Keep this matrix synced with `scripts/run-bdd-bucket-sweep.sh` so each bucket has at least one representative executable gate.

--- a/lib/__tests__/endpoint-security-compat.test.ts
+++ b/lib/__tests__/endpoint-security-compat.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { createOrRotateEndpoint } from "@/lib/onboarding/endpoint-manager";
+
+describe("endpoint security compatibility (Bucket D)", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("rejects endpoint creation without explicit consent", async () => {
+    await expect(
+      createOrRotateEndpoint({
+        consentExposeEndpoint: false,
+        port: 11434,
+      })
+    ).rejects.toThrow("Endpoint creation requires explicit endpoint exposure consent.");
+  });
+
+  it("returns x402 public bypass prefixes in endpoint result", async () => {
+    const result = await createOrRotateEndpoint({
+      consentExposeEndpoint: true,
+      port: 11434,
+      endpointUrl: "https://reddi-test.localtunnel.me",
+    });
+
+    expect(result.x402PublicPrefixes).toEqual(["/v1", "/x402", "/healthz"]);
+  });
+
+  it("generated token-gated proxy script bypasses public x402 paths and gates non-public paths", async () => {
+    await createOrRotateEndpoint({
+      consentExposeEndpoint: true,
+      port: 11434,
+      endpointUrl: "https://reddi-test.localtunnel.me",
+    });
+
+    const scriptPath = join(process.cwd(), "data", "onboarding", "token-gated-proxy.mjs");
+    const script = readFileSync(scriptPath, "utf8");
+
+    expect(script).toContain('const publicPrefixes = ["/v1","/x402","/healthz"]');
+    expect(script).toContain("const isPublicPath = publicPrefixes.some((prefix) => path.startsWith(prefix));");
+    expect(script).toContain("if (!isPublicPath && provided !== token)");
+    expect(script).toContain('res.statusCode = 401');
+  });
+});

--- a/lib/__tests__/planner-auditability.test.ts
+++ b/lib/__tests__/planner-auditability.test.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+jest.mock("@/lib/onboarding/specialist-index", () => ({
+  applyPlannerFeedback: jest.fn().mockReturnValue({ ok: true }),
+}));
+
+jest.mock("@/lib/onboarding/consumer-registry", () => ({
+  applyConsumerRating: jest.fn().mockReturnValue({ ok: true }),
+}));
+
+jest.mock("@/lib/onboarding/reputation-signal", () => ({
+  commitReputationRating: jest.fn().mockResolvedValue({ ok: true, txSignature: "sig" }),
+}));
+
+describe("planner auditability (H4.3)", () => {
+  const dataDir = join(process.cwd(), "data", "onboarding");
+  const runsPath = join(dataDir, "planner-runs.json");
+  const feedbackPath = join(dataDir, "planner-feedback.json");
+
+  let runsBackup: string | null = null;
+  let feedbackBackup: string | null = null;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mkdirSync(dataDir, { recursive: true });
+    runsBackup = existsSync(runsPath) ? readFileSync(runsPath, "utf8") : null;
+    feedbackBackup = existsSync(feedbackPath) ? readFileSync(feedbackPath, "utf8") : null;
+  });
+
+  afterEach(() => {
+    if (runsBackup === null) writeFileSync(runsPath, "[]");
+    else writeFileSync(runsPath, runsBackup);
+
+    if (feedbackBackup === null) writeFileSync(feedbackPath, "[]");
+    else writeFileSync(feedbackPath, feedbackBackup);
+  });
+
+  it("keeps settlement decision and quality signal independently auditable", async () => {
+    const baseRun = {
+      runId: "run_audit_1",
+      status: "completed",
+      paymentSatisfied: true,
+      selectedWallet: "So11111111111111111111111111111111111111112",
+      settlementState: "pending_evaluation",
+    };
+    writeFileSync(runsPath, JSON.stringify([baseRun], null, 2));
+    writeFileSync(feedbackPath, JSON.stringify([], null, 2));
+
+    const { decidePlannerSettlement } = await import("@/lib/onboarding/planner-settlement");
+    const { recordPlannerFeedback, listPlannerFeedback } = await import("@/lib/onboarding/planner-feedback");
+
+    const settlement = decidePlannerSettlement({
+      runId: "run_audit_1",
+      decision: "release",
+      notes: "meets quality bar",
+      consumerWallet: "So22222222222222222222222222222222222222222",
+    });
+
+    expect(settlement.ok).toBe(true);
+    expect(settlement.run.settlementState).toBe("released");
+
+    const feedback = await recordPlannerFeedback({
+      runId: "run_audit_1",
+      score: 2,
+      notes: "low quality despite settlement release decision",
+      consumerWallet: "So22222222222222222222222222222222222222222",
+    });
+
+    expect(feedback.ok).toBe(true);
+    expect(feedback.record.runId).toBe("run_audit_1");
+    expect(feedback.record.score).toBe(2);
+
+    const listed = listPlannerFeedback();
+    expect(listed.ok).toBe(true);
+    expect(listed.results.some((r) => r.runId === "run_audit_1" && r.score === 2)).toBe(true);
+
+    const runs = JSON.parse(readFileSync(runsPath, "utf8")) as Array<{ runId: string; settlementState?: string }>;
+    expect(runs.find((r) => r.runId === "run_audit_1")?.settlementState).toBe("released");
+  });
+});

--- a/lib/__tests__/planner-register-consumer-route.test.ts
+++ b/lib/__tests__/planner-register-consumer-route.test.ts
@@ -1,0 +1,60 @@
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/onboarding/consumer-registry", () => ({
+  registerConsumer: jest.fn(),
+  listConsumers: jest.fn().mockReturnValue({ ok: true, results: [] }),
+}));
+
+describe("planner register_consumer route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("registers consumer and returns next steps", async () => {
+    const { registerConsumer } = await import("@/lib/onboarding/consumer-registry");
+    (registerConsumer as jest.Mock).mockReturnValue({
+      ok: true,
+      alreadyRegistered: false,
+      profile: { walletAddress: "So11111111111111111111111111111111111111112" },
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/register-consumer/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/register-consumer", {
+      method: "POST",
+      body: JSON.stringify({ walletAddress: "So11111111111111111111111111111111111111112" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      alreadyRegistered: false,
+      next: {
+        registerOnchain: expect.any(String),
+      },
+    });
+  });
+
+  it("returns 400 on validation errors", async () => {
+    const { registerConsumer } = await import("@/lib/onboarding/consumer-registry");
+    (registerConsumer as jest.Mock).mockImplementation(() => {
+      throw new Error("Valid consumer wallet address is required.");
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/register-consumer/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/register-consumer", {
+      method: "POST",
+      body: JSON.stringify({ walletAddress: "bad" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Valid consumer wallet address is required.",
+    });
+  });
+});

--- a/lib/__tests__/planner-release-route.test.ts
+++ b/lib/__tests__/planner-release-route.test.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/onboarding/planner-settlement", () => ({
+  decidePlannerSettlement: jest.fn(),
+}));
+
+describe("planner decide_settlement route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("records release decision", async () => {
+    const { decidePlannerSettlement } = await import("@/lib/onboarding/planner-settlement");
+    (decidePlannerSettlement as jest.Mock).mockReturnValue({
+      ok: true,
+      run: { runId: "run_1", settlementState: "released" },
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/release/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/release", {
+      method: "POST",
+      body: JSON.stringify({ runId: "run_1", decision: "release" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      settlementState: "released",
+    });
+  });
+
+  it("rejects invalid decision value", async () => {
+    const { POST } = await import("@/app/api/planner/tools/release/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/release", {
+      method: "POST",
+      body: JSON.stringify({ runId: "run_1", decision: "invalid" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: "decision must be release or dispute",
+    });
+  });
+
+  it("returns 400 on settlement guardrail errors", async () => {
+    const { decidePlannerSettlement } = await import("@/lib/onboarding/planner-settlement");
+    (decidePlannerSettlement as jest.Mock).mockImplementation(() => {
+      throw new Error("Settlement decision requires a payment-satisfied run");
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/release/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/release", {
+      method: "POST",
+      body: JSON.stringify({ runId: "run_1", decision: "release" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Settlement decision requires a payment-satisfied run",
+    });
+  });
+});

--- a/lib/__tests__/planner-resolve-attestor-route.test.ts
+++ b/lib/__tests__/planner-resolve-attestor-route.test.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/onboarding/attestor-resolver", () => ({
+  resolveAttestor: jest.fn(),
+}));
+
+describe("planner resolve_attestor route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("returns candidate on success", async () => {
+    const { resolveAttestor } = await import("@/lib/onboarding/attestor-resolver");
+    (resolveAttestor as jest.Mock).mockResolvedValue({
+      ok: true,
+      candidate: { walletAddress: "So11111111111111111111111111111111111111112" },
+      alternatives: [],
+      count: 1,
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve-attestor/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/resolve-attestor", {
+      method: "POST",
+      body: JSON.stringify({ taskTypeHint: "review" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      count: 1,
+      candidate: { walletAddress: "So11111111111111111111111111111111111111112" },
+    });
+  });
+
+  it("returns 400 when no eligible attestor", async () => {
+    const { resolveAttestor } = await import("@/lib/onboarding/attestor-resolver");
+    (resolveAttestor as jest.Mock).mockResolvedValue({
+      ok: false,
+      candidate: null,
+      alternatives: [],
+      count: 0,
+      error: "No eligible attestors found.",
+    });
+
+    const { POST } = await import("@/app/api/planner/tools/resolve-attestor/route");
+    const req = new NextRequest("http://localhost/api/planner/tools/resolve-attestor", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: "No eligible attestors found.",
+    });
+  });
+});

--- a/lib/__tests__/planner-tools-manifest-route.test.ts
+++ b/lib/__tests__/planner-tools-manifest-route.test.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from "next/server";
+
+describe("planner tools manifest route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("returns manifest with core endpoints", async () => {
+    const { GET } = await import("@/app/api/planner/tools/route");
+    const req = new NextRequest("http://localhost/api/planner/tools", {
+      method: "GET",
+    });
+
+    const res = await GET(req as unknown as Request);
+    expect(res.status).toBe(200);
+
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      protocol: "reddi-agent-protocol",
+      tools: {
+        endpoints: {
+          resolve: "http://localhost/api/planner/tools/resolve",
+          invoke: "http://localhost/api/planner/tools/invoke",
+          signal: "http://localhost/api/planner/tools/signal",
+          register_consumer: "http://localhost/api/planner/tools/register-consumer",
+          resolve_attestor: "http://localhost/api/planner/tools/resolve-attestor",
+          decide_settlement: "http://localhost/api/planner/tools/release",
+        },
+      },
+    });
+  });
+});

--- a/lib/__tests__/program-rpc-config.test.ts
+++ b/lib/__tests__/program-rpc-config.test.ts
@@ -1,0 +1,57 @@
+describe("program/network configuration regression guards", () => {
+  const originalEnv = process.env;
+  const DEVNET_ESCROW_PROGRAM_ID = "794nTFNyJknzDrR13ApSfVyNCRvcvnCN3BVDfic8dcZD";
+  const OVERRIDE_PROGRAM_ID = "11111111111111111111111111111111";
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("uses NEXT_PUBLIC_RPC_ENDPOINT override when provided", async () => {
+    process.env.NEXT_PUBLIC_RPC_ENDPOINT = "http://127.0.0.1:8899";
+    const { DEVNET_RPC } = await import("@/lib/program");
+    expect(DEVNET_RPC).toBe("http://127.0.0.1:8899");
+  });
+
+  it("accepts NEXT_PUBLIC_RPC_URL alias when NEXT_PUBLIC_RPC_ENDPOINT is unset", async () => {
+    delete process.env.NEXT_PUBLIC_RPC_ENDPOINT;
+    process.env.NEXT_PUBLIC_RPC_URL = "https://rpc.example.com";
+
+    const { DEVNET_RPC } = await import("@/lib/program");
+    expect(DEVNET_RPC).toBe("https://rpc.example.com");
+  });
+
+  it("falls back to Solana devnet RPC when no env override is set", async () => {
+    delete process.env.NEXT_PUBLIC_RPC_ENDPOINT;
+    delete process.env.NEXT_PUBLIC_RPC_URL;
+    const { DEVNET_RPC } = await import("@/lib/program");
+    expect(DEVNET_RPC).toBe("https://api.devnet.solana.com");
+  });
+
+  it("ignores unsafe devnet escrow override by default", async () => {
+    process.env.NETWORK_PROFILE = "devnet";
+    process.env.NEXT_PUBLIC_ESCROW_PROGRAM_ID = OVERRIDE_PROGRAM_ID;
+    delete process.env.ALLOW_UNSAFE_ESCROW_OVERRIDE;
+
+    const { getNetworkProfile } = await import("@/lib/config/network");
+    const profile = getNetworkProfile();
+
+    expect(profile.programs.escrowProgramId).toBe(DEVNET_ESCROW_PROGRAM_ID);
+  });
+
+  it("allows explicit devnet escrow override only when ALLOW_UNSAFE_ESCROW_OVERRIDE=true", async () => {
+    process.env.NETWORK_PROFILE = "devnet";
+    process.env.NEXT_PUBLIC_ESCROW_PROGRAM_ID = OVERRIDE_PROGRAM_ID;
+    process.env.ALLOW_UNSAFE_ESCROW_OVERRIDE = "true";
+
+    const { getNetworkProfile } = await import("@/lib/config/network");
+    const profile = getNetworkProfile();
+
+    expect(profile.programs.escrowProgramId).toBe(OVERRIDE_PROGRAM_ID);
+  });
+});

--- a/lib/__tests__/registry-bridge-sort.test.ts
+++ b/lib/__tests__/registry-bridge-sort.test.ts
@@ -1,0 +1,112 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const mockGetProgramAccounts = jest.fn();
+const mockDecodeAgentAccount = jest.fn();
+
+jest.mock("@solana/web3.js", () => ({
+  Connection: jest.fn().mockImplementation(() => ({
+    getProgramAccounts: mockGetProgramAccounts,
+  })),
+}));
+
+jest.mock("@/lib/program", () => ({
+  DEVNET_RPC: "http://localhost:8899",
+  ESCROW_PROGRAM_ID: { toBase58: () => "program" },
+  ACCOUNT_DISC: { AgentAccount: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]) },
+  decodeAgentAccount: (buf: Buffer) => mockDecodeAgentAccount(buf),
+}));
+
+describe("registry bridge default sort", () => {
+  const onboardingDir = join(process.cwd(), "data", "onboarding");
+  const indexPath = join(onboardingDir, "specialist-index.json");
+  const attestPath = join(onboardingDir, "attestations.json");
+  const profilePath = join(onboardingDir, "specialist-profile.json");
+
+  let indexBackup: string | null = null;
+  let attestBackup: string | null = null;
+  let profileBackup: string | null = null;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    mkdirSync(onboardingDir, { recursive: true });
+    indexBackup = existsSync(indexPath) ? readFileSync(indexPath, "utf8") : null;
+    attestBackup = existsSync(attestPath) ? readFileSync(attestPath, "utf8") : null;
+    profileBackup = existsSync(profilePath) ? readFileSync(profilePath, "utf8") : null;
+  });
+
+  afterEach(() => {
+    if (indexBackup === null) writeFileSync(indexPath, "[]");
+    else writeFileSync(indexPath, indexBackup);
+
+    if (attestBackup === null) writeFileSync(attestPath, "[]");
+    else writeFileSync(attestPath, attestBackup);
+
+    if (profileBackup === null) writeFileSync(profilePath, "[]");
+    else writeFileSync(profilePath, profileBackup);
+  });
+
+  it("orders listings by attestation, then health, then feedback when no explicit sort is requested", async () => {
+    writeFileSync(
+      indexPath,
+      JSON.stringify(
+        [
+          {
+            walletAddress: "walletA",
+            attested: false,
+            healthcheckStatus: "pass",
+            routingSignals: { feedbackCount: 10, avgFeedbackScore: 9, attestationAgreements: 0, attestationDisagreements: 0 },
+            capabilities: { taskTypes: ["summarize"], inputModes: ["text"], outputModes: ["text"], privacyModes: ["public"], pricing: { baseUsd: 0, perCallUsd: 1 } },
+          },
+          {
+            walletAddress: "walletB",
+            attested: false,
+            healthcheckStatus: "fail",
+            routingSignals: { feedbackCount: 3, avgFeedbackScore: 1, attestationAgreements: 0, attestationDisagreements: 0 },
+            capabilities: { taskTypes: ["classify"], inputModes: ["text"], outputModes: ["text"], privacyModes: ["public"], pricing: { baseUsd: 0, perCallUsd: 1 } },
+          },
+          {
+            walletAddress: "walletC",
+            attested: false,
+            healthcheckStatus: "pass",
+            routingSignals: { feedbackCount: 4, avgFeedbackScore: 5, attestationAgreements: 0, attestationDisagreements: 0 },
+            capabilities: { taskTypes: ["classify"], inputModes: ["text"], outputModes: ["text"], privacyModes: ["public"], pricing: { baseUsd: 0, perCallUsd: 1 } },
+          },
+        ],
+        null,
+        2
+      )
+    );
+
+    writeFileSync(attestPath, JSON.stringify([{ walletAddress: "walletB", createdAt: new Date().toISOString() }], null, 2));
+    writeFileSync(
+      profilePath,
+      JSON.stringify(
+        [
+          { walletAddress: "walletA", endpointStatus: "online" },
+          { walletAddress: "walletB", endpointStatus: "offline" },
+          { walletAddress: "walletC", endpointStatus: "online" },
+        ],
+        null,
+        2
+      )
+    );
+
+    mockGetProgramAccounts.mockResolvedValue([
+      { pubkey: { toBase58: () => "pdaA" }, account: { data: new Uint8Array([1]) } },
+      { pubkey: { toBase58: () => "pdaB" }, account: { data: new Uint8Array([2]) } },
+    ]);
+
+    mockDecodeAgentAccount
+      .mockReturnValueOnce({ owner: "walletA", agentType: "Primary", model: "", rateLamports: 0n, minReputation: 0, reputationScore: 10, jobsCompleted: 0n, jobsFailed: 0n, createdAt: 0n, active: true, attestationAccuracy: 0 })
+      .mockReturnValueOnce({ owner: "walletB", agentType: "Primary", model: "", rateLamports: 0n, minReputation: 0, reputationScore: 10, jobsCompleted: 0n, jobsFailed: 0n, createdAt: 0n, active: true, attestationAccuracy: 0 });
+
+    const { fetchSpecialistListings } = await import("@/lib/registry/bridge");
+    const result = await fetchSpecialistListings();
+
+    expect(result.ok).toBe(true);
+    expect(result.listings.map((l) => l.walletAddress)).toEqual(["walletB", "walletA", "walletC"]);
+  });
+});

--- a/lib/onboarding/attestor-resolver.ts
+++ b/lib/onboarding/attestor-resolver.ts
@@ -1,0 +1,59 @@
+import "server-only";
+
+import { fetchSpecialistListings } from "@/lib/registry/bridge";
+
+export type ResolveAttestorInput = {
+  taskTypeHint?: string;
+  minAttestationAccuracy?: number;
+  maxPerCallUsd?: number;
+};
+
+export async function resolveAttestor(input: ResolveAttestorInput) {
+  const { listings } = await fetchSpecialistListings();
+
+  const filtered = listings
+    .filter((l) => l.health.status !== "fail")
+    .filter((l) => l.attestation.attested)
+    .filter((l) => {
+      if (typeof input.minAttestationAccuracy !== "number") return true;
+      return l.onchain.attestationAccuracy >= input.minAttestationAccuracy;
+    })
+    .filter((l) => {
+      if (typeof input.maxPerCallUsd !== "number") return true;
+      const cost = l.capabilities?.perCallUsd;
+      return typeof cost === "number" && cost <= input.maxPerCallUsd;
+    })
+    .map((l) => {
+      const reasons: string[] = ["attested", `accuracy:${l.onchain.attestationAccuracy}`];
+      if (l.health.status === "pass") reasons.push("health:pass");
+      if (typeof l.capabilities?.perCallUsd === "number") reasons.push(`cost:${l.capabilities.perCallUsd}`);
+      if (input.taskTypeHint && l.capabilities?.taskTypes.includes(input.taskTypeHint as never)) {
+        reasons.push(`task-fit:${input.taskTypeHint}`);
+      }
+
+      const score =
+        (l.health.status === "pass" ? 30 : 10) +
+        l.onchain.attestationAccuracy * 2 +
+        Math.min(l.signals.avgFeedbackScore * 5, 20) +
+        (input.taskTypeHint && l.capabilities?.taskTypes.includes(input.taskTypeHint as never) ? 20 : 0);
+
+      return {
+        walletAddress: l.walletAddress,
+        endpointUrl: l.health.endpointUrl,
+        attestationAccuracy: l.onchain.attestationAccuracy,
+        avgFeedbackScore: l.signals.avgFeedbackScore,
+        perCallUsd: l.capabilities?.perCallUsd,
+        reasons,
+        score,
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  return {
+    ok: filtered.length > 0,
+    candidate: filtered[0] ?? null,
+    alternatives: filtered.slice(1),
+    count: filtered.length,
+    error: filtered.length > 0 ? undefined : "No eligible attestors found.",
+  };
+}

--- a/lib/onboarding/planner-settlement.ts
+++ b/lib/onboarding/planner-settlement.ts
@@ -1,0 +1,79 @@
+import "server-only";
+
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+type PlannerRunSettlementState =
+  | "pending_evaluation"
+  | "released"
+  | "disputed"
+  | "not_required";
+
+type PlannerRunRecordLike = {
+  runId: string;
+  paymentSatisfied?: boolean;
+  settlementState?: PlannerRunSettlementState;
+  settlementDecisionAt?: string;
+  settlementNotes?: string;
+  settlementDecisionBy?: string;
+  [k: string]: unknown;
+};
+
+const RUNS_PATH = join(process.cwd(), "data", "onboarding", "planner-runs.json");
+
+function readRuns(): PlannerRunRecordLike[] {
+  try {
+    return JSON.parse(readFileSync(RUNS_PATH, "utf8")) as PlannerRunRecordLike[];
+  } catch {
+    return [];
+  }
+}
+
+function writeRuns(records: PlannerRunRecordLike[]) {
+  mkdirSync(join(process.cwd(), "data", "onboarding"), { recursive: true });
+  writeFileSync(RUNS_PATH, JSON.stringify(records, null, 2));
+}
+
+export function decidePlannerSettlement(input: {
+  runId: string;
+  decision: "release" | "dispute";
+  notes?: string;
+  consumerWallet?: string;
+}) {
+  if (!input.runId?.trim()) {
+    throw new Error("runId is required");
+  }
+
+  const runs = readRuns();
+  const idx = runs.findIndex((r) => r.runId === input.runId);
+  if (idx < 0) {
+    throw new Error("Run not found");
+  }
+
+  const run = runs[idx];
+
+  if (run.paymentSatisfied !== true) {
+    throw new Error("Settlement decision requires a payment-satisfied run");
+  }
+
+  const now = new Date().toISOString();
+  const settlementState: PlannerRunSettlementState =
+    input.decision === "release" ? "released" : "disputed";
+
+  const updated: PlannerRunRecordLike = {
+    ...run,
+    settlementState,
+    settlementDecisionAt: now,
+    settlementNotes: input.notes,
+    settlementDecisionBy: input.consumerWallet,
+  };
+
+  runs[idx] = updated;
+  writeRuns(runs);
+
+  return {
+    ok: true,
+    run: updated,
+    storagePath: RUNS_PATH,
+  };
+}


### PR DESCRIPTION
## Summary\n- restore missing bucket gate test files referenced by bdd sweep (B, D/E, H)\n- restore planner tools lifecycle routes: register-consumer, resolve-attestor, release\n- restore onboarding helpers used by lifecycle routes (attestor-resolver, planner-settlement)\n- update planner tools manifest to include restored endpoints\n- add use-case traceability matrix doc for this iteration\n\n## Verification\n- npm run test:bdd:sweep\n- artifact: artifacts/bdd-sweep/20260423-232338/SUMMARY.md\n\n## Why\nAfter PR #93 merged, representative bucket sweep referenced coverage files/routes that were absent on main. This PR restores executable parity so the gate remains trustworthy.