### PR TITLE
feat(app): add ReddiAgents APP adapter skeleton

### DIFF
--- a/app/.well-known/app-agent.json/route.ts
+++ b/app/.well-known/app-agent.json/route.ts
@@ -1,0 +1,7 @@
+import { buildAppAdapterManifest } from "@/lib/app-adapter/manifest";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return Response.json(buildAppAdapterManifest());
+}

--- a/app/app/agents/[agentId]/schema/route.ts
+++ b/app/app/agents/[agentId]/schema/route.ts
@@ -1,0 +1,18 @@
+import { findAppAdapterAgent } from "@/lib/app-adapter/registry";
+
+export const runtime = "nodejs";
+
+type RouteContext = {
+  params: Promise<{ agentId: string }> | { agentId: string };
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const params = await context.params;
+  const agent = findAppAdapterAgent(params.agentId);
+
+  if (!agent) {
+    return Response.json({ ok: false, error: "Unknown APP adapter agent" }, { status: 404 });
+  }
+
+  return Response.json({ ok: true, agent_id: agent.appAgentId, schema: agent.inputSchema });
+}

--- a/app/app/agents/route.ts
+++ b/app/app/agents/route.ts
@@ -1,0 +1,7 @@
+import { buildAppAdapterAgentList } from "@/lib/app-adapter/manifest";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return Response.json({ ok: true, agents: buildAppAdapterAgentList() });
+}

--- a/app/app/runs/[runId]/route.ts
+++ b/app/app/runs/[runId]/route.ts
@@ -1,0 +1,18 @@
+import { getAppAdapterRun } from "@/lib/app-adapter/store";
+
+export const runtime = "nodejs";
+
+type RouteContext = {
+  params: Promise<{ runId: string }> | { runId: string };
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const params = await context.params;
+  const run = getAppAdapterRun(params.runId);
+
+  if (!run) {
+    return Response.json({ ok: false, error: "Unknown APP adapter run", run_id: params.runId }, { status: 404 });
+  }
+
+  return Response.json({ ok: true, ...run });
+}

