### PR TITLE
feat: controlled Cloudflare tunnel re-enable with x402 fail-closed checks

### DIFF
--- a/app/api/register/probe/route.ts
+++ b/app/api/register/probe/route.ts
@@ -17,11 +17,6 @@ function normalizeEndpoint(endpoint: string) {
   }
 }
 
-function isCloudflareTunnelHost(hostname: string) {
-  const host = hostname.toLowerCase();
-  return host.includes("trycloudflare.com") || host.includes("cfargotunnel.com");
-}
-
 export async function POST(req: Request) {
   const body = await req.json().catch(() => null);
   const endpoint = body?.endpoint;
@@ -56,18 +51,6 @@ export async function POST(req: Request) {
           ok: false,
           status: "invalid_url",
           error: "Localhost/private-network targets are blocked in hosted context. Use a public tunnel URL (ngrok recommended, localtunnel fallback)."
-        },
-        { status: 400 }
-      );
-    }
-
-    if (isCloudflareTunnelHost(url.hostname)) {
-      return NextResponse.json(
-        {
-          ok: false,
-          status: "unsupported_tunnel_provider",
-          error:
-            "Cloudflare Tunnel is temporarily unsupported while RCA hardening is active. Use an ngrok HTTPS endpoint (recommended) or localtunnel fallback.",
         },
         { status: 400 }
       );

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -63,8 +63,7 @@ type EndpointProbeStatus =
   | "checking"
   | "reachable"
   | "no_ollama"
-  | "unreachable"
-  | "unsupported_provider";
+  | "unreachable";
 type HelpItem = { text: string; href?: string; code?: string };
 type HelpStep = { title: string; items: HelpItem[] };
 
@@ -206,15 +205,6 @@ function RegisterInner() {
       }
 
       if (!res.ok) {
-        if (data?.status === "unsupported_tunnel_provider") {
-          setEndpointProbeStatus("unsupported_provider");
-          setEndpointProbeMessage(
-            data.error ||
-              "Cloudflare tunnel is temporarily unsupported in onboarding. Use an ngrok HTTPS endpoint (recommended) or localtunnel fallback."
-          );
-          return;
-        }
-
         setEndpointProbeStatus("unreachable");
         setEndpointProbeMessage(
           data.error || "Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel."
@@ -705,7 +695,7 @@ function RegisterInner() {
                     ? "!border-blue-400"
                     : endpointProbeStatus === "reachable"
                       ? "!border-green-400"
-                      : endpointProbeStatus === "no_ollama" || endpointProbeStatus === "unsupported_provider"
+                    : endpointProbeStatus === "no_ollama"
                         ? "!border-yellow-400"
                         : endpointProbeStatus === "unreachable"
                           ? "!border-red-400"
@@ -722,7 +712,7 @@ function RegisterInner() {
                       ? "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/20 dark:text-blue-200"
                       : endpointProbeStatus === "reachable"
                         ? "border-green-200 bg-green-50 text-green-700 dark:border-green-900/40 dark:bg-green-950/20 dark:text-green-200"
-                        : endpointProbeStatus === "no_ollama" || endpointProbeStatus === "unsupported_provider"
+                        : endpointProbeStatus === "no_ollama"
                           ? "border-yellow-200 bg-yellow-50 text-yellow-700 dark:border-yellow-900/40 dark:bg-yellow-950/20 dark:text-yellow-200"
                           : "border-red-200 bg-red-50 text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-200"
                   }`}
@@ -731,7 +721,7 @@ function RegisterInner() {
                     <Loader2 className="mt-0.5 h-4 w-4 animate-spin" />
                   ) : endpointProbeStatus === "reachable" ? (
                     <CheckCircle2 className="mt-0.5 h-4 w-4" />
-                  ) : endpointProbeStatus === "no_ollama" || endpointProbeStatus === "unsupported_provider" ? (
+                  ) : endpointProbeStatus === "no_ollama" ? (
                     <AlertTriangle className="mt-0.5 h-4 w-4" />
                   ) : (
                     <XCircle className="mt-0.5 h-4 w-4" />
@@ -744,9 +734,7 @@ function RegisterInner() {
                           ? "Endpoint reachable"
                           : endpointProbeStatus === "no_ollama"
                           ? "Reachable, but no Ollama detected"
-                          : endpointProbeStatus === "unsupported_provider"
-                            ? "Unsupported tunnel provider"
-                            : "Unreachable"}
+                          : "Unreachable"}
                     </p>
                     {endpointProbeMessage && <p className="mt-0.5 text-[11px] font-normal">{endpointProbeMessage}</p>}
                     {endpointProbeModels.length > 0 && endpointProbeStatus === "reachable" && (

--- a/components/GuidedSetupModal.tsx
+++ b/components/GuidedSetupModal.tsx
@@ -133,11 +133,6 @@ function normalizePublicEndpoint(raw: string) {
   return value.startsWith("http://") || value.startsWith("https://") ? new URL(value) : new URL(`https://${value}`);
 }
 
-function isUnsupportedCloudflareTunnelHost(hostname: string) {
-  const host = hostname.toLowerCase();
-  return host.includes("trycloudflare.com") || host.includes("cfargotunnel.com");
-}
-
 async function probeLocalRuntime(baseUrl: string, runtime: RuntimeChoice) {
   const base = normalizeBaseUrl(baseUrl).replace(/\/$/, "");
   const path = runtime === "ollama" ? "/api/tags" : "/v1/models";
@@ -343,11 +338,6 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
         setDetailMessage("Private or localhost endpoints are not allowed. Use a public HTTPS URL from ngrok (recommended) or localtunnel fallback.");
         return;
       }
-      if (isUnsupportedCloudflareTunnelHost(parsed.hostname)) {
-        setTunnelStatus("error");
-        setDetailMessage("Cloudflare Tunnel is temporarily unsupported during RCA hardening. Use an ngrok HTTPS endpoint (recommended) or localtunnel fallback.");
-        return;
-      }
     } catch {
       setTunnelStatus("error");
       setDetailMessage("Invalid endpoint URL. Paste a public HTTPS URL from ngrok (recommended) or localtunnel fallback.");
@@ -360,7 +350,7 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
       const res = await fetch("/api/register/probe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ endpoint: candidate, runtimeTarget: runtimeConfig.runtimeTarget }),
+        body: JSON.stringify({ endpoint: candidate, runtimeTarget: runtimeConfig.runtimeTarget, requireX402: true }),
       });
       const data = (await res.json().catch(() => null)) as ProbeResult | null;
       if (data?.runtimeStatus === "runtime_detected" || data?.status === "ollama_detected") {
@@ -526,7 +516,7 @@ export default function GuidedSetupModal({ open, onClose, onComplete }: GuidedSe
           <StepCard
             index={3}
             title="Start the tunnel"
-            description="Use ngrok (recommended) for a stable public HTTPS URL. Cloudflare Tunnel is temporarily unsupported during RCA hardening."
+            description="Use ngrok (recommended) for a stable public HTTPS URL. Cloudflare tunnel is supported in controlled mode when endpoint compliance checks pass."
             completed={completedStep3}
             locked={!completedStep2}
           >

--- a/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
+++ b/docs/CLOUDFLARE-TUNNEL-RCA-2026-04-24.md
@@ -4,9 +4,9 @@
 Cloudflare Tunnel was intentionally deferred in specialist endpoint onboarding because endpoint reliability and x402-compatible behavior were inconsistent during fast setup flows.
 
 ## Current guardrail (live)
-- Onboarding endpoint manager rejects Cloudflare tunnel hostnames (`*.trycloudflare.com`, `*.cfargotunnel.com`) with a clear error.
-- Register probe route also rejects Cloudflare tunnel hostnames so unsupported endpoints fail before registration.
-- Operators are redirected to ngrok-first (or localtunnel fallback) until Cloudflare path is re-qualified.
+- Cloudflare tunnel path is re-enabled in controlled mode.
+- ngrok remains the default recommendation (localtunnel fallback supported).
+- Endpoint compliance is fail-closed: registration/onboarding checks require valid x402 challenge behavior (`/v1/chat/completions` and probe paths) before progression.
 
 ## Hypotheses to validate
 1. Cloudflare edge/proxy behavior around streaming and HEAD/health probes causes false negatives in onboarding heartbeat.
@@ -77,5 +77,5 @@ Evaluation PASS criteria:
 - No regression in registration probe security classification
 - Clear, minimal operator runbook with reproducible commands
 
-## Temporary operator policy
-Use ngrok HTTPS endpoint for onboarding and registration. Treat Cloudflare tunnel as unsupported until this RCA is closed.
+## Operator policy (post-RCA)
+Use ngrok HTTPS endpoint by default. Cloudflare tunnel is allowed when compliance checks pass; otherwise fail closed and fix endpoint policy/tunnel origin.

--- a/docs/SPECIALIST-ENDPOINT-SECURITY-GUIDANCE-2026-04-23.md
+++ b/docs/SPECIALIST-ENDPOINT-SECURITY-GUIDANCE-2026-04-23.md
@@ -5,8 +5,8 @@ Ollama has no built-in auth for public exposure. If a specialist exposes raw Oll
 
 ## Decision for next iteration
 - **Default tunnel guidance: ngrok-first**
-- **Cloudflare tunnel: deferred** until root-cause + reproducible tests are green
-- **Current guardrail:** onboarding + register probe reject Cloudflare tunnel hostnames during RCA window
+- **Cloudflare tunnel: allowed in controlled mode** after RCA pass
+- **Current guardrail:** onboarding + register probe enforce fail-closed endpoint compliance (x402 challenge behavior required)
 - Goal: minimum secure setup steps so specialists can monetize quickly
 
 ## Recommended security patterns (practical options)

--- a/lib/__tests__/endpoint-security-compat.test.ts
+++ b/lib/__tests__/endpoint-security-compat.test.ts
@@ -56,14 +56,15 @@ describe("endpoint security compatibility (Bucket D)", () => {
     expect(result.tunnelCommand).toContain("localtunnel");
   });
 
-  it("rejects Cloudflare tunnel endpoints while RCA hardening is active", async () => {
-    await expect(
-      createOrRotateEndpoint({
-        consentExposeEndpoint: true,
-        port: 11434,
-        endpointUrl: "https://abc.trycloudflare.com",
-      })
-    ).rejects.toThrow(/temporarily unsupported|RCA/i);
+  it("supports Cloudflare tunnel endpoints in controlled mode", async () => {
+    const result = await createOrRotateEndpoint({
+      consentExposeEndpoint: true,
+      port: 11434,
+      endpointUrl: "https://abc.trycloudflare.com",
+    });
+
+    expect(result.provider).toBe("cloudflare-tunnel");
+    expect(result.tunnelCommand).toContain("cloudflared tunnel --url http://127.0.0.1:");
   });
 
   it("generated token-gated proxy script bypasses public x402 paths and gates non-public paths", async () => {

--- a/lib/__tests__/register-probe-route.test.ts
+++ b/lib/__tests__/register-probe-route.test.ts
@@ -28,7 +28,19 @@ describe("register probe route", () => {
     });
   });
 
-  it("blocks Cloudflare tunnel endpoints while RCA hardening is active", async () => {
+  it("allows Cloudflare tunnel endpoints when endpoint checks pass", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ models: [{ name: "qwen3:8b" }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 402,
+        headers: { get: (name: string) => (name.toLowerCase() === "x402-request" ? "{}" : null) },
+      }) as unknown as typeof fetch;
+
     const { POST } = await import("@/app/api/register/probe/route");
     const req = new NextRequest("http://localhost/api/register/probe", {
       method: "POST",
@@ -37,10 +49,11 @@ describe("register probe route", () => {
     });
 
     const res = await POST(req as unknown as Request);
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchObject({
-      ok: false,
-      status: "unsupported_tunnel_provider",
+      ok: true,
+      status: "ollama_detected",
+      securityStatus: "x402_challenge_detected",
     });
   });
 

--- a/lib/onboarding/endpoint-manager.ts
+++ b/lib/onboarding/endpoint-manager.ts
@@ -15,7 +15,7 @@ export type EndpointActionResult = {
   status: "online" | "offline";
   heartbeatOk: boolean;
   heartbeatCheckedAt: string;
-  provider: "ngrok" | "localtunnel-compatible";
+  provider: "ngrok" | "cloudflare-tunnel" | "localtunnel-compatible";
   tunnelCommand: string;
   proxyCommand: string;
   proxyPort: number;
@@ -32,7 +32,7 @@ type SpecialistProfile = {
   endpoint: {
     url: string;
     status: "online" | "offline";
-    provider: "ngrok" | "localtunnel-compatible";
+    provider: "ngrok" | "cloudflare-tunnel" | "localtunnel-compatible";
     localPort: number;
     proxyPort: number;
     heartbeatOk: boolean;
@@ -92,9 +92,10 @@ function isCloudflareTunnelHost(endpointUrl: string) {
   }
 }
 
-function inferTunnelProvider(endpointUrl: string): "ngrok" | "localtunnel-compatible" {
+function inferTunnelProvider(endpointUrl: string): "ngrok" | "cloudflare-tunnel" | "localtunnel-compatible" {
   try {
     const host = new URL(endpointUrl).hostname.toLowerCase();
+    if (isCloudflareTunnelHost(endpointUrl)) return "cloudflare-tunnel";
     if (host.includes("localtunnel.me")) return "localtunnel-compatible";
   } catch {
     // default below
@@ -241,6 +242,9 @@ function readProfile(): SpecialistProfile | null {
 
 function buildTunnelCommand(proxyPort: number, endpointUrl: string) {
   const provider = inferTunnelProvider(endpointUrl);
+  if (provider === "cloudflare-tunnel") {
+    return `cloudflared tunnel --url http://127.0.0.1:${proxyPort}`;
+  }
   if (provider === "localtunnel-compatible") {
     const subdomain = inferSubdomain(endpointUrl);
     return `npx localtunnel --port ${proxyPort} --subdomain ${subdomain}`;
@@ -249,14 +253,26 @@ function buildTunnelCommand(proxyPort: number, endpointUrl: string) {
   return `ngrok http ${proxyPort}`;
 }
 
-function buildTunnelRecoveryNote(provider: "ngrok" | "localtunnel-compatible", tunnelCommand: string) {
+function buildTunnelRecoveryNote(
+  provider: "ngrok" | "cloudflare-tunnel" | "localtunnel-compatible",
+  tunnelCommand: string
+) {
+  if (provider === "cloudflare-tunnel") {
+    return `Tunnel appears down. Restart cloudflared against IPv4 localhost: ${tunnelCommand}`;
+  }
   if (provider === "ngrok") {
     return `Tunnel appears down. Restart ngrok: ${tunnelCommand}`;
   }
   return `Tunnel appears down. Re-open tunnel: ${tunnelCommand}`;
 }
 
-function buildHeartbeatRecoveryNote(provider: "ngrok" | "localtunnel-compatible", tunnelCommand: string) {
+function buildHeartbeatRecoveryNote(
+  provider: "ngrok" | "cloudflare-tunnel" | "localtunnel-compatible",
+  tunnelCommand: string
+) {
+  if (provider === "cloudflare-tunnel") {
+    return `Endpoint heartbeat failed. Restart cloudflared with IPv4 localhost origin: ${tunnelCommand}`;
+  }
   if (provider === "ngrok") {
     return `Endpoint heartbeat failed. Restart ngrok with: ${tunnelCommand}`;
   }
@@ -280,11 +296,6 @@ export async function createOrRotateEndpoint(input: EndpointActionInput): Promis
 
   const endpointUrl =
     normalizeEndpointUrl(input.endpointUrl) || `https://your-subdomain.ngrok-free.app`;
-  if (isCloudflareTunnelHost(endpointUrl)) {
-    throw new Error(
-      "Cloudflare Tunnel onboarding is temporarily unsupported while RCA is in progress. Use an ngrok HTTPS endpoint (recommended) or localtunnel fallback."
-    );
-  }
   const token = issueEndpointToken();
   const proxyPort = resolveProxyPort(input.port);
   const proxyCommand = buildProxyCommand(input.port, proxyPort, token);
@@ -360,11 +371,6 @@ export async function heartbeatEndpoint(input: {
 
   const port = input.port ?? existing?.endpoint.localPort;
   const endpointUrl = normalizeEndpointUrl(input.endpointUrl || existing?.endpoint.url);
-  if (endpointUrl && isCloudflareTunnelHost(endpointUrl)) {
-    throw new Error(
-      "Cloudflare Tunnel endpoint detected. This path is temporarily disabled pending RCA, use ngrok endpoint and rerun endpoint setup."
-    );
-  }
   const token = existing?.endpoint.auth.token;
   const proxyPort = existing?.endpoint.proxyPort ?? (port ? resolveProxyPort(port) : undefined);
 


### PR DESCRIPTION
## Summary
- re-enable Cloudflare tunnel endpoints in controlled mode instead of provider-level blocking
- keep ngrok-first guidance while allowing Cloudflare when endpoint compliance checks pass
- enforce fail-closed behavior through existing x402 compliance probes (`requireX402`) in guided setup/register flows
- update onboarding endpoint manager tunnel provider handling and recovery guidance
- update RCA/security docs to reflect post-RCA policy

## Why
RCA decision lane is now PASS with deterministic fixture evidence, so we can move from provider-blocking to behavior-gating.

## Validation
- `npx jest lib/__tests__/register-probe-route.test.ts lib/__tests__/endpoint-security-compat.test.ts --runInBand`
- `npm run test:bdd:sweep`
  - artifact: `artifacts/bdd-sweep/20260426-081621/SUMMARY.md`

## Notes
- left untracked local artifacts/onboarding data out of commit (no test/runtime temp files included)
