### PR TITLE
feat(specialist): add callable readiness dashboard

### DIFF
--- a/app/specialist/page.tsx
+++ b/app/specialist/page.tsx
@@ -8,6 +8,10 @@ import { Input } from "@/components/ui/input";
 import { TASK_TYPES } from "@/lib/capabilities/taxonomy";
 import { toExplorerAddressUrl } from "@/lib/config/explorer";
 import type { SpecialistListing } from "@/lib/registry/bridge";
+import {
+  summarizeSpecialistCallableReadiness,
+  type SpecialistX402ProbeSummary,
+} from "@/lib/specialist/callable-readiness";
 
 function shortWallet(w: string) {
   return !w || w.length < 12 ? w : `${w.slice(0, 8)}…${w.slice(-6)}`;
@@ -25,11 +29,19 @@ function HealthBadge({ status }: { status: string }) {
   );
 }
 
+function ReadinessPill({ status }: { status: "pass" | "warn" | "fail" }) {
+  if (status === "pass") return <span className="text-[#14F195]">Pass</span>;
+  if (status === "warn") return <span className="text-yellow-300">Check</span>;
+  return <span className="text-red-300">Blocked</span>;
+}
+
 export default function SpecialistDashboard() {
   const [wallet, setWallet] = useState("");
   const [listing, setListing] = useState<SpecialistListing | null>(null);
   const [walletInput, setWalletInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [checkingX402, setCheckingX402] = useState(false);
+  const [latestProbe, setLatestProbe] = useState<SpecialistX402ProbeSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // Auto-load from localStorage if wizard stored wallet
@@ -57,6 +69,7 @@ export default function SpecialistDashboard() {
       if (found) {
         setListing(found);
         setWallet(w.trim());
+        setLatestProbe(null);
       } else {
         setError("Wallet not found in registry. Complete onboarding first.");
         setListing(null);
@@ -68,6 +81,30 @@ export default function SpecialistDashboard() {
     }
   }, []);
 
+  const runCallableCheck = useCallback(async () => {
+    if (!listing?.health.endpointUrl) return;
+    setCheckingX402(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/onboarding/healthcheck", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          walletAddress: listing.walletAddress,
+          endpointUrl: listing.health.endpointUrl,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) throw new Error(data.error ?? "Callable readiness check failed");
+      await loadListing(listing.walletAddress);
+      setLatestProbe(data.result as SpecialistX402ProbeSummary);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Callable readiness check failed");
+    } finally {
+      setCheckingX402(false);
+    }
+  }, [listing, loadListing]);
+
   useEffect(() => {
     if (wallet) loadListing(wallet);
   }, [wallet, loadListing]);
@@ -75,6 +112,7 @@ export default function SpecialistDashboard() {
   const cap = listing?.capabilities;
   const onchain = listing?.onchain;
   const signals = listing?.signals;
+  const callableReadiness = listing ? summarizeSpecialistCallableReadiness(listing, latestProbe) : null;
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-12 space-y-8">
@@ -152,6 +190,49 @@ export default function SpecialistDashboard() {
               </Link>
             </div>
           </div>
+
+          {/* Callable readiness */}
+          {callableReadiness && (
+            <div className={`rounded-xl border p-5 space-y-4 ${
+              callableReadiness.status === "callable"
+                ? "border-[#14F195]/30 bg-[#14F195]/5"
+                : callableReadiness.status === "blocked"
+                  ? "border-red-500/30 bg-red-950/20"
+                  : "border-yellow-500/30 bg-yellow-950/20"
+            }`}>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Callable readiness</p>
+                  <h2 className="text-lg font-semibold">{callableReadiness.headline}</h2>
+                  <p className="text-sm text-muted-foreground">Next: {callableReadiness.nextAction}</p>
+                  {latestProbe && (
+                    <p className="text-xs text-muted-foreground/70">Last x402 check: {new Date(latestProbe.checkedAt).toLocaleString()} · {latestProbe.note}</p>
+                  )}
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={runCallableCheck}
+                  disabled={checkingX402 || !listing.health.endpointUrl}
+                >
+                  {checkingX402 ? "Checking…" : "Run x402 compliance check"}
+                </Button>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                {callableReadiness.items.map((item) => (
+                  <div key={item.id} className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm space-y-1">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="font-medium">{item.label}</p>
+                      <span className="text-xs font-semibold"><ReadinessPill status={item.status} /></span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">{item.detail}</p>
+                    {item.status !== "pass" && <p className="text-xs text-muted-foreground/70">Fix: {item.action}</p>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Metrics */}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -9,7 +9,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket A — Onboarding
 - Feature: `docs/bdd/features/bucket-a-onboarding.feature`
 - Verify:
-  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/onboarding-routes-wrappers.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts --runInBand`
+  - `npx jest lib/__tests__/onboarding-routes-core.test.ts lib/__tests__/onboarding-routes-support.test.ts lib/__tests__/onboarding-routes-wrappers.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts lib/__tests__/specialist-callable-readiness.test.ts --runInBand`
   - `npx playwright test e2e/onboarding.spec.ts --grep "consent gates|next button advances|back button returns|step 2 runtime — next is disabled|run button disabled when prompt is empty"`
 
 ### Bucket B — Discovery + Capability Index
@@ -25,7 +25,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket D/E — Security + Reliability
 - Feature: `docs/bdd/features/bucket-d-e-reliability.feature`
 - Verify:
-  - `npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/endpoint-manager-reliability.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts lib/__tests__/program-rpc-config.test.ts --runInBand`
+  - `npx jest lib/__tests__/endpoint-security-compat.test.ts lib/__tests__/endpoint-manager-reliability.test.ts lib/__tests__/operator-key-rotation.test.ts lib/__tests__/onboarding-operator-status-routes.test.ts lib/__tests__/program-rpc-config.test.ts lib/__tests__/specialist-callable-readiness.test.ts --runInBand`
   - `npm run test:e2e:integration-lane`
 
 ### Bucket F — Jupiter Cross-Token Settlement

--- a/docs/bdd/features/bucket-a-onboarding.feature
+++ b/docs/bdd/features/bucket-a-onboarding.feature
@@ -61,3 +61,10 @@ Feature: Bucket A Specialist Onboarding
     When onboarding reaches post-attestation settlement actions
     Then confirm/dispute flow is available and state-consistent
     And behavior is covered by onboarding and planner settlement contracts
+
+  @A3.2 @A3.3 @D2.1 @role-specialist @route-unit
+  Scenario: Specialist dashboard shows callable readiness
+    When a registered specialist opens their dashboard
+    Then the dashboard summarizes registry, endpoint, x402, capability, and attestation readiness
+    And an insecure open completion endpoint is blocked as unpaid-bypass risk
+    And the behavior is covered by "lib/__tests__/specialist-callable-readiness.test.ts"

--- a/docs/bdd/features/bucket-d-e-reliability.feature
+++ b/docs/bdd/features/bucket-d-e-reliability.feature
@@ -14,6 +14,13 @@ Feature: Bucket D and E Security + Reliability
     And misconfiguration is detectable in healthcheck behavior
     And the behavior is covered by "lib/__tests__/endpoint-security-compat.test.ts"
 
+  @D2.1 @A3.3 @role-specialist @route-unit
+  Scenario: Callable readiness fails closed on unpaid completion bypass
+    When specialist callable readiness receives an insecure open-completion probe result
+    Then the specialist is marked blocked instead of callable
+    And the next action instructs the operator to place x402 in front of `/v1/chat/completions`
+    And the behavior is covered by "lib/__tests__/specialist-callable-readiness.test.ts"
+
   @E2.1 @E2.2 @route-unit
   Scenario: Operator key status and rotation safeguards are explicit
     When operator key status and rotation validations run

--- a/lib/__tests__/specialist-callable-readiness.test.ts
+++ b/lib/__tests__/specialist-callable-readiness.test.ts
@@ -1,0 +1,65 @@
+import { summarizeSpecialistCallableReadiness } from "@/lib/specialist/callable-readiness";
+
+const baseListing = {
+  walletAddress: "wallet-11111111111111111111111111111111",
+  pda: "pda-1",
+  health: {
+    status: "pass" as const,
+    freshnessState: "fresh" as const,
+    endpointUrl: "https://agent.example.com",
+    lastCheckedAt: "2026-04-27T00:00:00.000Z",
+  },
+  capabilities: {
+    taskTypes: ["summarize"],
+    inputModes: ["text"],
+    outputModes: ["text"],
+    privacyModes: ["prompt_private"],
+    tags: [],
+    baseUsd: 0.01,
+    perCallUsd: 0.01,
+    context_requirements: [],
+    runtime_capabilities: [],
+  },
+  attestation: {
+    attested: true,
+    lastAttestedAt: "2026-04-27T00:00:00.000Z",
+  },
+};
+
+describe("specialist callable readiness", () => {
+  it("marks a healthy x402-protected specialist callable", () => {
+    const summary = summarizeSpecialistCallableReadiness(baseListing, {
+      status: "pass",
+      reachable: true,
+      x402Probe: "ok",
+      securityStatus: "x402_challenge_detected",
+      checkedAt: "2026-04-27T00:00:00.000Z",
+      note: "ok",
+    });
+
+    expect(summary.status).toBe("callable");
+    expect(summary.items.find((item) => item.id === "x402")?.status).toBe("pass");
+  });
+
+  it("blocks specialists whose completion endpoint is open without x402", () => {
+    const summary = summarizeSpecialistCallableReadiness(baseListing, {
+      status: "fail",
+      reachable: true,
+      x402Probe: "fail",
+      securityStatus: "insecure_open_completion",
+      checkedAt: "2026-04-27T00:00:00.000Z",
+      note: "open completion",
+    });
+
+    expect(summary.status).toBe("blocked");
+    expect(summary.headline).toMatch(/unpaid completions/i);
+    expect(summary.items.find((item) => item.id === "x402")?.detail).toMatch(/unpaid-bypass risk/i);
+  });
+
+  it("requires capability registration before safe marketplace calls", () => {
+    const summary = summarizeSpecialistCallableReadiness({ ...baseListing, capabilities: null }, null);
+
+    expect(summary.status).toBe("action_required");
+    expect(summary.items.find((item) => item.id === "capabilities")?.status).toBe("fail");
+  });
+});

--- a/lib/specialist/callable-readiness.ts
+++ b/lib/specialist/callable-readiness.ts
@@ -1,0 +1,117 @@
+import type { SpecialistListing } from "@/lib/registry/bridge";
+
+export type SpecialistX402ProbeSummary = {
+  status: "pass" | "degraded" | "fail";
+  reachable: boolean;
+  x402Probe: "ok" | "degraded" | "fail";
+  securityStatus: "unknown" | "x402_challenge_detected" | "insecure_open_completion";
+  checkedAt: string;
+  note: string;
+};
+
+export type CallableReadinessItem = {
+  id: "listing" | "endpoint" | "x402" | "capabilities" | "attestation";
+  label: string;
+  status: "pass" | "warn" | "fail";
+  detail: string;
+  action: string;
+};
+
+export type CallableReadinessSummary = {
+  status: "callable" | "action_required" | "blocked";
+  headline: string;
+  nextAction: string;
+  items: CallableReadinessItem[];
+};
+
+export function summarizeSpecialistCallableReadiness(
+  listing: Pick<SpecialistListing, "walletAddress" | "pda" | "health" | "capabilities" | "attestation">,
+  latestProbe?: SpecialistX402ProbeSummary | null
+): CallableReadinessSummary {
+  const hasListing = Boolean(listing.walletAddress && (listing.pda || listing.capabilities));
+  const hasEndpoint = Boolean(listing.health.endpointUrl);
+  const endpointPass = listing.health.status === "pass" || latestProbe?.status === "pass" || latestProbe?.status === "degraded";
+  const insecureOpenCompletion = latestProbe?.securityStatus === "insecure_open_completion";
+  const x402Pass = latestProbe?.securityStatus === "x402_challenge_detected" || (!latestProbe && listing.health.status === "pass");
+  const hasCapabilities = Boolean(listing.capabilities && listing.capabilities.taskTypes.length > 0);
+  const attested = listing.attestation.attested;
+
+  const items: CallableReadinessItem[] = [
+    {
+      id: "listing",
+      label: "Registry listing",
+      status: hasListing ? "pass" : "fail",
+      detail: hasListing ? "Wallet is visible in the marketplace registry." : "Wallet is not yet registered in the marketplace registry.",
+      action: hasListing ? "No action needed." : "Complete Specialist onboarding and submit registration.",
+    },
+    {
+      id: "endpoint",
+      label: "Endpoint health",
+      status: endpointPass ? "pass" : hasEndpoint ? "warn" : "fail",
+      detail: endpointPass
+        ? "Endpoint is reachable enough for consumers to route paid calls."
+        : hasEndpoint
+          ? "Endpoint exists, but the last healthcheck did not prove callable readiness."
+          : "No endpoint URL is attached to this specialist listing.",
+      action: endpointPass ? "Keep the tunnel/runtime online." : "Restart the runtime/tunnel and rerun the healthcheck.",
+    },
+    {
+      id: "x402",
+      label: "x402 protected completion",
+      status: insecureOpenCompletion ? "fail" : x402Pass ? "pass" : "warn",
+      detail: insecureOpenCompletion
+        ? "The completion endpoint returned 200 without an x402 challenge. This is blocked as unpaid-bypass risk."
+        : x402Pass
+          ? "`/v1/chat/completions` challenges first with HTTP 402 + x402-request before payment."
+          : "No fresh proof that `/v1/chat/completions` fails closed before payment.",
+      action: insecureOpenCompletion
+        ? "Put the x402 payment proxy in front of `/v1/chat/completions`, then rerun the check."
+        : x402Pass
+          ? "No action needed."
+          : "Run the x402 compliance check from this dashboard.",
+    },
+    {
+      id: "capabilities",
+      label: "Capability profile",
+      status: hasCapabilities ? "pass" : "fail",
+      detail: hasCapabilities ? "Task types, IO modes, privacy, and pricing are registered." : "Consumers cannot filter or understand this specialist without capabilities.",
+      action: hasCapabilities ? "Keep pricing/capability claims current." : "Complete capability setup in onboarding.",
+    },
+    {
+      id: "attestation",
+      label: "Attestation",
+      status: attested ? "pass" : "warn",
+      detail: attested ? "This specialist has attestation evidence." : "Specialist is callable, but lacks attestation evidence for higher-trust routing.",
+      action: attested ? "No action needed." : "Run attestation to improve trust and routing rank.",
+    },
+  ];
+
+  if (insecureOpenCompletion) {
+    return {
+      status: "blocked",
+      headline: "Blocked: endpoint can serve unpaid completions",
+      nextAction: "Put the x402 proxy in front of `/v1/chat/completions`, then rerun the compliance check.",
+      items,
+    };
+  }
+
+  const failedRequired = items.some((item) => ["listing", "endpoint", "x402", "capabilities"].includes(item.id) && item.status === "fail");
+  const warnedRequired = items.some((item) => ["endpoint", "x402"].includes(item.id) && item.status === "warn");
+
+  if (!failedRequired && !warnedRequired) {
+    return {
+      status: "callable",
+      headline: attested ? "Callable: consumers can pay and invoke this specialist" : "Callable with trust warning",
+      nextAction: attested ? "Keep runtime, tunnel, and x402 proxy online." : "Add attestation evidence to improve marketplace trust.",
+      items,
+    };
+  }
+
+  const firstAction = items.find((item) => item.status === "fail" || item.status === "warn")?.action ?? "Rerun readiness checks.";
+  return {
+    status: "action_required",
+    headline: "Action required before this specialist is safely callable",
+    nextAction: firstAction,
+    items,
+  };
+}


### PR DESCRIPTION
## Summary
- adds Specialist callable-readiness model and dashboard panel
- summarizes registry listing, endpoint health, x402 protected completion, capability profile, and attestation state
- adds dashboard-triggered x402 compliance check via existing onboarding healthcheck route
- blocks insecure open-completion endpoints as unpaid-bypass risk
- maps A3.2/A3.3/D2.1 BDD scenarios and updates the feature index

## Verification
- npx jest lib/__tests__/specialist-callable-readiness.test.ts lib/__tests__/healthcheck-x402.test.ts lib/__tests__/register-probe-route.test.ts --runInBand
- npm run test:bdd:index
- npm run build

## Notes
- continues the role/BDD alignment plan Iteration 2
- no direct push to main