### PR TITLE
feat: ngrok-first onboarding endpoint manager + fallback coverage

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -293,7 +293,7 @@ export default function OnboardingPage() {
 
   const endpointPreview = useMemo(() => {
     if (!state.ollamaPort || !state.consentExposeEndpoint) return "Not configured";
-    return state.endpointUrl || `https://your-agent.localtunnel.me (maps to :${state.ollamaPort})`;
+    return state.endpointUrl || `https://your-subdomain.ngrok-free.app (maps to :${state.ollamaPort})`;
   }, [state.ollamaPort, state.consentExposeEndpoint, state.endpointUrl]);
 
   const operatorStatusState = useMemo<"missing" | "invalid" | "ready" | "stale">(() => {
@@ -653,7 +653,7 @@ export default function OnboardingPage() {
         {step === 3 && (
           <div className="space-y-4">
             <h2 className="text-lg font-semibold">3. Endpoint setup</h2>
-            <p className="text-sm text-muted-foreground">Configure token-gated proxy + tunnel endpoint mapped to your local runtime port.</p>
+            <p className="text-sm text-muted-foreground">Configure token-gated proxy + tunnel endpoint mapped to your local runtime port (ngrok-first, localtunnel fallback).</p>
             <div>
               <Label className="mb-1 block">Tunnel endpoint (optional override)</Label>
               <Input
@@ -671,7 +671,7 @@ export default function OnboardingPage() {
                     endpointAuthToken: "",
                   }))
                 }
-                placeholder="https://my-specialist.localtunnel.me"
+                placeholder="https://your-subdomain.ngrok-free.app"
               />
             </div>
             <div className="rounded-lg border border-white/10 bg-black/30 p-3 text-sm">

--- a/lib/__tests__/endpoint-manager-reliability.test.ts
+++ b/lib/__tests__/endpoint-manager-reliability.test.ts
@@ -67,7 +67,7 @@ describe("endpoint manager reliability contracts (E1)", () => {
     const hb = await heartbeatEndpoint({});
     expect(hb.status).toBe("offline");
     expect(hb.heartbeatOk).toBe(false);
-    expect(hb.note).toMatch(/Re-open tunnel/i);
+    expect(hb.note).toMatch(/Restart ngrok|Re-open tunnel/i);
   });
 
   it("heartbeat reports proxy remediation when runtime is up but proxy/remote are down", async () => {

--- a/lib/__tests__/endpoint-security-compat.test.ts
+++ b/lib/__tests__/endpoint-security-compat.test.ts
@@ -28,10 +28,32 @@ describe("endpoint security compatibility (Bucket D)", () => {
     const result = await createOrRotateEndpoint({
       consentExposeEndpoint: true,
       port: 11434,
-      endpointUrl: "https://reddi-test.localtunnel.me",
+      endpointUrl: "https://reddi-test.ngrok-free.app",
     });
 
     expect(result.x402PublicPrefixes).toEqual(["/v1", "/x402", "/healthz"]);
+  });
+
+  it("defaults to ngrok provider + command when endpoint host is not localtunnel", async () => {
+    const result = await createOrRotateEndpoint({
+      consentExposeEndpoint: true,
+      port: 11434,
+      endpointUrl: "https://reddi-test.ngrok-free.app",
+    });
+
+    expect(result.provider).toBe("ngrok");
+    expect(result.tunnelCommand).toMatch(/^ngrok http /);
+  });
+
+  it("keeps localtunnel fallback support when localtunnel URL is used", async () => {
+    const result = await createOrRotateEndpoint({
+      consentExposeEndpoint: true,
+      port: 11434,
+      endpointUrl: "https://reddi-test.localtunnel.me",
+    });
+
+    expect(result.provider).toBe("localtunnel-compatible");
+    expect(result.tunnelCommand).toContain("localtunnel");
   });
 
   it("generated token-gated proxy script bypasses public x402 paths and gates non-public paths", async () => {

--- a/lib/onboarding/endpoint-manager.ts
+++ b/lib/onboarding/endpoint-manager.ts
@@ -15,7 +15,7 @@ export type EndpointActionResult = {
   status: "online" | "offline";
   heartbeatOk: boolean;
   heartbeatCheckedAt: string;
-  provider: "localtunnel-compatible";
+  provider: "ngrok" | "localtunnel-compatible";
   tunnelCommand: string;
   proxyCommand: string;
   proxyPort: number;
@@ -32,7 +32,7 @@ type SpecialistProfile = {
   endpoint: {
     url: string;
     status: "online" | "offline";
-    provider: "localtunnel-compatible";
+    provider: "ngrok" | "localtunnel-compatible";
     localPort: number;
     proxyPort: number;
     heartbeatOk: boolean;
@@ -81,6 +81,16 @@ function inferSubdomain(endpointUrl: string) {
   } catch {
     return `reddi-${randomSuffix()}`;
   }
+}
+
+function inferTunnelProvider(endpointUrl: string): "ngrok" | "localtunnel-compatible" {
+  try {
+    const host = new URL(endpointUrl).hostname.toLowerCase();
+    if (host.includes("localtunnel.me")) return "localtunnel-compatible";
+  } catch {
+    // default below
+  }
+  return "ngrok";
 }
 
 function resolveProxyPort(localPort: number) {
@@ -221,8 +231,27 @@ function readProfile(): SpecialistProfile | null {
 }
 
 function buildTunnelCommand(proxyPort: number, endpointUrl: string) {
-  const subdomain = inferSubdomain(endpointUrl);
-  return `npx localtunnel --port ${proxyPort} --subdomain ${subdomain}`;
+  const provider = inferTunnelProvider(endpointUrl);
+  if (provider === "localtunnel-compatible") {
+    const subdomain = inferSubdomain(endpointUrl);
+    return `npx localtunnel --port ${proxyPort} --subdomain ${subdomain}`;
+  }
+
+  return `ngrok http ${proxyPort}`;
+}
+
+function buildTunnelRecoveryNote(provider: "ngrok" | "localtunnel-compatible", tunnelCommand: string) {
+  if (provider === "ngrok") {
+    return `Tunnel appears down. Restart ngrok: ${tunnelCommand}`;
+  }
+  return `Tunnel appears down. Re-open tunnel: ${tunnelCommand}`;
+}
+
+function buildHeartbeatRecoveryNote(provider: "ngrok" | "localtunnel-compatible", tunnelCommand: string) {
+  if (provider === "ngrok") {
+    return `Endpoint heartbeat failed. Restart ngrok with: ${tunnelCommand}`;
+  }
+  return `Endpoint heartbeat failed. Re-open tunnel with: ${tunnelCommand}`;
 }
 
 function buildProxyCommand(localPort: number, proxyPort: number, token: string) {
@@ -241,11 +270,12 @@ export async function createOrRotateEndpoint(input: EndpointActionInput): Promis
   ensureTokenProxyScript();
 
   const endpointUrl =
-    normalizeEndpointUrl(input.endpointUrl) || `https://reddi-${randomSuffix()}.localtunnel.me`;
+    normalizeEndpointUrl(input.endpointUrl) || `https://your-subdomain.ngrok-free.app`;
   const token = issueEndpointToken();
   const proxyPort = resolveProxyPort(input.port);
   const proxyCommand = buildProxyCommand(input.port, proxyPort, token);
   const tunnelCommand = buildTunnelCommand(proxyPort, endpointUrl);
+  const provider = inferTunnelProvider(endpointUrl);
 
   const localOk = await checkLocalRuntime(input.port);
   const localProxyOk = await checkLocalTokenProxy(proxyPort, token);
@@ -260,7 +290,7 @@ export async function createOrRotateEndpoint(input: EndpointActionInput): Promis
     : !localProxyOk && !remoteOk
     ? `Token-gated proxy is not running. Start it first: ${proxyCommand}`
     : !remoteOk
-    ? `Tunnel appears down. Re-open tunnel: ${tunnelCommand}`
+    ? buildTunnelRecoveryNote(provider, tunnelCommand)
     : `Endpoint check failed. Re-run endpoint onboarding.`;
 
   const profile: SpecialistProfile = {
@@ -268,7 +298,7 @@ export async function createOrRotateEndpoint(input: EndpointActionInput): Promis
     endpoint: {
       url: endpointUrl,
       status: heartbeatOk ? "online" : "offline",
-      provider: "localtunnel-compatible",
+      provider,
       localPort: input.port,
       proxyPort,
       heartbeatOk,
@@ -292,7 +322,7 @@ export async function createOrRotateEndpoint(input: EndpointActionInput): Promis
     status: profile.endpoint.status,
     heartbeatOk,
     heartbeatCheckedAt,
-    provider: "localtunnel-compatible",
+    provider,
     tunnelCommand,
     proxyCommand,
     proxyPort,
@@ -324,6 +354,7 @@ export async function heartbeatEndpoint(input: {
   }
 
   const tunnelCommand = buildTunnelCommand(proxyPort, endpointUrl);
+  const provider = inferTunnelProvider(endpointUrl);
   const proxyCommand = buildProxyCommand(port, proxyPort, token);
 
   const localOk = await checkLocalRuntime(port);
@@ -339,7 +370,7 @@ export async function heartbeatEndpoint(input: {
     : !localProxyOk && !remoteOk
     ? `Token-gated proxy is offline. Start it with: ${proxyCommand}`
     : !remoteOk
-    ? `Endpoint heartbeat failed. Re-open tunnel with: ${tunnelCommand}`
+    ? buildHeartbeatRecoveryNote(provider, tunnelCommand)
     : "Endpoint heartbeat failed. Re-run endpoint onboarding.";
 
   const profile: SpecialistProfile = {
@@ -347,7 +378,7 @@ export async function heartbeatEndpoint(input: {
     endpoint: {
       url: endpointUrl,
       status: heartbeatOk ? "online" : "offline",
-      provider: "localtunnel-compatible",
+      provider,
       localPort: port,
       proxyPort,
       heartbeatOk,
@@ -371,7 +402,7 @@ export async function heartbeatEndpoint(input: {
     status: profile.endpoint.status,
     heartbeatOk,
     heartbeatCheckedAt,
-    provider: "localtunnel-compatible",
+    provider,
     tunnelCommand,
     proxyCommand,
     proxyPort,


### PR DESCRIPTION
## Summary
- switch onboarding endpoint manager to ngrok-first defaults while preserving localtunnel fallback
- update step-3 onboarding copy/placeholders to ngrok-first endpoint guidance
- add regression coverage for provider detection + tunnel command generation paths

## Validation
- npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/endpoint-manager-reliability.test.ts --runInBand
- npx eslint app/onboarding/page.tsx lib/onboarding/endpoint-manager.ts lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/endpoint-manager-reliability.test.ts