### PR TITLE
fix: gate RCA runs on x402 baseline preflight

### DIFF
--- a/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
+++ b/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
@@ -36,7 +36,9 @@ npm run test:tunnel:rca
 
 - Optional: set `X402_PROBE_PATH` (default `/x402/health`).
 - Artifact output: `artifacts/cloudflare-rca/<timestamp>/SUMMARY.md` + `results.json`.
+- Built-in x402 preflight now runs first (3x `GET <X402_PROBE_PATH>` against ngrok baseline); run aborts early if baseline has zero 402 responses.
 - Use `npm run test:tunnel:rca -- --dry-run` to validate config without sending probes.
+- Use `npm run test:tunnel:rca -- --skip-x402-preflight` only for debugging (not for decision-grade runs).
 
 After a real run, evaluate parity and stability gates:
 

--- a/scripts/run-cloudflare-rca-matrix.mjs
+++ b/scripts/run-cloudflare-rca-matrix.mjs
@@ -13,6 +13,7 @@ function parseArgs() {
   const args = new Set(process.argv.slice(2));
   return {
     dryRun: args.has("--dry-run"),
+    skipX402Preflight: args.has("--skip-x402-preflight"),
   };
 }
 
@@ -79,7 +80,7 @@ function summarizeSamples(samples) {
 }
 
 async function main() {
-  const { dryRun } = parseArgs();
+  const { dryRun, skipX402Preflight } = parseArgs();
 
   const sampleSize = Math.max(1, Number(process.env.RCA_SAMPLE_SIZE || 30));
   const ngrokBase = normalizeBaseUrl(process.env.NGROK_BASE_URL);
@@ -112,11 +113,71 @@ async function main() {
   const artifactDir = path.join(process.cwd(), "artifacts", "cloudflare-rca", nowStamp());
 
   if (dryRun) {
-    console.log(JSON.stringify({ sampleSize, ngrokBase, cloudflareBase, probes, artifactDir }, null, 2));
+    console.log(JSON.stringify({ sampleSize, ngrokBase, cloudflareBase, probes, artifactDir, skipX402Preflight }, null, 2));
     return;
   }
 
   await fs.mkdir(artifactDir, { recursive: true });
+
+  const preflightSamples = [];
+  const preflightRuns = 3;
+  const x402PreflightProbe = { id: "x402_probe", method: "GET", path: x402ProbePath, captureBody: true };
+  let x402Preflight = {
+    enabled: !skipX402Preflight,
+    probe: `${x402PreflightProbe.method} ${x402PreflightProbe.path}`,
+    runs: preflightRuns,
+    ngrok402Count: 0,
+    passed: true,
+  };
+
+  if (!skipX402Preflight) {
+    for (let i = 0; i < preflightRuns; i += 1) {
+      const sample = await runProbe(ngrokBase, x402PreflightProbe);
+      sample.run = i + 1;
+      preflightSamples.push(sample);
+    }
+
+    const ngrok402Count = preflightSamples.filter((s) => s.status === 402).length;
+    x402Preflight = {
+      ...x402Preflight,
+      ngrok402Count,
+      passed: ngrok402Count > 0,
+      samples: preflightSamples,
+    };
+
+    if (!x402Preflight.passed) {
+      const preflightOut = {
+        generatedAt: new Date().toISOString(),
+        status: "failed_preflight",
+        reason: "no_x402_baseline",
+        ngrokBase,
+        cloudflareBase,
+        x402Preflight,
+      };
+      const jsonPath = path.join(artifactDir, "results.json");
+      await fs.writeFile(jsonPath, JSON.stringify(preflightOut, null, 2));
+
+      const summaryPath = path.join(artifactDir, "SUMMARY.md");
+      const lines = [
+        "# Cloudflare Tunnel RCA Matrix Summary",
+        "",
+        "- Status: FAILED_PRECHECK",
+        "- Reason: ngrok baseline produced zero 402 responses on x402 preflight.",
+        `- Probe: ${x402Preflight.probe}`,
+        `- Runs: ${x402Preflight.runs}`,
+        `- ngrok 402 count: ${x402Preflight.ngrok402Count}`,
+        "",
+        "Fix: point both tunnels at an x402-assertive fixture, then rerun.",
+        `Results JSON: ${jsonPath}`,
+      ];
+      await fs.writeFile(summaryPath, `${lines.join("\n")}\n`);
+
+      console.error("[cloudflare-rca] preflight failed: ngrok baseline produced zero 402 responses");
+      console.error(`[cloudflare-rca] artifact: ${artifactDir}`);
+      console.error(`[cloudflare-rca] summary: ${summaryPath}`);
+      process.exit(2);
+    }
+  }
 
   const providers = [
     { id: "ngrok", baseUrl: ngrokBase },
@@ -126,6 +187,7 @@ async function main() {
   const results = {
     generatedAt: new Date().toISOString(),
     sampleSize,
+    x402Preflight,
     providers: {},
   };
 


### PR DESCRIPTION
## Summary
- add an x402 baseline preflight to `test:tunnel:rca` (3 probes against ngrok x402 path)
- abort early with artifacted `FAILED_PRECHECK` summary when baseline returns zero 402 responses
- document preflight behavior and optional debug bypass flag (`--skip-x402-preflight`)

## Why
We saw a real-run false pass path when fixtures returned generic 4xx without any x402 challenge signal. This preflight prevents wasting full 30-sample runs on non-decision-grade fixtures.

## Validation
- `NGROK_BASE_URL=... CLOUDFLARE_BASE_URL=... npm run test:tunnel:rca` now exits early with code 2 and writes artifact if x402 baseline is missing.
