### PR TITLE
feat: add Cloudflare RCA evaluation gate

### DIFF
--- a/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
+++ b/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
@@ -38,6 +38,19 @@ npm run test:tunnel:rca
 - Artifact output: `artifacts/cloudflare-rca/<timestamp>/SUMMARY.md` + `results.json`.
 - Use `npm run test:tunnel:rca -- --dry-run` to validate config without sending probes.
 
+After a real run, evaluate parity and stability gates:
+
+```bash
+npm run test:tunnel:rca:evaluate -- \
+  --results artifacts/cloudflare-rca/<timestamp>/results.json \
+  --out artifacts/cloudflare-rca/<timestamp>/EVALUATION.md
+```
+
+Evaluation PASS criteria:
+- no `classification=error` samples on either provider
+- probe mode-class parity between ngrok and Cloudflare for all 4 probes
+- x402 challenge preservation (Cloudflare keeps the same 402 count as ngrok baseline)
+
 ## Exit criteria to re-enable Cloudflare
 - 30/30 stable onboarding heartbeat checks
 - x402 challenge + non-public token gating both preserved

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:surfpool:jupiter-invoke": "./scripts/run-surfpool-jupiter-invoke-smoke.sh",
     "test:source:conformance": "./scripts/run-source-conformance.sh --source openclaw --mode smoke",
     "test:source:matrix": "./scripts/run-source-conformance-matrix.sh",
-    "test:tunnel:rca": "node ./scripts/run-cloudflare-rca-matrix.mjs"
+    "test:tunnel:rca": "node ./scripts/run-cloudflare-rca-matrix.mjs",
+    "test:tunnel:rca:evaluate": "node ./scripts/evaluate-cloudflare-rca.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/evaluate-cloudflare-rca.mjs
+++ b/scripts/evaluate-cloudflare-rca.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out = {};
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === "--results" && args[i + 1]) out.results = args[i + 1];
+    if (args[i] === "--out" && args[i + 1]) out.out = args[i + 1];
+  }
+  return out;
+}
+
+function modeClass(samples = []) {
+  const counts = new Map();
+  for (const s of samples) {
+    const key = s.classification || "unknown";
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  let best = "unknown";
+  let bestCount = -1;
+  for (const [k, v] of counts.entries()) {
+    if (v > bestCount) {
+      best = k;
+      bestCount = v;
+    }
+  }
+  return { className: best, count: Math.max(0, bestCount) };
+}
+
+function stable(samples = []) {
+  if (!samples.length) return false;
+  return samples.every((s) => s.classification !== "error");
+}
+
+function x402Preserved(ngrokSamples = [], cloudflareSamples = []) {
+  const ngrok402 = ngrokSamples.filter((s) => s.status === 402).length;
+  const cloudflare402 = cloudflareSamples.filter((s) => s.status === 402).length;
+  if (ngrok402 === 0) return true;
+  return cloudflare402 === ngrok402;
+}
+
+async function main() {
+  const { results: resultsArg, out } = parseArgs();
+  if (!resultsArg) {
+    console.error("Usage: node scripts/evaluate-cloudflare-rca.mjs --results <results.json> [--out <summary.md>]");
+    process.exit(1);
+  }
+
+  const raw = await fs.readFile(resultsArg, "utf8");
+  const data = JSON.parse(raw);
+
+  const probes = ["head_root", "get_healthz", "post_chat_completions", "x402_probe"];
+  const failures = [];
+  const rows = [];
+
+  for (const probe of probes) {
+    const ngrok = data.providers?.ngrok?.probes?.[probe]?.samples || [];
+    const cloudflare = data.providers?.cloudflare?.probes?.[probe]?.samples || [];
+
+    const ngrokMode = modeClass(ngrok);
+    const cloudflareMode = modeClass(cloudflare);
+    const ngrokStable = stable(ngrok);
+    const cloudflareStable = stable(cloudflare);
+
+    const parityOk = ngrokMode.className === cloudflareMode.className;
+
+    if (!ngrokStable) failures.push(`${probe}: ngrok samples contain errors`);
+    if (!cloudflareStable) failures.push(`${probe}: cloudflare samples contain errors`);
+    if (!parityOk) failures.push(`${probe}: classification mode mismatch (ngrok=${ngrokMode.className}, cloudflare=${cloudflareMode.className})`);
+
+    rows.push({
+      probe,
+      ngrokMode: `${ngrokMode.className} (${ngrokMode.count}/${ngrok.length})`,
+      cloudflareMode: `${cloudflareMode.className} (${cloudflareMode.count}/${cloudflare.length})`,
+      ngrokStable,
+      cloudflareStable,
+      parityOk,
+    });
+  }
+
+  const x402Ok = x402Preserved(
+    data.providers?.ngrok?.probes?.x402_probe?.samples || [],
+    data.providers?.cloudflare?.probes?.x402_probe?.samples || []
+  );
+  if (!x402Ok) failures.push("x402 probe: cloudflare did not preserve 402-challenge count relative to ngrok baseline");
+
+  const pass = failures.length === 0;
+
+  const lines = [];
+  lines.push("# Cloudflare RCA Evaluation");
+  lines.push("");
+  lines.push(`- Results: ${path.resolve(resultsArg)}`);
+  lines.push(`- Verdict: ${pass ? "PASS" : "FAIL"}`);
+  lines.push("");
+  lines.push("## Probe checks");
+  lines.push("");
+  lines.push("| Probe | ngrok mode | cloudflare mode | ngrok stable | cloudflare stable | mode parity |");
+  lines.push("|---|---:|---:|---:|---:|---:|");
+  for (const row of rows) {
+    lines.push(`| ${row.probe} | ${row.ngrokMode} | ${row.cloudflareMode} | ${row.ngrokStable ? "yes" : "no"} | ${row.cloudflareStable ? "yes" : "no"} | ${row.parityOk ? "yes" : "no"} |`);
+  }
+  lines.push("");
+  lines.push(`- x402 challenge preservation: ${x402Ok ? "yes" : "no"}`);
+  lines.push("");
+
+  if (!pass) {
+    lines.push("## Fail reasons");
+    lines.push("");
+    for (const f of failures) lines.push(`- ${f}`);
+  }
+
+  const content = `${lines.join("\n")}\n`;
+
+  if (out) {
+    await fs.writeFile(out, content, "utf8");
+    console.log(`Wrote: ${out}`);
+  } else {
+    process.stdout.write(content);
+  }
+
+  if (!pass) process.exit(2);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `test:tunnel:rca:evaluate` command to evaluate Cloudflare RCA matrix outputs
- add `scripts/evaluate-cloudflare-rca.mjs` to gate on stability + provider parity + x402 challenge preservation
- document post-run evaluation command and PASS criteria in Cloudflare RCA tracker doc

## Validation
- `npm run test:tunnel:rca:evaluate -- --results /tmp/rca-results-sample.json`
- `npm run test:bdd:sweep`
