### PR TITLE
feat(manager): surface volunteer tester evidence

### DIFF
--- a/app/manager/page.tsx
+++ b/app/manager/page.tsx
@@ -154,7 +154,15 @@ export default function ManagerPage() {
                     <span className={artifact.status === "present" ? "text-green-300" : "text-red-300"}>{artifact.status}</span>
                   </div>
                   <p className="mt-1 text-xs text-muted-foreground">{artifact.summary}</p>
-                  {artifact.path && <p className="mt-2 font-mono text-xs text-[#14F195]">{artifact.path}</p>}
+                  {artifact.path && (
+                    artifact.path.startsWith("/") ? (
+                      <Link href={artifact.path} className="mt-2 block font-mono text-xs text-[#14F195] hover:text-emerald-200">
+                        {artifact.path} →
+                      </Link>
+                    ) : (
+                      <p className="mt-2 font-mono text-xs text-[#14F195]">{artifact.path}</p>
+                    )
+                  )}
                 </div>
               ))}
             </div>

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,8 +1,21 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('Navigation', () => {
-  test('all 7 routes load with 200', async ({ page }) => {
-    const routes = ['/', '/agents', '/register', '/setup', '/onboarding', '/customize', '/dashboard']
+  test('core routes load with 200', async ({ page }) => {
+    const routes = [
+      '/',
+      '/agents',
+      '/register',
+      '/setup',
+      '/onboarding',
+      '/customize',
+      '/dashboard',
+      '/manager',
+      '/specialist',
+      '/planner',
+      '/attestation',
+      '/testers',
+    ]
     for (const route of routes) {
       const response = await page.goto(route)
       expect(response?.status(), `${route} should return 200`).toBe(200)

--- a/lib/__tests__/manager-evidence-pack.test.ts
+++ b/lib/__tests__/manager-evidence-pack.test.ts
@@ -24,7 +24,7 @@ describe("manager evidence pack", () => {
     const pack = buildManagerEvidencePack();
 
     expect(pack.status).toBe("ready");
-    expect(pack.artifacts.map((item) => item.id)).toEqual(["bdd", "onboarding", "attestor", "consumer", "settlement"]);
+    expect(pack.artifacts.map((item) => item.id)).toEqual(["bdd", "onboarding", "attestor", "consumer", "settlement", "volunteer"]);
     expect(pack.privacy).toMatchObject({ rawPromptsIncluded: false, secretsIncluded: false });
     expect(pack.artifacts[0]).toMatchObject({ status: "present", summary: "PASS evidence line" });
   });
@@ -37,7 +37,8 @@ describe("manager evidence pack", () => {
     const pack = buildManagerEvidencePack();
 
     expect(pack.status).toBe("incomplete");
-    expect(pack.artifacts.every((item) => item.status === "missing")).toBe(true);
+    expect(pack.artifacts.filter((item) => item.id !== "volunteer").every((item) => item.status === "missing")).toBe(true);
+    expect(pack.artifacts.find((item) => item.id === "volunteer")).toMatchObject({ status: "present", path: "/testers" });
     expect(pack.nextAction).toMatch(/Generate missing evidence/i);
   });
 });

--- a/lib/manager/evidence-pack.ts
+++ b/lib/manager/evidence-pack.ts
@@ -4,7 +4,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 
 export type EvidenceArtifact = {
-  id: "bdd" | "onboarding" | "attestor" | "consumer" | "settlement";
+  id: "bdd" | "onboarding" | "attestor" | "consumer" | "settlement" | "volunteer";
   label: string;
   path: string | null;
   status: "present" | "missing";
@@ -64,6 +64,16 @@ function artifact(id: EvidenceArtifact["id"], label: string, dir: string): Evide
   };
 }
 
+function routeArtifact(id: EvidenceArtifact["id"], label: string, route: string, summary: string): EvidenceArtifact {
+  return {
+    id,
+    label,
+    path: route,
+    status: "present",
+    summary,
+  };
+}
+
 export function buildManagerEvidencePack(): ManagerEvidencePack {
   const artifacts: EvidenceArtifact[] = [
     artifact("bdd", "Latest BDD confidence sweep", "bdd-sweep"),
@@ -71,6 +81,12 @@ export function buildManagerEvidencePack(): ManagerEvidencePack {
     artifact("attestor", "Attestor-gated specialist onboarding", "surfpool-onboarding"),
     artifact("consumer", "Consumer paid x402 invocation", "surfpool-jupiter-invoke"),
     artifact("settlement", "Solana escrow settlement smoke", "surfpool-smoke"),
+    routeArtifact(
+      "volunteer",
+      "Volunteer tester handback loop",
+      "/testers",
+      "Four-role devnet volunteer guide with reddi-x402 wrapper videos and copy/paste handback template.",
+    ),
   ];
   const missing = artifacts.filter((item) => item.status === "missing");
 


### PR DESCRIPTION
## Summary\n- add the /testers volunteer handback loop to the manager evidence pack\n- surface the four-role devnet guide, reddi-x402 wrapper videos, and handback template as judge-safe evidence\n- keep raw prompts/secrets/private logs excluded\n\n## Verification\n- npx jest lib/__tests__/manager-evidence-pack.test.ts lib/__tests__/manager-evidence-route.test.ts --runInBand\n- npm run build\n- npm run test:bdd:index\n- npm run test:bdd:sweep