--- a/app/app/runs/route.ts
+++ b/app/app/runs/route.ts
@@ -1,0 +1,54 @@
+import { dispatchAppAdapterRun } from "@/lib/app-adapter/dispatcher";
+import { findAppAdapterAgent } from "@/lib/app-adapter/registry";
+import { createRunId, saveAppAdapterRun } from "@/lib/app-adapter/store";
+import { normalizeTraceId, validateRunInput } from "@/lib/app-adapter/translator";
+import type { AppAdapterRun } from "@/lib/app-adapter/types";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return Response.json({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const agentId = typeof body.agent_id === "string" ? body.agent_id : "";
+  const agent = findAppAdapterAgent(agentId);
+  if (!agent || !agent.enabled) {
+    return Response.json({ ok: false, error: "Unknown or disabled APP adapter agent" }, { status: 404 });
+  }
+
+  const inputResult = validateRunInput(body.input);
+  if (!inputResult.ok) {
+    return Response.json({ ok: false, error: inputResult.error }, { status: 400 });
+  }
+
+  const context = body.context && typeof body.context === "object" ? (body.context as Record<string, unknown>) : {};
+  const now = new Date().toISOString();
+  const run: AppAdapterRun = {
+    runId: createRunId(),
+    agentId: agent.appAgentId,
+    status: "running",
+    input: inputResult.input,
+    context: {
+      conversationId: typeof context.conversation_id === "string" ? context.conversation_id : undefined,
+      userId: typeof context.user_id === "string" ? context.user_id : undefined,
+      traceId: normalizeTraceId(context.trace_id),
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  saveAppAdapterRun(run);
+  const completedRun = await dispatchAppAdapterRun(agent, run);
+  saveAppAdapterRun(completedRun);
+
+  return Response.json({
+    run_id: completedRun.runId,
+    agent_id: completedRun.agentId,
+    status: completedRun.status,
+    status_url: `/app/runs/${completedRun.runId}`,
+  });
+}

--- a/docs/REDDIAGENTS-APP-ADAPTER-SPEC.md
+++ b/docs/REDDIAGENTS-APP-ADAPTER-SPEC.md
@@ -1,0 +1,367 @@
+# ReddiAgents Lightweight APP Adapter — v0.1 Spec
+
+_Last updated: 2026-05-01 AEST_
+
+## 1. Purpose
+
+Create a lightweight APP Adapter that exposes ReddiAgents through an APP-compatible surface without replacing the existing Reddi Agent Protocol runtime, x402 payment rails, Solana escrow, attestation, or demo specialist infrastructure.
+
+The adapter is a translation layer:
+
+```text
+APP-compatible client / judge harness / partner agent
+        ↓
+ReddiAgents APP Adapter
+  - discovery manifest
+  - agent registry projection
+  - request/context normalization
+  - ReddiAgents dispatch bridge
+  - status/result/receipt translation
+        ↓
+Existing Reddi Agent Protocol app + registered specialists
+```
+
+## 2. Design Principles
+
+1. **Adapter, not rewrite** — use existing ReddiAgents registration, planner, specialist, x402, attestation, and evidence flows.
+2. **Small enough to ship now** — polling-based run lifecycle first; streaming/webhooks are optional follow-ups.
+3. **Fail closed** — never convert an unpaid/open completion path into a successful paid/callable APP result.
+4. **Judge-safe evidence** — every run returns a receipt envelope that points to safe public evidence, not private prompts, secrets, or raw logs.
+5. **Composable by default** — APP agent IDs map onto Reddi specialist capabilities and source-routing policy rather than hardcoded one-off endpoints.
+
+## 3. Non-goals for v0.1
+
+- No new orchestration engine.
+- No marketplace persistence beyond projecting the existing registry/readiness data.
+- No custom billing ledger outside existing x402/Solana receipt evidence.
+- No streaming requirement unless a consuming APP harness explicitly needs it.
+- No broad external write actions from the adapter; it should call the existing controlled planner/specialist paths.
+
+## 4. Minimal Public Surface
+
+### 4.1 Discovery
+
+`GET /.well-known/app-agent.json`
+
+Returns adapter metadata and the APP-exposed ReddiAgents.
+
+Example response:
+
+```json
+{
+  "name": "ReddiAgents",
+  "version": "0.1.0",
+  "protocol": "app",
+  "description": "APP-compatible adapter for Reddi Agent Protocol specialists with x402 payments, Solana escrow, and attested evidence.",
+  "agents": [
+    {
+      "id": "reddi.qa-testing-specialist",
+      "name": "Reddi QA Testing Specialist",
+      "description": "x402-paid QA specialist exposed through the ReddiAgents APP Adapter.",
+      "capabilities": ["qa.review", "test.plan", "evidence.summarize"],
+      "input_schema_url": "/app/agents/reddi.qa-testing-specialist/schema",
+      "run_url": "/app/runs",
+      "status": "available"
+    }
+  ]
+}
+```
+
+### 4.2 Agent List
+
+`GET /app/agents`
+
+Returns the same agent list as discovery plus Reddi-specific readiness metadata.
+
+Recommended Reddi extension fields:
+
+```json
+{
+  "id": "reddi.qa-testing-specialist",
+  "reddi": {
+    "source": "openclaw",
+    "wallet": "optional-public-wallet",
+    "x402_required": true,
+    "attestation_supported": true,
+    "evidence_routes": ["/manager", "/testers"]
+  }
+}
+```
+
+### 4.3 Agent Schema
+
+`GET /app/agents/:agentId/schema`
+
+Returns JSON Schema for the normalized run input.
+
+v0.1 should accept one generic task shape:
+
+```json
+{
+  "type": "object",
+  "required": ["task"],
+  "properties": {
+    "task": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The task for the selected ReddiAgent specialist."
+    },
+    "constraints": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "evidence_preference": {
+      "type": "string",
+      "enum": ["summary", "links", "full_receipt"],
+      "default": "summary"
+    }
+  }
+}
+```
+
+### 4.4 Create Run
+
+`POST /app/runs`
+
+Request:
+
+```json
+{
+  "agent_id": "reddi.qa-testing-specialist",
+  "input": {
+    "task": "Review this x402 integration plan for missing fail-closed checks.",
+    "constraints": ["Be concise", "Include test suggestions"],
+    "evidence_preference": "full_receipt"
+  },
+  "context": {
+    "conversation_id": "optional-external-thread-id",
+    "user_id": "optional-external-user-id",
+    "trace_id": "optional-caller-trace-id"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "run_id": "app_run_01hv...",
+  "agent_id": "reddi.qa-testing-specialist",
+  "status": "queued",
+  "status_url": "/app/runs/app_run_01hv..."
+}
+```
+
+### 4.5 Run Status / Result
+
+`GET /app/runs/:runId`
+
+Response:
+
+```json
+{
+  "run_id": "app_run_01hv...",
+  "agent_id": "reddi.qa-testing-specialist",
+  "status": "succeeded",
+  "output": {
+    "content": "Review result here...",
+    "evidence": [
+      {
+        "label": "x402 challenge observed",
+        "url": "/manager"
+      }
+    ]
+  },
+  "usage": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cost_usd": null
+  },
+  "receipt": {
+    "adapter": "reddiagents-app-adapter",
+    "adapter_version": "0.1.0",
+    "trace_id": "caller-or-generated-trace-id",
+    "x402_required": true,
+    "x402_satisfied": true,
+    "attestation_status": "not_requested",
+    "safe_public_evidence_only": true
+  }
+}
+```
+
+## 5. State Mapping
+
+| APP status | ReddiAgents source state | Notes |
+| --- | --- | --- |
+| `queued` | accepted, not yet dispatched | Run record exists locally. |
+| `running` | planner/specialist call in progress | Existing Reddi dispatch/session is active. |
+| `requires_payment` | x402 challenge returned, payment not yet satisfied | Optional if APP clients support this state; otherwise keep internal and continue existing paid flow. |
+| `succeeded` | specialist result + safe receipt generated | Must include receipt envelope. |
+| `failed` | probe, policy, payment, attestation, or specialist failure | Return safe error class, not raw logs. |
+| `cancelled` | caller/system cancellation | v0.1 may expose only if easy to wire. |
+
+## 6. Internal Module Boundaries
+
+Suggested Next.js/app module layout:
+
+```text
+app/.well-known/app-agent.json/route.ts
+app/app/agents/route.ts
+app/app/agents/[agentId]/schema/route.ts
+app/app/runs/route.ts
+app/app/runs/[runId]/route.ts
+lib/app-adapter/manifest.ts
+lib/app-adapter/registry.ts
+lib/app-adapter/dispatcher.ts
+lib/app-adapter/translator.ts
+lib/app-adapter/receipts.ts
+lib/app-adapter/store.ts
+lib/__tests__/app-adapter-*.test.ts
+```
+
+### 6.1 Registry Entry
+
+```ts
+export type AppAdapterAgent = {
+  appAgentId: string;
+  name: string;
+  description: string;
+  capabilities: string[];
+  enabled: boolean;
+  sourcePolicy: {
+    preferredSource?: "openclaw" | "external";
+    strictSourceMatch?: boolean;
+  };
+  reddi: {
+    specialistWallet?: string;
+    specialistEndpoint?: string;
+    x402Required: boolean;
+    attestationSupported: boolean;
+  };
+  inputSchema: unknown;
+};
+```
+
+### 6.2 Run Record
+
+```ts
+export type AppAdapterRun = {
+  runId: string;
+  agentId: string;
+  status: "queued" | "running" | "requires_payment" | "succeeded" | "failed" | "cancelled";
+  input: unknown;
+  context: {
+    conversationId?: string;
+    userId?: string;
+    traceId: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+  output?: unknown;
+  safeError?: {
+    code: string;
+    message: string;
+  };
+  receipt?: unknown;
+};
+```
+
+For v0.1, `store.ts` can be an in-memory store for demo/local use. If the adapter needs durable runs later, back it with the existing app database/storage pattern.
+
+## 7. Dispatch Bridge
+
+The adapter should prefer existing planner/specialist APIs instead of bypassing product logic.
+
+Recommended bridge order:
+
+1. Resolve `agent_id` from `lib/app-adapter/registry.ts`.
+2. Validate input against the agent schema.
+3. Apply Reddi source policy, e.g. `preferredSource: "openclaw"` for ReddiAgents demo specialists.
+4. Call existing planner/specialist route or shared function.
+5. Preserve x402 challenge/payment status.
+6. Normalize final result into APP output + Reddi receipt envelope.
+
+If a selected specialist endpoint does not return `402 + x402-request` for protected completion paths, the adapter must fail closed with `failed` and an error code such as `x402_required_but_missing`.
+
+## 8. Receipt Requirements
+
+Every terminal response should include a receipt object.
+
+Minimum receipt fields:
+
+```json
+{
+  "adapter": "reddiagents-app-adapter",
+  "adapter_version": "0.1.0",
+  "trace_id": "...",
+  "agent_id": "reddi.qa-testing-specialist",
+  "x402_required": true,
+  "x402_satisfied": true,
+  "attestation_status": "not_requested|pending|passed|failed",
+  "escrow_status": "not_used|locked|released|refunded|failed",
+  "safe_public_evidence_only": true
+}
+```
+
+Rules:
+
+- Do not include private prompts unless explicitly classified safe.
+- Do not include secrets, auth headers, wallet private keys, raw runtime logs, or unredacted environment values.
+- Prefer links to existing Manager/tester evidence surfaces over embedding large logs.
+
+## 9. First Demo Mapping
+
+Use the currently deployed demo specialists as the first APP-exposed agents:
+
+| APP agent ID | Existing specialist | Public endpoint |
+| --- | --- | --- |
+| `reddi.qa-testing-specialist` | QA Testing Specialist | `https://reddi-qa.preview.reddi.tech` |
+| `reddi.ux-testing-specialist` | UX Testing Specialist | `https://reddi-ux.preview.reddi.tech` |
+| `reddi.integration-testing-specialist` | Integration Testing Specialist | `https://reddi-integration.preview.reddi.tech` |
+
+v0.1 can ship with only `reddi.qa-testing-specialist` enabled and the other two present but disabled until route tests pass.
+
+## 10. Acceptance Criteria
+
+- `GET /.well-known/app-agent.json` returns valid JSON with at least one enabled ReddiAgent.
+- `GET /app/agents` lists the same enabled agent with Reddi readiness metadata.
+- `GET /app/agents/:agentId/schema` returns the input schema for the demo agent.
+- `POST /app/runs` accepts a task, creates a run record, and dispatches through the existing Reddi path.
+- `GET /app/runs/:runId` returns a normalized terminal status and receipt.
+- x402 bypass/open-completion conditions fail closed.
+- Contract tests cover manifest shape, schema route, run creation validation, status translation, and safe failure output.
+- A local demo command can create a run and print the final APP response.
+
+## 11. Implementation Slice Plan
+
+### Slice A — Spec + route skeleton
+
+- Add this spec.
+- Add manifest, registry, translator, receipt helpers.
+- Add discovery/list/schema routes.
+- Add contract tests for static routes.
+
+### Slice B — Demo run lifecycle
+
+- Add in-memory run store.
+- Add `POST /app/runs` and `GET /app/runs/:runId`.
+- Add mock dispatch implementation behind the dispatcher interface.
+- Add contract tests for queued/succeeded/failed mappings.
+
+### Slice C — Real Reddi dispatch bridge
+
+- Replace mock dispatch with existing planner/specialist call path.
+- Preserve x402 fail-closed behavior.
+- Emit safe receipt fields.
+- Add demo script.
+
+### Slice D — Optional live updates
+
+- Add `GET /app/runs/:runId/events` SSE only if APP consumers need progress streaming.
+
+## 12. Open Questions
+
+1. What exact APP protocol version and required field names should Colosseum or the judging harness expect?
+2. Should payment-required be exposed as an APP state, or should the adapter hide the x402 challenge/retry cycle behind the Reddi dispatch bridge?
+3. Do APP consumers require signed receipts, or is a safe evidence envelope enough for the hackathon submission?
+4. Which ReddiAgent should be the canonical first live demo: QA, UX, or Integration?

--- a/lib/__tests__/app-adapter-slice-a.test.ts
+++ b/lib/__tests__/app-adapter-slice-a.test.ts
@@ -1,0 +1,235 @@
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/lib/onboarding/planner-execution", () => ({
+  executePlannerSpecialistCall: jest.fn(),
+}));
+
+describe("ReddiAgents APP Adapter Slice A", () => {
+  const originalDispatchMode = process.env.REDDI_APP_ADAPTER_DISPATCH;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    if (originalDispatchMode === undefined) {
+      delete process.env.REDDI_APP_ADAPTER_DISPATCH;
+    } else {
+      process.env.REDDI_APP_ADAPTER_DISPATCH = originalDispatchMode;
+    }
+  });
+
+  it("serves a well-known APP discovery manifest with one enabled demo specialist", async () => {
+    const { GET } = await import("@/app/.well-known/app-agent.json/route");
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      name: "ReddiAgents",
+      version: "0.1.0",
+      protocol: "app",
+    });
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0]).toMatchObject({
+      id: "reddi.qa-testing-specialist",
+      status: "available",
+      input_schema_url: "/app/agents/reddi.qa-testing-specialist/schema",
+      run_url: "/app/runs",
+    });
+  });
+
+  it("lists enabled and staged APP adapter agents with Reddi readiness metadata", async () => {
+    const { GET } = await import("@/app/app/agents/route");
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.agents.map((agent: { id: string }) => agent.id)).toEqual([
+      "reddi.qa-testing-specialist",
+      "reddi.ux-testing-specialist",
+      "reddi.integration-testing-specialist",
+    ]);
+    expect(body.agents[0]).toMatchObject({
+      status: "available",
+      reddi: {
+        source: "openclaw",
+        strict_source_match: true,
+        specialist_endpoint: "https://reddi-qa.preview.reddi.tech",
+        x402_required: true,
+        attestation_supported: true,
+        evidence_routes: ["/manager", "/testers"],
+      },
+    });
+    expect(body.agents.slice(1).every((agent: { status: string }) => agent.status === "disabled")).toBe(true);
+  });
+
+  it("serves the normalized task schema for a known APP adapter agent", async () => {
+    const { GET } = await import("@/app/app/agents/[agentId]/schema/route");
+
+    const res = await GET(new Request("http://localhost/app/agents/reddi.qa-testing-specialist/schema"), {
+      params: { agentId: "reddi.qa-testing-specialist" },
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      agent_id: "reddi.qa-testing-specialist",
+      schema: {
+        type: "object",
+        required: ["task"],
+      },
+    });
+    expect(body.schema.properties.evidence_preference.enum).toEqual(["summary", "links", "full_receipt"]);
+  });
+
+  it("returns a safe 404 for unknown APP adapter agent schemas", async () => {
+    const { GET } = await import("@/app/app/agents/[agentId]/schema/route");
+
+    const res = await GET(new Request("http://localhost/app/agents/unknown/schema"), {
+      params: { agentId: "unknown" },
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body).toEqual({ ok: false, error: "Unknown APP adapter agent" });
+  });
+
+  it("creates and retrieves a mock APP adapter run with a safe receipt envelope", async () => {
+    const { clearAppAdapterRunsForTest } = await import("@/lib/app-adapter/store");
+    clearAppAdapterRunsForTest();
+    const createRun = await import("@/app/app/runs/route");
+    const getRun = await import("@/app/app/runs/[runId]/route");
+
+    const createRes = await createRun.POST(
+      new Request("http://localhost/app/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          agent_id: "reddi.qa-testing-specialist",
+          input: {
+            task: "Review this x402 integration plan.",
+            constraints: ["Be concise"],
+            evidence_preference: "full_receipt",
+          },
+          context: {
+            conversation_id: "thread-1",
+            user_id: "user-1",
+            trace_id: "trace-demo",
+          },
+        }),
+      })
+    );
+    const createBody = await createRes.json();
+
+    expect(createRes.status).toBe(200);
+    expect(createBody).toMatchObject({
+      agent_id: "reddi.qa-testing-specialist",
+      status: "succeeded",
+    });
+    expect(createBody.run_id).toMatch(/^app_run_/);
+    expect(createBody.status_url).toBe(`/app/runs/${createBody.run_id}`);
+
+    const getRes = await getRun.GET(new Request(`http://localhost/app/runs/${createBody.run_id}`), {
+      params: { runId: createBody.run_id },
+    });
+    const getBody = await getRes.json();
+
+    expect(getRes.status).toBe(200);
+    expect(getBody).toMatchObject({
+      ok: true,
+      runId: createBody.run_id,
+      agentId: "reddi.qa-testing-specialist",
+      status: "succeeded",
+      context: { traceId: "trace-demo" },
+      receipt: {
+        adapter: "reddiagents-app-adapter",
+        adapter_version: "0.1.0",
+        trace_id: "trace-demo",
+        x402_required: true,
+        x402_satisfied: true,
+        safe_public_evidence_only: true,
+      },
+    });
+    expect(getBody.output.content).toContain("Review this x402 integration plan");
+    expect(getBody.output.evidence).toEqual([
+      { label: "Manager evidence surface", url: "/manager" },
+      { label: "Volunteer tester evidence surface", url: "/testers" },
+    ]);
+  });
+
+  it("can dispatch through the real planner bridge behind an explicit env flag", async () => {
+    process.env.REDDI_APP_ADAPTER_DISPATCH = "planner";
+    const { executePlannerSpecialistCall } = await import("@/lib/onboarding/planner-execution");
+    (executePlannerSpecialistCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      result: {
+        runId: "planner_run_1",
+        responsePreview: "planner completed",
+        paymentSatisfied: true,
+      },
+    });
+    const { clearAppAdapterRunsForTest } = await import("@/lib/app-adapter/store");
+    clearAppAdapterRunsForTest();
+    const createRun = await import("@/app/app/runs/route");
+    const getRun = await import("@/app/app/runs/[runId]/route");
+
+    const createRes = await createRun.POST(
+      new Request("http://localhost/app/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          agent_id: "reddi.qa-testing-specialist",
+          input: { task: "Call the planner bridge" },
+          context: { trace_id: "trace-planner" },
+        }),
+      })
+    );
+    const createBody = await createRes.json();
+
+    expect(createRes.status).toBe(200);
+    expect(executePlannerSpecialistCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "Call the planner bridge",
+        policy: expect.objectContaining({ requiresAttested: true, requiresHealthPass: true }),
+      })
+    );
+
+    const getRes = await getRun.GET(new Request(`http://localhost/app/runs/${createBody.run_id}`), {
+      params: { runId: createBody.run_id },
+    });
+    const getBody = await getRes.json();
+    expect(getBody).toMatchObject({
+      status: "succeeded",
+      output: { content: "planner completed" },
+      receipt: {
+        trace_id: "trace-planner",
+        x402_satisfied: true,
+        attestation_status: "pending",
+        escrow_status: "released",
+      },
+    });
+  });
+
+  it("rejects disabled agents and invalid run inputs safely", async () => {
+    const createRun = await import("@/app/app/runs/route");
+
+    const disabledRes = await createRun.POST(
+      new Request("http://localhost/app/runs", {
+        method: "POST",
+        body: JSON.stringify({ agent_id: "reddi.ux-testing-specialist", input: { task: "test" } }),
+      })
+    );
+    expect(disabledRes.status).toBe(404);
+    expect(await disabledRes.json()).toEqual({ ok: false, error: "Unknown or disabled APP adapter agent" });
+
+    const invalidRes = await createRun.POST(
+      new Request("http://localhost/app/runs", {
+        method: "POST",
+        body: JSON.stringify({ agent_id: "reddi.qa-testing-specialist", input: { task: "" } }),
+      })
+    );
+    expect(invalidRes.status).toBe(400);
+    expect(await invalidRes.json()).toEqual({ ok: false, error: "input.task must be a non-empty string" });
+  });
+});

