### PR TITLE
test(onboarding): align healthcheck security probe expectations

### DIFF
--- a/lib/__tests__/onboarding-healthcheck-security.test.ts
+++ b/lib/__tests__/onboarding-healthcheck-security.test.ts
@@ -23,7 +23,6 @@ describe("onboarding healthcheck security enforcement", () => {
       .mockResolvedValueOnce(mockResponse(200, true))
       .mockResolvedValueOnce(mockResponse(200, true))
       .mockResolvedValueOnce(mockResponse(200, true))
-      .mockResolvedValueOnce(mockResponse(402, false))
       .mockResolvedValueOnce(mockResponse(402, false, { "x402-request": "{}" }));
 
     global.fetch = fetchMock as unknown as typeof fetch;
@@ -43,7 +42,6 @@ describe("onboarding healthcheck security enforcement", () => {
       .mockResolvedValueOnce(mockResponse(200, true))
       .mockResolvedValueOnce(mockResponse(200, true))
       .mockResolvedValueOnce(mockResponse(200, true))
-      .mockResolvedValueOnce(mockResponse(200, true))
       .mockResolvedValueOnce(mockResponse(200, true));
 
     global.fetch = fetchMock as unknown as typeof fetch;
@@ -56,6 +54,6 @@ describe("onboarding healthcheck security enforcement", () => {
     expect(result.securityStatus).toBe("insecure_open_completion");
     expect(result.x402Probe).toBe("fail");
     expect(result.status).toBe("fail");
-    expect(result.note).toMatch(/without x402 challenge/i);
+    expect(result.note).toMatch(/without an x402 challenge/i);
   });
 });


### PR DESCRIPTION
## Summary
- updates onboarding healthcheck security test mocks to the current four-probe flow
- aligns insecure-open note expectation with current fail-closed copy
- unblocks fresh representative BDD sweep after PR #119 merge

## Verification
- npx jest lib/__tests__/onboarding-healthcheck-security.test.ts --runInBand
- npm run test:bdd:sweep
- npm run test:bdd:status

## Evidence
- latest sweep: artifacts/bdd-sweep/20260427-130201/SUMMARY.md (8/8 passed)

## Notes
- test-only cleanup
- no direct push to main