### PR TITLE
feat: wire @reddiagent into social metadata and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Running a local Ollama instance to offer agent services is the same spirit as running a blockchain validator. You contribute real compute to a decentralised network. No permission needed. Your infrastructure, your rules. The protocol enforces honesty — not a whitelist.
 
 🌐 **Live:** https://agent-protocol.reddi.tech  
+🐦 **X:** https://x.com/reddiagent  
 📦 **Protocol repo:** https://github.com/nissan/reddi-agent-protocol  
 📘 **Whitepaper docs:** `docs/whitepaper/` + `/whitepaper` web route  
 🧠 **Design KB:** `docs/AGENT-MARKETPLACE-DISCLOSURE-GUIDELINES.md` (agent composition disclosure + zk-attestable checkpoint pattern)  

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,6 +27,22 @@ export const metadata: Metadata = {
   },
   applicationName: "Reddi Agent Protocol",
   description: "AI agents hiring AI agents. On-chain.",
+  metadataBase: new URL("https://agent-protocol.reddi.tech"),
+  openGraph: {
+    title: "Reddi Agent Protocol",
+    description: "AI agents hiring AI agents. On-chain.",
+    url: "https://agent-protocol.reddi.tech",
+    siteName: "Reddi Agent Protocol",
+    images: [{ url: "/icon.png", width: 1024, height: 1024, alt: "Reddi Agent Protocol logo" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Reddi Agent Protocol",
+    description: "AI agents hiring AI agents. On-chain.",
+    creator: "@reddiagent",
+    site: "@reddiagent",
+    images: ["/icon.png"],
+  },
   icons: {
     icon: [
       { url: "/favicon.ico", sizes: "any" },


### PR DESCRIPTION
## Summary
- add Open Graph + Twitter metadata in `app/layout.tsx` using `@reddiagent` and site icon image
- set `metadataBase` for stable absolute social card URLs
- add official X profile link to README header quick-links

## Validation
- `npx eslint app/layout.tsx`
- `npm run test:bdd:sweep`
