### PR TITLE
fix: guard Cloudflare tunnel onboarding while RCA is active

### DIFF
--- a/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
+++ b/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
@@ -1,0 +1,32 @@
+# Cloudflare Tunnel RCA (2026-04-24)
+
+## Context
+Cloudflare Tunnel was intentionally deferred in specialist endpoint onboarding because endpoint reliability and x402-compatible behavior were inconsistent during fast setup flows.
+
+## Current guardrail (live)
+- Onboarding endpoint manager now rejects Cloudflare tunnel hostnames (`*.trycloudflare.com`, `*.cfargotunnel.com`) with a clear error.
+- Operators are redirected to ngrok-first (or localtunnel fallback) until Cloudflare path is re-qualified.
+
+## Hypotheses to validate
+1. Cloudflare edge/proxy behavior around streaming and HEAD/health probes causes false negatives in onboarding heartbeat.
+2. Path handling for `/v1/*`, `/x402/*`, `/healthz` may differ from expected pass-through defaults.
+3. Long-lived tunnel stability under local-runtime restarts introduces onboarding flakiness.
+
+## Repro plan
+1. Establish controlled local fixture: token-gated proxy + deterministic mock upstream.
+2. Compare ngrok vs Cloudflare on the same proxy port across:
+   - `HEAD /`
+   - `GET /healthz`
+   - `POST /v1/chat/completions`
+   - x402 challenge path under `/x402/*`
+3. Record pass/fail + latency + error class for 30-run sample.
+4. Document required Cloudflare config to make checks deterministic.
+
+## Exit criteria to re-enable Cloudflare
+- 30/30 stable onboarding heartbeat checks
+- x402 challenge + non-public token gating both preserved
+- No regression in registration probe security classification
+- Clear, minimal operator runbook with reproducible commands
+
+## Temporary operator policy
+Use ngrok HTTPS endpoint for onboarding and registration. Treat Cloudflare tunnel as unsupported until this RCA is closed.

--- a/docs/SPECIALIST-ENDPOINT-SECURITY-GUIDANCE-2026-04-23.md
+++ b/docs/SPECIALIST-ENDPOINT-SECURITY-GUIDANCE-2026-04-23.md
@@ -6,6 +6,7 @@ Ollama has no built-in auth for public exposure. If a specialist exposes raw Oll
 ## Decision for next iteration
 - **Default tunnel guidance: ngrok-first**
 - **Cloudflare tunnel: deferred** until root-cause + reproducible tests are green
+- **Current guardrail:** onboarding rejects Cloudflare tunnel hostnames during RCA window
 - Goal: minimum secure setup steps so specialists can monetize quickly
 
 ## Recommended security patterns (practical options)
@@ -48,6 +49,7 @@ Pros: strongest posture; Cons: higher setup burden.
 
 ## References
 - ngrok Ollama example (traffic policy + optional basic auth): https://ngrok.com/docs/universal-gateway/examples/ollama
+- Cloudflare RCA tracker (active): `docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md`
 - Cloudflare tunnel common error diagnostics (kept for deferred RCA): https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/troubleshoot-tunnels/common-errors/
 - Observed issue threads for tunnel instability/perf to track during RCA:
   - https://github.com/ollama/ollama/issues/3271

--- a/lib/__tests__/endpoint-security-compat.test.ts
+++ b/lib/__tests__/endpoint-security-compat.test.ts
@@ -56,6 +56,16 @@ describe("endpoint security compatibility (Bucket D)", () => {
     expect(result.tunnelCommand).toContain("localtunnel");
   });
 
+  it("rejects Cloudflare tunnel endpoints while RCA hardening is active", async () => {
+    await expect(
+      createOrRotateEndpoint({
+        consentExposeEndpoint: true,
+        port: 11434,
+        endpointUrl: "https://abc.trycloudflare.com",
+      })
+    ).rejects.toThrow(/temporarily unsupported|RCA/i);
+  });
+
   it("generated token-gated proxy script bypasses public x402 paths and gates non-public paths", async () => {
     await createOrRotateEndpoint({
       consentExposeEndpoint: true,

--- a/lib/onboarding/endpoint-manager.ts
+++ b/lib/onboarding/endpoint-manager.ts
@@ -83,6 +83,15 @@ function inferSubdomain(endpointUrl: string) {
   }
 }
 
+function isCloudflareTunnelHost(endpointUrl: string) {
+  try {
+    const host = new URL(endpointUrl).hostname.toLowerCase();
+    return host.includes("trycloudflare.com") || host.includes("cfargotunnel.com");
+  } catch {
+    return false;
+  }
+}
+
 function inferTunnelProvider(endpointUrl: string): "ngrok" | "localtunnel-compatible" {
   try {
     const host = new URL(endpointUrl).hostname.toLowerCase();
@@ -271,6 +280,11 @@ export async function createOrRotateEndpoint(input: EndpointActionInput): Promis
 
   const endpointUrl =
     normalizeEndpointUrl(input.endpointUrl) || `https://your-subdomain.ngrok-free.app`;
+  if (isCloudflareTunnelHost(endpointUrl)) {
+    throw new Error(
+      "Cloudflare Tunnel onboarding is temporarily unsupported while RCA is in progress. Use an ngrok HTTPS endpoint (recommended) or localtunnel fallback."
+    );
+  }
   const token = issueEndpointToken();
   const proxyPort = resolveProxyPort(input.port);
   const proxyCommand = buildProxyCommand(input.port, proxyPort, token);
@@ -346,6 +360,11 @@ export async function heartbeatEndpoint(input: {
 
   const port = input.port ?? existing?.endpoint.localPort;
   const endpointUrl = normalizeEndpointUrl(input.endpointUrl || existing?.endpoint.url);
+  if (endpointUrl && isCloudflareTunnelHost(endpointUrl)) {
+    throw new Error(
+      "Cloudflare Tunnel endpoint detected. This path is temporarily disabled pending RCA, use ngrok endpoint and rerun endpoint setup."
+    );
+  }
   const token = existing?.endpoint.auth.token;
   const proxyPort = existing?.endpoint.proxyPort ?? (port ? resolveProxyPort(port) : undefined);
 


### PR DESCRIPTION
## Summary
- reject Cloudflare tunnel hostnames in onboarding endpoint create/heartbeat paths while RCA is unresolved
- keep operator path clear with actionable ngrok-first fallback error messaging
- add RCA tracker doc with hypotheses, repro plan, and re-enable exit criteria
- update specialist endpoint security guidance to reference active RCA + guardrail

## Validation
- npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/endpoint-manager-reliability.test.ts --runInBand
- npm run test:bdd:sweep