### PR TITLE
feat(consumer): add guided paid call policy and receipt

### DIFF
--- a/app/api/onboarding/planner/execute/route.ts
+++ b/app/api/onboarding/planner/execute/route.ts
@@ -22,6 +22,8 @@ export async function POST(req: Request) {
     const body = await req.json();
     const result = await executePlannerSpecialistCall({
       prompt: String(body.prompt || ""),
+      consumerWallet: typeof body.consumerWallet === "string" ? body.consumerWallet : undefined,
+      preferredWallet: typeof body.preferredWallet === "string" ? body.preferredWallet : undefined,
       policy: {
         requiredPrivacyMode:
           body.policy?.requiredPrivacyMode === "public" ||
@@ -41,6 +43,7 @@ export async function POST(req: Request) {
           body.policy?.maxPerCallUsd === undefined
             ? undefined
             : Number(body.policy.maxPerCallUsd),
+        preferredWallet: typeof body.policy?.preferredWallet === "string" ? body.policy.preferredWallet : undefined,
       },
     });
 

--- a/app/planner/page.tsx
+++ b/app/planner/page.tsx
@@ -15,6 +15,7 @@ import { PageHeader } from "@/components/ui/page-header"
 import { Textarea } from "@/components/ui/textarea"
 import { showToast } from "@/components/ui/toast"
 import { TASK_TYPES, PRIVACY_MODES } from "@/lib/capabilities/taxonomy"
+import { summarizeConsumerPolicy, summarizeConsumerReceipt } from "@/lib/consumer/guided-paid-call"
 import type { SpecialistListing } from "@/lib/registry/bridge"
 
 const WalletMultiButton = dynamic(async () => (await import("@solana/wallet-adapter-react-ui")).WalletMultiButton, { ssr: false })
@@ -86,6 +87,8 @@ function PlannerInner() {
   const [prompt, setPrompt] = useState("")
   const [taskType, setTaskType] = useState<string>(TASK_TYPES[0].id)
   const [privacyMode, setPrivacyMode] = useState<"public" | "per" | "vanish">("public")
+  const [maxPerCallUsd, setMaxPerCallUsd] = useState("0.01")
+  const [requiresAttested, setRequiresAttested] = useState(false)
   const [loadingCandidates, setLoadingCandidates] = useState(false)
   const [candidates, setCandidates] = useState<SpecialistListing[]>([])
   const [selectedWallet, setSelectedWallet] = useState<string>(preferredWallet)
@@ -134,6 +137,21 @@ function PlannerInner() {
     return scored.slice(0, 3)
   }, [allAgents])
 
+  const maxSpend = useMemo(() => {
+    const parsed = Number(maxPerCallUsd)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+  }, [maxPerCallUsd])
+
+  const consumerPolicy = useMemo(() => summarizeConsumerPolicy({
+    requiredPrivacyMode: privacyMode,
+    requiresHealthPass: true,
+    requiresAttested,
+    maxPerCallUsd: maxSpend,
+    preferredWallet: selectedWallet || undefined,
+  }), [privacyMode, requiresAttested, maxSpend, selectedWallet])
+
+  const receiptSummary = useMemo(() => run ? summarizeConsumerReceipt(run, maxSpend) : null, [run, maxSpend])
+
   useEffect(() => {
     if (!preferredWallet) return
     setSelectedWallet(preferredWallet)
@@ -149,7 +167,11 @@ function PlannerInner() {
         body: JSON.stringify({
           task: prompt,
           taskTypeHint: taskType,
-          policy: { preferredPrivacyMode: privacyMode },
+          policy: {
+            preferredPrivacyMode: privacyMode,
+            maxPerCallUsd: maxSpend,
+            requireAttestation: requiresAttested,
+          },
         }),
       })
       const data: ResolveResult = await res.json()
@@ -172,9 +194,13 @@ function PlannerInner() {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           prompt,
+          preferredWallet: selectedWallet,
           policy: {
             requiredPrivacyMode: privacyMode,
             requiresHealthPass: true,
+            requiresAttested,
+            maxPerCallUsd: maxSpend,
+            preferredWallet: selectedWallet,
           },
         }),
       })