--- a/lib/app-adapter/dispatcher.ts
+++ b/lib/app-adapter/dispatcher.ts
@@ -1,0 +1,96 @@
+import { buildAppAdapterReceipt } from "./receipts";
+import type { AppAdapterAgent, AppAdapterRun } from "./types";
+
+export type AppAdapterDispatchMode = "mock" | "planner";
+
+export function getAppAdapterDispatchMode(env = process.env): AppAdapterDispatchMode {
+  return env.REDDI_APP_ADAPTER_DISPATCH === "planner" ? "planner" : "mock";
+}
+
+export async function dispatchAppAdapterRun(agent: AppAdapterAgent, run: AppAdapterRun): Promise<AppAdapterRun> {
+  if (getAppAdapterDispatchMode() === "planner") {
+    return dispatchPlannerAppAdapterRun(agent, run);
+  }
+  return dispatchMockAppAdapterRun(agent, run);
+}
+
+export async function dispatchMockAppAdapterRun(agent: AppAdapterAgent, run: AppAdapterRun): Promise<AppAdapterRun> {
+  const now = new Date().toISOString();
+  const constraints = run.input.constraints?.length ? ` Constraints: ${run.input.constraints.join("; ")}.` : "";
+
+  return {
+    ...run,
+    status: "succeeded",
+    updatedAt: now,
+    output: {
+      content: `[Mock ReddiAgents APP Adapter] ${agent.name} accepted task: ${run.input.task}.${constraints}`,
+      evidence: agent.reddi.evidenceRoutes.map((url) => ({
+        label: url === "/manager" ? "Manager evidence surface" : "Volunteer tester evidence surface",
+        url,
+      })),
+    },
+    usage: {
+      input_tokens: null,
+      output_tokens: null,
+      cost_usd: null,
+    },
+    receipt: buildAppAdapterReceipt(agent, run, {
+      x402Satisfied: agent.reddi.x402Required,
+      attestationStatus: "not_requested",
+      escrowStatus: "not_used",
+    }),
+  };
+}
+
+export async function dispatchPlannerAppAdapterRun(agent: AppAdapterAgent, run: AppAdapterRun): Promise<AppAdapterRun> {
+  const { executePlannerSpecialistCall } = await import("@/lib/onboarding/planner-execution");
+  const result = await executePlannerSpecialistCall({
+    prompt: run.input.task,
+    preferredWallet: agent.reddi.specialistWallet,
+    policy: {
+      requiresAttested: agent.reddi.attestationSupported,
+      requiresHealthPass: true,
+    },
+  });
+  const now = new Date().toISOString();
+
+  if (!result.ok) {
+    return {
+      ...run,
+      status: "failed",
+      updatedAt: now,
+      safeError: {
+        code: "planner_dispatch_failed",
+        message: result.result.error ?? "Reddi planner dispatch failed",
+      },
+      receipt: buildAppAdapterReceipt(agent, run, {
+        x402Satisfied: Boolean(result.result.paymentSatisfied),
+        attestationStatus: "not_requested",
+        escrowStatus: "failed",
+      }),
+    };
+  }
+
+  return {
+    ...run,
+    status: "succeeded",
+    updatedAt: now,
+    output: {
+      content: result.result.responsePreview ?? "Reddi planner completed without a response preview.",
+      evidence: agent.reddi.evidenceRoutes.map((url) => ({
+        label: url === "/manager" ? "Manager evidence surface" : "Volunteer tester evidence surface",
+        url,
+      })),
+    },
+    usage: {
+      input_tokens: null,
+      output_tokens: null,
+      cost_usd: null,
+    },
+    receipt: buildAppAdapterReceipt(agent, run, {
+      x402Satisfied: Boolean(result.result.paymentSatisfied),
+      attestationStatus: agent.reddi.attestationSupported ? "pending" : "not_requested",
+      escrowStatus: result.result.paymentSatisfied ? "released" : "not_used",
+    }),
+  };
+}

