### PR TITLE
feat: add deterministic x402 fixture for RCA runs

### DIFF
--- a/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
+++ b/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
@@ -34,6 +34,23 @@ RCA_SAMPLE_SIZE=30 \
 npm run test:tunnel:rca
 ```
 
+### Quick local x402 fixture (recommended for decision-grade runs)
+Start a deterministic fixture locally (Terminal 1):
+
+```bash
+cd /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code-pr97
+npm run dev:rca:x402-fixture
+```
+
+Start tunnels to the same local port (Terminal 2 + 3):
+
+```bash
+ngrok http 19090
+cloudflared tunnel --url http://127.0.0.1:19090
+```
+
+Use the printed HTTPS URLs as `NGROK_BASE_URL` and `CLOUDFLARE_BASE_URL`, then run matrix + evaluator.
+
 - Optional: set `X402_PROBE_PATH` (default `/x402/health`).
 - Artifact output: `artifacts/cloudflare-rca/<timestamp>/SUMMARY.md` + `results.json`.
 - Built-in x402 preflight now runs first (3x `GET <X402_PROBE_PATH>` against ngrok baseline); run aborts early if baseline has zero 402 responses.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:source:conformance": "./scripts/run-source-conformance.sh --source openclaw --mode smoke",
     "test:source:matrix": "./scripts/run-source-conformance-matrix.sh",
     "test:tunnel:rca": "node ./scripts/run-cloudflare-rca-matrix.mjs",
-    "test:tunnel:rca:evaluate": "node ./scripts/evaluate-cloudflare-rca.mjs"
+    "test:tunnel:rca:evaluate": "node ./scripts/evaluate-cloudflare-rca.mjs",
+    "dev:rca:x402-fixture": "node ./scripts/run-rca-x402-fixture.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/run-rca-x402-fixture.mjs
+++ b/scripts/run-rca-x402-fixture.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import http from "node:http";
+
+const port = Number(process.env.RCA_FIXTURE_PORT || 19090);
+
+const json = (res, status, body, headers = {}) => {
+  res.writeHead(status, {
+    "content-type": "application/json",
+    ...headers,
+  });
+  res.end(JSON.stringify(body));
+};
+
+const x402Header = JSON.stringify({
+  version: 1,
+  network: "solana",
+  amount: "1000",
+  paymentAddress: "11111111111111111111111111111111",
+  nonce: "rca-fixture",
+  resource: "/v1/chat/completions",
+});
+
+const server = http.createServer((req, res) => {
+  if (!req.url) {
+    return json(res, 400, { error: "missing_url" });
+  }
+
+  if (req.method === "HEAD" && req.url === "/") {
+    res.writeHead(200);
+    res.end();
+    return;
+  }
+
+  if (req.method === "GET" && req.url === "/") {
+    return json(res, 200, { ok: true, fixture: "rca-x402" });
+  }
+
+  if (req.method === "GET" && req.url === "/healthz") {
+    return json(res, 200, { status: "ok", fixture: "rca-x402" });
+  }
+
+  if (req.method === "GET" && req.url === "/x402/health") {
+    return json(
+      res,
+      402,
+      { error: "payment_required", reason: "x402_fixture_probe" },
+      { "x402-request": x402Header }
+    );
+  }
+
+  if (req.method === "POST" && req.url === "/v1/chat/completions") {
+    return json(
+      res,
+      402,
+      { error: "payment_required", reason: "x402_fixture_chat" },
+      { "x402-request": x402Header }
+    );
+  }
+
+  return json(res, 404, { error: "not_found", path: req.url, method: req.method });
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`[rca-x402-fixture] listening on http://127.0.0.1:${port}`);
+  console.log("[rca-x402-fixture] routes: HEAD /, GET /healthz, POST /v1/chat/completions (402), GET /x402/health (402)");
+});


### PR DESCRIPTION
## Summary
- add `dev:rca:x402-fixture` deterministic local fixture for decision-grade RCA runs
- fixture serves:
  - `HEAD /` -> 200
  - `GET /healthz` -> 200
  - `GET /x402/health` -> 402 + x402-request header
  - `POST /v1/chat/completions` -> 402 + x402-request header
- add quickstart instructions in Cloudflare RCA doc for running fixture + ngrok + cloudflared

## Why
After PR #110/#111 hardening, RCA runs require a real x402 baseline signal. This fixture gives a repeatable setup so the team can complete the final Cloudflare decision lane quickly.

## Validation
- local fixture route checks:
  - `/healthz` -> 200
  - `/x402/health` -> 402
  - `/v1/chat/completions` -> 402
