### PR TITLE
fix: enforce Cloudflare tunnel guardrail in register probe

### DIFF
--- a/app/api/register/probe/route.ts
+++ b/app/api/register/probe/route.ts
@@ -17,6 +17,11 @@ function normalizeEndpoint(endpoint: string) {
   }
 }
 
+function isCloudflareTunnelHost(hostname: string) {
+  const host = hostname.toLowerCase();
+  return host.includes("trycloudflare.com") || host.includes("cfargotunnel.com");
+}
+
 export async function POST(req: Request) {
   const body = await req.json().catch(() => null);
   const endpoint = body?.endpoint;
@@ -51,6 +56,18 @@ export async function POST(req: Request) {
           ok: false,
           status: "invalid_url",
           error: "Localhost/private-network targets are blocked in hosted context. Use a public tunnel URL (ngrok recommended, localtunnel fallback)."
+        },
+        { status: 400 }
+      );
+    }
+
+    if (isCloudflareTunnelHost(url.hostname)) {
+      return NextResponse.json(
+        {
+          ok: false,
+          status: "unsupported_tunnel_provider",
+          error:
+            "Cloudflare Tunnel is temporarily unsupported while RCA hardening is active. Use an ngrok HTTPS endpoint (recommended) or localtunnel fallback.",
         },
         { status: 400 }
       );

--- a/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
+++ b/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
@@ -4,7 +4,8 @@
 Cloudflare Tunnel was intentionally deferred in specialist endpoint onboarding because endpoint reliability and x402-compatible behavior were inconsistent during fast setup flows.
 
 ## Current guardrail (live)
-- Onboarding endpoint manager now rejects Cloudflare tunnel hostnames (`*.trycloudflare.com`, `*.cfargotunnel.com`) with a clear error.
+- Onboarding endpoint manager rejects Cloudflare tunnel hostnames (`*.trycloudflare.com`, `*.cfargotunnel.com`) with a clear error.
+- Register probe route also rejects Cloudflare tunnel hostnames so unsupported endpoints fail before registration.
 - Operators are redirected to ngrok-first (or localtunnel fallback) until Cloudflare path is re-qualified.
 
 ## Hypotheses to validate

--- a/docs/SPECIALIST-ENDPOINT-SECURITY-GUIDANCE-2026-04-23.md
+++ b/docs/SPECIALIST-ENDPOINT-SECURITY-GUIDANCE-2026-04-23.md
@@ -6,7 +6,7 @@ Ollama has no built-in auth for public exposure. If a specialist exposes raw Oll
 ## Decision for next iteration
 - **Default tunnel guidance: ngrok-first**
 - **Cloudflare tunnel: deferred** until root-cause + reproducible tests are green
-- **Current guardrail:** onboarding rejects Cloudflare tunnel hostnames during RCA window
+- **Current guardrail:** onboarding + register probe reject Cloudflare tunnel hostnames during RCA window
 - Goal: minimum secure setup steps so specialists can monetize quickly
 
 ## Recommended security patterns (practical options)

--- a/lib/__tests__/register-probe-route.test.ts
+++ b/lib/__tests__/register-probe-route.test.ts
@@ -28,6 +28,22 @@ describe("register probe route", () => {
     });
   });
 
+  it("blocks Cloudflare tunnel endpoints while RCA hardening is active", async () => {
+    const { POST } = await import("@/app/api/register/probe/route");
+    const req = new NextRequest("http://localhost/api/register/probe", {
+      method: "POST",
+      body: JSON.stringify({ endpoint: "https://abc.trycloudflare.com" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      status: "unsupported_tunnel_provider",
+    });
+  });
+
   it("rejects malformed sourceAdapter manifests with actionable errors", async () => {
     const { POST } = await import("@/app/api/register/probe/route");
     const req = new NextRequest("http://localhost/api/register/probe", {


### PR DESCRIPTION
## Summary
- add Cloudflare tunnel hostname rejection in `/api/register/probe` (`*.trycloudflare.com`, `*.cfargotunnel.com`)
- return explicit `unsupported_tunnel_provider` status with ngrok-first fallback guidance
- add route test coverage for Cloudflare endpoint rejection
- update RCA/security guidance docs to reflect guardrail now applies in onboarding + register probe

## Validation
- `npx jest lib/__tests__/register-probe-route.test.ts lib/__tests__/endpoint-security-compat.test.ts --runInBand`
- `npm run test:bdd:sweep`