--- a/lib/app-adapter/manifest.ts
+++ b/lib/app-adapter/manifest.ts
@@ -1,0 +1,39 @@
+import { listAppAdapterAgents } from "./registry";
+import type { AppAdapterAgent, AppAdapterManifestAgent } from "./types";
+
+export function toManifestAgent(agent: AppAdapterAgent): AppAdapterManifestAgent {
+  return {
+    id: agent.appAgentId,
+    name: agent.name,
+    description: agent.description,
+    capabilities: agent.capabilities,
+    input_schema_url: agent.inputSchemaUrl,
+    run_url: agent.runUrl,
+    status: agent.enabled ? "available" : "disabled",
+  };
+}
+
+export function buildAppAdapterManifest() {
+  return {
+    name: "ReddiAgents",
+    version: "0.1.0",
+    protocol: "app",
+    description:
+      "APP-compatible adapter for Reddi Agent Protocol specialists with x402 payments, Solana escrow, and attested evidence.",
+    agents: listAppAdapterAgents().map(toManifestAgent),
+  };
+}
+
+export function buildAppAdapterAgentList() {
+  return listAppAdapterAgents({ includeDisabled: true }).map((agent) => ({
+    ...toManifestAgent(agent),
+    reddi: {
+      source: agent.sourcePolicy.preferredSource ?? "openclaw",
+      strict_source_match: agent.sourcePolicy.strictSourceMatch ?? false,
+      specialist_endpoint: agent.reddi.specialistEndpoint,
+      x402_required: agent.reddi.x402Required,
+      attestation_supported: agent.reddi.attestationSupported,
+      evidence_routes: agent.reddi.evidenceRoutes,
+    },
+  }));
+}

