### PR TITLE
fix: switch guided setup tunnel flow to ngrok-first

### DIFF
--- a/components/GuidedSetupModal.tsx
+++ b/components/GuidedSetupModal.tsx
@@ -28,12 +28,21 @@ type ProbeResult = {
 
 const STEP_BADGE = "w-7 h-7 rounded-full bg-blue-600 text-white text-sm font-bold flex items-center justify-center";
 
-const CLOUDFLARED_INSTALL: Record<Platform, string> = {
-  macos: "brew install cloudflared",
-  linux:
-    "curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o cloudflared && chmod +x cloudflared && sudo mv cloudflared /usr/local/bin/",
-  windows: "winget install Cloudflare.cloudflared",
+const NGROK_INSTALL: Record<Platform, string> = {
+  macos: "brew install ngrok/ngrok/ngrok",
+  linux: "Download from https://ngrok.com/download and install ngrok binary",
+  windows: "winget install Ngrok.Ngrok",
 };
+
+function inferTunnelPort(baseUrl: string, fallback: number) {
+  try {
+    const parsed = new URL(normalizeBaseUrl(baseUrl));
+    if (parsed.port) return Number(parsed.port);
+    return parsed.protocol === "https:" ? 443 : 80;
+  } catch {
+    return fallback;
+  }
+}
 
 const RUNTIME_CONFIG: Record<
   RuntimeChoice,
@@ -221,11 +230,11 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
   const completedStep4 = tunnelStatus === "done";
 
   const selectedRuntimeInstall = useMemo(() => runtimeConfig.install[platform], [platform, runtimeConfig]);
-  const selectedCloudflaredInstall = useMemo(() => CLOUDFLARED_INSTALL[platform], [platform]);
-  const tunnelCommand = useMemo(
-    () => `cloudflared tunnel --url ${runtimeBaseUrl || runtimeConfig.defaultBaseUrl}`,
-    [runtimeBaseUrl, runtimeConfig]
-  );
+  const selectedNgrokInstall = useMemo(() => NGROK_INSTALL[platform], [platform]);
+  const tunnelCommand = useMemo(() => {
+    const port = inferTunnelPort(runtimeBaseUrl || runtimeConfig.defaultBaseUrl, runtimeChoice === "ollama" ? 11434 : 8080);
+    return `ngrok http ${port}`;
+  }, [runtimeBaseUrl, runtimeConfig, runtimeChoice]);
   const sshFallback = useMemo(() => {
     try {
       const url = new URL(normalizeBaseUrl(runtimeBaseUrl || runtimeConfig.defaultBaseUrl));
@@ -311,7 +320,7 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
     const candidate = endpointInput.trim();
     if (!candidate) {
       setTunnelStatus("error");
-      setDetailMessage("Paste your cloudflared URL first.");
+      setDetailMessage("Paste your tunnel URL first (ngrok recommended).");
       return;
     }
 
@@ -342,10 +351,10 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
         return;
       }
       setTunnelStatus("error");
-      setDetailMessage(data?.error || "Can't reach that URL. Is cloudflared still running?");
+      setDetailMessage(data?.error || "Can't reach that URL. Is ngrok or localtunnel still running?");
     } catch {
       setTunnelStatus("error");
-      setDetailMessage("Can't reach that URL. Is cloudflared still running?");
+      setDetailMessage("Can't reach that URL. Is ngrok or localtunnel still running?");
     }
   };
 
@@ -487,14 +496,14 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
           <StepCard
             index={3}
             title="Start the tunnel"
-            description="cloudflared gives you a public HTTPS URL, no account needed."
+            description="Use ngrok (recommended) for a stable public HTTPS URL."
             completed={completedStep3}
             locked={!completedStep2}
           >
             <div className="space-y-3">
               <div className="space-y-2">
-                <p className="text-xs uppercase tracking-wide text-muted-foreground">Install cloudflared</p>
-                <CommandBlock command={selectedCloudflaredInstall} />
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Install ngrok</p>
+                <CommandBlock command={selectedNgrokInstall} />
               </div>
               <div className="space-y-2">
                 <p className="text-xs uppercase tracking-wide text-muted-foreground">Start tunnel</p>
@@ -502,11 +511,11 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
               </div>
               <div className="flex items-end gap-2">
                 <div className="flex-1 space-y-2">
-                  <p className="text-sm text-muted-foreground">Paste the https:// URL from your terminal output.</p>
+                  <p className="text-sm text-muted-foreground">Paste the https:// URL from ngrok output (or localtunnel fallback).</p>
                   <Input
                     value={endpointInput}
                     onChange={(e) => setEndpointInput(e.target.value)}
-                    placeholder="https://random-words.trycloudflare.com"
+                    placeholder="https://your-subdomain.ngrok-free.app"
                   />
                 </div>
                 <Button type="button" variant="outline" onClick={checkTunnel} disabled={tunnelStatus === "checking" || modelStatus !== "done"}>


### PR DESCRIPTION
## Summary
- replace cloudflared-first Quick Setup tunnel guidance with ngrok-first guidance
- update install/start commands, endpoint placeholder, and tunnel troubleshooting copy
- keep fallback paths (localtunnel/SSH) while aligning messaging with active RCA guardrail policy

## Validation
- 
- 
> web@0.1.0 test:bdd:sweep
> ./scripts/run-bdd-bucket-sweep.sh

[bdd-sweep] starting representative per-bucket verification
[bdd-sweep] artifacts: /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code-pr97/artifacts/bdd-sweep/20260424-075938

[bdd-sweep] >>> Bucket A (onboarding/operator gates)
PASS lib/__tests__/operator-key-rotation.test.ts
PASS lib/__tests__/onboarding-operator-status-routes.test.ts

Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        0.431 s, estimated 1 s
Ran all test suites matching lib/__tests__/operator-key-rotation.test.ts|lib/__tests__/onboarding-operator-status-routes.test.ts.

[bdd-sweep] >>> Bucket B (discovery + ranking contracts)
PASS lib/__tests__/registry-route.test.ts
PASS lib/__tests__/registry-bridge-sort.test.ts

Test Suites: 2 passed, 2 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        0.159 s, estimated 1 s
Ran all test suites matching lib/__tests__/registry-route.test.ts|lib/__tests__/registry-bridge-sort.test.ts.

[bdd-sweep] >>> Bucket C (planner consumption contracts)
PASS lib/__tests__/planner-resolve-route.test.ts
PASS lib/__tests__/planner-invoke-route.test.ts
PASS lib/__tests__/planner-signal-route.test.ts

Test Suites: 3 passed, 3 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        0.218 s, estimated 1 s
Ran all test suites matching lib/__tests__/planner-resolve-route.test.ts|lib/__tests__/planner-invoke-route.test.ts|lib/__tests__/planner-signal-route.test.ts.

[bdd-sweep] >>> Bucket D/E (security + reliability contracts)
PASS lib/__tests__/register-probe-route.test.ts
PASS lib/__tests__/program-rpc-config.test.ts
PASS lib/__tests__/endpoint-security-compat.test.ts
PASS lib/__tests__/onboarding-healthcheck-security.test.ts

Test Suites: 4 passed, 4 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        0.289 s, estimated 1 s
Ran all test suites matching lib/__tests__/endpoint-security-compat.test.ts|lib/__tests__/program-rpc-config.test.ts|lib/__tests__/register-probe-route.test.ts|lib/__tests__/onboarding-healthcheck-security.test.ts.

[bdd-sweep] >>> Bucket F (jupiter + payment contracts)
PASS lib/__tests__/jupiter-client.test.ts
PASS lib/__tests__/planner-invoke-route.test.ts

Test Suites: 2 passed, 2 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        0.154 s, estimated 1 s
Ran all test suites matching lib/__tests__/jupiter-client.test.ts|lib/__tests__/planner-invoke-route.test.ts.

[bdd-sweep] >>> Bucket F package payment contracts

> @reddi/x402-solana@0.1.0 test
> jest --runInBand tests/payment.test.ts

PASS tests/payment.test.ts
  x402 Payment Module
    parseX402Header
      ✓ should parse valid x402-request header (2 ms)
      ✓ should reject zero amount (3 ms)
      ✓ should reject negative amount
      ✓ should reject missing paymentAddress
      ✓ should reject missing nonce
      ✓ should reject invalid JSON
    Nonce Store
      ✓ should accept first nonce (1 ms)
      ✓ should reject duplicate nonce
      ✓ should accept different nonces
      ✓ should allow re-acceptance after clearNonces
    Payment Address Validation
      ✓ should validate correct Solana address
      ✓ should reject address that is too short
      ✓ should reject address that is too long
      ✓ should accept 32-44 character addresses
    sendPayment
      ✓ should return receipt with matching amount and nonce (1 ms)
      ✓ should mark swap as performed for token mismatch with autoSwap
      ✓ should fail when token mismatch requires swap and no client configured
    needsAutoSwap
      ✓ should detect mismatch when autoSwap=true
    Middleware Helper
      ✓ should create valid x402-request header

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        0.547 s, estimated 1 s
Ran all test suites matching /tests\/payment.test.ts/i.

[bdd-sweep] >>> Bucket G (torque retention contracts)
PASS lib/__tests__/torque-client.test.ts
PASS lib/__tests__/torque-event-route.test.ts
PASS lib/__tests__/torque-leaderboard-route.test.ts
PASS lib/__tests__/torque-onboarding-event.test.ts

Test Suites: 4 passed, 4 total
Tests:       17 passed, 17 total
Snapshots:   0 total
Time:        0.203 s, estimated 1 s
Ran all test suites matching lib/__tests__/torque-client.test.ts|lib/__tests__/torque-event-route.test.ts|lib/__tests__/torque-leaderboard-route.test.ts|lib/__tests__/torque-onboarding-event.test.ts.

[bdd-sweep] >>> Bucket H (consumer orchestrator lifecycle contracts)
PASS lib/__tests__/planner-auditability.test.ts
PASS lib/__tests__/planner-release-route.test.ts
PASS lib/__tests__/planner-tools-manifest-route.test.ts
PASS lib/__tests__/planner-resolve-attestor-route.test.ts
PASS lib/__tests__/planner-register-consumer-route.test.ts

Test Suites: 5 passed, 5 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        0.205 s, estimated 1 s
Ran all test suites matching lib/__tests__/planner-register-consumer-route.test.ts|lib/__tests__/planner-tools-manifest-route.test.ts|lib/__tests__/planner-resolve-attestor-route.test.ts|lib/__tests__/planner-release-route.test.ts|lib/__tests__/planner-auditability.test.ts.

[bdd-sweep] complete: representative per-bucket suite is green
[bdd-sweep] summary: /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code-pr97/artifacts/bdd-sweep/20260424-075938/SUMMARY.md