### PR TITLE
feat(demo): add x402-protected testing specialists

### DIFF
--- a/docs/demo/VPS-TESTING-SPECIALISTS-X402-DEMO-PLAN.md
+++ b/docs/demo/VPS-TESTING-SPECIALISTS-X402-DEMO-PLAN.md
@@ -1,0 +1,154 @@
+# VPS testing specialists with reddi-x402 demo plan
+
+_Linked issue: #130_
+
+## Goal
+
+Run demo-only testing specialist agents on the VPS via Coolify. They are intentionally not GPU/Ollama endpoints. Each service is a deterministic mock specialist that:
+
+1. exposes OpenAI-compatible discovery and completion routes;
+2. fails closed with `402 + x402-request` before any completion;
+3. accepts a demo `x402-payment` retry;
+4. returns a predefined high-confidence testing response when the prompt matches a known case;
+5. returns the nearest best-effort response with lower `matchConfidence` and `reputationScore` when the prompt is uncertain.
+
+This shows the value of Reddi Agent Protocol versus a normal public endpoint: endpoint protection, Solana x402 payment flow, registry/reputation metadata, and replayable evidence.
+
+## Specialist profiles
+
+The package lives at `packages/testing-specialists`.
+
+Run one Coolify service per profile:
+
+- `qa-security` — endpoint security, unpaid-completion bypass, replay/nonce review.
+- `ux-usability` — onboarding and judge/demo-flow review.
+- `integration-tester` — Coolify smoke, devnet registration, recording checklist.
+
+All profiles expose the same routes:
+
+- `GET /healthz` and `GET /x402/health`
+- `GET /v1/models`
+- `GET /api/tags`
+- `POST /v1/chat/completions`
+
+Unpaid completion calls return `402` and an `x402-request` challenge. Paid retry returns an OpenAI-style chat completion plus:
+
+```json
+{
+  "reddi_demo": {
+    "predefinedMatch": true,
+    "matchedCaseId": "insecure-open-completion",
+    "matchConfidence": 0.97,
+    "reputationScore": 96,
+    "paymentStatus": "demo_x402_payment_header_accepted"
+  }
+}
+```
+
+## Local run
+
+```bash
+cd packages/x402-solana && npm install && npm run build
+cd ../testing-specialists && npm install && npm run build
+SPECIALIST_PROFILE=qa-security \
+SPECIALIST_WALLET=<devnet-wallet> \
+PUBLIC_BASE_URL=http://127.0.0.1:8080 \
+npm start
+```
+
+Smoke it:
+
+```bash
+cd ../..
+npm run demo:testing-specialist:smoke -- http://127.0.0.1:8080
+```
+
+Artifacts are written under `artifacts/demo-testing-specialists/<timestamp>/`.
+
+## Coolify deployment
+
+Create three Docker services from the repo using:
+
+- Dockerfile: `packages/testing-specialists/Dockerfile`
+- Port: `8080`
+- Healthcheck path: `/healthz`
+
+Environment per service:
+
+```bash
+PORT=8080
+HOST=0.0.0.0
+X402_NETWORK=solana-devnet
+PRICE_LAMPORTS=1000000
+SPECIALIST_PROFILE=qa-security # or ux-usability / integration-tester
+SPECIALIST_WALLET=<dev-wallet-public-key-for-this-specialist>
+PUBLIC_BASE_URL=https://<coolify-domain>
+```
+
+Do not commit wallet secrets. The service only needs the public specialist wallet for challenge generation.
+
+After deploy, run from the repo:
+
+```bash
+TESTING_SPECIALIST_ENDPOINT=https://<coolify-domain> npm run demo:testing-specialist:smoke
+```
+
+## Devnet registration flow
+
+Recommended demo flow:
+
+1. Fund/prepare the dev specialist wallet.
+2. Deploy the x402-protected mock specialist in Coolify.
+3. Run the smoke script and keep the artifact path.
+4. Register the specialist in the Reddi app on Solana devnet using the Coolify endpoint, model name, rate, capabilities, and public wallet.
+5. Capture the registration transaction signature and Explorer URL.
+6. Resolve the specialist from the planner and perform a paid invocation.
+7. Save the paid invocation payload showing `matchConfidence` and `reputationScore`.
+
+Guardrails:
+
+- Use Solana devnet only for this demo.
+- Do not expose a completion route that returns 200 without x402.
+- Do not store raw prompts in public artifacts unless deliberately demo-safe.
+
+## Screen capture plan
+
+Use Playwright when possible because it gives reproducible screenshots and trace artifacts. Use Chrome DevTools or Peekaboo only for manual wallet popups or Coolify dashboard moments that Playwright cannot drive cleanly.
+
+Capture sequence:
+
+1. Coolify service overview showing deployed endpoint + healthy status.
+2. Terminal/browser smoke: unpaid call returns `402 + x402-request`.
+3. Reddi `/register` with endpoint probe passing.
+4. Wallet/devnet registration transaction confirmation.
+5. Reddi `/planner` selecting the testing specialist.
+6. Paid invocation response showing high confidence for a known test query.
+7. Paid invocation response showing lower confidence for an unknown query.
+8. `/manager` evidence pack or artifacts folder showing replayable receipts.
+
+Artifact convention:
+
+```text
+artifacts/demo-testing-specialists/<timestamp>/
+  01-healthz.json
+  02-models.json
+  03-unpaid-completion.json
+  04-paid-completion.json
+  SUMMARY.md
+  screens/
+  traces/
+```
+
+## Demo prompts
+
+High-confidence examples:
+
+- `Audit this specialist for an unpaid completion bypass without x402.`
+- `Review replay nonce protection for duplicate payment receipts.`
+- `Find specialist onboarding friction before registration.`
+- `Create a Coolify VPS smoke plan for the protected endpoint.`
+- `Give me the devnet registration recording checklist.`
+
+Low-confidence example:
+
+- `What colour should the launch banner be?`

