### PR TITLE
feat(attestor): add role readiness path

### DIFF
--- a/app/attestation/page.tsx
+++ b/app/attestation/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
+import { summarizeAttestorRole, type AttestorCandidate } from "@/lib/attestor/role-readiness";
 
 type AuditAttestation = {
   timestamp: string;
@@ -23,6 +24,10 @@ export default function AttestationDashboardPage() {
   const { connected } = useWallet();
   const [attestations, setAttestations] = useState<AuditAttestation[]>([]);
   const [commits, setCommits] = useState<RevealCommit[]>([]);
+  const [candidate, setCandidate] = useState<AttestorCandidate | null>(null);
+  const [candidateCount, setCandidateCount] = useState(0);
+  const [resolving, setResolving] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!connected) return;
@@ -43,6 +48,34 @@ export default function AttestationDashboardPage() {
   }, [connected]);
 
   const onchainCount = useMemo(() => attestations.filter((a) => Boolean(a.tx_signature)).length, [attestations]);
+  const roleSummary = useMemo(() => summarizeAttestorRole({
+    attestationRecords: attestations.length,
+    onchainAttestations: onchainCount,
+    revealCommits: commits.length,
+    availableAttestors: candidateCount,
+  }, candidate), [attestations.length, onchainCount, commits.length, candidateCount, candidate]);
+
+  async function resolveAttestor() {
+    setResolving(true);
+    setResolveError(null);
+    try {
+      const res = await fetch("/api/planner/tools/resolve-attestor", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ minAttestationAccuracy: 0, maxPerCallUsd: 1 }),
+      });
+      const data = await res.json();
+      setCandidate(data.candidate ?? null);
+      setCandidateCount(typeof data.count === "number" ? data.count : 0);
+      if (!res.ok || !data.ok) setResolveError(data.error ?? "No eligible attestor found.");
+    } catch (error) {
+      setCandidate(null);
+      setCandidateCount(0);
+      setResolveError(error instanceof Error ? error.message : "No eligible attestor found.");
+    } finally {
+      setResolving(false);
+    }
+  }
 
   if (!connected) {
     return <PageNotice title="Attestation Dashboard" text="Connect wallet to review attestation-owner protocol statistics." />;
@@ -60,6 +93,47 @@ export default function AttestationDashboardPage() {
         <Stat label="On-chain attestations" value={onchainCount} />
         <Stat label="Reveal commits" value={commits.length} />
       </div>
+
+      <section className={`rounded-xl border p-5 space-y-4 ${
+        roleSummary.status === "ready"
+          ? "border-[#14F195]/30 bg-[#14F195]/5"
+          : roleSummary.status === "needs_attestor"
+            ? "border-red-500/30 bg-red-950/20"
+            : "border-yellow-500/30 bg-yellow-950/20"
+      }`}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Attestor role path</p>
+            <h2 className="text-lg font-semibold">{roleSummary.headline}</h2>
+            <p className="text-sm text-muted-foreground">Next: {roleSummary.nextAction}</p>
+            {candidate && (
+              <p className="text-xs text-muted-foreground/70 font-mono">
+                Resolved attestor: {short(candidate.walletAddress)} · accuracy {candidate.attestationAccuracy ?? "—"} · {candidate.reasons?.join(" · ") ?? "attested"}
+              </p>
+            )}
+            {resolveError && <p className="text-xs text-red-300">{resolveError}</p>}
+          </div>
+          <button
+            onClick={resolveAttestor}
+            disabled={resolving}
+            className="rounded-lg border border-white/15 px-3 py-2 text-sm text-white hover:bg-white/10 disabled:opacity-60"
+          >
+            {resolving ? "Resolving…" : "Resolve attestor"}
+          </button>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {roleSummary.checks.map((check) => (
+            <div key={check.id} className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm space-y-1">
+              <div className="flex items-center justify-between gap-3">
+                <p className="font-medium">{check.label}</p>
+                <span className={check.status === "pass" ? "text-[#14F195]" : check.status === "warn" ? "text-yellow-300" : "text-red-300"}>{check.status}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">{check.detail}</p>
+            </div>
+          ))}
+        </div>
+      </section>
 
       <section className="rounded-xl border border-white/10 bg-card/20 p-5 space-y-3">
         <h2 className="text-lg font-semibold">Recent attestation records</h2>

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -43,7 +43,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket H — Consumer Orchestrator Lifecycle
 - Feature: `docs/bdd/features/bucket-h-consumer-orchestrator.feature`
 - Verify:
-  - `npx jest lib/__tests__/planner-register-consumer-route.test.ts lib/__tests__/planner-tools-manifest-route.test.ts lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-resolve-attestor-route.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-release-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/planner-auditability.test.ts lib/__tests__/dogfood-testing-specialist-route.test.ts lib/__tests__/dogfood-testing-attestor-route.test.ts lib/__tests__/dogfood-consumer-run-route.test.ts --runInBand`
+  - `npx jest lib/__tests__/planner-register-consumer-route.test.ts lib/__tests__/planner-tools-manifest-route.test.ts lib/__tests__/planner-resolve-route.test.ts lib/__tests__/planner-resolve-attestor-route.test.ts lib/__tests__/attestor-role-readiness.test.ts lib/__tests__/planner-invoke-route.test.ts lib/__tests__/planner-release-route.test.ts lib/__tests__/planner-signal-route.test.ts lib/__tests__/planner-auditability.test.ts lib/__tests__/dogfood-testing-specialist-route.test.ts lib/__tests__/dogfood-testing-attestor-route.test.ts lib/__tests__/dogfood-consumer-run-route.test.ts --runInBand`
   - `npx playwright test e2e/dogfood.spec.ts`
 
 ### Bucket S — Source Adapter Onboarding

--- a/docs/bdd/features/bucket-h-consumer-orchestrator.feature
+++ b/docs/bdd/features/bucket-h-consumer-orchestrator.feature
@@ -73,3 +73,12 @@ Feature: Bucket H Consumer Orchestrator Lifecycle
     When an operator runs forced pass and forced fail from /dogfood
     Then released and refunded outcomes are both visible in UI output
     And the behavior is covered by "e2e/dogfood.spec.ts"
+
+  @H6.1 @H6.2 @H6.3 @role-attestor @route-unit
+  Scenario: Attestor role path exposes verifier readiness and audit proof
+    When an attestor opens the attestation dashboard
+    Then the role path summarizes profile resolution, work queue, audit proof, and release/refund gate readiness
+    And no-candidate, no-activity, and ready states have explicit next actions
+    And the behavior is covered by:
+      | lib/__tests__/attestor-role-readiness.test.ts |
+      | lib/__tests__/planner-resolve-attestor-route.test.ts |

--- a/lib/__tests__/attestor-role-readiness.test.ts
+++ b/lib/__tests__/attestor-role-readiness.test.ts
@@ -1,0 +1,45 @@
+import { summarizeAttestorRole } from "@/lib/attestor/role-readiness";
+
+describe("attestor role readiness", () => {
+  it("requires an eligible attestor candidate before role is ready", () => {
+    const summary = summarizeAttestorRole({
+      attestationRecords: 0,
+      onchainAttestations: 0,
+      revealCommits: 0,
+      availableAttestors: 0,
+    });
+
+    expect(summary.status).toBe("needs_attestor");
+    expect(summary.nextAction).toMatch(/Register or attest/i);
+    expect(summary.checks.find((check) => check.id === "profile")?.status).toBe("fail");
+  });
+
+  it("marks discoverable attestor role as needing activity when no jobs exist", () => {
+    const summary = summarizeAttestorRole({
+      attestationRecords: 0,
+      onchainAttestations: 0,
+      revealCommits: 0,
+      availableAttestors: 1,
+    });
+
+    expect(summary.status).toBe("needs_activity");
+    expect(summary.headline).toMatch(/discoverable/i);
+  });
+
+  it("marks attestor role ready when verification and audit evidence exist", () => {
+    const summary = summarizeAttestorRole({
+      attestationRecords: 3,
+      onchainAttestations: 2,
+      revealCommits: 1,
+      availableAttestors: 1,
+    }, {
+      walletAddress: "wallet-attestor",
+      attestationAccuracy: 95,
+      reasons: ["attested", "health:pass"],
+    });
+
+    expect(summary.status).toBe("ready");
+    expect(summary.checks.map((check) => check.status)).toEqual(["pass", "pass", "pass", "pass"]);
+    expect(summary.nextAction).toMatch(/release\/refund/i);
+  });
+});

--- a/lib/attestor/role-readiness.ts
+++ b/lib/attestor/role-readiness.ts
@@ -1,0 +1,96 @@
+export type AttestorRoleCounts = {
+  attestationRecords: number;
+  onchainAttestations: number;
+  revealCommits: number;
+  availableAttestors: number;
+};
+
+export type AttestorCandidate = {
+  walletAddress: string;
+  endpointUrl?: string | null;
+  attestationAccuracy?: number;
+  avgFeedbackScore?: number;
+  perCallUsd?: number;
+  reasons?: string[];
+};
+
+export type AttestorRoleSummary = {
+  status: "ready" | "needs_attestor" | "needs_activity";
+  headline: string;
+  nextAction: string;
+  checks: Array<{
+    id: "profile" | "work_queue" | "audit" | "settlement_gate";
+    label: string;
+    status: "pass" | "warn" | "fail";
+    detail: string;
+  }>;
+};
+
+export function summarizeAttestorRole(counts: AttestorRoleCounts, candidate?: AttestorCandidate | null): AttestorRoleSummary {
+  const hasCandidate = Boolean(candidate?.walletAddress) || counts.availableAttestors > 0;
+  const hasRecords = counts.attestationRecords > 0;
+  const hasOnchain = counts.onchainAttestations > 0;
+  const hasRevealAudit = counts.revealCommits > 0;
+
+  const checks: AttestorRoleSummary["checks"] = [
+    {
+      id: "profile",
+      label: "Attestor profile",
+      status: hasCandidate ? "pass" : "fail",
+      detail: hasCandidate
+        ? "An attested specialist can be resolved as a verifier/judge."
+        : "No eligible attestor is currently resolvable; attested specialist evidence is required.",
+    },
+    {
+      id: "work_queue",
+      label: "Verification work queue",
+      status: hasRecords ? "pass" : "warn",
+      detail: hasRecords
+        ? `${counts.attestationRecords} attestation record(s) are available for review.`
+        : "No attestation jobs have been recorded yet; run dogfood or specialist health/attestation flow.",
+    },
+    {
+      id: "audit",
+      label: "Audit proof",
+      status: hasOnchain ? "pass" : hasRecords ? "warn" : "fail",
+      detail: hasOnchain
+        ? `${counts.onchainAttestations} attestation(s) include on-chain proof.`
+        : hasRecords
+          ? "Only local attestation evidence is visible; on-chain proof strengthens judge readiness."
+          : "No attestation audit proof is visible yet.",
+    },
+    {
+      id: "settlement_gate",
+      label: "Release/refund gate",
+      status: hasRevealAudit ? "pass" : "warn",
+      detail: hasRevealAudit
+        ? `${counts.revealCommits} reveal/settlement audit event(s) link verifier decisions to outcomes.`
+        : "No reveal/settlement decisions are visible yet; dogfood pass/fail demonstrates this gate.",
+    },
+  ];
+
+  if (!hasCandidate) {
+    return {
+      status: "needs_attestor",
+      headline: "Attestor path needs an eligible verifier",
+      nextAction: "Register or attest at least one specialist, then resolve an attestor for verification work.",
+      checks,
+    };
+  }
+
+  if (!hasRecords) {
+    return {
+      status: "needs_activity",
+      headline: "Attestor role is discoverable; verification activity is still needed",
+      nextAction: "Run the dogfood attestor flow or submit specialist attestation evidence.",
+      checks,
+    };
+  }
+
+  return {
+    status: "ready",
+    headline: hasOnchain ? "Attestor role is ready with audit evidence" : "Attestor role is ready with local audit evidence",
+    nextAction: hasRevealAudit ? "Use attestor decisions to gate release/refund flows." : "Run a pass/fail dogfood settlement to show release/refund gating.",
+    checks,
+  };
+}


### PR DESCRIPTION
## Summary
- adds Attestor role readiness model and dashboard panel on /attestation
- summarizes profile resolution, verification work queue, audit proof, and release/refund gate readiness
- lets dashboard resolve an eligible attestor through existing /api/planner/tools/resolve-attestor
- covers no-candidate, no-activity, and ready next-action states
- maps Bucket H H6.1/H6.2/H6.3 in BDD feature index

## Verification
- npx jest lib/__tests__/attestor-role-readiness.test.ts lib/__tests__/planner-resolve-attestor-route.test.ts lib/__tests__/dogfood-testing-attestor-route.test.ts lib/__tests__/dogfood-consumer-run-route.test.ts --runInBand
- npm run test:bdd:index
- npm run build

## Notes
- continues role/BDD alignment plan Iteration 4
- no direct push to main