@@ -275,6 +301,28 @@ function PlannerInner() {
                         {PRIVACY_MODES.map((mode) => <option key={mode.id} value={mode.id}>{mode.label}</option>)}
                       </select>
                     </label>
+                    <label className="space-y-2 text-sm text-gray-400">
+                      <span>Max spend / call (USD)</span>
+                      <input
+                        className="w-full rounded-lg border border-border bg-page px-3 py-2 text-white"
+                        inputMode="decimal"
+                        value={maxPerCallUsd}
+                        onChange={(e) => setMaxPerCallUsd(e.target.value)}
+                      />
+                    </label>
+                    <label className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-gray-300">
+                      <input type="checkbox" checked={requiresAttested} onChange={(e) => setRequiresAttested(e.target.checked)} />
+                      Require attested specialist
+                    </label>
+                  </div>
+                  <div className="rounded-xl border border-indigo-500/20 bg-indigo-500/10 p-4 text-sm text-gray-300">
+                    <p className="font-medium text-white">Policy before payment</p>
+                    <div className="mt-2 grid gap-2 text-xs sm:grid-cols-3">
+                      <span>Budget: {consumerPolicy.maxSpendLabel}</span>
+                      <span>Privacy: {consumerPolicy.privacyLabel}</span>
+                      <span>Trust: {consumerPolicy.attestationLabel}</span>
+                    </div>
+                    <p className="mt-2 text-xs text-gray-400">{consumerPolicy.safeguards[1]}</p>
                   </div>
                   <Button className="w-full" disabled={!prompt.trim() || loadingCandidates} onClick={findSpecialists}>
                     {loadingCandidates ? "Finding specialists…" : "Find Specialists →"}
@@ -342,9 +390,18 @@ function PlannerInner() {
                     <div className="mt-3 space-y-1 font-mono text-xs text-gray-400">
                       <p>tx: {run.x402TxSignature ?? "n/a"}</p>
                       <p>nonce: {run.x402ReceiptNonce ?? "n/a"}</p>
+                      <p>specialist: {run.selectedWallet ?? "n/a"}</p>
+                      <p>amount: {receiptSummary?.amountLabel ?? "n/a"}</p>
+                      <p>prompt: {receiptSummary?.promptStorage === "sha256_only" ? "sha256 only (raw prompt not required)" : "n/a"}</p>
                       <p>status: {run.status}</p>
                     </div>
                   </details>
+                  {receiptSummary ? (
+                    <div className={`rounded-xl border p-4 text-sm ${receiptSummary.status === "paid" ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200" : receiptSummary.status === "blocked" ? "border-red-500/30 bg-red-500/10 text-red-200" : "border-yellow-500/30 bg-yellow-500/10 text-yellow-100"}`}>
+                      <p className="font-medium">{receiptSummary.status === "paid" ? "Paid receipt captured" : receiptSummary.status === "blocked" ? "Unpaid completion blocked" : "Run did not complete"}</p>
+                      <p className="mt-1 text-xs opacity-80">{receiptSummary.message}</p>
+                    </div>
+                  ) : null}
                   <Button className="w-full" onClick={() => setStep(3)}>
                     Continue to feedback →
                   </Button>

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -20,7 +20,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket C — Planner-Native Consumption
 - Feature: `docs/bdd/features/bucket-c-planner-consumption.feature`
 - Verify:
-  - `npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-client.test.ts --runInBand`
+  - `npx jest lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-execute-route-preferred-wallet.test.ts lib/__tests__/consumer-guided-paid-call.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/torque-event-route.test.ts lib/__tests__/torque-client.test.ts --runInBand`
 
 ### Bucket D/E — Security + Reliability
 - Feature: `docs/bdd/features/bucket-d-e-reliability.feature`

--- a/docs/bdd/features/bucket-c-planner-consumption.feature
+++ b/docs/bdd/features/bucket-c-planner-consumption.feature
@@ -35,3 +35,13 @@ Feature: Bucket C Planner-Native Specialist Consumption
       | lib/__tests__/planner-signal-route.test.ts |
       | lib/__tests__/torque-event-route.test.ts |
       | lib/__tests__/torque-client.test.ts |
+
+  @C5.1 @C5.2 @C5.3 @role-consumer @route-unit
+  Scenario: Consumer guided paid call exposes policy and receipt safeguards
+    When a consumer prepares and executes a specialist call
+    Then max spend, privacy mode, attestation requirement, and selected specialist are visible before payment
+    And unpaid open-completion responses are marked blocked rather than successful
+    And the receipt shows tx, nonce, specialist wallet, amount bound, and prompt-hash-only storage
+    And the behavior is covered by:
+      | lib/__tests__/consumer-guided-paid-call.test.ts |
+      | lib/__tests__/planner-execute-route-preferred-wallet.test.ts |

--- a/lib/__tests__/consumer-guided-paid-call.test.ts
+++ b/lib/__tests__/consumer-guided-paid-call.test.ts
@@ -1,0 +1,76 @@
+import { summarizeConsumerPolicy, summarizeConsumerReceipt } from "@/lib/consumer/guided-paid-call";
+
+describe("consumer guided paid call summaries", () => {
+  it("requires specialist selection before execution", () => {
+    const summary = summarizeConsumerPolicy({
+      requiredPrivacyMode: "per",
+      requiresHealthPass: true,
+      requiresAttested: true,
+      maxPerCallUsd: 0.05,
+    });
+
+    expect(summary.status).toBe("needs_selection");
+    expect(summary.nextAction).toMatch(/Select a resolved specialist/i);
+    expect(summary.safeguards.join(" ")).toMatch(/HTTP 402/);
+  });
+
+  it("marks policy ready when spend, privacy, attestation, and wallet are explicit", () => {
+    const summary = summarizeConsumerPolicy({
+      requiredPrivacyMode: "vanish",
+      requiresHealthPass: true,
+      requiresAttested: false,
+      maxPerCallUsd: 0.01,
+      preferredWallet: "wallet-specialist",
+    });
+
+    expect(summary.status).toBe("ready");
+    expect(summary.maxSpendLabel).toBe("$0.0100 max");
+    expect(summary.privacyLabel).toMatch(/Vanish/);
+  });
+
+  it("summarizes paid receipt without raw prompt storage", () => {
+    const receipt = summarizeConsumerReceipt({
+      runId: "run_1",
+      createdAt: "2026-04-27T00:00:00.000Z",
+      selectedWallet: "wallet-specialist",
+      endpointUrl: "https://agent.example",
+      policy: { requiredPrivacyMode: "public" },
+      promptSha256: "abc",
+      status: "completed",
+      challengeSeen: true,
+      paymentAttempted: true,
+      paymentSatisfied: true,
+      x402TxSignature: "tx_123",
+      x402ReceiptNonce: "nonce_123",
+      trace: [],
+    }, 0.01);
+
+    expect(receipt).toMatchObject({
+      status: "paid",
+      txSignature: "tx_123",
+      nonce: "nonce_123",
+      promptStorage: "sha256_only",
+    });
+  });
+
+  it("marks unpaid open-completion responses as blocked receipts", () => {
+    const receipt = summarizeConsumerReceipt({
+      runId: "run_2",
+      createdAt: "2026-04-27T00:00:00.000Z",
+      selectedWallet: "wallet-specialist",
+      endpointUrl: "https://agent.example",
+      policy: { requiredPrivacyMode: "public" },
+      promptSha256: "abc",
+      status: "failed",
+      challengeSeen: false,
+      paymentAttempted: false,
+      paymentSatisfied: false,
+      error: "Specialist endpoint returned a completion without an x402 challenge. Refusing unpaid response.",
+      trace: ["x402:missing_challenge_unpaid_response_blocked"],
+    });
+
+    expect(receipt.status).toBe("blocked");
+    expect(receipt.amountLabel).toBe("No payment accepted");
+    expect(receipt.message).toMatch(/failed closed/i);
+  });
+});

--- a/lib/__tests__/planner-execute-route-preferred-wallet.test.ts
+++ b/lib/__tests__/planner-execute-route-preferred-wallet.test.ts
@@ -1,0 +1,60 @@
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/onboarding/planner-execution", () => ({
+  executePlannerSpecialistCall: jest.fn(),
+  listPlannerRuns: jest.fn(),
+}));
+
+describe("onboarding planner execute route preferred wallet", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("passes selected specialist, consumer wallet, and policy into execution", async () => {
+    const { executePlannerSpecialistCall } = await import("@/lib/onboarding/planner-execution");
+    (executePlannerSpecialistCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      result: {
+        runId: "run_123",
+        status: "completed",
+        selectedWallet: "wallet-specialist",
+        paymentSatisfied: true,
+      },
+    });
+
+    const { POST } = await import("@/app/api/onboarding/planner/execute/route");
+    const req = new NextRequest("http://localhost/api/onboarding/planner/execute", {
+      method: "POST",
+      body: JSON.stringify({
+        prompt: "summarize this",
+        consumerWallet: "wallet-consumer",
+        preferredWallet: "wallet-specialist",
+        policy: {
+          requiredPrivacyMode: "per",
+          requiresHealthPass: true,
+          requiresAttested: true,
+          maxPerCallUsd: 0.01,
+          preferredWallet: "wallet-specialist",
+        },
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const res = await POST(req as unknown as Request);
+
+    expect(res.status).toBe(200);
+    expect(executePlannerSpecialistCall).toHaveBeenCalledWith({
+      prompt: "summarize this",
+      consumerWallet: "wallet-consumer",
+      preferredWallet: "wallet-specialist",
+      policy: {
+        requiredPrivacyMode: "per",
+        requiresHealthPass: true,
+        requiresAttested: true,
+        maxPerCallUsd: 0.01,
+        preferredWallet: "wallet-specialist",
+      },
+    });
+  });
+});

--- a/lib/consumer/guided-paid-call.ts
+++ b/lib/consumer/guided-paid-call.ts
@@ -1,0 +1,114 @@
+export type ConsumerGuidedPolicy = {
+  requiredPrivacyMode: "public" | "per" | "vanish";
+  requiresHealthPass: boolean;
+  requiresAttested: boolean;
+  maxPerCallUsd?: number;
+  preferredWallet?: string;
+};
+
+export type ConsumerPolicySummary = {
+  status: "ready" | "needs_selection" | "blocked";
+  maxSpendLabel: string;
+  privacyLabel: string;
+  attestationLabel: string;
+  nextAction: string;
+  safeguards: string[];
+};
+
+export type ConsumerReceiptSummary = {
+  status: "paid" | "blocked" | "failed";
+  txSignature: string | null;
+  nonce: string | null;
+  specialistWallet: string | null;
+  amountLabel: string;
+  promptStorage: "sha256_only";
+  message: string;
+};
+
+export function summarizeConsumerPolicy(policy: ConsumerGuidedPolicy): ConsumerPolicySummary {
+  const maxSpendLabel = policy.maxPerCallUsd === undefined ? "Protocol/default budget" : `$${policy.maxPerCallUsd.toFixed(4)} max`;
+  const privacyLabel = policy.requiredPrivacyMode === "per" ? "Private PER mode" : policy.requiredPrivacyMode === "vanish" ? "Vanish/no-retention mode" : "Public mode";
+  const attestationLabel = policy.requiresAttested ? "Attested specialists only" : "Attestation optional";
+
+  if (!policy.preferredWallet) {
+    return {
+      status: "needs_selection",
+      maxSpendLabel,
+      privacyLabel,
+      attestationLabel,
+      nextAction: "Select a resolved specialist before executing the paid call.",
+      safeguards: [
+        "Healthcheck pass is required before invocation.",
+        "First response must be HTTP 402 + x402-request before any completion is accepted.",
+      ],
+    };
+  }
+
+  if (policy.maxPerCallUsd !== undefined && policy.maxPerCallUsd <= 0) {
+    return {
+      status: "blocked",
+      maxSpendLabel,
+      privacyLabel,
+      attestationLabel,
+      nextAction: "Set a max spend greater than $0 before execution.",
+      safeguards: ["No paid call will start with an invalid spend cap."],
+    };
+  }
+
+  return {
+    status: "ready",
+    maxSpendLabel,
+    privacyLabel,
+    attestationLabel,
+    nextAction: "Execute only after reviewing specialist, budget, privacy, and attestation policy.",
+    safeguards: [
+      "Healthcheck pass is required before invocation.",
+      "Unpaid 200 completions are refused as bypass risk.",
+      "Receipt stores tx/nonce and prompt hash; raw prompt is not required for audit.",
+    ],
+  };
+}
+
+export function summarizeConsumerReceipt(run: {
+  status: "completed" | "failed";
+  paymentSatisfied: boolean;
+  paymentAttempted: boolean;
+  selectedWallet?: string;
+  x402TxSignature?: string;
+  x402ReceiptNonce?: string;
+  error?: string;
+}, maxPerCallUsd?: number): ConsumerReceiptSummary {
+  if (run.status === "completed" && run.paymentSatisfied) {
+    return {
+      status: "paid",
+      txSignature: run.x402TxSignature ?? null,
+      nonce: run.x402ReceiptNonce ?? null,
+      specialistWallet: run.selectedWallet ?? null,
+      amountLabel: maxPerCallUsd === undefined ? "Within protocol/default budget" : `≤ $${maxPerCallUsd.toFixed(4)}`,
+      promptStorage: "sha256_only",
+      message: "Paid x402 retry completed; receipt is safe to show without raw prompt storage.",
+    };
+  }
+
+  if (run.error?.toLowerCase().includes("without an x402 challenge")) {
+    return {
+      status: "blocked",
+      txSignature: null,
+      nonce: null,
+      specialistWallet: run.selectedWallet ?? null,
+      amountLabel: "No payment accepted",
+      promptStorage: "sha256_only",
+      message: "Specialist returned an unpaid completion. The consumer flow failed closed and did not accept it as success.",
+    };
+  }
+
+  return {
+    status: "failed",
+    txSignature: run.x402TxSignature ?? null,
+    nonce: run.x402ReceiptNonce ?? null,
+    specialistWallet: run.selectedWallet ?? null,
+    amountLabel: run.paymentAttempted ? "Payment attempted" : "No payment accepted",
+    promptStorage: "sha256_only",
+    message: run.error ?? "Specialist call did not complete.",
+  };
+}

--- a/lib/onboarding/planner-execution.ts
+++ b/lib/onboarding/planner-execution.ts
@@ -16,6 +16,8 @@ export type PlannerExecuteInput = {
   slippageBps?: number;
   /** Consumer wallet address — used for Torque event attribution */
   consumerWallet?: string;
+  /** Preferred specialist wallet selected by the consumer UI or MCP caller. */
+  preferredWallet?: string;
 };
 
 export type PlannerRunRecord = {
@@ -80,6 +82,7 @@ export async function executePlannerSpecialistCall(input: PlannerExecuteInput) {
   const policy: PlannerPolicyInput = {
     requiresHealthPass: true,
     ...input.policy,
+    preferredWallet: input.preferredWallet ?? input.policy?.preferredWallet,
   };
 
   const runId = `run_${randomUUID()}`;

--- a/lib/onboarding/planner-router.ts
+++ b/lib/onboarding/planner-router.ts
@@ -7,6 +7,7 @@ export type PlannerPolicyInput = {
   requiresAttested?: boolean;
   requiresHealthPass?: boolean;
   maxPerCallUsd?: number;
+  preferredWallet?: string;
 };
 
 export type PlannerCandidate = {
@@ -102,7 +103,13 @@ export function routePlannerPolicy(policy: PlannerPolicyInput) {
     });
   }
 
-  accepted.sort((a, b) => b.score - a.score);
+  accepted.sort((a, b) => {
+    if (policy.preferredWallet) {
+      if (a.walletAddress === policy.preferredWallet && b.walletAddress !== policy.preferredWallet) return -1;
+      if (b.walletAddress === policy.preferredWallet && a.walletAddress !== policy.preferredWallet) return 1;
+    }
+    return b.score - a.score;
+  });
 
   return {
     ok: true,


### PR DESCRIPTION
## Summary
- adds consumer guided paid-call policy summary for max spend, privacy mode, attestation requirement, selected specialist, and x402 safeguards
- updates /planner to show policy before payment and receipt after execution
- passes selected specialist/preferred wallet and consumer wallet through onboarding planner execute
- receipt summarizes tx, nonce, specialist wallet, amount bound, prompt-hash-only storage, and blocked unpaid-completion status
- maps Bucket C C5.1/C5.2/C5.3 in BDD feature index

## Verification
- npx jest lib/__tests__/consumer-guided-paid-call.test.ts lib/__tests__/planner-execute-route-preferred-wallet.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-execution-x402.test.ts --runInBand
- npm run test:bdd:index
- npm run build

## Notes
- continues role/BDD alignment plan Iteration 3
- no direct push to main