### PR TITLE
Registration gate: require passing strict endpoint probe before submit

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -167,6 +167,8 @@ function RegisterInner() {
   const [endpointProbeModels, setEndpointProbeModels] = useState<string[]>([]);
   const endpointProbeTimeoutRef = useRef<number | null>(null);
   const endpointProbeRequestRef = useRef(0);
+  const endpointCompliancePassed = endpointProbeStatus === "reachable";
+  const canAdvanceToReview = Boolean(form.name && form.model && form.endpoint.trim() && endpointCompliancePassed);
 
   const runEndpointProbe = async (rawEndpoint: string) => {
     const endpoint = rawEndpoint.trim();
@@ -894,12 +896,18 @@ function RegisterInner() {
             </Button>
             <Button
               onClick={() => setStep(3)}
-              disabled={!form.name || !form.model}
+              disabled={!canAdvanceToReview}
               className="w-full !rounded-lg !bg-blue-600 !px-4 !py-2.5 !font-semibold !text-white !transition hover:!bg-blue-700 disabled:!bg-blue-300"
             >
               Review & Register →
             </Button>
           </div>
+
+          {!endpointCompliancePassed && (
+            <p className="text-xs text-amber-300">
+              Run endpoint probe until it passes compliance before proceeding to registration.
+            </p>
+          )}
         </div>
       )}
       {/* Step 3: Review & confirm */}
@@ -976,10 +984,10 @@ function RegisterInner() {
             </Button>
             <Button
               onClick={handleRegister}
-              disabled={registering}
+              disabled={registering || !endpointCompliancePassed}
               className="w-full !rounded-lg !bg-blue-600 !px-4 !py-2.5 !font-semibold !text-white !transition hover:!bg-blue-700 disabled:!bg-blue-300"
             >
-              {registering ? "Registering..." : "Register Agent (0.01 SOL)"}
+              {registering ? "Registering..." : !endpointCompliancePassed ? "Probe endpoint compliance first" : "Register Agent (0.01 SOL)"}
             </Button>
           </div>
           {txError && (


### PR DESCRIPTION
## Summary
- block Step 2 -> Step 3 progression unless endpoint compliance probe is passed
- block final Register submit unless endpoint compliance probe is passed
- keep strict probe mode (requireX402) active from register UI
- show explicit inline guidance when compliance probe is not yet passing

## Verification
- npx jest lib/__tests__/register-probe-route.test.ts --runInBand
- npm run test:bdd:sweep
- artifact: artifacts/bdd-sweep/20260423-233910/SUMMARY.md

## Why
Previous slice detected insecure endpoints; this slice enforces compliance in registration UX so specialists cannot proceed until endpoint security checks pass.
