### PR TITLE
fix(demo): support Coolify healthchecks

### DIFF
--- a/docs/demo/VPS-TESTING-SPECIALISTS-X402-DEMO-PLAN.md
+++ b/docs/demo/VPS-TESTING-SPECIALISTS-X402-DEMO-PLAN.md
@@ -11,7 +11,7 @@ Run demo-only testing specialist agents on the VPS via Coolify. They are intenti
 3. accepts a demo-shaped `x402-payment` retry with a non-empty `txSignature`;
 4. clearly marks that the mock service validates demo payment header shape only, not production payment settlement;
 5. returns a predefined high-confidence testing response when the prompt matches a known case;
-5. returns the nearest best-effort response with lower `matchConfidence` and `reputationScore` when the prompt is uncertain.
+6. returns the nearest best-effort response with lower `matchConfidence` and `reputationScore` when the prompt is uncertain.
 
 This shows the value of Reddi Agent Protocol versus a normal public endpoint: endpoint protection, Solana x402 payment flow, registry/reputation metadata, and replayable evidence.
 

--- a/packages/testing-specialists/Dockerfile
+++ b/packages/testing-specialists/Dockerfile
@@ -16,6 +16,7 @@ RUN cd packages/testing-specialists && npm run build
 
 FROM node:24-alpine
 WORKDIR /app/packages/testing-specialists
+RUN apk add --no-cache curl
 ENV NODE_ENV=production PORT=8080 HOST=0.0.0.0
 COPY --from=build /app/packages/x402-solana /app/packages/x402-solana
 COPY --from=build /app/packages/testing-specialists /app/packages/testing-specialists

--- a/scripts/capture-testing-specialist-demo.mjs
+++ b/scripts/capture-testing-specialist-demo.mjs
@@ -20,14 +20,21 @@ async function main() {
   await page.screenshot({ path: path.join(screenDir, "01-healthz.png"), fullPage: true });
 
   const result = await page.evaluate(async (baseUrl) => {
+    const health = await fetch(`${baseUrl}/healthz`).then((r) => r.json());
     const models = await fetch(`${baseUrl}/v1/models`).then((r) => r.json());
-    const body = { model: models?.data?.[0]?.id, messages: [{ role: "user", content: "Audit unpaid completion bypass without x402" }] };
+    const promptByProfile = {
+      "qa-security": "Audit unpaid completion bypass without x402",
+      "ux-usability": "Find specialist onboarding friction before registration",
+      "integration-tester": "Create a Coolify VPS smoke plan for the protected endpoint",
+    };
+    const prompt = promptByProfile[health?.profile] || "Audit unpaid completion bypass without x402";
+    const body = { model: models?.data?.[0]?.id, messages: [{ role: "user", content: prompt }] };
     const unpaid = await fetch(`${baseUrl}/v1/chat/completions`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
     const x402Request = unpaid.headers.get("x402-request");
     const unpaidBody = await unpaid.json();
     const paid = await fetch(`${baseUrl}/v1/chat/completions`, { method: "POST", headers: { "content-type": "application/json", "x402-payment": JSON.stringify({ txSignature: "demo-capture", network: "solana-devnet" }) }, body: JSON.stringify(body) });
     const paidBody = await paid.json();
-    return { models, unpaid: { status: unpaid.status, x402Request: x402Request ? JSON.parse(x402Request) : null, body: unpaidBody }, paid: { status: paid.status, body: paidBody } };
+    return { health, models, prompt, unpaid: { status: unpaid.status, x402Request: x402Request ? JSON.parse(x402Request) : null, body: unpaidBody }, paid: { status: paid.status, body: paidBody } };
   }, endpoint);
 
   const checks = [
@@ -49,11 +56,12 @@ async function main() {
 body{font-family:Inter,ui-sans-serif,system-ui;background:#0b1020;color:#eef2ff;margin:0;padding:40px} .card{background:#111936;border:1px solid #2d3b70;border-radius:18px;padding:24px;margin:0 0 24px;box-shadow:0 20px 60px #0005} h1{font-size:34px;margin:0 0 8px}.ok{color:#75f0b1}.warn{color:#ffd166} pre{white-space:pre-wrap;background:#050816;padding:18px;border-radius:12px;overflow:auto}.grid{display:grid;grid-template-columns:1fr 1fr;gap:24px}.pill{display:inline-block;padding:6px 10px;border-radius:999px;background:#19315f;margin-right:8px}</style>
 </head><body>
 <h1>Reddi x402 protected testing specialist</h1>
-<p><span class="pill">${esc(endpoint)}</span><span class="pill">Solana devnet</span><span class="pill">mock runtime, real fail-closed rail</span></p>
+<p><span class="pill">${esc(endpoint)}</span><span class="pill">${esc(result.health?.profile || "unknown-profile")}</span><span class="pill">Solana devnet</span><span class="pill">mock runtime, real fail-closed rail</span></p>
 <div class="grid">
   <section class="card"><h2 class="warn">1. Unpaid call is blocked</h2><p>HTTP ${result.unpaid.status} with <code>x402-request</code>.</p><pre>${esc(JSON.stringify(result.unpaid.x402Request, null, 2))}</pre></section>
   <section class="card"><h2 class="ok">2. Paid retry returns specialist answer</h2><p>HTTP ${result.paid.status}; match confidence ${esc(result.paid.body?.reddi_demo?.matchConfidence)}; reputation ${esc(result.paid.body?.reddi_demo?.reputationScore)}/100.</p><pre>${esc(JSON.stringify(result.paid.body?.reddi_demo, null, 2))}</pre></section>
 </div>
+<section class="card"><h2>Prompt</h2><pre>${esc(result.prompt || "")}</pre></section>
 <section class="card"><h2>Assistant payload</h2><pre>${esc(result.paid.body?.choices?.[0]?.message?.content || "")}</pre></section>
 </body></html>`);
   await page.screenshot({ path: path.join(screenDir, "02-x402-paid-flow.png"), fullPage: true });


### PR DESCRIPTION
## Summary
- Adds `curl` to the testing-specialists runtime image so Coolify Dockerfile healthchecks can run.
- Fixes duplicate numbering in the demo plan.

## Why
The three Coolify deployments from PR #131 built and started successfully, but Coolify marked them unhealthy because the Alpine image had neither `curl` nor usable `wget` for its healthcheck runner. Container logs showed the services listening on `0.0.0.0:8080` before rollback.

## Validation
- `docker build -f packages/testing-specialists/Dockerfile .` ✅

## Follow-up after merge
Redeploy these existing Coolify apps:
- `reddi-qa-testing-specialist` (`ydlzndg7wqpqshvlhhjxvy8c`)
- `reddi-ux-testing-specialist` (`nixsypbsz5cv49g2dridh9dd`)
- `reddi-integration-testing-specialist` (`e1oc8msvyen5pruwli59maja`)
