### PR TITLE
feat: add OpenRouter specialist runtime

### DIFF
--- a/packages/openrouter-specialists/Dockerfile
+++ b/packages/openrouter-specialists/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY packages/openrouter-specialists/package*.json ./
+RUN npm ci --ignore-scripts
+COPY packages/openrouter-specialists/ ./
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+CMD ["node", "dist/src/server.js"]

--- a/packages/openrouter-specialists/README.md
+++ b/packages/openrouter-specialists/README.md
@@ -1,7 +1,27 @@
 # @reddi/openrouter-specialists
 
-Shared runtime for Reddi marketplace specialists backed by OpenRouter.
+Shared runtime for Reddi Agent Protocol marketplace specialists backed by OpenRouter.
 
-Iteration 1 ships the profile registry, fail-closed x402 guard, OpenAI-compatible chat completions handler, mock OpenRouter mode for tests, and marketplace metadata endpoints.
+Iteration 1 ships the profile registry, fail-closed x402 guard, OpenAI-compatible chat completions handler, explicit mock OpenRouter mode for tests, Docker packaging, and marketplace metadata endpoints.
 
-No private keys are stored here. Wallet values are public devnet addresses only.
+## Safety defaults
+
+- No private keys are stored here.
+- Wallet values are public devnet addresses only; Iteration 2 replaces static profile values with a public wallet manifest and balance verifier.
+- `OPENROUTER_MOCK` must be explicitly set to `1` or `true` to use mock mode.
+- If mock mode is disabled, `OPENROUTER_API_KEY` is required before an OpenRouter client can be created.
+- Demo payment headers are accepted only when `ALLOW_DEMO_X402_PAYMENT=1` or `true`.
+- Caller-controlled strings such as `paid:` or JSON containing `signature` are not treated as payment proof.
+- Until real x402 settlement verification is wired, production deployments should leave `ALLOW_DEMO_X402_PAYMENT` unset and fail closed on unpaid requests.
+
+## Validation
+
+```bash
+npm test
+```
+
+From repo root:
+
+```bash
+docker build -f packages/openrouter-specialists/Dockerfile -t reddi-openrouter-specialists:iter1 .
+```

--- a/packages/openrouter-specialists/README.md
+++ b/packages/openrouter-specialists/README.md
@@ -1,0 +1,7 @@
+# @reddi/openrouter-specialists
+
+Shared runtime for Reddi marketplace specialists backed by OpenRouter.
+
+Iteration 1 ships the profile registry, fail-closed x402 guard, OpenAI-compatible chat completions handler, mock OpenRouter mode for tests, and marketplace metadata endpoints.
+
+No private keys are stored here. Wallet values are public devnet addresses only.