--- a/docs/demo/VPS-TESTING-SPECIALISTS-X402-DEMO-PLAN.md
+++ b/docs/demo/VPS-TESTING-SPECIALISTS-X402-DEMO-PLAN.md
@@ -8,8 +8,9 @@ Run demo-only testing specialist agents on the VPS via Coolify. They are intenti
 
 1. exposes OpenAI-compatible discovery and completion routes;
 2. fails closed with `402 + x402-request` before any completion;
-3. accepts a demo `x402-payment` retry;
-4. returns a predefined high-confidence testing response when the prompt matches a known case;
+3. accepts a demo-shaped `x402-payment` retry with a non-empty `txSignature`;
+4. clearly marks that the mock service validates demo payment header shape only, not production payment settlement;
+5. returns a predefined high-confidence testing response when the prompt matches a known case;
 5. returns the nearest best-effort response with lower `matchConfidence` and `reputationScore` when the prompt is uncertain.
 
 This shows the value of Reddi Agent Protocol versus a normal public endpoint: endpoint protection, Solana x402 payment flow, registry/reputation metadata, and replayable evidence.
@@ -31,7 +32,7 @@ All profiles expose the same routes:
 - `GET /api/tags`
 - `POST /v1/chat/completions`
 
-Unpaid completion calls return `402` and an `x402-request` challenge. Paid retry returns an OpenAI-style chat completion plus:
+Unpaid completion calls return `402` and an `x402-request` challenge. Paid retry requires JSON such as `{ "txSignature": "demo-smoke", "network": "solana-devnet" }` and returns an OpenAI-style chat completion plus:
 
 ```json
 {
@@ -40,7 +41,7 @@ Unpaid completion calls return `402` and an `x402-request` challenge. Paid retry
     "matchedCaseId": "insecure-open-completion",
     "matchConfidence": 0.97,
     "reputationScore": 96,
-    "paymentStatus": "demo_x402_payment_header_accepted"
+    "paymentStatus": "demo_x402_payment_header_shape_accepted_not_production_verified"
   }
 }
 ```
@@ -109,11 +110,12 @@ Guardrails:
 
 - Use Solana devnet only for this demo.
 - Do not expose a completion route that returns 200 without x402.
+- Treat this package as a deterministic demo specialist only: it checks demo `x402-payment` header shape but does not verify production Solana settlement.
 - Do not store raw prompts in public artifacts unless deliberately demo-safe.
 
 ## Screen capture plan
 
-Use Playwright when possible because it gives reproducible screenshots and trace artifacts. Use Chrome DevTools or Peekaboo only for manual wallet popups or Coolify dashboard moments that Playwright cannot drive cleanly.
+Use Playwright when possible because it gives reproducible screenshots and trace artifacts. The provided capture script asserts the endpoint x402 flow before writing success artifacts, but it only captures endpoint-level evidence. Use Chrome DevTools or Peekaboo for manual wallet popups, Coolify dashboard moments, and full app registration/planner/evidence walkthroughs that Playwright cannot drive cleanly.
 
 Capture sequence:
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "test:source:matrix": "./scripts/run-source-conformance-matrix.sh",
     "test:tunnel:rca": "node ./scripts/run-cloudflare-rca-matrix.mjs",
     "test:tunnel:rca:evaluate": "node ./scripts/evaluate-cloudflare-rca.mjs",
-    "dev:rca:x402-fixture": "node ./scripts/run-rca-x402-fixture.mjs"
+    "dev:rca:x402-fixture": "node ./scripts/run-rca-x402-fixture.mjs",
+    "demo:testing-specialist:smoke": "node ./scripts/run-testing-specialist-smoke.mjs",
+    "demo:testing-specialist:capture": "node ./scripts/capture-testing-specialist-demo.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/packages/testing-specialists/.gitignore
+++ b/packages/testing-specialists/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+.env.*

--- a/packages/testing-specialists/Dockerfile
+++ b/packages/testing-specialists/Dockerfile
@@ -6,7 +6,7 @@ COPY packages/x402-solana/src ./packages/x402-solana/src
 COPY packages/testing-specialists/package*.json ./packages/testing-specialists/
 COPY packages/testing-specialists/tsconfig.json ./packages/testing-specialists/
 RUN cd packages/x402-solana && npm ci && npm run build
-RUN cd packages/testing-specialists && npm install
+RUN cd packages/testing-specialists && npm ci
 
 FROM node:24-alpine AS build
 WORKDIR /app

