### PR TITLE
Security follow-up: enforce strict x402 probe in registration flow

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -186,14 +186,22 @@ function RegisterInner() {
       const res = await fetch("/api/register/probe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ endpoint }),
+        body: JSON.stringify({ endpoint, requireX402: true }),
       });
       const data = await res.json().catch(() => null);
       if (requestId !== endpointProbeRequestRef.current) return;
 
-      if (!res.ok || !data) {
+      if (!data) {
         setEndpointProbeStatus("unreachable");
         setEndpointProbeMessage("Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel.");
+        return;
+      }
+
+      if (!res.ok) {
+        setEndpointProbeStatus("unreachable");
+        setEndpointProbeMessage(
+          data.error || "Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel."
+        );
         return;
       }
 

--- a/docs/USECASE-TRACEABILITY-MATRIX-2026-04-23.md
+++ b/docs/USECASE-TRACEABILITY-MATRIX-2026-04-23.md
@@ -10,7 +10,7 @@ This matrix maps product use-cases to executable coverage lanes so regressions a
 | A | Onboarding/operator gates | `operator-key-rotation.test.ts`, `onboarding-operator-status-routes.test.ts` | ✅ |
 | B | Discovery/ranking | `registry-route.test.ts`, `registry-bridge-sort.test.ts` | ✅ |
 | C | Planner resolve/invoke/signal | `planner-resolve-route.test.ts`, `planner-invoke-route.test.ts`, `planner-signal-route.test.ts` | ✅ |
-| D/E | Endpoint security + reliability | `endpoint-security-compat.test.ts`, `program-rpc-config.test.ts` | ✅ |
+| D/E | Endpoint security + reliability | `endpoint-security-compat.test.ts`, `program-rpc-config.test.ts`, `register-probe-route.test.ts` | ✅ |
 | F | Jupiter/x402 settlement | `jupiter-client.test.ts`, `packages/x402-solana/tests/payment.test.ts` | ✅ |
 | G | Torque retention layer | `torque-client.test.ts`, `torque-event-route.test.ts`, `torque-leaderboard-route.test.ts`, `torque-onboarding-event.test.ts` | ✅ |
 | H | Consumer lifecycle | `planner-register-consumer-route.test.ts`, `planner-tools-manifest-route.test.ts`, `planner-resolve-attestor-route.test.ts`, `planner-release-route.test.ts`, `planner-auditability.test.ts` | ✅ |
@@ -31,3 +31,4 @@ This matrix maps product use-cases to executable coverage lanes so regressions a
 
 ## Next follow-up
 - Keep this matrix synced with `scripts/run-bdd-bucket-sweep.sh` so each bucket has at least one representative executable gate.
+- Maintain strict registration probe behavior (`requireX402`) so insecure open-completion endpoints fail compliance checks by default.

--- a/scripts/run-bdd-bucket-sweep.sh
+++ b/scripts/run-bdd-bucket-sweep.sh
@@ -46,7 +46,7 @@ run_step "Bucket C (planner consumption contracts)" \
   npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-signal-route.test.ts --runInBand
 
 run_step "Bucket D/E (security + reliability contracts)" \
-  npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/program-rpc-config.test.ts --runInBand
+  npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/program-rpc-config.test.ts lib/__tests__/register-probe-route.test.ts --runInBand
 
 run_step "Bucket F (jupiter + payment contracts)" \
   npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts --runInBand


### PR DESCRIPTION
## Summary
- register endpoint probe now runs in strict mode from UI (`requireX402: true`)
- register page now surfaces API-provided compliance errors when probe fails (instead of generic unreachable text)
- bdd representative sweep now includes `register-probe-route.test.ts` in Bucket D/E
- updated traceability matrix to include register probe security coverage

## Verification
- npm run test:bdd:sweep
- artifact: artifacts/bdd-sweep/20260423-233043/SUMMARY.md

## Why
This closes the gap between warning-only detection and enforcement during specialist endpoint registration compliance checks.
