### PR TITLE
fix: preflight tunnel endpoint policy inside guided setup

### DIFF
--- a/components/GuidedSetupModal.tsx
+++ b/components/GuidedSetupModal.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
+import { isUnsafeHostedTarget } from "@/lib/integrations/openonion/network-policy";
 
 interface GuidedSetupModalProps {
   open: boolean;
@@ -124,6 +125,17 @@ function normalizeBaseUrl(raw: string) {
   const value = raw.trim();
   if (!value) throw new Error("Base URL is required");
   return value.startsWith("http://") || value.startsWith("https://") ? value : `http://${value}`;
+}
+
+function normalizePublicEndpoint(raw: string) {
+  const value = raw.trim();
+  if (!value) throw new Error("Endpoint URL is required");
+  return value.startsWith("http://") || value.startsWith("https://") ? new URL(value) : new URL(`https://${value}`);
+}
+
+function isUnsupportedCloudflareTunnelHost(hostname: string) {
+  const host = hostname.toLowerCase();
+  return host.includes("trycloudflare.com") || host.includes("cfargotunnel.com");
 }
 
 async function probeLocalRuntime(baseUrl: string, runtime: RuntimeChoice) {
@@ -324,6 +336,24 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
       return;
     }
 
+    try {
+      const parsed = normalizePublicEndpoint(candidate);
+      if (isUnsafeHostedTarget(parsed.hostname)) {
+        setTunnelStatus("error");
+        setDetailMessage("Private or localhost endpoints are not allowed. Use a public HTTPS URL from ngrok (recommended) or localtunnel fallback.");
+        return;
+      }
+      if (isUnsupportedCloudflareTunnelHost(parsed.hostname)) {
+        setTunnelStatus("error");
+        setDetailMessage("Cloudflare Tunnel is temporarily unsupported during RCA hardening. Use an ngrok HTTPS endpoint (recommended) or localtunnel fallback.");
+        return;
+      }
+    } catch {
+      setTunnelStatus("error");
+      setDetailMessage("Invalid endpoint URL. Paste a public HTTPS URL from ngrok (recommended) or localtunnel fallback.");
+      return;
+    }
+
     setTunnelStatus("checking");
     setDetailMessage("");
     try {
@@ -496,7 +526,7 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
           <StepCard
             index={3}
             title="Start the tunnel"
-            description="Use ngrok (recommended) for a stable public HTTPS URL."
+            description="Use ngrok (recommended) for a stable public HTTPS URL. Cloudflare Tunnel is temporarily unsupported during RCA hardening."
             completed={completedStep3}
             locked={!completedStep2}
           >


### PR DESCRIPTION
## Summary
- add client-side preflight validation in Guided Setup tunnel step before probe call
- block localhost/private targets early with explicit public-endpoint guidance
- block Cloudflare tunnel hostnames early with RCA-aware ngrok-first fallback messaging
- keep existing register-probe server enforcement as backend safety net

## Validation
- 
- 
> web@0.1.0 test:bdd:sweep
> ./scripts/run-bdd-bucket-sweep.sh

[bdd-sweep] starting representative per-bucket verification
[bdd-sweep] artifacts: /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code-pr97/artifacts/bdd-sweep/20260424-081113

[bdd-sweep] >>> Bucket A (onboarding/operator gates)
PASS lib/__tests__/operator-key-rotation.test.ts
PASS lib/__tests__/onboarding-operator-status-routes.test.ts

Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        0.352 s, estimated 1 s
Ran all test suites matching lib/__tests__/operator-key-rotation.test.ts|lib/__tests__/onboarding-operator-status-routes.test.ts.

[bdd-sweep] >>> Bucket B (discovery + ranking contracts)
PASS lib/__tests__/registry-route.test.ts
PASS lib/__tests__/registry-bridge-sort.test.ts

Test Suites: 2 passed, 2 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        0.157 s, estimated 1 s
Ran all test suites matching lib/__tests__/registry-route.test.ts|lib/__tests__/registry-bridge-sort.test.ts.

[bdd-sweep] >>> Bucket C (planner consumption contracts)
PASS lib/__tests__/planner-resolve-route.test.ts
PASS lib/__tests__/planner-invoke-route.test.ts
PASS lib/__tests__/planner-signal-route.test.ts

Test Suites: 3 passed, 3 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        0.19 s, estimated 1 s
Ran all test suites matching lib/__tests__/planner-resolve-route.test.ts|lib/__tests__/planner-invoke-route.test.ts|lib/__tests__/planner-signal-route.test.ts.

[bdd-sweep] >>> Bucket D/E (security + reliability contracts)
PASS lib/__tests__/register-probe-route.test.ts
PASS lib/__tests__/program-rpc-config.test.ts
PASS lib/__tests__/endpoint-security-compat.test.ts
PASS lib/__tests__/onboarding-healthcheck-security.test.ts

Test Suites: 4 passed, 4 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        0.289 s, estimated 1 s
Ran all test suites matching lib/__tests__/endpoint-security-compat.test.ts|lib/__tests__/program-rpc-config.test.ts|lib/__tests__/register-probe-route.test.ts|lib/__tests__/onboarding-healthcheck-security.test.ts.

[bdd-sweep] >>> Bucket F (jupiter + payment contracts)
PASS lib/__tests__/jupiter-client.test.ts
PASS lib/__tests__/planner-invoke-route.test.ts

Test Suites: 2 passed, 2 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        0.168 s, estimated 1 s
Ran all test suites matching lib/__tests__/jupiter-client.test.ts|lib/__tests__/planner-invoke-route.test.ts.

[bdd-sweep] >>> Bucket F package payment contracts

> @reddi/x402-solana@0.1.0 test
> jest --runInBand tests/payment.test.ts

PASS tests/payment.test.ts
  x402 Payment Module
    parseX402Header
      ✓ should parse valid x402-request header (1 ms)
      ✓ should reject zero amount (5 ms)
      ✓ should reject negative amount
      ✓ should reject missing paymentAddress (1 ms)
      ✓ should reject missing nonce
      ✓ should reject invalid JSON
    Nonce Store
      ✓ should accept first nonce
      ✓ should reject duplicate nonce
      ✓ should accept different nonces
      ✓ should allow re-acceptance after clearNonces (1 ms)
    Payment Address Validation
      ✓ should validate correct Solana address
      ✓ should reject address that is too short
      ✓ should reject address that is too long
      ✓ should accept 32-44 character addresses
    sendPayment
      ✓ should return receipt with matching amount and nonce
      ✓ should mark swap as performed for token mismatch with autoSwap
      ✓ should fail when token mismatch requires swap and no client configured (1 ms)
    needsAutoSwap
      ✓ should detect mismatch when autoSwap=true
    Middleware Helper
      ✓ should create valid x402-request header

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        0.614 s, estimated 1 s
Ran all test suites matching /tests\/payment.test.ts/i.

[bdd-sweep] >>> Bucket G (torque retention contracts)
PASS lib/__tests__/torque-client.test.ts
PASS lib/__tests__/torque-event-route.test.ts
PASS lib/__tests__/torque-leaderboard-route.test.ts
PASS lib/__tests__/torque-onboarding-event.test.ts

Test Suites: 4 passed, 4 total
Tests:       17 passed, 17 total
Snapshots:   0 total
Time:        0.238 s, estimated 1 s
Ran all test suites matching lib/__tests__/torque-client.test.ts|lib/__tests__/torque-event-route.test.ts|lib/__tests__/torque-leaderboard-route.test.ts|lib/__tests__/torque-onboarding-event.test.ts.

[bdd-sweep] >>> Bucket H (consumer orchestrator lifecycle contracts)
PASS lib/__tests__/planner-auditability.test.ts
PASS lib/__tests__/planner-release-route.test.ts
PASS lib/__tests__/planner-resolve-attestor-route.test.ts
PASS lib/__tests__/planner-tools-manifest-route.test.ts
PASS lib/__tests__/planner-register-consumer-route.test.ts

Test Suites: 5 passed, 5 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        0.283 s, estimated 1 s
Ran all test suites matching lib/__tests__/planner-register-consumer-route.test.ts|lib/__tests__/planner-tools-manifest-route.test.ts|lib/__tests__/planner-resolve-attestor-route.test.ts|lib/__tests__/planner-release-route.test.ts|lib/__tests__/planner-auditability.test.ts.

[bdd-sweep] complete: representative per-bucket suite is green
[bdd-sweep] summary: /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code-pr97/artifacts/bdd-sweep/20260424-081113/SUMMARY.md