### PR TITLE
Onboarding enforcement: fail healthcheck on x402 bypass endpoints

### DIFF
--- a/docs/USECASE-TRACEABILITY-MATRIX-2026-04-23.md
+++ b/docs/USECASE-TRACEABILITY-MATRIX-2026-04-23.md
@@ -10,7 +10,7 @@ This matrix maps product use-cases to executable coverage lanes so regressions a
 | A | Onboarding/operator gates | `operator-key-rotation.test.ts`, `onboarding-operator-status-routes.test.ts` | ✅ |
 | B | Discovery/ranking | `registry-route.test.ts`, `registry-bridge-sort.test.ts` | ✅ |
 | C | Planner resolve/invoke/signal | `planner-resolve-route.test.ts`, `planner-invoke-route.test.ts`, `planner-signal-route.test.ts` | ✅ |
-| D/E | Endpoint security + reliability | `endpoint-security-compat.test.ts`, `program-rpc-config.test.ts`, `register-probe-route.test.ts` | ✅ |
+| D/E | Endpoint security + reliability | `endpoint-security-compat.test.ts`, `program-rpc-config.test.ts`, `register-probe-route.test.ts`, `onboarding-healthcheck-security.test.ts` | ✅ |
 | F | Jupiter/x402 settlement | `jupiter-client.test.ts`, `packages/x402-solana/tests/payment.test.ts` | ✅ |
 | G | Torque retention layer | `torque-client.test.ts`, `torque-event-route.test.ts`, `torque-leaderboard-route.test.ts`, `torque-onboarding-event.test.ts` | ✅ |
 | H | Consumer lifecycle | `planner-register-consumer-route.test.ts`, `planner-tools-manifest-route.test.ts`, `planner-resolve-attestor-route.test.ts`, `planner-release-route.test.ts`, `planner-auditability.test.ts` | ✅ |
@@ -32,3 +32,4 @@ This matrix maps product use-cases to executable coverage lanes so regressions a
 ## Next follow-up
 - Keep this matrix synced with `scripts/run-bdd-bucket-sweep.sh` so each bucket has at least one representative executable gate.
 - Maintain strict registration probe behavior (`requireX402`) so insecure open-completion endpoints fail compliance checks by default.
+- Keep onboarding healthcheck x402 compliance checks aligned with register probe enforcement to prevent bypass via wizard path.

--- a/lib/__tests__/onboarding-healthcheck-security.test.ts
+++ b/lib/__tests__/onboarding-healthcheck-security.test.ts
@@ -1,0 +1,61 @@
+import { runSpecialistHealthcheck } from "@/lib/onboarding/healthcheck";
+
+describe("onboarding healthcheck security enforcement", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  function mockResponse(status: number, ok: boolean, headers?: Record<string, string | null>) {
+    return {
+      status,
+      ok,
+      headers: {
+        get: (name: string) => headers?.[name] ?? headers?.[name.toLowerCase()] ?? null,
+      },
+    } as Response;
+  }
+
+  it("passes when x402 challenge is detected", async () => {
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(mockResponse(200, true))
+      .mockResolvedValueOnce(mockResponse(200, true))
+      .mockResolvedValueOnce(mockResponse(200, true))
+      .mockResolvedValueOnce(mockResponse(402, false))
+      .mockResolvedValueOnce(mockResponse(402, false, { "x402-request": "{}" }));
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await runSpecialistHealthcheck({
+      endpointUrl: "https://specialist.example",
+      walletAddress: "11111111111111111111111111111111",
+    });
+
+    expect(result.securityStatus).toBe("x402_challenge_detected");
+    expect(result.x402Probe).toBe("ok");
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails when endpoint serves open completion without x402 challenge", async () => {
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(mockResponse(200, true))
+      .mockResolvedValueOnce(mockResponse(200, true))
+      .mockResolvedValueOnce(mockResponse(200, true))
+      .mockResolvedValueOnce(mockResponse(200, true))
+      .mockResolvedValueOnce(mockResponse(200, true));
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await runSpecialistHealthcheck({
+      endpointUrl: "https://specialist.example",
+      walletAddress: "11111111111111111111111111111111",
+    });
+
+    expect(result.securityStatus).toBe("insecure_open_completion");
+    expect(result.x402Probe).toBe("fail");
+    expect(result.status).toBe("fail");
+    expect(result.note).toMatch(/without x402 challenge/i);
+  });
+});