--- a/packages/testing-specialists/Dockerfile
+++ b/packages/testing-specialists/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:24-alpine AS deps
+WORKDIR /app
+COPY packages/x402-solana/package*.json ./packages/x402-solana/
+COPY packages/x402-solana/tsconfig.json ./packages/x402-solana/
+COPY packages/x402-solana/src ./packages/x402-solana/src
+COPY packages/testing-specialists/package*.json ./packages/testing-specialists/
+COPY packages/testing-specialists/tsconfig.json ./packages/testing-specialists/
+RUN cd packages/x402-solana && npm ci && npm run build
+RUN cd packages/testing-specialists && npm install
+
+FROM node:24-alpine AS build
+WORKDIR /app
+COPY --from=deps /app /app
+COPY packages/testing-specialists/src ./packages/testing-specialists/src
+RUN cd packages/testing-specialists && npm run build
+
+FROM node:24-alpine
+WORKDIR /app/packages/testing-specialists
+ENV NODE_ENV=production PORT=8080 HOST=0.0.0.0
+COPY --from=build /app/packages/x402-solana /app/packages/x402-solana
+COPY --from=build /app/packages/testing-specialists /app/packages/testing-specialists
+EXPOSE 8080
+CMD ["node", "dist/server.js"]

--- a/packages/testing-specialists/package-lock.json
+++ b/packages/testing-specialists/package-lock.json
@@ -1,0 +1,256 @@
+{
+  "name": "@reddi/testing-specialists",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@reddi/testing-specialists",
+      "version": "0.1.0",
+      "dependencies": {
+        "@reddi/x402-solana": "file:../x402-solana"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "ts-node": "^10",
+        "typescript": "^5"
+      }
+    },
+    "../x402-solana": {
+      "name": "@reddi/x402-solana",
+      "version": "0.1.0",
+      "dependencies": {
+        "@solana/web3.js": "^1.95.8"
+      },
+      "devDependencies": {
+        "@types/jest": "^29",
+        "@types/node": "^20",
+        "jest": "^29",
+        "ts-jest": "^29",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@reddi/x402-solana": {
+      "resolved": "../x402-solana",
+      "link": true
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/packages/testing-specialists/package.json
+++ b/packages/testing-specialists/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@reddi/testing-specialists",
+  "version": "0.1.0",
+  "description": "Deterministic x402-protected mock testing specialists for Reddi Agent Protocol demos",
+  "private": true,
+  "main": "dist/server.js",
+  "types": "dist/server.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts",
+    "test": "npm run build && node --test tests/*.test.js"
+  },
+  "dependencies": {
+    "@reddi/x402-solana": "file:../x402-solana"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "ts-node": "^10",
+    "typescript": "^5"
+  }
+}

--- a/packages/testing-specialists/src/server.ts
+++ b/packages/testing-specialists/src/server.ts
@@ -205,6 +205,21 @@ function x402Challenge() {
   });
 }
 