--- a/lib/app-adapter/receipts.ts
+++ b/lib/app-adapter/receipts.ts
@@ -1,0 +1,25 @@
+import type { AppAdapterAgent, AppAdapterRun } from "./types";
+
+type ReceiptOptions = {
+  x402Satisfied?: boolean;
+  attestationStatus?: "not_requested" | "pending" | "passed" | "failed";
+  escrowStatus?: "not_used" | "locked" | "released" | "refunded" | "failed";
+};
+
+export function buildAppAdapterReceipt(
+  agent: AppAdapterAgent,
+  run: Pick<AppAdapterRun, "context" | "agentId">,
+  options: ReceiptOptions = {}
+) {
+  return {
+    adapter: "reddiagents-app-adapter" as const,
+    adapter_version: "0.1.0" as const,
+    trace_id: run.context.traceId,
+    agent_id: run.agentId,
+    x402_required: agent.reddi.x402Required,
+    x402_satisfied: options.x402Satisfied ?? false,
+    attestation_status: options.attestationStatus ?? "not_requested" as const,
+    escrow_status: options.escrowStatus ?? "not_used" as const,
+    safe_public_evidence_only: true as const,
+  };
+}

--- a/lib/app-adapter/registry.ts
+++ b/lib/app-adapter/registry.ts
@@ -1,0 +1,95 @@
+import type { AppAdapterAgent } from "./types";
+
+export const appAdapterInputSchema = {
+  type: "object",
+  required: ["task"],
+  additionalProperties: false,
+  properties: {
+    task: {
+      type: "string",
+      minLength: 1,
+      description: "The task for the selected ReddiAgent specialist.",
+    },
+    constraints: {
+      type: "array",
+      items: { type: "string" },
+      description: "Optional caller constraints for the specialist run.",
+    },
+    evidence_preference: {
+      type: "string",
+      enum: ["summary", "links", "full_receipt"],
+      default: "summary",
+    },
+  },
+} as const;
+
+export const appAdapterAgents: AppAdapterAgent[] = [
+  {
+    appAgentId: "reddi.qa-testing-specialist",
+    name: "Reddi QA Testing Specialist",
+    description: "x402-paid QA specialist exposed through the ReddiAgents APP Adapter.",
+    capabilities: ["qa.review", "test.plan", "evidence.summarize"],
+    enabled: true,
+    inputSchemaUrl: "/app/agents/reddi.qa-testing-specialist/schema",
+    runUrl: "/app/runs",
+    sourcePolicy: {
+      preferredSource: "openclaw",
+      strictSourceMatch: true,
+    },
+    reddi: {
+      specialistEndpoint: "https://reddi-qa.preview.reddi.tech",
+      x402Required: true,
+      attestationSupported: true,
+      evidenceRoutes: ["/manager", "/testers"],
+    },
+    inputSchema: appAdapterInputSchema,
+  },
+  {
+    appAgentId: "reddi.ux-testing-specialist",
+    name: "Reddi UX Testing Specialist",
+    description: "UX testing specialist prepared for APP exposure after route-level contract tests pass.",
+    capabilities: ["ux.review", "flow.audit", "evidence.summarize"],
+    enabled: false,
+    inputSchemaUrl: "/app/agents/reddi.ux-testing-specialist/schema",
+    runUrl: "/app/runs",
+    sourcePolicy: {
+      preferredSource: "openclaw",
+      strictSourceMatch: true,
+    },
+    reddi: {
+      specialistEndpoint: "https://reddi-ux.preview.reddi.tech",
+      x402Required: true,
+      attestationSupported: true,
+      evidenceRoutes: ["/manager", "/testers"],
+    },
+    inputSchema: appAdapterInputSchema,
+  },
+  {
+    appAgentId: "reddi.integration-testing-specialist",
+    name: "Reddi Integration Testing Specialist",
+    description: "Integration testing specialist prepared for APP exposure after route-level contract tests pass.",
+    capabilities: ["integration.review", "api.audit", "evidence.summarize"],
+    enabled: false,
+    inputSchemaUrl: "/app/agents/reddi.integration-testing-specialist/schema",
+    runUrl: "/app/runs",
+    sourcePolicy: {
+      preferredSource: "openclaw",
+      strictSourceMatch: true,
+    },
+    reddi: {
+      specialistEndpoint: "https://reddi-integration.preview.reddi.tech",
+      x402Required: true,
+      attestationSupported: true,
+      evidenceRoutes: ["/manager", "/testers"],
+    },
+    inputSchema: appAdapterInputSchema,
+  },
+];
+
+export function listAppAdapterAgents(options: { includeDisabled?: boolean } = {}) {
+  return options.includeDisabled ? appAdapterAgents : appAdapterAgents.filter((agent) => agent.enabled);
+}
+
+export function findAppAdapterAgent(agentId: string) {
+  return appAdapterAgents.find((agent) => agent.appAgentId === agentId);
+}