--- a/lib/onboarding/healthcheck.ts
+++ b/lib/onboarding/healthcheck.ts
@@ -15,6 +15,7 @@ export type SpecialistHealthcheckResult = {
   status: "pass" | "degraded" | "fail";
   reachable: boolean;
   x402Probe: "ok" | "degraded" | "fail";
+  securityStatus: "unknown" | "x402_challenge_detected" | "insecure_open_completion";
   endpoint: string;
   checkedAt: string;
   note: string;
@@ -87,9 +88,36 @@ export async function runSpecialistHealthcheck(
     redirect: "follow",
   });
 
+  let securityStatus: SpecialistHealthcheckResult["securityStatus"] = "unknown";
+  try {
+    const challengeProbe = await fetch(`${endpoint.replace(/\/$/, "")}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "probe",
+        messages: [{ role: "user", content: "ping" }],
+        max_tokens: 1,
+      }),
+      signal: AbortSignal.timeout(3000),
+    });
+
+    const x402Header =
+      challengeProbe.headers?.get("x402-request") || challengeProbe.headers?.get("X-402-Request");
+
+    if (challengeProbe.status === 402 && x402Header) {
+      securityStatus = "x402_challenge_detected";
+    } else if (challengeProbe.ok) {
+      securityStatus = "insecure_open_completion";
+    }
+  } catch {
+    securityStatus = "unknown";
+  }
+
   const reachable = rootProbe.ok || healthProbe.ok || tagsProbe.ok;
   const x402Probe: SpecialistHealthcheckResult["x402Probe"] =
-    x402ModelsProbe.status === 402 || x402ModelsProbe.ok
+    securityStatus === "insecure_open_completion"
+      ? "fail"
+    : x402ModelsProbe.status === 402 || x402ModelsProbe.ok
       ? "ok"
       : x402ModelsProbe.status === 404 || x402ModelsProbe.status === 405
       ? "degraded"
@@ -104,6 +132,8 @@ export async function runSpecialistHealthcheck(
   const status: SpecialistHealthcheckResult["status"] =
     reachable && runtimeOk && x402Probe === "ok"
       ? "pass"
+    : x402Probe === "fail"
+      ? "fail"
     : reachable
       ? "degraded"
       : "fail";
@@ -111,6 +141,8 @@ export async function runSpecialistHealthcheck(
   const note =
     status === "pass"
       ? "Endpoint reachable, runtime probe succeeded (`/api/tags`), and x402 public path probe succeeded (`/v1/models`)."
+    : securityStatus === "insecure_open_completion"
+      ? "Endpoint served completion without x402 challenge. Put a payment-enforcing gateway/proxy in front before onboarding attestation."
     : status === "degraded"
       ? "Endpoint reachable but runtime or x402 probe is degraded. Confirm token-gated proxy is running and x402 public path (`/v1/*`) is exposed without token."
       : "Endpoint unreachable. Re-open tunnel and verify local runtime is listening.";
@@ -119,6 +151,7 @@ export async function runSpecialistHealthcheck(
     status,
     reachable,
     x402Probe,
+    securityStatus,
     endpoint,
     checkedAt,
     note,

--- a/scripts/run-bdd-bucket-sweep.sh
+++ b/scripts/run-bdd-bucket-sweep.sh
@@ -46,7 +46,7 @@ run_step "Bucket C (planner consumption contracts)" \
   npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-signal-route.test.ts --runInBand
 
 run_step "Bucket D/E (security + reliability contracts)" \
-  npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/program-rpc-config.test.ts lib/__tests__/register-probe-route.test.ts --runInBand
+  npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/program-rpc-config.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/onboarding-healthcheck-security.test.ts --runInBand
 
 run_step "Bucket F (jupiter + payment contracts)" \
   npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts --runInBand


### PR DESCRIPTION
## Summary
- onboarding healthcheck now challenge-probes `/v1/chat/completions` and marks `securityStatus` as:
  - `x402_challenge_detected`
  - `insecure_open_completion`
  - `unknown`
- healthcheck now hard-fails when endpoint serves open completions without an x402 challenge
- adds dedicated contract test: `lib/__tests__/onboarding-healthcheck-security.test.ts`
- includes the new healthcheck security contract in Bucket D/E representative sweep
- updates use-case traceability matrix with onboarding healthcheck security lane

## Verification
- npx jest lib/__tests__/onboarding-healthcheck-security.test.ts --runInBand
- npm run test:bdd:sweep
- artifact: artifacts/bdd-sweep/20260423-235247/SUMMARY.md

## Why
PR #95 and #96 made register-time x402 checks strict. This closes the remaining bypass path by enforcing the same security contract in onboarding healthcheck before attestation completion.