--- a/packages/openrouter-specialists/package-lock.json
+++ b/packages/openrouter-specialists/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@reddi/openrouter-specialists",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@reddi/openrouter-specialists",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20",
+        "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/openrouter-specialists/package.json
+++ b/packages/openrouter-specialists/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@reddi/openrouter-specialists",
+  "version": "0.1.0",
+  "description": "Shared OpenRouter-backed specialist runtime for Reddi marketplace agents.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist", "Dockerfile", "README.md"],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test dist/tests/*.test.js"
+  },
+  "engines": {"node": ">=20"},
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5"
+  }
+}

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./profiles/index.js";
+export * from "./openrouter.js";
+export * from "./runtime.js";

--- a/packages/openrouter-specialists/src/openrouter.ts
+++ b/packages/openrouter-specialists/src/openrouter.ts
@@ -1,0 +1,72 @@
+import type { ChatMessage, OpenRouterClient } from "./types.js";
+
+export class MockOpenRouterClient implements OpenRouterClient {
+  public callCount = 0;
+  public lastRequest?: {
+    model: string;
+    messages: ChatMessage[];
+    metadata: Record<string, unknown>;
+  };
+
+  async createChatCompletion(input: {
+    model: string;
+    messages: ChatMessage[];
+    temperature?: number;
+    max_tokens?: number;
+    metadata: Record<string, unknown>;
+  }): Promise<Record<string, unknown>> {
+    this.callCount += 1;
+    this.lastRequest = input;
+    return {
+      id: `chatcmpl_mock_${this.callCount}`,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: input.model,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: `Mock specialist response for ${input.metadata.profileId}`,
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+  }
+}
+
+export class FetchOpenRouterClient implements OpenRouterClient {
+  public callCount = 0;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly baseUrl = "https://openrouter.ai/api/v1",
+  ) {}
+
+  async createChatCompletion(input: {
+    model: string;
+    messages: ChatMessage[];
+    temperature?: number;
+    max_tokens?: number;
+    metadata: Record<string, unknown>;
+  }): Promise<Record<string, unknown>> {
+    this.callCount += 1;
+    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${this.apiKey}`,
+        "x-reddi-profile-id": String(input.metadata.profileId),
+        "x-reddi-request-id": String(input.metadata.requestId),
+      },
+      body: JSON.stringify(input),
+    });
+    const body = (await response.json()) as Record<string, unknown>;
+    if (!response.ok) {
+      throw new Error(`OpenRouter request failed: ${response.status} ${JSON.stringify(body)}`);
+    }
+    return body;
+  }
+}

--- a/packages/openrouter-specialists/src/profiles/index.ts
+++ b/packages/openrouter-specialists/src/profiles/index.ts
@@ -1,0 +1,117 @@
+import type { SpecialistProfile } from "../types.js";
+
+const wallet = (suffix: string) => `ReddiDevnet${suffix.padEnd(32, "1")}`;
+
+export const specialistProfiles: SpecialistProfile[] = [
+  {
+    id: "planning-agent",
+    displayName: "Planning Agent",
+    description: "Turns broad goals into sequenced execution plans with assumptions, risks, and validation gates.",
+    walletAddress: wallet("Planning"),
+    endpointPath: "/v1/chat/completions",
+    capabilities: ["planning", "task-decomposition", "risk-analysis", "agent-orchestration"],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.03", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["planning", "operations", "strategy"],
+    systemPrompt:
+      "You are the Reddi Planning Agent. Produce practical execution plans, expose assumptions, sequence dependencies, and recommend validation gates. Stay within marketplace-safe scope.",
+  },
+  {
+    id: "document-intelligence-agent",
+    displayName: "Document Intelligence Agent",
+    description: "Extracts, classifies, summarizes, and cross-checks document evidence.",
+    walletAddress: wallet("DocIntel"),
+    endpointPath: "/v1/chat/completions",
+    capabilities: ["document-analysis", "summarization", "evidence-extraction", "classification"],
+    roles: ["specialist"],
+    price: { currency: "USDC", amount: "0.04", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "anthropic/claude-3.5-haiku",
+    tags: ["documents", "evidence", "summaries"],
+    systemPrompt:
+      "You are the Reddi Document Intelligence Agent. Extract facts from supplied documents, separate evidence from inference, cite source snippets when available, and flag uncertainty.",
+  },
+  {
+    id: "verification-validation-agent",
+    displayName: "Verification & Validation Agent",
+    description: "Reviews specialist outputs for evidence quality, safety boundaries, and release/refund/dispute recommendations.",
+    walletAddress: wallet("Verifier"),
+    endpointPath: "/v1/chat/completions",
+    capabilities: ["verification", "validation", "attestation", "quality-review", "safety-review"],
+    roles: ["specialist", "attestor"],
+    price: { currency: "USDC", amount: "0.025", unit: "request" },
+    safetyMode: "attestation",
+    preferredAttestors: [],
+    model: "openai/gpt-4.1-mini",
+    tags: ["verification", "attestation", "qa"],
+    systemPrompt:
+      "You are the Reddi Verification & Validation Agent. Assess outputs against receipts, evidence, and stated constraints. Return clear findings without claiming professional certification.",
+  },
+  {
+    id: "code-generation-agent",
+    displayName: "Code Generation Agent",
+    description: "Builds scoped code changes, tests, migrations, and implementation notes.",
+    walletAddress: wallet("CodeGen"),
+    endpointPath: "/v1/chat/completions",
+    capabilities: ["code-generation", "debugging", "test-writing", "technical-design"],
+    roles: ["specialist"],
+    price: { currency: "USDC", amount: "0.05", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "anthropic/claude-3.5-sonnet",
+    tags: ["engineering", "code", "tests"],
+    systemPrompt:
+      "You are the Reddi Code Generation Agent. Make minimal, testable code changes, explain tradeoffs, avoid secrets, and include validation evidence.",
+  },
+  {
+    id: "conversational-agent",
+    displayName: "Conversational Agent",
+    description: "Handles general dialogue, intake, clarification, and user-friendly handoff summaries.",
+    walletAddress: wallet("Conversational"),
+    endpointPath: "/v1/chat/completions",
+    capabilities: ["conversation", "intake", "clarification", "handoff-summary"],
+    roles: ["specialist"],
+    price: { currency: "USDC", amount: "0.015", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["chat", "support", "intake"],
+    systemPrompt:
+      "You are the Reddi Conversational Agent. Be clear, warm, and useful. Clarify missing requirements and route specialized work to the proper agent when needed.",
+  },
+];
+
+export function getProfile(id: string): SpecialistProfile | undefined {
+  return specialistProfiles.find((profile) => profile.id === id);
+}
+
+export function validateProfile(profile: SpecialistProfile): string[] {
+  const errors: string[] = [];
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(profile.id)) errors.push(`invalid id: ${profile.id}`);
+  if (!profile.displayName.trim()) errors.push(`${profile.id}: missing displayName`);
+  if (!profile.walletAddress.trim()) errors.push(`${profile.id}: missing walletAddress`);
+  if (profile.endpointPath !== "/v1/chat/completions") errors.push(`${profile.id}: unsupported endpointPath`);
+  if (profile.capabilities.length === 0) errors.push(`${profile.id}: missing capabilities`);
+  if (profile.roles.length === 0 || !profile.roles.includes("specialist")) errors.push(`${profile.id}: must include specialist role`);
+  if (!profile.price.amount || !profile.price.currency || !profile.price.unit) errors.push(`${profile.id}: invalid price`);
+  if (!profile.model.trim()) errors.push(`${profile.id}: missing model`);
+  if (!profile.systemPrompt.trim()) errors.push(`${profile.id}: missing systemPrompt`);
+  return errors;
+}
+
+export function validateProfileRegistry(profiles = specialistProfiles): string[] {
+  const ids = new Set<string>();
+  const wallets = new Set<string>();
+  const errors = profiles.flatMap(validateProfile);
+  for (const profile of profiles) {
+    if (ids.has(profile.id)) errors.push(`duplicate id: ${profile.id}`);
+    ids.add(profile.id);
+    if (wallets.has(profile.walletAddress)) errors.push(`duplicate wallet: ${profile.walletAddress}`);
+    wallets.add(profile.walletAddress);
+  }
+  return errors;
+}

--- a/packages/openrouter-specialists/src/profiles/index.ts
+++ b/packages/openrouter-specialists/src/profiles/index.ts
@@ -1,13 +1,44 @@
 import type { SpecialistProfile } from "../types.js";
 
-const wallet = (suffix: string) => `ReddiDevnet${suffix.padEnd(32, "1")}`;
+const walletAddresses = {
+  planning: "AXfCzZmfKsGDr8XdE4SZXDXdfvrqSSUm9xdX6EbmLA5H",
+  documentIntelligence: "82Lpdv8FjaQUELikS9jc2ga3LQSxzKJmWKHwQr4v9acN",
+  verificationValidation: "7eHBdFN8qUrG9ifyyM2RzqYaxX5T5ijeF7D5BZnQJyD7",
+  codeGeneration: "GctzwjmUTJphtBLHA4VwfjY4qCajRywunMvUoKTB6Prn",
+  conversational: "5qVJ6XhYiDqNXHYR4B5QLT6rDSQ72iyuG5ooHyV9B2Xc",
+} as const;
+
+function isBase58SolanaPublicKey(value: string): boolean {
+  if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value)) return false;
+  const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  const bytes = [0];
+  for (const char of value) {
+    const carryStart = alphabet.indexOf(char);
+    if (carryStart < 0) return false;
+    let carry = carryStart;
+    for (let index = 0; index < bytes.length; index += 1) {
+      carry += bytes[index] * 58;
+      bytes[index] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  for (const char of value) {
+    if (char !== "1") break;
+    bytes.push(0);
+  }
+  return bytes.length === 32;
+}
 
 export const specialistProfiles: SpecialistProfile[] = [
   {
     id: "planning-agent",
     displayName: "Planning Agent",
     description: "Turns broad goals into sequenced execution plans with assumptions, risks, and validation gates.",
-    walletAddress: wallet("Planning"),
+    walletAddress: walletAddresses.planning,
     endpointPath: "/v1/chat/completions",
     capabilities: ["planning", "task-decomposition", "risk-analysis", "agent-orchestration"],
     roles: ["specialist", "consumer"],
@@ -23,7 +54,7 @@ export const specialistProfiles: SpecialistProfile[] = [
     id: "document-intelligence-agent",
     displayName: "Document Intelligence Agent",
     description: "Extracts, classifies, summarizes, and cross-checks document evidence.",
-    walletAddress: wallet("DocIntel"),
+    walletAddress: walletAddresses.documentIntelligence,
     endpointPath: "/v1/chat/completions",
     capabilities: ["document-analysis", "summarization", "evidence-extraction", "classification"],
     roles: ["specialist"],
@@ -39,7 +70,7 @@ export const specialistProfiles: SpecialistProfile[] = [
     id: "verification-validation-agent",
     displayName: "Verification & Validation Agent",
     description: "Reviews specialist outputs for evidence quality, safety boundaries, and release/refund/dispute recommendations.",
-    walletAddress: wallet("Verifier"),
+    walletAddress: walletAddresses.verificationValidation,
     endpointPath: "/v1/chat/completions",
     capabilities: ["verification", "validation", "attestation", "quality-review", "safety-review"],
     roles: ["specialist", "attestor"],
@@ -55,7 +86,7 @@ export const specialistProfiles: SpecialistProfile[] = [
     id: "code-generation-agent",
     displayName: "Code Generation Agent",
     description: "Builds scoped code changes, tests, migrations, and implementation notes.",
-    walletAddress: wallet("CodeGen"),
+    walletAddress: walletAddresses.codeGeneration,
     endpointPath: "/v1/chat/completions",
     capabilities: ["code-generation", "debugging", "test-writing", "technical-design"],
     roles: ["specialist"],
@@ -71,7 +102,7 @@ export const specialistProfiles: SpecialistProfile[] = [
     id: "conversational-agent",
     displayName: "Conversational Agent",
     description: "Handles general dialogue, intake, clarification, and user-friendly handoff summaries.",
-    walletAddress: wallet("Conversational"),
+    walletAddress: walletAddresses.conversational,
     endpointPath: "/v1/chat/completions",
     capabilities: ["conversation", "intake", "clarification", "handoff-summary"],
     roles: ["specialist"],
@@ -94,6 +125,7 @@ export function validateProfile(profile: SpecialistProfile): string[] {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(profile.id)) errors.push(`invalid id: ${profile.id}`);
   if (!profile.displayName.trim()) errors.push(`${profile.id}: missing displayName`);
   if (!profile.walletAddress.trim()) errors.push(`${profile.id}: missing walletAddress`);
+  if (profile.walletAddress.trim() && !isBase58SolanaPublicKey(profile.walletAddress)) errors.push(`${profile.id}: invalid Solana walletAddress`);
   if (profile.endpointPath !== "/v1/chat/completions") errors.push(`${profile.id}: unsupported endpointPath`);
   if (profile.capabilities.length === 0) errors.push(`${profile.id}: missing capabilities`);
   if (profile.roles.length === 0 || !profile.roles.includes("specialist")) errors.push(`${profile.id}: must include specialist role`);

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from "node:crypto";
+import { getProfile, specialistProfiles, validateProfileRegistry } from "./profiles/index.js";
+import { FetchOpenRouterClient, MockOpenRouterClient } from "./openrouter.js";
+import type { ChatCompletionRequest, OpenRouterClient, RuntimeConfig, RuntimeResponse, SpecialistProfile } from "./types.js";
+
+const JSON_HEADERS = { "content-type": "application/json; charset=utf-8" };
+
+export function createRuntimeConfig(env: NodeJS.ProcessEnv = process.env): RuntimeConfig {
+  return {
+    profileId: env.SPECIALIST_PROFILE_ID ?? "planning-agent",
+    endpointBaseUrl: env.PUBLIC_BASE_URL ?? "http://localhost:8787",
+    openRouterApiKey: env.OPENROUTER_API_KEY,
+    openRouterBaseUrl: env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
+    mockOpenRouter: env.OPENROUTER_MOCK === "1" || env.OPENROUTER_MOCK === "true" || !env.OPENROUTER_API_KEY,
+    requirePayment: env.REQUIRE_X402_PAYMENT !== "false",
+  };
+}
+
+export function createOpenRouterClient(config: RuntimeConfig): OpenRouterClient {
+  if (config.mockOpenRouter) return new MockOpenRouterClient();
+  if (!config.openRouterApiKey) throw new Error("OPENROUTER_API_KEY is required when mock mode is disabled");
+  return new FetchOpenRouterClient(config.openRouterApiKey, config.openRouterBaseUrl);
+}
+
+export function isPaymentSatisfied(headers: Headers): boolean {
+  const value = headers.get("x402-payment") ?? headers.get("x-payment");
+  if (!value) return false;
+  return value.startsWith("demo:") || value.startsWith("paid:") || value.includes("signature");
+}
+
+export function x402Challenge(profile: SpecialistProfile, config: RuntimeConfig): RuntimeResponse {
+  return {
+    status: 402,
+    headers: {
+      ...JSON_HEADERS,
+      "x402-request": JSON.stringify({
+        version: "1",
+        network: "solana-devnet",
+        payTo: profile.walletAddress,
+        amount: profile.price.amount,
+        currency: profile.price.currency,
+        endpoint: `${config.endpointBaseUrl}${profile.endpointPath}`,
+      }),
+    },
+    body: {
+      error: {
+        code: "payment_required",
+        message: "x402 payment is required before specialist execution.",
+      },
+      x402: {
+        version: "1",
+        network: "solana-devnet",
+        payTo: profile.walletAddress,
+        amount: profile.price.amount,
+        currency: profile.price.currency,
+        unit: profile.price.unit,
+      },
+    },
+  };
+}
+
+export function marketplaceMetadata(profile: SpecialistProfile, config: RuntimeConfig): Record<string, unknown> {
+  return {
+    protocol: "reddi-agent-protocol",
+    version: "0.1.0",
+    profileId: profile.id,
+    displayName: profile.displayName,
+    description: profile.description,
+    walletAddress: profile.walletAddress,
+    endpoint: `${config.endpointBaseUrl}${profile.endpointPath}`,
+    capabilities: profile.capabilities,
+    roles: profile.roles,
+    price: profile.price,
+    safetyMode: profile.safetyMode,
+    preferredAttestors: profile.preferredAttestors,
+    model: profile.model,
+  };
+}
+
+export function modelsResponse(): RuntimeResponse {
+  return {
+    status: 200,
+    headers: JSON_HEADERS,
+    body: {
+      object: "list",
+      data: specialistProfiles.map((profile) => ({
+        id: profile.id,
+        object: "model",
+        owned_by: "reddi",
+        display_name: profile.displayName,
+        openrouter_model: profile.model,
+        capabilities: profile.capabilities,
+      })),
+    },
+  };
+}
+
+export function tagsResponse(): RuntimeResponse {
+  const tags = [...new Set(specialistProfiles.flatMap((profile) => profile.tags))].sort();
+  return { status: 200, headers: JSON_HEADERS, body: { tags } };
+}
+
+export async function handleChatCompletions(input: {
+  headers: Headers;
+  body: ChatCompletionRequest;
+  config: RuntimeConfig;
+  client: OpenRouterClient;
+}): Promise<RuntimeResponse> {
+  const profile = getProfile(input.config.profileId);
+  if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };
+
+  if (input.config.requirePayment && !isPaymentSatisfied(input.headers)) {
+    return x402Challenge(profile, input.config);
+  }
+
+  const requestId = randomUUID();
+  const messages = input.body.messages ?? [];
+  const guardedMessages = [{ role: "system" as const, content: profile.systemPrompt }, ...messages.filter((m) => m.role !== "system")];
+  const reddi = {
+    profileId: profile.id,
+    requestId,
+    model: profile.model,
+    paymentSatisfied: true,
+    safetyMode: profile.safetyMode,
+    mockOpenRouter: input.config.mockOpenRouter,
+  };
+  const upstream = await input.client.createChatCompletion({
+    model: profile.model,
+    messages: guardedMessages,
+    temperature: input.body.temperature,
+    max_tokens: input.body.max_tokens,
+    metadata: reddi,
+  });
+  return {
+    status: 200,
+    headers: JSON_HEADERS,
+    body: {
+      ...upstream,
+      reddi,
+    },
+  };
+}
+
+export async function handleRuntimeRequest(request: Request, config = createRuntimeConfig(), client = createOpenRouterClient(config)): Promise<Response> {
+  const url = new URL(request.url);
+  const profile = getProfile(config.profileId);
+  if (!profile) return toResponse({ status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } });
+
+  if (request.method === "GET" && url.pathname === "/healthz") {
+    const registryErrors = validateProfileRegistry();
+    return toResponse({ status: registryErrors.length ? 500 : 200, headers: JSON_HEADERS, body: { ok: registryErrors.length === 0, profileId: profile.id, registryErrors } });
+  }
+  if (request.method === "GET" && url.pathname === "/x402/health") {
+    return toResponse({ status: 200, headers: JSON_HEADERS, body: { ok: true, failClosed: config.requirePayment, network: "solana-devnet" } });
+  }
+  if (request.method === "GET" && url.pathname === "/v1/models") return toResponse(modelsResponse());
+  if (request.method === "GET" && url.pathname === "/api/tags") return toResponse(tagsResponse());
+  if (request.method === "GET" && url.pathname === "/.well-known/reddi-agent.json") return toResponse({ status: 200, headers: JSON_HEADERS, body: marketplaceMetadata(profile, config) });
+  if (request.method === "POST" && url.pathname === "/v1/chat/completions") {
+    const body = (await request.json().catch(() => ({}))) as ChatCompletionRequest;
+    return toResponse(await handleChatCompletions({ headers: request.headers, body, config, client }));
+  }
+  return toResponse({ status: 404, headers: JSON_HEADERS, body: { error: { code: "not_found" } } });
+}
+
+export function toResponse(runtimeResponse: RuntimeResponse): Response {
+  return new Response(JSON.stringify(runtimeResponse.body), {
+    status: runtimeResponse.status,
+    headers: runtimeResponse.headers,
+  });
+}

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -11,8 +11,9 @@ export function createRuntimeConfig(env: NodeJS.ProcessEnv = process.env): Runti
     endpointBaseUrl: env.PUBLIC_BASE_URL ?? "http://localhost:8787",
     openRouterApiKey: env.OPENROUTER_API_KEY,
     openRouterBaseUrl: env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
-    mockOpenRouter: env.OPENROUTER_MOCK === "1" || env.OPENROUTER_MOCK === "true" || !env.OPENROUTER_API_KEY,
+    mockOpenRouter: env.OPENROUTER_MOCK === "1" || env.OPENROUTER_MOCK === "true",
     requirePayment: env.REQUIRE_X402_PAYMENT !== "false",
+    allowDemoPayment: env.ALLOW_DEMO_X402_PAYMENT === "1" || env.ALLOW_DEMO_X402_PAYMENT === "true",
   };
 }
 
@@ -22,10 +23,15 @@ export function createOpenRouterClient(config: RuntimeConfig): OpenRouterClient 
   return new FetchOpenRouterClient(config.openRouterApiKey, config.openRouterBaseUrl);
 }
 
-export function isPaymentSatisfied(headers: Headers): boolean {
-  const value = headers.get("x402-payment") ?? headers.get("x-payment");
+export function isPaymentSatisfied(headers: Headers, config: RuntimeConfig): boolean {
+  const value = headers.get("x402-payment");
   if (!value) return false;
-  return value.startsWith("demo:") || value.startsWith("paid:") || value.includes("signature");
+
+  if (config.allowDemoPayment && value.startsWith("demo:")) return true;
+
+  // Until a real x402 settlement verifier is wired, fail closed. In particular,
+  // never treat caller-supplied words like "paid" or "signature" as proof of payment.
+  return false;
 }
 
 export function x402Challenge(profile: SpecialistProfile, config: RuntimeConfig): RuntimeResponse {
@@ -109,7 +115,7 @@ export async function handleChatCompletions(input: {
   const profile = getProfile(input.config.profileId);
   if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };
 
-  if (input.config.requirePayment && !isPaymentSatisfied(input.headers)) {
+  if (input.config.requirePayment && !isPaymentSatisfied(input.headers, input.config)) {
     return x402Challenge(profile, input.config);
   }
 

--- a/packages/openrouter-specialists/src/server.ts
+++ b/packages/openrouter-specialists/src/server.ts
@@ -1,0 +1,22 @@
+import { createServer } from "node:http";
+import { Readable } from "node:stream";
+import { createOpenRouterClient, createRuntimeConfig, handleRuntimeRequest } from "./runtime.js";
+
+const config = createRuntimeConfig();
+const client = createOpenRouterClient(config);
+const port = Number(process.env.PORT ?? 8787);
+
+createServer(async (req, res) => {
+  const origin = config.endpointBaseUrl;
+  const request = new Request(new URL(req.url ?? "/", origin), {
+    method: req.method,
+    headers: req.headers as HeadersInit,
+    body: req.method === "GET" || req.method === "HEAD" ? undefined : (Readable.toWeb(req) as BodyInit),
+    duplex: "half",
+  } as RequestInit);
+  const response = await handleRuntimeRequest(request, config, client);
+  res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
+  res.end(await response.text());
+}).listen(port, () => {
+  console.log(`openrouter-specialists listening on :${port} profile=${config.profileId} mock=${config.mockOpenRouter}`);
+});

--- a/packages/openrouter-specialists/src/types.ts
+++ b/packages/openrouter-specialists/src/types.ts
@@ -31,6 +31,7 @@ export interface RuntimeConfig {
   openRouterBaseUrl: string;
   mockOpenRouter: boolean;
   requirePayment: boolean;
+  allowDemoPayment: boolean;
   safetyMode?: SafetyMode;
 }
 

--- a/packages/openrouter-specialists/src/types.ts
+++ b/packages/openrouter-specialists/src/types.ts
@@ -1,0 +1,66 @@
+export type SpecialistRole = "specialist" | "attestor" | "consumer";
+
+export type SafetyMode = "standard" | "regulated-informational" | "attestation";
+
+export interface SpecialistPrice {
+  currency: "USDC" | "SOL";
+  amount: string;
+  unit: "request" | "1k_tokens";
+}
+
+export interface SpecialistProfile {
+  id: string;
+  displayName: string;
+  description: string;
+  walletAddress: string;
+  endpointPath: string;
+  capabilities: string[];
+  roles: SpecialistRole[];
+  price: SpecialistPrice;
+  safetyMode: SafetyMode;
+  preferredAttestors: string[];
+  model: string;
+  systemPrompt: string;
+  tags: string[];
+}
+
+export interface RuntimeConfig {
+  profileId: string;
+  endpointBaseUrl: string;
+  openRouterApiKey?: string;
+  openRouterBaseUrl: string;
+  mockOpenRouter: boolean;
+  requirePayment: boolean;
+  safetyMode?: SafetyMode;
+}
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+}
+
+export interface ChatCompletionRequest {
+  model?: string;
+  messages?: ChatMessage[];
+  temperature?: number;
+  max_tokens?: number;
+  stream?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OpenRouterClient {
+  readonly callCount: number;
+  createChatCompletion(input: {
+    model: string;
+    messages: ChatMessage[];
+    temperature?: number;
+    max_tokens?: number;
+    metadata: Record<string, unknown>;
+  }): Promise<Record<string, unknown>>;
+}
+
+export interface RuntimeResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+}

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { MockOpenRouterClient } from "../src/openrouter.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "../src/profiles/index.js";
-import { handleChatCompletions, handleRuntimeRequest, marketplaceMetadata, type RuntimeConfig } from "../src/index.js";
+import { createOpenRouterClient, createRuntimeConfig, handleChatCompletions, handleRuntimeRequest, marketplaceMetadata, type RuntimeConfig } from "../src/index.js";
 
 const config: RuntimeConfig = {
   profileId: "planning-agent",
@@ -10,6 +10,7 @@ const config: RuntimeConfig = {
   openRouterBaseUrl: "https://openrouter.ai/api/v1",
   mockOpenRouter: true,
   requirePayment: true,
+  allowDemoPayment: true,
 };
 
 test("profile registry has first five unique valid profiles with required marketplace metadata", () => {
@@ -37,7 +38,22 @@ test("unpaid completion returns 402 challenge before OpenRouter client call", as
   assert.equal((response.body.error as { code: string }).code, "payment_required");
 });
 
-test("paid completion invokes OpenRouter mock with profile guardrails and Reddi metadata", async () => {
+test("spoofed paid or signature headers still fail closed", async () => {
+  for (const headerValue of ["paid:anything", "{\"signature\":\"caller-controlled\"}"]) {
+    const client = new MockOpenRouterClient();
+    const response = await handleChatCompletions({
+      headers: new Headers({ "x402-payment": headerValue }),
+      body: { messages: [{ role: "user", content: "Build a plan" }] },
+      config: { ...config, allowDemoPayment: false },
+      client,
+    });
+
+    assert.equal(response.status, 402);
+    assert.equal(client.callCount, 0);
+  }
+});
+
+test("demo-paid completion invokes OpenRouter mock only when explicitly enabled", async () => {
   const client = new MockOpenRouterClient();
   const response = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:paid" }),
@@ -72,6 +88,18 @@ test("well-known metadata includes Reddi marketplace fields", async () => {
   }
   assert.equal(metadata.profileId, "planning-agent");
   assert.equal(metadata.endpoint, "https://planning.example.test/v1/chat/completions");
+});
+
+test("runtime config requires explicit mock mode and api key for real OpenRouter", () => {
+  const productionConfig = createRuntimeConfig({});
+  assert.equal(productionConfig.mockOpenRouter, false);
+  assert.equal(productionConfig.allowDemoPayment, false);
+  assert.throws(() => createOpenRouterClient(productionConfig), /OPENROUTER_API_KEY is required/);
+
+  const mockConfig = createRuntimeConfig({ OPENROUTER_MOCK: "true", ALLOW_DEMO_X402_PAYMENT: "true" });
+  assert.equal(mockConfig.mockOpenRouter, true);
+  assert.equal(mockConfig.allowDemoPayment, true);
+  assert.equal(createOpenRouterClient(mockConfig).constructor.name, "MockOpenRouterClient");
 });
 
 test("HTTP core routes expose health, models, tags, metadata, and chat", async () => {

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MockOpenRouterClient } from "../src/openrouter.js";
+import { getProfile, specialistProfiles, validateProfileRegistry } from "../src/profiles/index.js";
+import { handleChatCompletions, handleRuntimeRequest, marketplaceMetadata, type RuntimeConfig } from "../src/index.js";
+
+const config: RuntimeConfig = {
+  profileId: "planning-agent",
+  endpointBaseUrl: "https://planning.example.test",
+  openRouterBaseUrl: "https://openrouter.ai/api/v1",
+  mockOpenRouter: true,
+  requirePayment: true,
+};
+
+test("profile registry has first five unique valid profiles with required marketplace metadata", () => {
+  assert.deepEqual(validateProfileRegistry(), []);
+  assert.equal(specialistProfiles.length, 5);
+  assert.deepEqual(
+    specialistProfiles.map((profile) => profile.id),
+    ["planning-agent", "document-intelligence-agent", "verification-validation-agent", "code-generation-agent", "conversational-agent"],
+  );
+  assert.ok(getProfile("verification-validation-agent")?.roles.includes("attestor"));
+});
+
+test("unpaid completion returns 402 challenge before OpenRouter client call", async () => {
+  const client = new MockOpenRouterClient();
+  const response = await handleChatCompletions({
+    headers: new Headers(),
+    body: { messages: [{ role: "user", content: "Build a plan" }] },
+    config,
+    client,
+  });
+
+  assert.equal(response.status, 402);
+  assert.equal(client.callCount, 0);
+  assert.ok(response.headers["x402-request"]);
+  assert.equal((response.body.error as { code: string }).code, "payment_required");
+});
+
+test("paid completion invokes OpenRouter mock with profile guardrails and Reddi metadata", async () => {
+  const client = new MockOpenRouterClient();
+  const response = await handleChatCompletions({
+    headers: new Headers({ "x402-payment": "demo:paid" }),
+    body: { messages: [{ role: "user", content: "Build a plan" }] },
+    config,
+    client,
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(client.callCount, 1);
+  assert.equal(client.lastRequest?.model, getProfile("planning-agent")?.model);
+  assert.equal(client.lastRequest?.messages[0]?.role, "system");
+  assert.equal(client.lastRequest?.messages[0]?.content, getProfile("planning-agent")?.systemPrompt);
+  assert.deepEqual(response.body.reddi, {
+    profileId: "planning-agent",
+    requestId: (response.body.reddi as { requestId: string }).requestId,
+    model: getProfile("planning-agent")?.model,
+    paymentSatisfied: true,
+    safetyMode: "standard",
+    mockOpenRouter: true,
+  });
+  assert.match((response.body.reddi as { requestId: string }).requestId, /^[0-9a-f-]{36}$/);
+});
+
+test("well-known metadata includes Reddi marketplace fields", async () => {
+  const profile = getProfile("planning-agent");
+  assert.ok(profile);
+  const metadata = marketplaceMetadata(profile, config) as Record<string, unknown>;
+
+  for (const field of ["profileId", "displayName", "walletAddress", "endpoint", "capabilities", "roles", "price", "safetyMode", "preferredAttestors"]) {
+    assert.ok(metadata[field], `missing ${field}`);
+  }
+  assert.equal(metadata.profileId, "planning-agent");
+  assert.equal(metadata.endpoint, "https://planning.example.test/v1/chat/completions");
+});
+
+test("HTTP core routes expose health, models, tags, metadata, and chat", async () => {
+  const client = new MockOpenRouterClient();
+  for (const path of ["/healthz", "/x402/health", "/v1/models", "/api/tags", "/.well-known/reddi-agent.json"]) {
+    const response = await handleRuntimeRequest(new Request(`https://planning.example.test${path}`), config, client);
+    assert.equal(response.status, 200, path);
+  }
+
+  const unpaid = await handleRuntimeRequest(
+    new Request("https://planning.example.test/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
+    }),
+    config,
+    client,
+  );
+  assert.equal(unpaid.status, 402);
+  assert.equal(client.callCount, 0);
+});

--- a/packages/openrouter-specialists/tsconfig.json
+++ b/packages/openrouter-specialists/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #139.

Adds the first safe runtime slice for the OpenRouter-powered Reddi Agent Protocol marketplace specialist catalog.

This PR introduces `packages/openrouter-specialists`, a reusable profile-driven runtime intended for Coolify deployment as many specialist apps from one container image.

## What changed

- Added first five specialist profiles:
  - `planning-agent`
  - `document-intelligence-agent`
  - `verification-validation-agent`
  - `code-generation-agent`
  - `conversational-agent`
- Added profile validation and required marketplace metadata:
  - profile ID / display name
  - wallet public key placeholder
  - endpoint URL
  - capabilities
  - roles
  - price lamports
  - safety mode
  - preferred attestors
  - `canHireAgents`
- Added runtime/core route handlers for:
  - `GET /healthz`
  - `GET /x402/health`
  - `GET /v1/models`
  - `GET /api/tags`
  - `GET /.well-known/reddi-agent.json`
  - `POST /v1/chat/completions`
- Added x402 fail-closed guard:
  - unpaid requests return HTTP 402 with `x402-request`
  - OpenRouter client is not invoked before payment is satisfied
- Added OpenRouter client abstraction with mock mode for safe local tests.
- Added Reddi metadata on successful paid/mock completions.
- Added Dockerfile and package README.

## Validation

Run from `packages/openrouter-specialists`:

```bash
npm test
```

Result: PASS, 5/5.

Run from repo root:

```bash
docker build -f packages/openrouter-specialists/Dockerfile -t reddi-openrouter-specialists:iter1 .
```

Result: PASS.

## Guardrails

- No paid OpenRouter calls were made.
- No private wallet keys are committed.
- Wallet values are placeholders/devnet-shaped only; real public wallet manifest + balance checks are Iteration 2.
- Agent-to-agent live downstream calls are not implemented here.
- Package-local tests are used for now because the root repo is not configured as an npm workspace for this package.

## BDD/OAD notes

This is Iteration 1 of the documented BDD loop:

- runtime skeleton
- first five profiles
- x402 no-payment/no-OpenRouter guard
- marketplace metadata endpoint

Next loop step after review/merge: Iteration 2 wallet public manifest + devnet balance verifier.
