### PR TITLE
feat(manager): add judge evidence pack

### DIFF
--- a/app/api/manager/evidence/route.ts
+++ b/app/api/manager/evidence/route.ts
@@ -1,0 +1,14 @@
+import { buildManagerEvidencePack } from "@/lib/manager/evidence-pack";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    return Response.json({ ok: true, result: buildManagerEvidencePack() });
+  } catch (error) {
+    return Response.json(
+      { ok: false, error: error instanceof Error ? error.message : "Evidence pack failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/manager/page.tsx
+++ b/app/manager/page.tsx
@@ -32,8 +32,24 @@ type Readiness = {
   roles: ManagerRole[];
 };
 
+type EvidencePack = {
+  generatedAt: string;
+  status: "ready" | "incomplete";
+  command: string;
+  artifacts: Array<{
+    id: string;
+    label: string;
+    path: string | null;
+    status: "present" | "missing";
+    summary: string;
+  }>;
+  privacy: { note: string; rawPromptsIncluded: false; secretsIncluded: false };
+  nextAction: string;
+};
+
 export default function ManagerPage() {
   const [readiness, setReadiness] = useState<Readiness | null>(null);
+  const [evidence, setEvidence] = useState<EvidencePack | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
@@ -43,6 +59,9 @@ export default function ManagerPage() {
       const data = await res.json();
       if (!data.ok) throw new Error(data.error ?? "Readiness failed");
       setReadiness(data.result);
+      const evidenceRes = await fetch("/api/manager/evidence", { cache: "no-store" });
+      const evidenceData = await evidenceRes.json();
+      if (evidenceData.ok) setEvidence(evidenceData.result);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to load manager readiness");
     }
@@ -119,8 +138,30 @@ export default function ManagerPage() {
       <section className="rounded-2xl border border-white/10 bg-card/20 p-5 space-y-3">
         <h2 className="text-lg font-semibold">BDD confidence</h2>
         <p className="text-sm text-muted-foreground">
-          Current docs-only gate for Bucket I: <code className="rounded bg-black/30 px-1.5 py-0.5">npm run test:bdd:index</code>. Full manager evidence pack will add latest sweep status and artifact links in a later iteration.
+          Manager confidence command: <code className="rounded bg-black/30 px-1.5 py-0.5">{evidence?.command ?? "npm run test:bdd:status && npm run test:bdd:sweep"}</code>.
         </p>
+        {evidence && (
+          <div className="space-y-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">Evidence status: <span className={evidence.status === "ready" ? "text-green-300" : "text-amber-200"}>{evidence.status}</span></p>
+              <p className="text-xs text-muted-foreground">Generated {new Date(evidence.generatedAt).toLocaleString()}</p>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              {evidence.artifacts.map((artifact) => (
+                <div key={artifact.id} className="rounded-xl border border-white/10 bg-black/20 p-3 text-sm">
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="font-medium">{artifact.label}</p>
+                    <span className={artifact.status === "present" ? "text-green-300" : "text-red-300"}>{artifact.status}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">{artifact.summary}</p>
+                  {artifact.path && <p className="mt-2 font-mono text-xs text-[#14F195]">{artifact.path}</p>}
+                </div>
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">{evidence.privacy.note}</p>
+            <p className="text-sm text-white">Next: {evidence.nextAction}</p>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -58,7 +58,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket I — Agent Manager Operations
 - Feature: `docs/bdd/features/bucket-i-agent-manager-operations.feature`
 - Verify:
-  - `npx jest lib/__tests__/manager-readiness-route.test.ts --runInBand`
+  - `npx jest lib/__tests__/manager-readiness-route.test.ts lib/__tests__/manager-evidence-pack.test.ts lib/__tests__/manager-evidence-route.test.ts --runInBand`
   - `npm run test:bdd:index`
   - E2E target: manager launchpad Playwright smoke once added to representative sweep
 

--- a/docs/bdd/features/bucket-i-agent-manager-operations.feature
+++ b/docs/bdd/features/bucket-i-agent-manager-operations.feature
@@ -18,17 +18,21 @@ Feature: Bucket I Agent Manager Operations
     Then it includes live specialists, available attestors, registered consumers, insecure endpoints, pending attestations, and failed healthchecks
     And any unusable role has a concrete next action
 
-  @I1.3 @manager @manual
+  @I1.3 @manager @route-unit
   Scenario: Manager can inspect the latest BDD confidence status
     When the manager asks for protocol confidence
     Then the latest BDD sweep/status command and artifact path are visible
     And missing or stale evidence is called out explicitly
+    And the behavior is covered by "lib/__tests__/manager-evidence-pack.test.ts"
 
-  @I1.4 @manager @manual
+  @I1.4 @manager @route-unit
   Scenario: Manager can produce a judge-safe evidence pack
     When the manager generates an evidence summary
     Then role-critical artifacts are listed without raw prompts, secrets, or private runtime logs
     And the evidence links cover specialist onboarding, attestor-gated settlement, consumer paid invocation, and Solana settlement
+    And the behavior is covered by:
+      | lib/__tests__/manager-evidence-pack.test.ts |
+      | lib/__tests__/manager-evidence-route.test.ts |
 
   @I1.5 @manager @e2e-ui
   Scenario: Manager sees the next concrete fix before demo

--- a/lib/__tests__/manager-evidence-pack.test.ts
+++ b/lib/__tests__/manager-evidence-pack.test.ts
@@ -1,0 +1,43 @@
+jest.mock("server-only", () => ({}));
+
+jest.mock("fs", () => ({
+  existsSync: jest.fn(),
+  readdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  statSync: jest.fn(),
+}));
+
+describe("manager evidence pack", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("lists judge-safe role-critical artifact summaries", async () => {
+    const fs = await import("fs");
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readdirSync as jest.Mock).mockReturnValue(["20260427-120000"]);
+    (fs.statSync as jest.Mock).mockReturnValue({ mtimeMs: 1 });
+    (fs.readFileSync as jest.Mock).mockReturnValue("# Summary\nPASS evidence line\nsecret=should-not-be-parsed");
+
+    const { buildManagerEvidencePack } = await import("@/lib/manager/evidence-pack");
+    const pack = buildManagerEvidencePack();
+
+    expect(pack.status).toBe("ready");
+    expect(pack.artifacts.map((item) => item.id)).toEqual(["bdd", "onboarding", "attestor", "consumer", "settlement"]);
+    expect(pack.privacy).toMatchObject({ rawPromptsIncluded: false, secretsIncluded: false });
+    expect(pack.artifacts[0]).toMatchObject({ status: "present", summary: "PASS evidence line" });
+  });
+
+  it("calls out missing evidence explicitly", async () => {
+    const fs = await import("fs");
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+    const { buildManagerEvidencePack } = await import("@/lib/manager/evidence-pack");
+    const pack = buildManagerEvidencePack();
+
+    expect(pack.status).toBe("incomplete");
+    expect(pack.artifacts.every((item) => item.status === "missing")).toBe(true);
+    expect(pack.nextAction).toMatch(/Generate missing evidence/i);
+  });
+});

--- a/lib/__tests__/manager-evidence-route.test.ts
+++ b/lib/__tests__/manager-evidence-route.test.ts
@@ -1,0 +1,31 @@
+jest.mock("@/lib/manager/evidence-pack", () => ({
+  buildManagerEvidencePack: jest.fn(),
+}));
+
+describe("manager evidence route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("returns evidence pack result", async () => {
+    const { buildManagerEvidencePack } = await import("@/lib/manager/evidence-pack");
+    (buildManagerEvidencePack as jest.Mock).mockReturnValue({
+      generatedAt: "2026-04-27T00:00:00.000Z",
+      status: "ready",
+      command: "npm run test:bdd:status && npm run test:bdd:sweep",
+      artifacts: [],
+      privacy: { rawPromptsIncluded: false, secretsIncluded: false, note: "safe" },
+      nextAction: "Attach evidence.",
+    });
+
+    const { GET } = await import("@/app/api/manager/evidence/route");
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      result: { status: "ready", command: expect.stringContaining("test:bdd:status") },
+    });
+  });
+});

--- a/lib/manager/evidence-pack.ts
+++ b/lib/manager/evidence-pack.ts
@@ -1,0 +1,91 @@
+import "server-only";
+
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+
+export type EvidenceArtifact = {
+  id: "bdd" | "onboarding" | "attestor" | "consumer" | "settlement";
+  label: string;
+  path: string | null;
+  status: "present" | "missing";
+  summary: string;
+};
+
+export type ManagerEvidencePack = {
+  generatedAt: string;
+  status: "ready" | "incomplete";
+  command: string;
+  artifacts: EvidenceArtifact[];
+  privacy: {
+    rawPromptsIncluded: false;
+    secretsIncluded: false;
+    note: string;
+  };
+  nextAction: string;
+};
+
+const ARTIFACT_ROOT = join(process.cwd(), "artifacts");
+
+function latestSummary(dir: string): { relative: string; absolute: string } | null {
+  const root = join(ARTIFACT_ROOT, dir);
+  if (!existsSync(root)) return null;
+  const candidates = readdirSync(root)
+    .map((name) => ({
+      relative: `artifacts/${dir}/${name}/SUMMARY.md`,
+      absolute: join(ARTIFACT_ROOT, dir, name, "SUMMARY.md"),
+    }))
+    .filter((item) => existsSync(item.absolute))
+    .sort((a, b) => statSync(b.absolute).mtimeMs - statSync(a.absolute).mtimeMs);
+  return candidates[0] ?? null;
+}
+
+function firstUsefulLine(path: { relative: string; absolute: string } | null) {
+  if (!path) return "No artifact found yet.";
+  try {
+    const raw = readFileSync(path.absolute, "utf8");
+    const line = raw
+      .split(/\r?\n/)
+      .map((value) => value.trim())
+      .find((value) => value && !value.startsWith("#"));
+    return line ?? "Artifact exists; open summary for details.";
+  } catch {
+    return "Artifact exists; summary could not be read.";
+  }
+}
+
+function artifact(id: EvidenceArtifact["id"], label: string, dir: string): EvidenceArtifact {
+  const path = latestSummary(dir);
+  return {
+    id,
+    label,
+    path: path?.relative ?? null,
+    status: path ? "present" : "missing",
+    summary: firstUsefulLine(path),
+  };
+}
+
+export function buildManagerEvidencePack(): ManagerEvidencePack {
+  const artifacts: EvidenceArtifact[] = [
+    artifact("bdd", "Latest BDD confidence sweep", "bdd-sweep"),
+    artifact("onboarding", "Specialist onboarding wrapper", "surfpool-onboarding-wrapper"),
+    artifact("attestor", "Attestor-gated specialist onboarding", "surfpool-onboarding"),
+    artifact("consumer", "Consumer paid x402 invocation", "surfpool-jupiter-invoke"),
+    artifact("settlement", "Solana escrow settlement smoke", "surfpool-smoke"),
+  ];
+  const missing = artifacts.filter((item) => item.status === "missing");
+
+  return {
+    generatedAt: new Date().toISOString(),
+    status: missing.length === 0 ? "ready" : "incomplete",
+    command: "npm run test:bdd:status && npm run test:bdd:sweep",
+    artifacts,
+    privacy: {
+      rawPromptsIncluded: false,
+      secretsIncluded: false,
+      note: "Evidence pack links SUMMARY.md artifacts only; raw prompts, API keys, private runtime logs, and payment secrets are intentionally excluded.",
+    },
+    nextAction: missing.length === 0
+      ? "Attach these summary links to judge/demo notes and rerun sweep if evidence gets stale."
+      : `Generate missing evidence: ${missing.map((item) => item.label).join(", ")}.`,
+  };
+}


### PR DESCRIPTION
## Summary
- adds /api/manager/evidence and manager UI evidence section
- links latest SUMMARY.md artifacts for BDD sweep, specialist onboarding wrapper, attestor-gated onboarding, consumer x402 invocation, and Solana escrow settlement
- explicitly excludes raw prompts, secrets, and private runtime logs from evidence pack
- maps Bucket I I1.3/I1.4 in BDD feature index

## Verification
- npx jest lib/__tests__/manager-evidence-pack.test.ts lib/__tests__/manager-evidence-route.test.ts lib/__tests__/manager-readiness-route.test.ts --runInBand
- npm run test:bdd:index
- npm run build

## Notes
- completes role/BDD alignment plan Iteration 5
- no direct push to main