+function parseDemoPaymentHeader(payment: string) {
+  try {
+    const parsed = JSON.parse(payment);
+    const txSignature = typeof parsed.txSignature === "string" ? parsed.txSignature.trim() : "";
+    if (!txSignature) return undefined;
+    return {
+      txSignature,
+      network: typeof parsed.network === "string" ? parsed.network : network,
+      demoOnly: parsed.demoOnly !== false,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 function modelPayload() {
   return {
     object: "list",
@@ -266,6 +281,14 @@ const server = http.createServer(async (req, res) => {
       );
     }
 
+    const demoPayment = parseDemoPaymentHeader(payment);
+    if (!demoPayment) {
+      return sendJson(res, 400, {
+        error: "invalid_demo_x402_payment",
+        detail: "demo mock requires JSON x402-payment with a non-empty txSignature; this service does not perform production payment verification",
+      });
+    }
+
     let parsed: CompletionBody = {};
     try {
       const raw = await readBody(req);
@@ -299,7 +322,8 @@ const server = http.createServer(async (req, res) => {
         matchedCaseTitle: response.selected?.title || null,
         matchConfidence: response.confidence,
         reputationScore: response.reputationScore,
-        paymentStatus: "demo_x402_payment_header_accepted",
+        paymentStatus: "demo_x402_payment_header_shape_accepted_not_production_verified",
+        paymentReceipt: demoPayment,
         evidence: response.selected?.evidence || [],
         requestId,
       },

--- a/packages/testing-specialists/src/server.ts
+++ b/packages/testing-specialists/src/server.ts
@@ -1,0 +1,319 @@
+import http from "node:http";
+import crypto from "node:crypto";
+import { createX402Header } from "@reddi/x402-solana";
+
+type SpecialistProfileId = "qa-security" | "ux-usability" | "integration-tester";
+
+type DemoCase = {
+  id: string;
+  title: string;
+  triggers: string[];
+  answer: string;
+  evidence: string[];
+};
+
+type SpecialistProfile = {
+  id: SpecialistProfileId;
+  name: string;
+  model: string;
+  role: string;
+  capabilities: string[];
+  cases: DemoCase[];
+};
+
+type CompletionBody = {
+  model?: string;
+  messages?: Array<{ role?: string; content?: string | Array<{ type?: string; text?: string }> }>;
+  prompt?: string;
+};
+
+const profiles: Record<SpecialistProfileId, SpecialistProfile> = {
+  "qa-security": {
+    id: "qa-security",
+    name: "Reddi QA Sentinel",
+    model: "reddi-demo/qa-security-sentinel",
+    role: "Security and endpoint-compliance tester",
+    capabilities: ["x402_fail_closed_audit", "endpoint_security", "negative_path_testing"],
+    cases: [
+      {
+        id: "insecure-open-completion",
+        title: "Detect an unpaid completion bypass",
+        triggers: ["unpaid completion", "insecure endpoint", "open completion", "without x402", "bypass"],
+        answer:
+          "Finding: the specialist endpoint is unsafe if `/v1/chat/completions` returns a 200 response before an `x402-payment` receipt is supplied. Fix: fail closed with HTTP 402 and an `x402-request` challenge, then allow exactly one paid retry. Demo verdict: block registration until the probe observes 402 + x402-request.",
+        evidence: ["probe:/v1/chat/completions", "expected_status:402", "required_header:x402-request"],
+      },
+      {
+        id: "replay-nonce",
+        title: "Replay/nonce protection review",
+        triggers: ["replay", "nonce", "duplicate payment", "same receipt", "re-use"],
+        answer:
+          "Finding: payment receipts need nonce and route binding. A duplicate nonce or receipt replay should be rejected before model execution. Demo verdict: accept fresh paid calls, reject duplicate nonce attempts, and preserve requestId in the receipt trail.",
+        evidence: ["field:nonce", "field:requestId", "policy:single_use_payment"],
+      },
+    ],
+  },
+  "ux-usability": {
+    id: "ux-usability",
+    name: "Reddi UX Inspector",
+    model: "reddi-demo/ux-usability-inspector",
+    role: "Onboarding and demo-flow usability tester",
+    capabilities: ["onboarding_review", "copy_clarity", "demo_flow_testing"],
+    cases: [
+      {
+        id: "specialist-onboarding-friction",
+        title: "Specialist onboarding friction audit",
+        triggers: ["onboarding", "specialist setup", "register specialist", "confusing", "friction"],
+        answer:
+          "Usability review: keep the specialist operator path to four visible checks — wallet funded, endpoint online, x402 challenge observed, registration transaction confirmed. The highest-risk friction is unclear endpoint failure messaging, so show the active RPC/program, probe result, and exact next command.",
+        evidence: ["screen:/testers", "screen:/register", "check:x402_probe", "check:wallet_network"],
+      },
+      {
+        id: "manager-evidence-review",
+        title: "Manager evidence review flow",
+        triggers: ["manager", "evidence pack", "judge", "demo video", "screenshots"],
+        answer:
+          "Demo-flow review: start at Manager evidence, open Specialist readiness, then show Consumer paid-call receipt and Attestor release/refund controls. This sequence makes Reddi's value obvious: discovery, payment protection, escrow/reputation, and replayable evidence.",
+        evidence: ["screen:/manager", "screen:/specialist", "screen:/planner", "screen:/attestation"],
+      },
+    ],
+  },
+  "integration-tester": {
+    id: "integration-tester",
+    name: "Reddi Integration Runner",
+    model: "reddi-demo/integration-runner",
+    role: "End-to-end integration test specialist",
+    capabilities: ["playwright_capture", "devnet_registration", "coolify_smoke"],
+    cases: [
+      {
+        id: "vps-coolify-smoke",
+        title: "Coolify deployment smoke plan",
+        triggers: ["coolify", "vps", "deploy", "healthcheck", "smoke"],
+        answer:
+          "Integration plan: deploy one container per specialist profile with `SPECIALIST_PROFILE`, `SPECIALIST_WALLET`, and `PUBLIC_BASE_URL` set. Smoke sequence: GET /healthz, GET /v1/models, unpaid POST /v1/chat/completions expecting 402 + x402-request, then paid retry with x402-payment expecting matched response metadata.",
+        evidence: ["env:SPECIALIST_PROFILE", "env:SPECIALIST_WALLET", "route:/healthz", "route:/v1/chat/completions"],
+      },
+      {
+        id: "devnet-registration-recording",
+        title: "Devnet registration and recording checklist",
+        triggers: ["devnet registration", "record", "playwright", "screenshot", "wallet"],
+        answer:
+          "Recording checklist: capture endpoint smoke first, then registration with the dev wallet on Solana devnet, then planner resolution and a paid invocation. Save screenshots and JSON receipts under `artifacts/demo-testing-specialists/<timestamp>/` so the demo video can replay the exact evidence chain.",
+        evidence: ["artifact:screens", "artifact:receipts", "chain:solana-devnet", "wallet:dev"],
+      },
+    ],
+  },
+};
+
+const profileId = parseProfile(process.env.SPECIALIST_PROFILE || "qa-security");
+const profile = profiles[profileId];
+const port = Number(process.env.PORT || 8080);
+const host = process.env.HOST || "127.0.0.1";
+const specialistWallet = process.env.SPECIALIST_WALLET || "11111111111111111111111111111111";
+const priceLamports = Number(process.env.PRICE_LAMPORTS || 1_000_000);
+const network = process.env.X402_NETWORK || "solana-devnet";
+const publicBaseUrl = process.env.PUBLIC_BASE_URL || `http://${host}:${port}`;
+
+function parseProfile(raw: string): SpecialistProfileId {
+  if (raw === "ux-usability" || raw === "integration-tester" || raw === "qa-security") return raw;
+  return "qa-security";
+}
+
+function sendJson(res: http.ServerResponse, status: number, payload: unknown, headers: Record<string, string> = {}) {
+  res.writeHead(status, { "content-type": "application/json", ...headers });
+  res.end(JSON.stringify(payload, null, 2));
+}
+
+async function readBody(req: http.IncomingMessage): Promise<string> {
+  let body = "";
+  for await (const chunk of req) body += chunk;
+  return body;
+}
+
+function extractPrompt(body: CompletionBody): string {
+  if (typeof body.prompt === "string") return body.prompt;
+  const parts: string[] = [];
+  for (const message of body.messages || []) {
+    if (typeof message.content === "string") parts.push(message.content);
+    if (Array.isArray(message.content)) {
+      for (const item of message.content) if (typeof item.text === "string") parts.push(item.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function tokenize(value: string): Set<string> {
+  return new Set(value.toLowerCase().replace(/[^a-z0-9/:-]+/g, " ").split(/\s+/).filter(Boolean));
+}
+
+function scoreCase(prompt: string, demoCase: DemoCase): number {
+  const promptLower = prompt.toLowerCase();
+  let score = 0;
+  for (const trigger of demoCase.triggers) {
+    if (promptLower.includes(trigger.toLowerCase())) score += 3;
+  }
+  const promptTokens = tokenize(prompt);
+  const caseTokens = tokenize([...demoCase.triggers, demoCase.title].join(" "));
+  let overlap = 0;
+  for (const token of caseTokens) if (promptTokens.has(token)) overlap += 1;
+  return score + overlap / Math.max(caseTokens.size, 1);
+}
+
+function chooseResponse(prompt: string) {
+  const ranked = profile.cases
+    .map((demoCase) => ({ demoCase, score: scoreCase(prompt, demoCase) }))
+    .sort((a, b) => b.score - a.score);
+  const best = ranked[0];
+  const predefinedMatch = Boolean(best && best.score >= 3);
+  const partialMatch = Boolean(best && best.score >= 0.2);
+  const confidence = predefinedMatch ? 0.97 : partialMatch ? 0.58 : 0.24;
+  const reputationScore = predefinedMatch ? 96 : partialMatch ? 58 : 24;
+  const selected = best?.demoCase;
+
+  if (selected && (predefinedMatch || partialMatch)) {
+    return {
+      content: `${selected.answer}\n\nMatch confidence: ${confidence.toFixed(2)}. Reputation signal: ${reputationScore}/100.`,
+      selected,
+      predefinedMatch,
+      confidence,
+      reputationScore,
+    };
+  }
+
+  return {
+    content:
+      `I do not have a predefined high-confidence answer for that exact testing query. Best effort from ${profile.name}: verify the endpoint fails closed with 402 + x402-request before any mock specialist response, then record the paid retry receipt and matching confidence in the demo artifact.\n\nMatch confidence: ${confidence.toFixed(2)}. Reputation signal: ${reputationScore}/100.`,
+    selected: undefined,
+    predefinedMatch: false,
+    confidence,
+    reputationScore,
+  };
+}
+
+function x402Challenge() {
+  const nonce = crypto.randomBytes(16).toString("hex");
+  const challenge = createX402Header(priceLamports, specialistWallet, nonce, "SOL");
+  const parsed = JSON.parse(challenge);
+  return JSON.stringify({
+    ...parsed,
+    chain: network,
+    route: "/v1/chat/completions",
+    payee: specialistWallet,
+    specialistProfile: profile.id,
+    publicBaseUrl,
+    memo: `reddi-demo-testing-specialist:${profile.id}`,
+  });
+}
+
+function modelPayload() {
+  return {
+    object: "list",
+    data: [
+      {
+        id: profile.model,
+        object: "model",
+        owned_by: "reddi-agent-protocol-demo",
+        metadata: {
+          specialistProfile: profile.id,
+          name: profile.name,
+          role: profile.role,
+          capabilities: profile.capabilities,
+          x402Protected: true,
+          mockRuntime: true,
+        },
+      },
+    ],
+  };
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || "/", `http://${req.headers.host || `${host}:${port}`}`);
+
+  if (req.method === "GET" && (url.pathname === "/" || url.pathname === "/healthz" || url.pathname === "/x402/health")) {
+    return sendJson(res, 200, {
+      ok: true,
+      service: "reddi-demo-testing-specialist",
+      profile: profile.id,
+      name: profile.name,
+      model: profile.model,
+      role: profile.role,
+      capabilities: profile.capabilities,
+      x402: {
+        protectedRoutes: ["/v1/chat/completions"],
+        unpaidBehavior: "402 + x402-request",
+        network,
+        priceLamports,
+        specialistWallet,
+      },
+    });
+  }
+
+  if (req.method === "GET" && (url.pathname === "/v1/models" || url.pathname === "/api/tags")) {
+    if (url.pathname === "/api/tags") {
+      return sendJson(res, 200, { models: [{ name: profile.model, model: profile.model }] });
+    }
+    return sendJson(res, 200, modelPayload());
+  }
+
+  if (req.method === "POST" && url.pathname === "/v1/chat/completions") {
+    const payment = req.headers["x402-payment"];
+    if (!payment || Array.isArray(payment)) {
+      return sendJson(
+        res,
+        402,
+        { error: "payment_required", detail: "retry with x402-payment to execute mock testing specialist" },
+        { "x402-request": x402Challenge() },
+      );
+    }
+
+    let parsed: CompletionBody = {};
+    try {
+      const raw = await readBody(req);
+      parsed = raw ? JSON.parse(raw) : {};
+    } catch {
+      return sendJson(res, 400, { error: "invalid_json" });
+    }
+
+    const prompt = extractPrompt(parsed);
+    const response = chooseResponse(prompt);
+    const requestId = `reddi_demo_${crypto.randomBytes(8).toString("hex")}`;
+
+    return sendJson(res, 200, {
+      id: requestId,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: parsed.model || profile.model,
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: response.content },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: tokenize(prompt).size, completion_tokens: tokenize(response.content).size, total_tokens: tokenize(prompt).size + tokenize(response.content).size },
+      reddi_demo: {
+        specialistProfile: profile.id,
+        specialistName: profile.name,
+        predefinedMatch: response.predefinedMatch,
+        matchedCaseId: response.selected?.id || null,
+        matchedCaseTitle: response.selected?.title || null,
+        matchConfidence: response.confidence,
+        reputationScore: response.reputationScore,
+        paymentStatus: "demo_x402_payment_header_accepted",
+        evidence: response.selected?.evidence || [],
+        requestId,
+      },
+    });
+  }
+
+  return sendJson(res, 404, { error: "not_found" });
+});
+
+if (require.main === module) {
+  server.listen(port, host, () => {
+    console.log(`${profile.name} listening on http://${host}:${port}`);
+    console.log(`Profile=${profile.id} Model=${profile.model} Wallet=${specialistWallet}`);
+  });
+}
+
+export { server, profiles, chooseResponse };

--- a/packages/testing-specialists/tests/server.test.js
+++ b/packages/testing-specialists/tests/server.test.js
@@ -40,9 +40,16 @@ test("completion route fails closed with x402 challenge, then accepts paid retry
     assert.equal(challenge.route, "/v1/chat/completions");
     assert.equal(challenge.specialistProfile, "qa-security");
 
+    const invalidPayment = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x402-payment": "junk" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "audit unpaid completion bypass" }] }),
+    });
+    assert.equal(invalidPayment.status, 400);
+
     const paid = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: "POST",
-      headers: { "content-type": "application/json", "x402-payment": JSON.stringify({ txSignature: "demo" }) },
+      headers: { "content-type": "application/json", "x402-payment": JSON.stringify({ txSignature: "demo", network: "solana-devnet" }) },
       body: JSON.stringify({ messages: [{ role: "user", content: "audit unpaid completion bypass" }] }),
     });
     assert.equal(paid.status, 200);
@@ -50,6 +57,7 @@ test("completion route fails closed with x402 challenge, then accepts paid retry
     assert.equal(payload.reddi_demo.predefinedMatch, true);
     assert.equal(payload.reddi_demo.matchConfidence, 0.97);
     assert.equal(payload.reddi_demo.reputationScore, 96);
+    assert.equal(payload.reddi_demo.paymentStatus, "demo_x402_payment_header_shape_accepted_not_production_verified");
   } finally {
     await new Promise((resolve) => instance.close(resolve));
   }

--- a/packages/testing-specialists/tests/server.test.js
+++ b/packages/testing-specialists/tests/server.test.js
@@ -1,0 +1,56 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { server, chooseResponse } = require("../dist/server.js");
+
+function listen() {
+  return new Promise((resolve) => {
+    const instance = server.listen(0, "127.0.0.1", () => {
+      const address = instance.address();
+      resolve({ instance, baseUrl: `http://127.0.0.1:${address.port}` });
+    });
+  });
+}
+
+test("known query produces high-confidence predefined response", () => {
+  const response = chooseResponse("Please audit this endpoint for an unpaid completion bypass without x402.");
+  assert.equal(response.predefinedMatch, true);
+  assert.equal(response.selected.id, "insecure-open-completion");
+  assert.equal(response.confidence, 0.97);
+  assert.equal(response.reputationScore, 96);
+});
+
+test("unknown query produces low-confidence best effort", () => {
+  const response = chooseResponse("What colour should the launch banner be?");
+  assert.equal(response.predefinedMatch, false);
+  assert.equal(response.confidence, 0.24);
+  assert.equal(response.reputationScore, 24);
+});
+
+test("completion route fails closed with x402 challenge, then accepts paid retry", async () => {
+  const { instance, baseUrl } = await listen();
+  try {
+    const unpaid = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "audit unpaid completion bypass" }] }),
+    });
+    assert.equal(unpaid.status, 402);
+    assert.ok(unpaid.headers.get("x402-request"));
+    const challenge = JSON.parse(unpaid.headers.get("x402-request"));
+    assert.equal(challenge.route, "/v1/chat/completions");
+    assert.equal(challenge.specialistProfile, "qa-security");
+
+    const paid = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x402-payment": JSON.stringify({ txSignature: "demo" }) },
+      body: JSON.stringify({ messages: [{ role: "user", content: "audit unpaid completion bypass" }] }),
+    });
+    assert.equal(paid.status, 200);
+    const payload = await paid.json();
+    assert.equal(payload.reddi_demo.predefinedMatch, true);
+    assert.equal(payload.reddi_demo.matchConfidence, 0.97);
+    assert.equal(payload.reddi_demo.reputationScore, 96);
+  } finally {
+    await new Promise((resolve) => instance.close(resolve));
+  }
+});