--- a/lib/app-adapter/store.ts
+++ b/lib/app-adapter/store.ts
@@ -1,0 +1,20 @@
+import type { AppAdapterRun } from "./types";
+
+const runs = new Map<string, AppAdapterRun>();
+
+export function createRunId() {
+  return `app_run_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function saveAppAdapterRun(run: AppAdapterRun) {
+  runs.set(run.runId, run);
+  return run;
+}
+
+export function getAppAdapterRun(runId: string) {
+  return runs.get(runId);
+}
+
+export function clearAppAdapterRunsForTest() {
+  runs.clear();
+}

--- a/lib/app-adapter/translator.ts
+++ b/lib/app-adapter/translator.ts
@@ -1,0 +1,42 @@
+import type { AppAdapterRunInput } from "./types";
+
+export function normalizeTraceId(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : `trace_${Date.now().toString(36)}`;
+}
+
+export function validateRunInput(value: unknown): { ok: true; input: AppAdapterRunInput } | { ok: false; error: string } {
+  if (!value || typeof value !== "object") {
+    return { ok: false, error: "input must be an object" };
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.task !== "string" || !candidate.task.trim()) {
+    return { ok: false, error: "input.task must be a non-empty string" };
+  }
+
+  if (
+    candidate.constraints !== undefined &&
+    (!Array.isArray(candidate.constraints) || candidate.constraints.some((item) => typeof item !== "string"))
+  ) {
+    return { ok: false, error: "input.constraints must be an array of strings" };
+  }
+
+  const evidencePreference = candidate.evidence_preference;
+  if (
+    evidencePreference !== undefined &&
+    evidencePreference !== "summary" &&
+    evidencePreference !== "links" &&
+    evidencePreference !== "full_receipt"
+  ) {
+    return { ok: false, error: "input.evidence_preference must be summary, links, or full_receipt" };
+  }
+
+  return {
+    ok: true,
+    input: {
+      task: candidate.task.trim(),
+      constraints: candidate.constraints as string[] | undefined,
+      evidence_preference: evidencePreference as AppAdapterRunInput["evidence_preference"],
+    },
+  };
+}

--- a/lib/app-adapter/types.ts
+++ b/lib/app-adapter/types.ts
@@ -1,0 +1,79 @@
+export type AppAdapterStatus = "available" | "disabled";
+
+export type AppAdapterAgent = {
+  appAgentId: string;
+  name: string;
+  description: string;
+  capabilities: string[];
+  enabled: boolean;
+  inputSchemaUrl: string;
+  runUrl: string;
+  sourcePolicy: {
+    preferredSource?: "openclaw" | "external";
+    strictSourceMatch?: boolean;
+  };
+  reddi: {
+    specialistEndpoint?: string;
+    specialistWallet?: string;
+    x402Required: boolean;
+    attestationSupported: boolean;
+    evidenceRoutes: string[];
+  };
+  inputSchema: Record<string, unknown>;
+};
+
+export type AppAdapterManifestAgent = {
+  id: string;
+  name: string;
+  description: string;
+  capabilities: string[];
+  input_schema_url: string;
+  run_url: string;
+  status: AppAdapterStatus;
+};
+
+export type AppAdapterRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled";
+
+export type AppAdapterRunInput = {
+  task: string;
+  constraints?: string[];
+  evidence_preference?: "summary" | "links" | "full_receipt";
+};
+
+export type AppAdapterRun = {
+  runId: string;
+  agentId: string;
+  status: AppAdapterRunStatus;
+  input: AppAdapterRunInput;
+  context: {
+    conversationId?: string;
+    userId?: string;
+    traceId: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+  output?: {
+    content: string;
+    evidence: Array<{ label: string; url: string }>;
+  };
+  usage?: {
+    input_tokens: number | null;
+    output_tokens: number | null;
+    cost_usd: number | null;
+  };
+  receipt?: {
+    adapter: "reddiagents-app-adapter";
+    adapter_version: "0.1.0";
+    trace_id: string;
+    agent_id: string;
+    x402_required: boolean;
+    x402_satisfied: boolean;
+    attestation_status: "not_requested" | "pending" | "passed" | "failed";
+    escrow_status: "not_used" | "locked" | "released" | "refunded" | "failed";
+    safe_public_evidence_only: true;
+  };
+  safeError?: {
+    code: string;
+    message: string;
+  };
+};


### PR DESCRIPTION
## Summary
- Adds a lightweight ReddiAgents APP Adapter spec and route surface.
- Exposes discovery, agent list, schema, and run lifecycle endpoints.
- Adds a safe default mock dispatcher plus opt-in planner bridge via `REDDI_APP_ADAPTER_DISPATCH=planner`.
- Emits safe receipt envelopes carrying x402/payment/attestation/escrow state.

## Routes
- `GET /.well-known/app-agent.json`
- `GET /app/agents`
- `GET /app/agents/:agentId/schema`
- `POST /app/runs`
- `GET /app/runs/:runId`

## Guardrails
- Default run lifecycle is mock-only; no accidental paid/planner calls.
- Real Reddi planner bridge is env-gated.
- UX and Integration specialists are staged as disabled until live checks pass.
- Receipts expose safe public evidence only.

## Validation
- `npx jest lib/__tests__/app-adapter-slice-a.test.ts --runInBand` PASS (7/7)
- `git diff --check` PASS
- `npm run build` PASS

Closes #133
