### PR TITLE
fix: use canonical Reddi Agent Protocol naming

### DIFF
--- a/app/testers/page.tsx
+++ b/app/testers/page.tsx
@@ -115,7 +115,7 @@ const wrapperVideos = [
   {
     title: "OpenOnion/ConnectOnion → reddi-x402 for Solana endpoint",
     description:
-      "Add the Reddi-Agent Protocol adapter manifest, enforce x402 on public chat completions, forward paid calls to OpenOnion, then register the adapter URL.",
+      "Add the Reddi Agent Protocol adapter manifest, enforce x402 on public chat completions, forward paid calls to OpenOnion, then register the adapter URL.",
     src: "/video/volunteers/reddi-openonion-x402-wrapper-guide-20260427.mp4",
     href: "#openonion-guide",
   },
@@ -183,7 +183,7 @@ export default function TestersPage() {
               We need volunteers across four roles: Ollama specialists,
               OpenOnion specialists, attestor/judge agents, and consumer
               orchestrators. Every path uses devnet SOL only and registers
-              against the same deployed Reddi-Agent Protocol contracts.
+              against the same deployed Reddi Agent Protocol contracts.
             </p>
             <div className="flex flex-wrap gap-3">
               <Link href="#ollama-guide"><Button size="lg">Ollama specialist</Button></Link>
@@ -280,7 +280,7 @@ export default function TestersPage() {
             Register an OpenOnion specialist adapter
           </h2>
           <p className="text-sm leading-6 text-gray-400">
-            Keep your OpenOnion runtime, then add the Reddi-Agent Protocol adapter contract and
+            Keep your OpenOnion runtime, then add the Reddi Agent Protocol adapter contract and
             payment-required completion behavior. The register probe validates
             the adapter before accepting the endpoint.
           </p>

--- a/packages/testing-specialists/src/server.ts
+++ b/packages/testing-specialists/src/server.ts
@@ -73,7 +73,7 @@ const profiles: Record<SpecialistProfileId, SpecialistProfile> = {
         title: "Manager evidence review flow",
         triggers: ["manager", "evidence pack", "judge", "demo video", "screenshots"],
         answer:
-          "Demo-flow review: start at Manager evidence, open Specialist readiness, then show Consumer paid-call receipt and Attestor release/refund controls. This sequence makes Reddi's value obvious: discovery, payment protection, escrow/reputation, and replayable evidence.",
+          "Demo-flow review: start at Manager evidence, open Specialist readiness, then show Consumer paid-call receipt and Attestor release/refund controls. This sequence makes Reddi Agent Protocol's value obvious: discovery, payment protection, escrow/reputation, and replayable evidence.",
         evidence: ["screen:/manager", "screen:/specialist", "screen:/planner", "screen:/attestation"],
       },
     ],


### PR DESCRIPTION
## Summary
- Replace stale "Reddi-Agent Protocol" copy with canonical "Reddi Agent Protocol" on the tester portal
- Expand demo testing specialist wording from "Reddi's value" to "Reddi Agent Protocol's value" for clearer product naming

## Classification
These leftover local modifications are intentional naming/copy polish, not functional changes. They belong in a separate small PR from the FAQ work.

## Validation
- npm run build ✅
- npm run build --workspace packages/testing-specialists ✅