--- a/packages/testing-specialists/tsconfig.json
+++ b/packages/testing-specialists/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/capture-testing-specialist-demo.mjs
+++ b/scripts/capture-testing-specialist-demo.mjs
@@ -30,7 +30,18 @@ async function main() {
     return { models, unpaid: { status: unpaid.status, x402Request: x402Request ? JSON.parse(x402Request) : null, body: unpaidBody }, paid: { status: paid.status, body: paidBody } };
   }, endpoint);
 
-  fs.writeFileSync(path.join(outRoot, "capture-flow.json"), JSON.stringify(result, null, 2));
+  const checks = [
+    { name: "unpaid call returns 402", ok: result.unpaid.status === 402 },
+    { name: "unpaid call includes x402-request", ok: Boolean(result.unpaid.x402Request) },
+    { name: "paid retry returns 200", ok: result.paid.status === 200 },
+    { name: "paid retry has high confidence", ok: (result.paid.body?.reddi_demo?.matchConfidence || 0) >= 0.9 },
+  ];
+  const failed = checks.filter((check) => !check.ok);
+  fs.writeFileSync(path.join(outRoot, "capture-flow.json"), JSON.stringify({ ...result, checks }, null, 2));
+  if (failed.length > 0) {
+    fs.writeFileSync(path.join(outRoot, "CAPTURE-FAILED.md"), failed.map((check) => `- ${check.name}`).join("\n"));
+    throw new Error(`capture assertions failed: ${failed.map((check) => check.name).join(", ")}`);
+  }
 
   await page.setContent(`<!doctype html>
 <html><head><meta charset="utf-8"><title>Reddi x402 testing specialist capture</title>

--- a/scripts/capture-testing-specialist-demo.mjs
+++ b/scripts/capture-testing-specialist-demo.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { chromium } from "playwright";
+
+const endpoint = process.env.TESTING_SPECIALIST_ENDPOINT || process.argv[2] || "http://127.0.0.1:8080";
+const outRoot = process.env.ARTIFACT_DIR || path.join("artifacts", "demo-testing-specialists", new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z"));
+const screenDir = path.join(outRoot, "screens");
+fs.mkdirSync(screenDir, { recursive: true });
+
+function esc(value) {
+  return String(value).replace(/[&<>"']/g, (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;" })[ch]);
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+
+  await page.goto(`${endpoint}/healthz`);
+  await page.screenshot({ path: path.join(screenDir, "01-healthz.png"), fullPage: true });
+
+  const result = await page.evaluate(async (baseUrl) => {
+    const models = await fetch(`${baseUrl}/v1/models`).then((r) => r.json());
+    const body = { model: models?.data?.[0]?.id, messages: [{ role: "user", content: "Audit unpaid completion bypass without x402" }] };
+    const unpaid = await fetch(`${baseUrl}/v1/chat/completions`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const x402Request = unpaid.headers.get("x402-request");
+    const unpaidBody = await unpaid.json();
+    const paid = await fetch(`${baseUrl}/v1/chat/completions`, { method: "POST", headers: { "content-type": "application/json", "x402-payment": JSON.stringify({ txSignature: "demo-capture", network: "solana-devnet" }) }, body: JSON.stringify(body) });
+    const paidBody = await paid.json();
+    return { models, unpaid: { status: unpaid.status, x402Request: x402Request ? JSON.parse(x402Request) : null, body: unpaidBody }, paid: { status: paid.status, body: paidBody } };
+  }, endpoint);
+
+  fs.writeFileSync(path.join(outRoot, "capture-flow.json"), JSON.stringify(result, null, 2));
+
+  await page.setContent(`<!doctype html>
+<html><head><meta charset="utf-8"><title>Reddi x402 testing specialist capture</title>
+<style>
+body{font-family:Inter,ui-sans-serif,system-ui;background:#0b1020;color:#eef2ff;margin:0;padding:40px} .card{background:#111936;border:1px solid #2d3b70;border-radius:18px;padding:24px;margin:0 0 24px;box-shadow:0 20px 60px #0005} h1{font-size:34px;margin:0 0 8px}.ok{color:#75f0b1}.warn{color:#ffd166} pre{white-space:pre-wrap;background:#050816;padding:18px;border-radius:12px;overflow:auto}.grid{display:grid;grid-template-columns:1fr 1fr;gap:24px}.pill{display:inline-block;padding:6px 10px;border-radius:999px;background:#19315f;margin-right:8px}</style>
+</head><body>
+<h1>Reddi x402 protected testing specialist</h1>
+<p><span class="pill">${esc(endpoint)}</span><span class="pill">Solana devnet</span><span class="pill">mock runtime, real fail-closed rail</span></p>
+<div class="grid">
+  <section class="card"><h2 class="warn">1. Unpaid call is blocked</h2><p>HTTP ${result.unpaid.status} with <code>x402-request</code>.</p><pre>${esc(JSON.stringify(result.unpaid.x402Request, null, 2))}</pre></section>
+  <section class="card"><h2 class="ok">2. Paid retry returns specialist answer</h2><p>HTTP ${result.paid.status}; match confidence ${esc(result.paid.body?.reddi_demo?.matchConfidence)}; reputation ${esc(result.paid.body?.reddi_demo?.reputationScore)}/100.</p><pre>${esc(JSON.stringify(result.paid.body?.reddi_demo, null, 2))}</pre></section>
+</div>
+<section class="card"><h2>Assistant payload</h2><pre>${esc(result.paid.body?.choices?.[0]?.message?.content || "")}</pre></section>
+</body></html>`);
+  await page.screenshot({ path: path.join(screenDir, "02-x402-paid-flow.png"), fullPage: true });
+  await browser.close();
+
+  fs.writeFileSync(path.join(outRoot, "CAPTURE-SUMMARY.md"), `# Testing specialist capture\n\nEndpoint: ${endpoint}\n\nScreens:\n\n- screens/01-healthz.png\n- screens/02-x402-paid-flow.png\n\nJSON: capture-flow.json\n`);
+  console.log(`CAPTURED ${outRoot}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/run-testing-specialist-smoke.mjs
+++ b/scripts/run-testing-specialist-smoke.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const endpoint = process.env.TESTING_SPECIALIST_ENDPOINT || process.argv[2] || "http://127.0.0.1:8080";
+const outRoot = process.env.ARTIFACT_DIR || path.join("artifacts", "demo-testing-specialists", new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z"));
+fs.mkdirSync(outRoot, { recursive: true });
+
+async function writeJson(name, payload) {
+  fs.writeFileSync(path.join(outRoot, name), JSON.stringify(payload, null, 2));
+}
+
+async function main() {
+  const summary = { endpoint, checks: [], ok: false };
+
+  const health = await fetch(`${endpoint}/healthz`);
+  const healthPayload = await health.json().catch(() => ({}));
+  summary.checks.push({ name: "healthz", status: health.status, ok: health.ok });
+  await writeJson("01-healthz.json", healthPayload);
+
+  const models = await fetch(`${endpoint}/v1/models`);
+  const modelsPayload = await models.json().catch(() => ({}));
+  summary.checks.push({ name: "models", status: models.status, ok: models.ok });
+  await writeJson("02-models.json", modelsPayload);
+
+  const promptByProfile = {
+    "qa-security": "Audit unpaid completion bypass without x402",
+    "ux-usability": "Find specialist onboarding friction before registration",
+    "integration-tester": "Create a Coolify VPS smoke plan for the protected endpoint"
+  };
+  const prompt = promptByProfile[healthPayload?.profile] || "Audit unpaid completion bypass without x402";
+  const body = { model: modelsPayload?.data?.[0]?.id || "reddi-demo/testing-specialist", messages: [{ role: "user", content: prompt }] };
+  const unpaid = await fetch(`${endpoint}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const unpaidPayload = await unpaid.json().catch(() => ({}));
+  const x402Request = unpaid.headers.get("x402-request");
+  summary.checks.push({ name: "unpaid_completion_fails_closed", status: unpaid.status, ok: unpaid.status === 402 && Boolean(x402Request) });
+  await writeJson("03-unpaid-completion.json", { status: unpaid.status, x402Request: x402Request ? JSON.parse(x402Request) : null, body: unpaidPayload });
+
+  const paid = await fetch(`${endpoint}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x402-payment": JSON.stringify({ txSignature: "demo-smoke", network: "solana-devnet" }) },
+    body: JSON.stringify(body),
+  });
+  const paidPayload = await paid.json().catch(() => ({}));
+  summary.checks.push({ name: "paid_completion_returns_match_metadata", status: paid.status, ok: paid.ok && paidPayload?.reddi_demo?.matchConfidence >= 0.9 });
+  await writeJson("04-paid-completion.json", paidPayload);
+
+  summary.ok = summary.checks.every((check) => check.ok);
+  fs.writeFileSync(path.join(outRoot, "SUMMARY.md"), [
+    `# Testing Specialist Smoke`,
+    ``,
+    `Endpoint: ${endpoint}`,
+    `Result: ${summary.ok ? "PASS" : "FAIL"}`,
+    ``,
+    ...summary.checks.map((check) => `- ${check.ok ? "✅" : "❌"} ${check.name}: HTTP ${check.status}`),
+    ``,
+  ].join("\n"));
+  await writeJson("summary.json", summary);
+  console.log(`${summary.ok ? "PASS" : "FAIL"} ${outRoot}`);
+  if (!summary.ok) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `packages/testing-specialists`: deterministic mock testing specialists protected by reddi-x402 fail-closed challenge flow.
- Adds Coolify/VPS deployment + devnet registration/capture plan in `docs/demo/VPS-TESTING-SPECIALISTS-X402-DEMO-PLAN.md`.
- Adds artifacted smoke and Playwright capture scripts for replayable demo evidence.

## Linked issue
Closes #130

## Validation
- `npm run build` ✅
- `npm run test:bdd:index` ✅
- `cd packages/testing-specialists && npm test` ✅
- `TESTING_SPECIALIST_ENDPOINT=http://127.0.0.1:18080 npm run demo:testing-specialist:smoke` ✅ (`artifacts/demo-testing-specialists/20260429T203859Z`)
- `TESTING_SPECIALIST_ENDPOINT=http://127.0.0.1:18081 npm run demo:testing-specialist:capture` ✅ (`artifacts/demo-testing-specialists/20260429T204014Z`)

## Guardrails
- Devnet/mock-only; no GPU or paid inference dependency.
- The completion route returns no answer before `x402-payment` is present.
- No secrets committed; service only requires public specialist wallet in env.
