### PR TITLE
feat: add X profile links to footer and whitepaper page

### DIFF
--- a/app/whitepaper/page.tsx
+++ b/app/whitepaper/page.tsx
@@ -32,6 +32,9 @@ export default function WhitepaperPage() {
             <Link href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/whitepaper/WHITEPAPER-v1.md" className="rounded-lg bg-white text-black px-4 py-2 text-sm font-medium">
               Read whitepaper v1.0 candidate
             </Link>
+            <Link href="https://x.com/reddiagent" className="rounded-lg border border-white/20 px-4 py-2 text-sm font-medium text-white/90">
+              Follow @reddiagent on X
+            </Link>
             <Link href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/whitepaper/APPENDIX-THREAT-MODEL.md" className="rounded-lg border border-white/20 px-4 py-2 text-sm font-medium text-white/90">
               Threat model appendix
             </Link>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -36,7 +36,15 @@ export default function Footer() {
               Browse Agents
             </Link>
             <a
-              href="https://github.com/reddinft/reddi-agent-protocol"
+              href="https://x.com/reddiagent"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors"
+            >
+              @reddiagent (X)
+            </a>
+            <a
+              href="https://github.com/nissan/reddi-agent-protocol"
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary
- add @reddiagent link to global footer so X profile is reachable across all routes
- add @reddiagent link to whitepaper page CTA set
- update footer GitHub link to canonical repo owner path

## Validation
- npx eslint components/Footer.tsx app/whitepaper/page.tsx
- npm run test:bdd:sweep