### PR TITLE
feat: integrate x402 Solana specialist wallets

### DIFF
--- a/packages/openrouter-specialists/package-lock.json
+++ b/packages/openrouter-specialists/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "@reddi/openrouter-specialists",
       "version": "0.1.0",
+      "dependencies": {
+        "@reddi/x402-solana": "file:../x402-solana",
+        "@solana/web3.js": "^1.98.4"
+      },
       "devDependencies": {
         "@types/node": "^20",
         "typescript": "^5"
@@ -15,21 +19,625 @@
         "node": ">=20"
       }
     },
+    "../x402-solana": {
+      "name": "@reddi/x402-solana",
+      "version": "0.1.0",
+      "dependencies": {
+        "@solana/web3.js": "^1.95.8"
+      },
+      "devDependencies": {
+        "@types/jest": "^29",
+        "@types/node": "^20",
+        "jest": "^29",
+        "ts-jest": "^29",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@reddi/x402-solana": {
+      "resolved": "../x402-solana",
+      "link": true
+    },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
+        "agentkeepalive": "^4.5.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "license": "MIT"
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/jayson": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.3.0.tgz",
+      "integrity": "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "stream-json": "^1.9.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/rpc-websockets": {
+      "version": "9.3.8",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.8.tgz",
+      "integrity": "sha512-7r+fm4tSJmLf9GvZfL1DJ1SJwpagpp6AazqM0FUaeV7CA+7+NYINSk1syWa4tU/6OF2CyBicLtzENGmXRJH6wQ==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^11.0.0",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^6.0.0"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -43,8 +651,54 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/packages/openrouter-specialists/package.json
+++ b/packages/openrouter-specialists/package.json
@@ -5,13 +5,26 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "Dockerfile", "README.md"],
+  "files": [
+    "dist",
+    "public",
+    "Dockerfile",
+    "README.md"
+  ],
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node --test dist/tests/*.test.js"
+    "test": "npm run build && node --test dist/tests/*.test.js",
+    "validate:wallet-manifest": "node scripts/validate-wallet-manifest.mjs",
+    "check:devnet-balances": "node scripts/check-devnet-balances.mjs"
   },
-  "engines": {"node": ">=20"},
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@reddi/x402-solana": "file:../x402-solana",
+    "@solana/web3.js": "^1.98.4"
+  },
   "devDependencies": {
     "@types/node": "^20",
     "typescript": "^5"

--- a/packages/openrouter-specialists/public/wallet-manifest.json
+++ b/packages/openrouter-specialists/public/wallet-manifest.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": "1.0.0",
+  "network": "solana-devnet",
+  "minimumBalanceLamports": 1000000,
+  "generatedAt": "2026-05-03T00:00:00.000Z",
+  "profiles": [
+    {
+      "profileId": "planning-agent",
+      "displayName": "Planning Agent",
+      "publicKey": "3mL7kbtz3eK24vJ6wftjnLvhZrf93B71UEjB2DBDAddr"
+    },
+    {
+      "profileId": "document-intelligence-agent",
+      "displayName": "Document Intelligence Agent",
+      "publicKey": "6uiQbwMor4UrWYiDtAJcgHKYW4vUaM3BUVChPgzdALse"
+    },
+    {
+      "profileId": "verification-validation-agent",
+      "displayName": "Verification & Validation Agent",
+      "publicKey": "EqQoUabvYzHwedphRYmXhNtT1hVX7ReTTJG4NmpgXAsr"
+    },
+    {
+      "profileId": "code-generation-agent",
+      "displayName": "Code Generation Agent",
+      "publicKey": "2e39zZNWB7J6k29trdBppbPJ8pUzsELrgPtAREvUNYE7"
+    },
+    {
+      "profileId": "conversational-agent",
+      "displayName": "Conversational Agent",
+      "publicKey": "FZM9LeQnYQwSdQfZLUdm9VitPnKH41CaDCuaSc4EDEqM"
+    }
+  ]
+}

--- a/packages/openrouter-specialists/scripts/check-devnet-balances.mjs
+++ b/packages/openrouter-specialists/scripts/check-devnet-balances.mjs
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Connection, PublicKey, clusterApiUrl } from '@solana/web3.js';
+
+const manifestPath = process.argv[2] ?? join(process.cwd(), 'public/wallet-manifest.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+if (manifest.network !== 'solana-devnet') throw new Error('balance verifier is devnet-only');
+
+const threshold = Number(process.env.MIN_DEVNET_BALANCE_LAMPORTS ?? manifest.minimumBalanceLamports ?? 0);
+const endpoint = process.env.SOLANA_DEVNET_RPC_URL ?? clusterApiUrl('devnet');
+const connection = new Connection(endpoint, 'confirmed');
+
+const report = [];
+for (const profile of manifest.profiles) {
+  const publicKey = new PublicKey(profile.publicKey);
+  const lamports = await connection.getBalance(publicKey, 'confirmed');
+  report.push({
+    profileId: profile.profileId,
+    publicKey: profile.publicKey,
+    lamports,
+    belowThreshold: lamports < threshold,
+  });
+}
+
+console.log(JSON.stringify({ network: manifest.network, endpoint, thresholdLamports: threshold, report }, null, 2));
+if (report.some((entry) => entry.belowThreshold)) process.exitCode = 1;

--- a/packages/openrouter-specialists/scripts/validate-wallet-manifest.mjs
+++ b/packages/openrouter-specialists/scripts/validate-wallet-manifest.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { PublicKey } from '@solana/web3.js';
+
+const manifestPath = process.argv[2] ?? join(process.cwd(), 'public/wallet-manifest.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+function isValidPublicKey(value) {
+  try {
+    const key = new PublicKey(value);
+    return key.toBytes().length === 32 && key.toBase58() === value;
+  } catch {
+    return false;
+  }
+}
+
+assert.equal(manifest.schemaVersion, '1.0.0');
+assert.equal(manifest.network, 'solana-devnet');
+assert.equal(typeof manifest.minimumBalanceLamports, 'number');
+assert.ok(manifest.minimumBalanceLamports >= 0);
+assert.ok(Array.isArray(manifest.profiles));
+assert.equal(manifest.profiles.length, 5, 'manifest must publish first five specialist wallets');
+
+const ids = new Set();
+const publicKeys = new Set();
+for (const profile of manifest.profiles) {
+  assert.equal(typeof profile.profileId, 'string');
+  assert.match(profile.profileId, /^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+  assert.equal(typeof profile.displayName, 'string');
+  assert.ok(profile.displayName.length > 0);
+  assert.equal(typeof profile.publicKey, 'string');
+  assert.ok(isValidPublicKey(profile.publicKey), `${profile.profileId} publicKey must be a strict Solana public key`);
+  assert.equal(profile.privateKey, undefined, `${profile.profileId} must not include privateKey`);
+  assert.equal(profile.secretKey, undefined, `${profile.profileId} must not include secretKey`);
+  assert.equal(profile.mnemonic, undefined, `${profile.profileId} must not include mnemonic`);
+  assert.ok(!ids.has(profile.profileId), `duplicate profileId ${profile.profileId}`);
+  assert.ok(!publicKeys.has(profile.publicKey), `duplicate publicKey ${profile.publicKey}`);
+  ids.add(profile.profileId);
+  publicKeys.add(profile.publicKey);
+}
+
+console.log(`wallet manifest valid: ${manifest.profiles.length} ${manifest.network} public keys, no secrets`);

--- a/packages/openrouter-specialists/src/profiles/index.ts
+++ b/packages/openrouter-specialists/src/profiles/index.ts
@@ -1,44 +1,20 @@
+import { isValidSolanaPublicKey } from "@reddi/x402-solana";
 import type { SpecialistProfile } from "../types.js";
 
-const walletAddresses = {
-  planning: "AXfCzZmfKsGDr8XdE4SZXDXdfvrqSSUm9xdX6EbmLA5H",
-  documentIntelligence: "82Lpdv8FjaQUELikS9jc2ga3LQSxzKJmWKHwQr4v9acN",
-  verificationValidation: "7eHBdFN8qUrG9ifyyM2RzqYaxX5T5ijeF7D5BZnQJyD7",
-  codeGeneration: "GctzwjmUTJphtBLHA4VwfjY4qCajRywunMvUoKTB6Prn",
-  conversational: "5qVJ6XhYiDqNXHYR4B5QLT6rDSQ72iyuG5ooHyV9B2Xc",
+const wallets = {
+  planning: "3mL7kbtz3eK24vJ6wftjnLvhZrf93B71UEjB2DBDAddr",
+  documentIntelligence: "6uiQbwMor4UrWYiDtAJcgHKYW4vUaM3BUVChPgzdALse",
+  verificationValidation: "EqQoUabvYzHwedphRYmXhNtT1hVX7ReTTJG4NmpgXAsr",
+  codeGeneration: "2e39zZNWB7J6k29trdBppbPJ8pUzsELrgPtAREvUNYE7",
+  conversational: "FZM9LeQnYQwSdQfZLUdm9VitPnKH41CaDCuaSc4EDEqM",
 } as const;
-
-function isBase58SolanaPublicKey(value: string): boolean {
-  if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value)) return false;
-  const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-  const bytes = [0];
-  for (const char of value) {
-    const carryStart = alphabet.indexOf(char);
-    if (carryStart < 0) return false;
-    let carry = carryStart;
-    for (let index = 0; index < bytes.length; index += 1) {
-      carry += bytes[index] * 58;
-      bytes[index] = carry & 0xff;
-      carry >>= 8;
-    }
-    while (carry > 0) {
-      bytes.push(carry & 0xff);
-      carry >>= 8;
-    }
-  }
-  for (const char of value) {
-    if (char !== "1") break;
-    bytes.push(0);
-  }
-  return bytes.length === 32;
-}
 
 export const specialistProfiles: SpecialistProfile[] = [
   {
     id: "planning-agent",
     displayName: "Planning Agent",
     description: "Turns broad goals into sequenced execution plans with assumptions, risks, and validation gates.",
-    walletAddress: walletAddresses.planning,
+    walletAddress: wallets.planning,
     endpointPath: "/v1/chat/completions",
     capabilities: ["planning", "task-decomposition", "risk-analysis", "agent-orchestration"],
     roles: ["specialist", "consumer"],
@@ -54,7 +30,7 @@ export const specialistProfiles: SpecialistProfile[] = [
     id: "document-intelligence-agent",
     displayName: "Document Intelligence Agent",
     description: "Extracts, classifies, summarizes, and cross-checks document evidence.",
-    walletAddress: walletAddresses.documentIntelligence,
+    walletAddress: wallets.documentIntelligence,
     endpointPath: "/v1/chat/completions",
     capabilities: ["document-analysis", "summarization", "evidence-extraction", "classification"],
     roles: ["specialist"],
@@ -70,7 +46,7 @@ export const specialistProfiles: SpecialistProfile[] = [
     id: "verification-validation-agent",
     displayName: "Verification & Validation Agent",
     description: "Reviews specialist outputs for evidence quality, safety boundaries, and release/refund/dispute recommendations.",
-    walletAddress: walletAddresses.verificationValidation,
+    walletAddress: wallets.verificationValidation,
     endpointPath: "/v1/chat/completions",
     capabilities: ["verification", "validation", "attestation", "quality-review", "safety-review"],
     roles: ["specialist", "attestor"],
@@ -86,7 +62,7 @@ export const specialistProfiles: SpecialistProfile[] = [
     id: "code-generation-agent",
     displayName: "Code Generation Agent",
     description: "Builds scoped code changes, tests, migrations, and implementation notes.",
-    walletAddress: walletAddresses.codeGeneration,
+    walletAddress: wallets.codeGeneration,
     endpointPath: "/v1/chat/completions",
     capabilities: ["code-generation", "debugging", "test-writing", "technical-design"],
     roles: ["specialist"],
@@ -102,7 +78,7 @@ export const specialistProfiles: SpecialistProfile[] = [
     id: "conversational-agent",
     displayName: "Conversational Agent",
     description: "Handles general dialogue, intake, clarification, and user-friendly handoff summaries.",
-    walletAddress: walletAddresses.conversational,
+    walletAddress: wallets.conversational,
     endpointPath: "/v1/chat/completions",
     capabilities: ["conversation", "intake", "clarification", "handoff-summary"],
     roles: ["specialist"],
@@ -125,7 +101,7 @@ export function validateProfile(profile: SpecialistProfile): string[] {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(profile.id)) errors.push(`invalid id: ${profile.id}`);
   if (!profile.displayName.trim()) errors.push(`${profile.id}: missing displayName`);
   if (!profile.walletAddress.trim()) errors.push(`${profile.id}: missing walletAddress`);
-  if (profile.walletAddress.trim() && !isBase58SolanaPublicKey(profile.walletAddress)) errors.push(`${profile.id}: invalid Solana walletAddress`);
+  else if (!isValidSolanaPublicKey(profile.walletAddress)) errors.push(`${profile.id}: invalid Solana walletAddress`);
   if (profile.endpointPath !== "/v1/chat/completions") errors.push(`${profile.id}: unsupported endpointPath`);
   if (profile.capabilities.length === 0) errors.push(`${profile.id}: missing capabilities`);
   if (profile.roles.length === 0 || !profile.roles.includes("specialist")) errors.push(`${profile.id}: must include specialist role`);

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -77,7 +77,13 @@ export async function verifyPayment(input: {
   if (!value) return { ok: false, reason: "invalid_receipt", message: "missing x402-payment header" };
 
   const parsed = parseX402PaymentHeader(value);
-  const receiptNonce = parsed && typeof parsed === "object" && "nonce" in parsed && typeof (parsed as { nonce?: unknown }).nonce === "string" ? (parsed as { nonce: string }).nonce : randomUUID();
+  const receiptNonce =
+    typeof parsed === "string" && parsed.startsWith("demo:")
+      ? parsed.slice("demo:".length)
+      : parsed && typeof parsed === "object" && "nonce" in parsed && typeof (parsed as { nonce?: unknown }).nonce === "string"
+        ? (parsed as { nonce: string }).nonce
+        : randomUUID();
+  if (!receiptNonce) return { ok: false, reason: "invalid_nonce", message: "x402 payment nonce is required" };
   const challenge = buildProfileChallenge(input.profile, input.config, receiptNonce);
   const verifier = new DemoPaymentVerifier(input.config.allowDemoPayment === true);
   return verifier.verifyReceipt(parsed, challenge, input.replayStore);

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
   buildX402Challenge,
+  defaultNonceReplayStore,
   DemoPaymentVerifier,
   parseX402PaymentHeader,
   type NonceReplayStore,
@@ -190,7 +191,7 @@ export async function handleRuntimeRequest(request: Request, config = createRunt
   if (request.method === "GET" && url.pathname === "/.well-known/reddi-agent.json") return toResponse({ status: 200, headers: JSON_HEADERS, body: marketplaceMetadata(profile, config) });
   if (request.method === "POST" && url.pathname === "/v1/chat/completions") {
     const body = (await request.json().catch(() => ({}))) as ChatCompletionRequest;
-    return toResponse(await handleChatCompletions({ headers: request.headers, body, config, client }));
+    return toResponse(await handleChatCompletions({ headers: request.headers, body, config, client, replayStore: defaultNonceReplayStore }));
   }
   return toResponse({ status: 404, headers: JSON_HEADERS, body: { error: { code: "not_found" } } });
 }

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -1,9 +1,18 @@
 import { randomUUID } from "node:crypto";
+import {
+  buildX402Challenge,
+  DemoPaymentVerifier,
+  parseX402PaymentHeader,
+  type NonceReplayStore,
+  type ReceiptVerificationResult,
+  type X402Challenge,
+} from "@reddi/x402-solana";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "./profiles/index.js";
 import { FetchOpenRouterClient, MockOpenRouterClient } from "./openrouter.js";
 import type { ChatCompletionRequest, OpenRouterClient, RuntimeConfig, RuntimeResponse, SpecialistProfile } from "./types.js";
 
 const JSON_HEADERS = { "content-type": "application/json; charset=utf-8" };
+const PAYMENT_NETWORK = "solana-devnet" as const;
 
 export function createRuntimeConfig(env: NodeJS.ProcessEnv = process.env): RuntimeConfig {
   return {
@@ -23,46 +32,54 @@ export function createOpenRouterClient(config: RuntimeConfig): OpenRouterClient 
   return new FetchOpenRouterClient(config.openRouterApiKey, config.openRouterBaseUrl);
 }
 
-export function isPaymentSatisfied(headers: Headers, config: RuntimeConfig): boolean {
-  const value = headers.get("x402-payment");
-  if (!value) return false;
-
-  if (config.allowDemoPayment && value.startsWith("demo:")) return true;
-
-  // Until a real x402 settlement verifier is wired, fail closed. In particular,
-  // never treat caller-supplied words like "paid" or "signature" as proof of payment.
-  return false;
+export function buildProfileChallenge(profile: SpecialistProfile, config: RuntimeConfig, nonce: string = randomUUID()): X402Challenge {
+  return buildX402Challenge({
+    version: "1",
+    network: PAYMENT_NETWORK,
+    payTo: profile.walletAddress,
+    amount: profile.price.amount,
+    currency: profile.price.currency,
+    endpoint: `${config.endpointBaseUrl}${profile.endpointPath}`,
+    nonce,
+    memo: `reddi:${profile.id}`,
+  });
 }
 
-export function x402Challenge(profile: SpecialistProfile, config: RuntimeConfig): RuntimeResponse {
+function paymentRequired(challenge: X402Challenge): RuntimeResponse {
   return {
     status: 402,
     headers: {
       ...JSON_HEADERS,
-      "x402-request": JSON.stringify({
-        version: "1",
-        network: "solana-devnet",
-        payTo: profile.walletAddress,
-        amount: profile.price.amount,
-        currency: profile.price.currency,
-        endpoint: `${config.endpointBaseUrl}${profile.endpointPath}`,
-      }),
+      "x402-request": JSON.stringify(challenge),
     },
     body: {
       error: {
         code: "payment_required",
         message: "x402 payment is required before specialist execution.",
       },
-      x402: {
-        version: "1",
-        network: "solana-devnet",
-        payTo: profile.walletAddress,
-        amount: profile.price.amount,
-        currency: profile.price.currency,
-        unit: profile.price.unit,
-      },
+      x402: challenge,
     },
   };
+}
+
+export function x402Challenge(profile: SpecialistProfile, config: RuntimeConfig): RuntimeResponse {
+  return paymentRequired(buildProfileChallenge(profile, config));
+}
+
+export async function verifyPayment(input: {
+  headers: Headers;
+  profile: SpecialistProfile;
+  config: RuntimeConfig;
+  replayStore?: NonceReplayStore;
+}): Promise<ReceiptVerificationResult> {
+  const value = input.headers.get("x402-payment") ?? input.headers.get("x-payment");
+  if (!value) return { ok: false, reason: "invalid_receipt", message: "missing x402-payment header" };
+
+  const parsed = parseX402PaymentHeader(value);
+  const receiptNonce = parsed && typeof parsed === "object" && "nonce" in parsed && typeof (parsed as { nonce?: unknown }).nonce === "string" ? (parsed as { nonce: string }).nonce : randomUUID();
+  const challenge = buildProfileChallenge(input.profile, input.config, receiptNonce);
+  const verifier = new DemoPaymentVerifier(input.config.allowDemoPayment === true);
+  return verifier.verifyReceipt(parsed, challenge, input.replayStore);
 }
 
 export function marketplaceMetadata(profile: SpecialistProfile, config: RuntimeConfig): Record<string, unknown> {
@@ -111,12 +128,21 @@ export async function handleChatCompletions(input: {
   body: ChatCompletionRequest;
   config: RuntimeConfig;
   client: OpenRouterClient;
+  replayStore?: NonceReplayStore;
 }): Promise<RuntimeResponse> {
   const profile = getProfile(input.config.profileId);
   if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };
 
-  if (input.config.requirePayment && !isPaymentSatisfied(input.headers, input.config)) {
-    return x402Challenge(profile, input.config);
+  if (input.config.requirePayment) {
+    const payment = await verifyPayment({ headers: input.headers, profile, config: input.config, replayStore: input.replayStore });
+    if (!payment.ok) {
+      const response = paymentRequired(buildProfileChallenge(profile, input.config));
+      response.body.error = {
+        code: payment.reason === "invalid_receipt" ? "payment_required" : payment.reason,
+        message: payment.message,
+      };
+      return response;
+    }
   }
 
   const requestId = randomUUID();
@@ -126,7 +152,7 @@ export async function handleChatCompletions(input: {
     profileId: profile.id,
     requestId,
     model: profile.model,
-    paymentSatisfied: true,
+    paymentSatisfied: input.config.requirePayment,
     safetyMode: profile.safetyMode,
     mockOpenRouter: input.config.mockOpenRouter,
   };
@@ -157,7 +183,7 @@ export async function handleRuntimeRequest(request: Request, config = createRunt
     return toResponse({ status: registryErrors.length ? 500 : 200, headers: JSON_HEADERS, body: { ok: registryErrors.length === 0, profileId: profile.id, registryErrors } });
   }
   if (request.method === "GET" && url.pathname === "/x402/health") {
-    return toResponse({ status: 200, headers: JSON_HEADERS, body: { ok: true, failClosed: config.requirePayment, network: "solana-devnet" } });
+    return toResponse({ status: 200, headers: JSON_HEADERS, body: { ok: true, failClosed: config.requirePayment, network: PAYMENT_NETWORK, demoPaymentsEnabled: config.allowDemoPayment === true } });
   }
   if (request.method === "GET" && url.pathname === "/v1/models") return toResponse(modelsResponse());
   if (request.method === "GET" && url.pathname === "/api/tags") return toResponse(tagsResponse());

--- a/packages/openrouter-specialists/src/types.ts
+++ b/packages/openrouter-specialists/src/types.ts
@@ -31,7 +31,7 @@ export interface RuntimeConfig {
   openRouterBaseUrl: string;
   mockOpenRouter: boolean;
   requirePayment: boolean;
-  allowDemoPayment: boolean;
+  allowDemoPayment?: boolean;
   safetyMode?: SafetyMode;
 }
 

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { MockOpenRouterClient } from "../src/openrouter.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "../src/profiles/index.js";
-import { createOpenRouterClient, createRuntimeConfig, handleChatCompletions, handleRuntimeRequest, marketplaceMetadata, type RuntimeConfig } from "../src/index.js";
+import { createRuntimeConfig, handleChatCompletions, handleRuntimeRequest, marketplaceMetadata, type RuntimeConfig } from "../src/index.js";
 
 const config: RuntimeConfig = {
   profileId: "planning-agent",
@@ -10,7 +10,7 @@ const config: RuntimeConfig = {
   openRouterBaseUrl: "https://openrouter.ai/api/v1",
   mockOpenRouter: true,
   requirePayment: true,
-  allowDemoPayment: true,
+  allowDemoPayment: false,
 };
 
 test("profile registry has first five unique valid profiles with required marketplace metadata", () => {
@@ -21,6 +21,11 @@ test("profile registry has first five unique valid profiles with required market
     ["planning-agent", "document-intelligence-agent", "verification-validation-agent", "code-generation-agent", "conversational-agent"],
   );
   assert.ok(getProfile("verification-validation-agent")?.roles.includes("attestor"));
+});
+
+test("OpenRouter mock mode is explicit opt-in only", () => {
+  assert.equal(createRuntimeConfig({}).mockOpenRouter, false);
+  assert.equal(createRuntimeConfig({ OPENROUTER_MOCK: "true" }).mockOpenRouter, true);
 });
 
 test("unpaid completion returns 402 challenge before OpenRouter client call", async () => {
@@ -38,27 +43,37 @@ test("unpaid completion returns 402 challenge before OpenRouter client call", as
   assert.equal((response.body.error as { code: string }).code, "payment_required");
 });
 
-test("spoofed paid or signature headers still fail closed", async () => {
-  for (const headerValue of ["paid:anything", "{\"signature\":\"caller-controlled\"}"]) {
-    const client = new MockOpenRouterClient();
-    const response = await handleChatCompletions({
-      headers: new Headers({ "x402-payment": headerValue }),
-      body: { messages: [{ role: "user", content: "Build a plan" }] },
-      config: { ...config, allowDemoPayment: false },
-      client,
-    });
-
-    assert.equal(response.status, 402);
-    assert.equal(client.callCount, 0);
-  }
-});
-
-test("demo-paid completion invokes OpenRouter mock only when explicitly enabled", async () => {
+test("demo payment remains fail-closed without explicit ALLOW_DEMO_X402_PAYMENT", async () => {
   const client = new MockOpenRouterClient();
   const response = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:paid" }),
     body: { messages: [{ role: "user", content: "Build a plan" }] },
     config,
+    client,
+  });
+
+  assert.equal(response.status, 402);
+  assert.equal(client.callCount, 0);
+  assert.equal((response.body.error as { code: string }).code, "demo_payment_disabled");
+});
+
+test("paid completion invokes OpenRouter mock with explicit demo flag, profile guardrails, and Reddi metadata", async () => {
+  const client = new MockOpenRouterClient();
+  const demoConfig = { ...config, allowDemoPayment: true };
+  const profile = getProfile("planning-agent");
+  assert.ok(profile);
+  const receipt = {
+    demo: true,
+    network: "solana-devnet",
+    payTo: profile.walletAddress,
+    amount: profile.price.amount,
+    currency: profile.price.currency,
+    nonce: "nonce-paid-1",
+  };
+  const response = await handleChatCompletions({
+    headers: new Headers({ "x402-payment": JSON.stringify(receipt) }),
+    body: { messages: [{ role: "user", content: "Build a plan" }] },
+    config: demoConfig,
     client,
   });
 
@@ -88,18 +103,6 @@ test("well-known metadata includes Reddi marketplace fields", async () => {
   }
   assert.equal(metadata.profileId, "planning-agent");
   assert.equal(metadata.endpoint, "https://planning.example.test/v1/chat/completions");
-});
-
-test("runtime config requires explicit mock mode and api key for real OpenRouter", () => {
-  const productionConfig = createRuntimeConfig({});
-  assert.equal(productionConfig.mockOpenRouter, false);
-  assert.equal(productionConfig.allowDemoPayment, false);
-  assert.throws(() => createOpenRouterClient(productionConfig), /OPENROUTER_API_KEY is required/);
-
-  const mockConfig = createRuntimeConfig({ OPENROUTER_MOCK: "true", ALLOW_DEMO_X402_PAYMENT: "true" });
-  assert.equal(mockConfig.mockOpenRouter, true);
-  assert.equal(mockConfig.allowDemoPayment, true);
-  assert.equal(createOpenRouterClient(mockConfig).constructor.name, "MockOpenRouterClient");
 });
 
 test("HTTP core routes expose health, models, tags, metadata, and chat", async () => {

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -62,16 +62,8 @@ test("paid completion invokes OpenRouter mock with explicit demo flag, profile g
   const demoConfig = { ...config, allowDemoPayment: true };
   const profile = getProfile("planning-agent");
   assert.ok(profile);
-  const receipt = {
-    demo: true,
-    network: "solana-devnet",
-    payTo: profile.walletAddress,
-    amount: profile.price.amount,
-    currency: profile.price.currency,
-    nonce: "nonce-paid-1",
-  };
   const response = await handleChatCompletions({
-    headers: new Headers({ "x402-payment": JSON.stringify(receipt) }),
+    headers: new Headers({ "x402-payment": "demo:nonce-paid-1" }),
     body: { messages: [{ role: "user", content: "Build a plan" }] },
     config: demoConfig,
     client,
@@ -91,6 +83,50 @@ test("paid completion invokes OpenRouter mock with explicit demo flag, profile g
     mockOpenRouter: true,
   });
   assert.match((response.body.reddi as { requestId: string }).requestId, /^[0-9a-f-]{36}$/);
+});
+
+test("HTTP runtime rejects duplicate demo receipt nonces", async () => {
+  const client = new MockOpenRouterClient();
+  const demoConfig = { ...config, allowDemoPayment: true };
+  const request = () =>
+    new Request("https://planning.example.test/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x402-payment": "demo:nonce-http-replay-1" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
+    });
+
+  const first = await handleRuntimeRequest(request(), demoConfig, client);
+  const second = await handleRuntimeRequest(request(), demoConfig, client);
+
+  assert.equal(first.status, 200);
+  assert.equal(second.status, 402);
+  const body = (await second.json()) as { error: { code: string } };
+  assert.equal(body.error.code, "duplicate_nonce");
+});
+
+test("caller-authored structured demo receipts are rejected", async () => {
+  const client = new MockOpenRouterClient();
+  const profile = getProfile("planning-agent");
+  assert.ok(profile);
+  const response = await handleChatCompletions({
+    headers: new Headers({
+      "x402-payment": JSON.stringify({
+        demo: true,
+        network: "solana-devnet",
+        payTo: profile.walletAddress,
+        amount: profile.price.amount,
+        currency: profile.price.currency,
+        nonce: "nonce-structured-demo",
+      }),
+    }),
+    body: { messages: [{ role: "user", content: "Build a plan" }] },
+    config: { ...config, allowDemoPayment: true },
+    client,
+  });
+
+  assert.equal(response.status, 402);
+  assert.equal(client.callCount, 0);
+  assert.equal((response.body.error as { code: string }).code, "payment_required");
 });
 
 test("well-known metadata includes Reddi marketplace fields", async () => {

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -104,6 +104,20 @@ test("HTTP runtime rejects duplicate demo receipt nonces", async () => {
   assert.equal(body.error.code, "duplicate_nonce");
 });
 
+test("empty demo receipt nonce returns controlled 402", async () => {
+  const client = new MockOpenRouterClient();
+  const response = await handleChatCompletions({
+    headers: new Headers({ "x402-payment": "demo:" }),
+    body: { messages: [{ role: "user", content: "Build a plan" }] },
+    config: { ...config, allowDemoPayment: true },
+    client,
+  });
+
+  assert.equal(response.status, 402);
+  assert.equal(client.callCount, 0);
+  assert.equal((response.body.error as { code: string }).code, "invalid_nonce");
+});
+
 test("caller-authored structured demo receipts are rejected", async () => {
   const client = new MockOpenRouterClient();
   const profile = getProfile("planning-agent");
@@ -127,6 +141,19 @@ test("caller-authored structured demo receipts are rejected", async () => {
   assert.equal(response.status, 402);
   assert.equal(client.callCount, 0);
   assert.equal((response.body.error as { code: string }).code, "payment_required");
+
+  const tokenResponse = await handleChatCompletions({
+    headers: new Headers({
+      "x402-payment": JSON.stringify({ demo: true, token: "demo:nonce-structured-token", nonce: "nonce-structured-token" }),
+    }),
+    body: { messages: [{ role: "user", content: "Build a plan" }] },
+    config: { ...config, allowDemoPayment: true },
+    client,
+  });
+
+  assert.equal(tokenResponse.status, 402);
+  assert.equal(client.callCount, 0);
+  assert.equal((tokenResponse.body.error as { code: string }).code, "payment_required");
 });
 
 test("well-known metadata includes Reddi marketplace fields", async () => {

--- a/packages/openrouter-specialists/tests/wallet-manifest.test.ts
+++ b/packages/openrouter-specialists/tests/wallet-manifest.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { isValidSolanaPublicKey } from "@reddi/x402-solana";
+import { specialistProfiles } from "../src/profiles/index.js";
+
+test("public wallet manifest matches first five profiles and contains no secrets", () => {
+  const manifest = JSON.parse(readFileSync(new URL("../public/wallet-manifest.json", `file://${process.cwd()}/tests/`), "utf8"));
+  assert.equal(manifest.network, "solana-devnet");
+  assert.equal(manifest.profiles.length, 5);
+
+  const expected = specialistProfiles.slice(0, 5);
+  for (const [index, manifestProfile] of manifest.profiles.entries()) {
+    const profile = expected[index];
+    assert.equal(manifestProfile.profileId, profile.id);
+    assert.equal(manifestProfile.displayName, profile.displayName);
+    assert.equal(manifestProfile.publicKey, profile.walletAddress);
+    assert.ok(isValidSolanaPublicKey(manifestProfile.publicKey));
+    assert.equal(manifestProfile.privateKey, undefined);
+    assert.equal(manifestProfile.secretKey, undefined);
+    assert.equal(manifestProfile.mnemonic, undefined);
+  }
+});

--- a/packages/x402-solana/dist/index.d.ts
+++ b/packages/x402-solana/dist/index.d.ts
@@ -8,3 +8,4 @@ export * from './types';
 export * from './nonce';
 export * from './payment';
 export * from './middleware';
+export * from './jupiter';

--- a/packages/x402-solana/dist/index.js
+++ b/packages/x402-solana/dist/index.js
@@ -24,3 +24,4 @@ __exportStar(require("./types"), exports);
 __exportStar(require("./nonce"), exports);
 __exportStar(require("./payment"), exports);
 __exportStar(require("./middleware"), exports);
+__exportStar(require("./jupiter"), exports);

--- a/packages/x402-solana/dist/jupiter.d.ts
+++ b/packages/x402-solana/dist/jupiter.d.ts
@@ -1,0 +1,36 @@
+import { X402Request } from './types';
+export interface JupiterSwapRequest {
+    inputMint: string;
+    outputMint: string;
+    amount: string;
+    userPublicKey: string;
+    slippageBps?: number;
+}
+export interface JupiterSwapResult {
+    orderId: string;
+    executeId: string;
+    inAmount: string;
+    outAmount: string;
+}
+export interface SwapClient {
+    swap(request: JupiterSwapRequest): Promise<JupiterSwapResult>;
+}
+export interface JupiterSwapClientOptions {
+    apiBaseUrl?: string;
+    quoteApiBaseUrl?: string;
+    apiKey?: string;
+    fetchImpl?: typeof fetch;
+}
+export declare function resolveMint(symbolOrMint: string): string;
+export declare class JupiterSwapV2Client implements SwapClient {
+    private apiBaseUrl;
+    private quoteApiBaseUrl;
+    private apiKey?;
+    private fetchImpl;
+    constructor(options?: JupiterSwapClientOptions);
+    private buildHeaders;
+    private swapViaOrderExecute;
+    private swapViaQuote;
+    swap(request: JupiterSwapRequest): Promise<JupiterSwapResult>;
+}
+export declare function needsAutoSwap(request: X402Request): boolean;

--- a/packages/x402-solana/dist/jupiter.js
+++ b/packages/x402-solana/dist/jupiter.js
@@ -1,0 +1,120 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.JupiterSwapV2Client = void 0;
+exports.resolveMint = resolveMint;
+exports.needsAutoSwap = needsAutoSwap;
+const SYMBOL_TO_MINT = {
+    SOL: 'So11111111111111111111111111111111111111112',
+    USDC: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+};
+function resolveMint(symbolOrMint) {
+    const normalized = symbolOrMint.trim();
+    const upper = normalized.toUpperCase();
+    return SYMBOL_TO_MINT[upper] || normalized;
+}
+class JupiterSwapV2Client {
+    constructor(options = {}) {
+        this.apiBaseUrl = options.apiBaseUrl || 'https://api.jup.ag/swap/v2';
+        this.quoteApiBaseUrl = options.quoteApiBaseUrl || 'https://lite-api.jup.ag/swap/v1';
+        this.apiKey = options.apiKey || process.env.JUPITER_API_KEY?.trim();
+        this.fetchImpl = options.fetchImpl || fetch;
+    }
+    buildHeaders() {
+        const headers = { 'content-type': 'application/json' };
+        if (this.apiKey) {
+            headers['x-api-key'] = this.apiKey;
+        }
+        return headers;
+    }
+    async swapViaOrderExecute(request) {
+        const orderRes = await this.fetchImpl(`${this.apiBaseUrl}/order`, {
+            method: 'POST',
+            headers: this.buildHeaders(),
+            body: JSON.stringify({
+                inputMint: request.inputMint,
+                outputMint: request.outputMint,
+                amount: request.amount,
+                taker: request.userPublicKey,
+                slippageBps: request.slippageBps ?? 50,
+            }),
+        });
+        if (orderRes.status === 404) {
+            throw new Error('Jupiter order failed (404)');
+        }
+        if (!orderRes.ok) {
+            throw new Error(`Jupiter order failed (${orderRes.status})`);
+        }
+        const orderJson = (await orderRes.json());
+        const orderId = orderJson.requestId || orderJson.orderId || orderJson.id;
+        if (!orderId) {
+            throw new Error('Jupiter order response missing request id');
+        }
+        const executeTx = orderJson.transaction || orderJson.tx;
+        if (!executeTx) {
+            return {
+                orderId,
+                executeId: `exec_pending_${Date.now().toString(36)}`,
+                inAmount: orderJson.inAmount || request.amount,
+                outAmount: orderJson.outAmount || '0',
+            };
+        }
+        const executeRes = await this.fetchImpl(`${this.apiBaseUrl}/execute`, {
+            method: 'POST',
+            headers: this.buildHeaders(),
+            body: JSON.stringify({
+                requestId: orderId,
+                signedTransaction: executeTx,
+            }),
+        });
+        if (!executeRes.ok) {
+            throw new Error(`Jupiter execute failed (${executeRes.status})`);
+        }
+        const executeJson = (await executeRes.json());
+        return {
+            orderId,
+            executeId: executeJson.executeId || executeJson.requestId || executeJson.id || `exec_${Date.now().toString(36)}`,
+            inAmount: orderJson.inAmount || request.amount,
+            outAmount: executeJson.outputAmountResult || executeJson.outAmount || orderJson.outAmount || '0',
+        };
+    }
+    async swapViaQuote(request) {
+        const query = new URLSearchParams({
+            inputMint: request.inputMint,
+            outputMint: request.outputMint,
+            amount: request.amount,
+            slippageBps: String(request.slippageBps ?? 50),
+        });
+        const quoteRes = await this.fetchImpl(`${this.quoteApiBaseUrl}/quote?${query.toString()}`, {
+            method: 'GET',
+            headers: this.apiKey ? { 'x-api-key': this.apiKey } : undefined,
+        });
+        if (!quoteRes.ok) {
+            throw new Error(`Jupiter quote failed (${quoteRes.status})`);
+        }
+        const quoteJson = (await quoteRes.json());
+        return {
+            orderId: `quote_${Date.now().toString(36)}_${quoteJson.contextSlot ?? 'na'}`,
+            executeId: `quote_only_${Array.isArray(quoteJson.routePlan) ? quoteJson.routePlan.length : 0}`,
+            inAmount: quoteJson.inAmount || request.amount,
+            outAmount: quoteJson.outAmount || '0',
+        };
+    }
+    async swap(request) {
+        try {
+            return await this.swapViaOrderExecute(request);
+        }
+        catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (!message.includes('404') && !message.includes('fetch failed')) {
+                throw error;
+            }
+            return this.swapViaQuote(request);
+        }
+    }
+}
+exports.JupiterSwapV2Client = JupiterSwapV2Client;
+function needsAutoSwap(request) {
+    const payerCurrency = (request.payerCurrency || request.currency).toUpperCase();
+    const settlementCurrency = request.currency.toUpperCase();
+    return Boolean(request.autoSwap && payerCurrency !== settlementCurrency);
+}

--- a/packages/x402-solana/dist/nonce.d.ts
+++ b/packages/x402-solana/dist/nonce.d.ts
@@ -1,14 +1,17 @@
+import type { NonceReplayStore } from './types';
+export declare class MemoryNonceReplayStore implements NonceReplayStore {
+    private readonly seen;
+    checkAndStore(nonce: string): boolean;
+    clear(): void;
+    get size(): number;
+}
 /**
- * Check if nonce has been seen before, and store it if new
- * @param nonce The nonce to check
- * @returns true if nonce is new, false if duplicate
+ * Check if nonce has been seen before, and store it if new.
+ * @returns true if nonce is new, false if duplicate.
  */
 export declare function checkAndStoreNonce(nonce: string): boolean;
-/**
- * Clear all stored nonces (for testing)
- */
+export declare const defaultNonceReplayStore: NonceReplayStore;
+/** Clear all stored nonces (for testing). */
 export declare function clearNonces(): void;
-/**
- * Get count of stored nonces (for debugging)
- */
+/** Get count of stored nonces (for debugging). */
 export declare function getNonceCount(): number;

--- a/packages/x402-solana/dist/nonce.js
+++ b/packages/x402-solana/dist/nonce.js
@@ -1,34 +1,50 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.defaultNonceReplayStore = exports.MemoryNonceReplayStore = void 0;
 exports.checkAndStoreNonce = checkAndStoreNonce;
 exports.clearNonces = clearNonces;
 exports.getNonceCount = getNonceCount;
 /**
- * In-memory nonce store for replay protection
- * In production, this should use a persistent store (Redis, DB) with TTL
+ * In-memory nonce store for replay protection.
+ * In production, callers should provide a persistent store (Redis/DB) with TTL.
  */
 const seenNonces = new Set();
+class MemoryNonceReplayStore {
+    constructor() {
+        this.seen = new Set();
+    }
+    checkAndStore(nonce) {
+        if (this.seen.has(nonce))
+            return false;
+        this.seen.add(nonce);
+        return true;
+    }
+    clear() {
+        this.seen.clear();
+    }
+    get size() {
+        return this.seen.size;
+    }
+}
+exports.MemoryNonceReplayStore = MemoryNonceReplayStore;
 /**
- * Check if nonce has been seen before, and store it if new
- * @param nonce The nonce to check
- * @returns true if nonce is new, false if duplicate
+ * Check if nonce has been seen before, and store it if new.
+ * @returns true if nonce is new, false if duplicate.
  */
 function checkAndStoreNonce(nonce) {
-    if (seenNonces.has(nonce)) {
-        return false; // Duplicate detected
-    }
+    if (seenNonces.has(nonce))
+        return false;
     seenNonces.add(nonce);
     return true;
 }
-/**
- * Clear all stored nonces (for testing)
- */
+exports.defaultNonceReplayStore = {
+    checkAndStore: checkAndStoreNonce,
+};
+/** Clear all stored nonces (for testing). */
 function clearNonces() {
     seenNonces.clear();
 }
-/**
- * Get count of stored nonces (for debugging)
- */
+/** Get count of stored nonces (for debugging). */
 function getNonceCount() {
     return seenNonces.size;
 }

--- a/packages/x402-solana/dist/payment.d.ts
+++ b/packages/x402-solana/dist/payment.d.ts
@@ -1,19 +1,38 @@
+import { SwapClient } from './jupiter';
 import { X402Request, PaymentReceipt } from './types';
+import type { NonceReplayStore, ReceiptVerificationResult, ReceiptVerifier, X402Challenge, X402ChallengeInput } from './types';
 /**
- * Parse x402-request header into structured request
- * Expected format: JSON string with amount, currency, paymentAddress, nonce
- * @throws Error if header is invalid
+ * Strictly validate canonical Solana public-key text.
+ * Requires base58 decode to exactly 32 bytes and round-trips to the same string.
+ */
+export declare function isValidSolanaPublicKey(address: string): boolean;
+/** Backwards-compatible alias for older callers. */
+export declare const isValidPaymentAddress: typeof isValidSolanaPublicKey;
+export declare function buildX402Challenge(input: X402ChallengeInput): X402Challenge;
+/**
+ * Parse x402-request header into structured request.
+ * Expected format: JSON string with amount, currency, paymentAddress, nonce.
+ * @throws Error if header is invalid.
  */
 export declare function parseX402Header(header: string): X402Request;
+export declare function parseX402PaymentHeader(header: string): unknown;
+export declare function verifyDemoPaymentReceipt(input: {
+    receipt: unknown;
+    challenge: X402Challenge;
+    allowDemoPayment: boolean;
+    replayStore?: NonceReplayStore;
+}): Promise<ReceiptVerificationResult>;
+export declare class DemoPaymentVerifier implements ReceiptVerifier {
+    private readonly allowDemoPayment;
+    constructor(allowDemoPayment: boolean);
+    verifyReceipt(receipt: unknown, challenge: X402Challenge, replayStore?: NonceReplayStore): Promise<ReceiptVerificationResult>;
+}
+export interface SendPaymentOptions {
+    swapClient?: SwapClient;
+    slippageBps?: number;
+}
 /**
- * Send a payment via Solana SystemProgram.transfer
- * In Phase 1, this is a stub. Full implementation in Phase 2.
- * @param request The payment request
- * @returns Promise resolving to payment receipt
+ * Send a payment via Solana SystemProgram.transfer.
+ * In this package version, this remains a test stub; no funding transactions are submitted.
  */
-export declare function sendPayment(request: X402Request): Promise<PaymentReceipt>;
-/**
- * Validate payment address format (basic check)
- * Real validation would use @solana/web3.js PublicKey
- */
-export declare function isValidPaymentAddress(address: string): boolean;
+export declare function sendPayment(request: X402Request, options?: SendPaymentOptions): Promise<PaymentReceipt>;

--- a/packages/x402-solana/dist/payment.js
+++ b/packages/x402-solana/dist/payment.js
@@ -77,10 +77,8 @@ function parseX402Header(header) {
     }
 }
 function parseX402PaymentHeader(header) {
-    if (header.startsWith('demo:')) {
-        const nonce = header.slice('demo:'.length);
-        return { demo: true, token: header, nonce };
-    }
+    if (header.startsWith('demo:'))
+        return header;
     try {
         return JSON.parse(header);
     }
@@ -89,19 +87,19 @@ function parseX402PaymentHeader(header) {
     }
 }
 function normalizeReceipt(receipt) {
-    if (!receipt || typeof receipt !== 'object')
-        return undefined;
-    const record = receipt;
-    if (typeof record.token === 'string' && record.token.startsWith('demo:') && record.demo === true) {
+    if (typeof receipt === 'string' && receipt.startsWith('demo:')) {
         return {
             demo: true,
             network: 'solana-devnet',
             payTo: '',
             amount: '',
             currency: '',
-            nonce: typeof record.nonce === 'string' ? record.nonce : record.token.slice('demo:'.length),
+            nonce: receipt.slice('demo:'.length),
         };
     }
+    if (!receipt || typeof receipt !== 'object')
+        return undefined;
+    const record = receipt;
     if (record.demo === true)
         return undefined;
     if (typeof record.network !== 'string' ||

--- a/packages/x402-solana/dist/payment.js
+++ b/packages/x402-solana/dist/payment.js
@@ -77,8 +77,10 @@ function parseX402Header(header) {
     }
 }
 function parseX402PaymentHeader(header) {
-    if (header.startsWith('demo:'))
-        return { demo: true, token: header };
+    if (header.startsWith('demo:')) {
+        const nonce = header.slice('demo:'.length);
+        return { demo: true, token: header, nonce };
+    }
     try {
         return JSON.parse(header);
     }
@@ -90,19 +92,18 @@ function normalizeReceipt(receipt) {
     if (!receipt || typeof receipt !== 'object')
         return undefined;
     const record = receipt;
-    if (record.demo === true || (typeof record.token === 'string' && record.token.startsWith('demo:'))) {
+    if (typeof record.token === 'string' && record.token.startsWith('demo:') && record.demo === true) {
         return {
             demo: true,
-            network: typeof record.network === 'string' ? record.network : 'solana-devnet',
-            payTo: typeof record.payTo === 'string' ? record.payTo : '',
-            amount: typeof record.amount === 'string' || typeof record.amount === 'number' ? record.amount : '',
-            currency: typeof record.currency === 'string' ? record.currency : '',
-            nonce: typeof record.nonce === 'string' ? record.nonce : '',
-            signature: typeof record.signature === 'string' ? record.signature : undefined,
-            txSignature: typeof record.txSignature === 'string' ? record.txSignature : undefined,
-            payer: typeof record.payer === 'string' ? record.payer : undefined,
+            network: 'solana-devnet',
+            payTo: '',
+            amount: '',
+            currency: '',
+            nonce: typeof record.nonce === 'string' ? record.nonce : record.token.slice('demo:'.length),
         };
     }
+    if (record.demo === true)
+        return undefined;
     if (typeof record.network !== 'string' ||
         typeof record.payTo !== 'string' ||
         (typeof record.amount !== 'string' && typeof record.amount !== 'number') ||
@@ -128,13 +129,14 @@ async function verifyDemoPaymentReceipt(input) {
     }
     const receipt = normalizeReceipt(input.receipt);
     if (!receipt)
-        return { ok: false, reason: 'invalid_receipt', message: 'x402 payment receipt is not structured JSON/demo receipt' };
+        return { ok: false, reason: 'invalid_receipt', message: 'x402 payment receipt is not an explicit demo receipt' };
+    if (!receipt.demo)
+        return { ok: false, reason: 'unsupported_receipt', message: 'real Solana receipt verification is not implemented yet' };
     const expected = input.challenge;
-    if (receipt.demo && receipt.payTo === '' && receipt.amount === '' && receipt.currency === '' && receipt.nonce === '') {
+    if (receipt.demo && receipt.payTo === '' && receipt.amount === '' && receipt.currency === '') {
         receipt.payTo = expected.payTo;
         receipt.amount = expected.amount;
         receipt.currency = expected.currency;
-        receipt.nonce = expected.nonce;
         receipt.network = expected.network;
     }
     if (receipt.network !== expected.network) {

--- a/packages/x402-solana/dist/payment.js
+++ b/packages/x402-solana/dist/payment.js
@@ -1,68 +1,217 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.DemoPaymentVerifier = exports.isValidPaymentAddress = void 0;
+exports.isValidSolanaPublicKey = isValidSolanaPublicKey;
+exports.buildX402Challenge = buildX402Challenge;
 exports.parseX402Header = parseX402Header;
+exports.parseX402PaymentHeader = parseX402PaymentHeader;
+exports.verifyDemoPaymentReceipt = verifyDemoPaymentReceipt;
 exports.sendPayment = sendPayment;
-exports.isValidPaymentAddress = isValidPaymentAddress;
+const web3_js_1 = require("@solana/web3.js");
+const jupiter_1 = require("./jupiter");
+const SUPPORTED_NETWORKS = ['solana-devnet', 'solana-mainnet-beta', 'solana-testnet'];
 /**
- * Parse x402-request header into structured request
- * Expected format: JSON string with amount, currency, paymentAddress, nonce
- * @throws Error if header is invalid
+ * Strictly validate canonical Solana public-key text.
+ * Requires base58 decode to exactly 32 bytes and round-trips to the same string.
+ */
+function isValidSolanaPublicKey(address) {
+    if (typeof address !== 'string' || address.trim() !== address || address.length === 0)
+        return false;
+    try {
+        const publicKey = new web3_js_1.PublicKey(address);
+        return publicKey.toBytes().length === 32 && publicKey.toBase58() === address;
+    }
+    catch {
+        return false;
+    }
+}
+/** Backwards-compatible alias for older callers. */
+exports.isValidPaymentAddress = isValidSolanaPublicKey;
+function buildX402Challenge(input) {
+    if (!SUPPORTED_NETWORKS.includes(input.network))
+        throw new Error(`unsupported Solana network: ${input.network}`);
+    if (!isValidSolanaPublicKey(input.payTo))
+        throw new Error('payTo must be a valid Solana public key');
+    if (!input.nonce || typeof input.nonce !== 'string')
+        throw new Error('nonce is required');
+    if (!input.currency || typeof input.currency !== 'string')
+        throw new Error('currency is required');
+    if (String(input.amount).length === 0 || Number(input.amount) <= 0)
+        throw new Error('amount must be positive');
+    if (!input.endpoint || typeof input.endpoint !== 'string')
+        throw new Error('endpoint is required');
+    return { version: input.version ?? '1', ...input };
+}
+/**
+ * Parse x402-request header into structured request.
+ * Expected format: JSON string with amount, currency, paymentAddress, nonce.
+ * @throws Error if header is invalid.
  */
 function parseX402Header(header) {
     try {
         const parsed = JSON.parse(header);
-        // Validate required fields
-        if (typeof parsed.amount !== 'number' || parsed.amount <= 0) {
+        if (typeof parsed.amount !== 'number' || parsed.amount <= 0)
             throw new Error('amount must be a positive number');
-        }
-        if (!parsed.currency || typeof parsed.currency !== 'string') {
+        if (!parsed.currency || typeof parsed.currency !== 'string')
             throw new Error('currency is required (e.g., "SOL")');
-        }
-        if (!parsed.paymentAddress || typeof parsed.paymentAddress !== 'string') {
+        if (!parsed.paymentAddress || typeof parsed.paymentAddress !== 'string')
             throw new Error('paymentAddress is required');
-        }
-        if (!parsed.nonce || typeof parsed.nonce !== 'string') {
+        if (!parsed.nonce || typeof parsed.nonce !== 'string')
             throw new Error('nonce is required');
-        }
+        if (!isValidSolanaPublicKey(parsed.paymentAddress))
+            throw new Error('paymentAddress must be a valid Solana public key');
         return {
             amount: parsed.amount,
             currency: parsed.currency,
             paymentAddress: parsed.paymentAddress,
             nonce: parsed.nonce,
+            payerCurrency: typeof parsed.payerCurrency === 'string' ? parsed.payerCurrency : undefined,
+            payerAddress: typeof parsed.payerAddress === 'string' ? parsed.payerAddress : undefined,
+            autoSwap: typeof parsed.autoSwap === 'boolean' ? parsed.autoSwap : false,
         };
     }
     catch (e) {
-        if (e instanceof SyntaxError) {
+        if (e instanceof SyntaxError)
             throw new Error('x402-request header is not valid JSON');
-        }
         throw e;
     }
 }
+function parseX402PaymentHeader(header) {
+    if (header.startsWith('demo:'))
+        return { demo: true, token: header };
+    try {
+        return JSON.parse(header);
+    }
+    catch {
+        return header;
+    }
+}
+function normalizeReceipt(receipt) {
+    if (!receipt || typeof receipt !== 'object')
+        return undefined;
+    const record = receipt;
+    if (record.demo === true || (typeof record.token === 'string' && record.token.startsWith('demo:'))) {
+        return {
+            demo: true,
+            network: typeof record.network === 'string' ? record.network : 'solana-devnet',
+            payTo: typeof record.payTo === 'string' ? record.payTo : '',
+            amount: typeof record.amount === 'string' || typeof record.amount === 'number' ? record.amount : '',
+            currency: typeof record.currency === 'string' ? record.currency : '',
+            nonce: typeof record.nonce === 'string' ? record.nonce : '',
+            signature: typeof record.signature === 'string' ? record.signature : undefined,
+            txSignature: typeof record.txSignature === 'string' ? record.txSignature : undefined,
+            payer: typeof record.payer === 'string' ? record.payer : undefined,
+        };
+    }
+    if (typeof record.network !== 'string' ||
+        typeof record.payTo !== 'string' ||
+        (typeof record.amount !== 'string' && typeof record.amount !== 'number') ||
+        typeof record.currency !== 'string' ||
+        typeof record.nonce !== 'string') {
+        return undefined;
+    }
+    return {
+        network: record.network,
+        payTo: record.payTo,
+        amount: record.amount,
+        currency: record.currency,
+        nonce: record.nonce,
+        signature: typeof record.signature === 'string' ? record.signature : undefined,
+        txSignature: typeof record.txSignature === 'string' ? record.txSignature : undefined,
+        payer: typeof record.payer === 'string' ? record.payer : undefined,
+        demo: record.demo === true,
+    };
+}
+async function verifyDemoPaymentReceipt(input) {
+    if (!input.allowDemoPayment) {
+        return { ok: false, reason: 'demo_payment_disabled', message: 'demo x402 payments require explicit ALLOW_DEMO_X402_PAYMENT' };
+    }
+    const receipt = normalizeReceipt(input.receipt);
+    if (!receipt)
+        return { ok: false, reason: 'invalid_receipt', message: 'x402 payment receipt is not structured JSON/demo receipt' };
+    const expected = input.challenge;
+    if (receipt.demo && receipt.payTo === '' && receipt.amount === '' && receipt.currency === '' && receipt.nonce === '') {
+        receipt.payTo = expected.payTo;
+        receipt.amount = expected.amount;
+        receipt.currency = expected.currency;
+        receipt.nonce = expected.nonce;
+        receipt.network = expected.network;
+    }
+    if (receipt.network !== expected.network) {
+        return { ok: false, reason: 'wrong_network', message: 'receipt network does not match challenge', expected: expected.network, actual: receipt.network };
+    }
+    if (!isValidSolanaPublicKey(receipt.payTo)) {
+        return { ok: false, reason: 'invalid_payee', message: 'receipt payTo is not a valid Solana public key', actual: receipt.payTo };
+    }
+    if (receipt.payTo !== expected.payTo) {
+        return { ok: false, reason: 'wrong_payee', message: 'receipt payee does not match challenge', expected: expected.payTo, actual: receipt.payTo };
+    }
+    if (String(receipt.amount) !== String(expected.amount)) {
+        return { ok: false, reason: 'wrong_amount', message: 'receipt amount does not match challenge', expected: expected.amount, actual: receipt.amount };
+    }
+    if (receipt.currency !== expected.currency) {
+        return { ok: false, reason: 'wrong_currency', message: 'receipt currency does not match challenge', expected: expected.currency, actual: receipt.currency };
+    }
+    if (receipt.nonce !== expected.nonce) {
+        return { ok: false, reason: 'invalid_nonce', message: 'receipt nonce does not match challenge', expected: expected.nonce, actual: receipt.nonce };
+    }
+    if (input.replayStore) {
+        const accepted = await input.replayStore.checkAndStore(receipt.nonce);
+        if (!accepted)
+            return { ok: false, reason: 'duplicate_nonce', message: 'receipt nonce has already been used', actual: receipt.nonce };
+    }
+    return { ok: true, receipt, demo: true };
+}
+class DemoPaymentVerifier {
+    constructor(allowDemoPayment) {
+        this.allowDemoPayment = allowDemoPayment;
+    }
+    verifyReceipt(receipt, challenge, replayStore) {
+        return verifyDemoPaymentReceipt({ receipt, challenge, allowDemoPayment: this.allowDemoPayment, replayStore });
+    }
+}
+exports.DemoPaymentVerifier = DemoPaymentVerifier;
 /**
- * Send a payment via Solana SystemProgram.transfer
- * In Phase 1, this is a stub. Full implementation in Phase 2.
- * @param request The payment request
- * @returns Promise resolving to payment receipt
+ * Send a payment via Solana SystemProgram.transfer.
+ * In this package version, this remains a test stub; no funding transactions are submitted.
  */
-async function sendPayment(request) {
-    // Phase 2 implementation will:
-    // - Create a Solana connection
-    // - Load payer keypair
-    // - Create SystemProgram.transfer instruction
-    // - Send and confirm transaction with 5s timeout
-    // - Return receipt with txSignature, slot, etc.
-    // For now, return a mock receipt for testing
+async function sendPayment(request, options = {}) {
+    let swapMeta;
+    if ((0, jupiter_1.needsAutoSwap)(request)) {
+        if (!options.swapClient)
+            throw new Error('token_mismatch_requires_swap_client');
+        if (!request.payerAddress)
+            throw new Error('payerAddress is required when autoSwap=true');
+        const swapResult = await options.swapClient.swap({
+            inputMint: (0, jupiter_1.resolveMint)(request.payerCurrency || request.currency),
+            outputMint: (0, jupiter_1.resolveMint)(request.currency),
+            amount: String(request.amount),
+            userPublicKey: request.payerAddress,
+            slippageBps: options.slippageBps ?? 50,
+        });
+        swapMeta = {
+            performed: true,
+            fromCurrency: request.payerCurrency,
+            toCurrency: request.currency,
+            orderId: swapResult.orderId,
+            executeId: swapResult.executeId,
+            inAmount: swapResult.inAmount,
+            outAmount: swapResult.outAmount,
+        };
+    }
+    else {
+        swapMeta = {
+            performed: false,
+            fromCurrency: request.payerCurrency || request.currency,
+            toCurrency: request.currency,
+        };
+    }
     return {
         txSignature: 'mock_tx_signature_' + Math.random().toString(36).substring(7),
         slot: Math.floor(Math.random() * 1000000),
         lamports: request.amount,
         nonce: request.nonce,
+        settlementCurrency: request.currency,
+        swap: swapMeta,
     };
-}
-/**
- * Validate payment address format (basic check)
- * Real validation would use @solana/web3.js PublicKey
- */
-function isValidPaymentAddress(address) {
-    return address.length >= 32 && address.length <= 44; // Base58 Solana addresses
 }

--- a/packages/x402-solana/dist/types.d.ts
+++ b/packages/x402-solana/dist/types.d.ts
@@ -1,22 +1,83 @@
 /**
- * x402 payment request parsed from HTTP header
+ * x402 payment request parsed from HTTP header.
+ * Amount is represented as the smallest payment unit for the declared currency.
  */
 export interface X402Request {
     amount: number;
     currency: string;
     paymentAddress: string;
     nonce: string;
+    payerCurrency?: string;
+    payerAddress?: string;
+    autoSwap?: boolean;
+}
+export type SolanaPaymentNetwork = 'solana-devnet' | 'solana-mainnet-beta' | 'solana-testnet';
+export interface X402ChallengeInput {
+    version?: string;
+    network: SolanaPaymentNetwork;
+    payTo: string;
+    amount: string | number;
+    currency: string;
+    endpoint: string;
+    nonce: string;
+    memo?: string;
+}
+export interface X402Challenge extends X402ChallengeInput {
+    version: string;
 }
 /**
- * Payment receipt after successful SOL transfer
+ * Receipt shape used by specialist-side verifiers. This package deliberately
+ * does not require secrets or submit transactions.
+ */
+export interface X402PaymentReceipt {
+    network: SolanaPaymentNetwork;
+    payTo: string;
+    amount: string | number;
+    currency: string;
+    nonce: string;
+    signature?: string;
+    txSignature?: string;
+    payer?: string;
+    demo?: boolean;
+}
+/**
+ * Payment receipt after successful SOL transfer.
  */
 export interface PaymentReceipt {
     txSignature: string;
     slot: number;
     lamports: number;
     nonce: string;
+    settlementCurrency?: string;
+    swap?: {
+        performed: boolean;
+        fromCurrency?: string;
+        toCurrency?: string;
+        orderId?: string;
+        executeId?: string;
+        inAmount?: string;
+        outAmount?: string;
+    };
+}
+export type ReceiptVerificationFailureReason = 'invalid_receipt' | 'invalid_payee' | 'invalid_nonce' | 'duplicate_nonce' | 'wrong_amount' | 'wrong_currency' | 'wrong_payee' | 'wrong_network' | 'demo_payment_disabled' | 'unsupported_receipt';
+export type ReceiptVerificationResult = {
+    ok: true;
+    receipt: X402PaymentReceipt;
+    demo: boolean;
+} | {
+    ok: false;
+    reason: ReceiptVerificationFailureReason;
+    message: string;
+    expected?: unknown;
+    actual?: unknown;
+};
+export interface NonceReplayStore {
+    checkAndStore(nonce: string): boolean | Promise<boolean>;
+}
+export interface ReceiptVerifier {
+    verifyReceipt(receipt: unknown, challenge: X402Challenge, replayStore?: NonceReplayStore): Promise<ReceiptVerificationResult>;
 }
 /**
- * x402 error codes
+ * x402 error codes.
  */
 export type X402Error = 'insufficient_funds' | 'duplicate_nonce' | 'invalid_request' | 'rpc_timeout' | 'unauthorized';

--- a/packages/x402-solana/package-lock.json
+++ b/packages/x402-solana/package-lock.json
@@ -4937,20 +4937,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",

--- a/packages/x402-solana/package.json
+++ b/packages/x402-solana/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "node ./node_modules/typescript/lib/tsc.js",
     "test": "jest",
     "clean": "rm -rf dist"
   },

--- a/packages/x402-solana/src/index.ts
+++ b/packages/x402-solana/src/index.ts
@@ -9,3 +9,4 @@ export * from './types';
 export * from './nonce';
 export * from './payment';
 export * from './middleware';
+export * from './jupiter';

--- a/packages/x402-solana/src/index.ts
+++ b/packages/x402-solana/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * @reddi/x402-solana — HTTP 402 Payment Middleware for Solana
- * 
+ *
  * Enables trustless micropayment flows between agents using x402 standard
  * and Solana's on-chain escrow (Phase 0: Anchor program)
  */
@@ -9,4 +9,3 @@ export * from './types';
 export * from './nonce';
 export * from './payment';
 export * from './middleware';
-export * from './jupiter';

--- a/packages/x402-solana/src/middleware.ts
+++ b/packages/x402-solana/src/middleware.ts
@@ -1,31 +1,13 @@
 import { parseX402Header, sendPayment, isValidPaymentAddress } from './payment';
 import { checkAndStoreNonce } from './nonce';
 import { X402Request, PaymentReceipt } from './types';
-import { SwapClient } from './jupiter';
-
-type ReqLike = {
-  headers: Record<string, string | undefined>;
-};
-
-type ResLike = {
-  status: (code: number) => ResLike;
-  json: (payload: unknown) => unknown;
-  setHeader: (name: string, value: string) => void;
-};
-
-type NextLike = () => unknown;
-
-export interface X402MiddlewareOptions {
-  swapClient?: SwapClient;
-  slippageBps?: number;
-}
 
 /**
  * Express middleware for x402 payment processing
  * Intercepts requests with x402-request header, validates, and sends payment
  */
-export function createX402Middleware(options: X402MiddlewareOptions = {}) {
-  return async (req: ReqLike, res: ResLike, next: NextLike) => {
+export function createX402Middleware() {
+  return async (req: any, res: any, next: any) => {
     // Check for x402-request header
     const header = req.headers['x402-request'] as string | undefined;
     if (!header) {
@@ -53,10 +35,7 @@ export function createX402Middleware(options: X402MiddlewareOptions = {}) {
       }
 
       // Send the payment (Phase 2 will implement actual Solana transfer)
-      const receipt: PaymentReceipt = await sendPayment(x402req, {
-        swapClient: options.swapClient,
-        slippageBps: options.slippageBps,
-      });
+      const receipt: PaymentReceipt = await sendPayment(x402req);
 
       // Set response headers
       res.setHeader('x402-payment', JSON.stringify(receipt));
@@ -64,33 +43,25 @@ export function createX402Middleware(options: X402MiddlewareOptions = {}) {
         message: 'payment_processed',
         receipt,
       });
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : 'invalid_request';
-
+    } catch (error: any) {
       // Handle different error types
-      if (message.includes('JSON')) {
+      if (error.message.includes('JSON')) {
         return res.status(400).json({
           error: 'invalid_request',
-          detail: message,
+          detail: error.message,
         });
       }
-      if (message.includes('timeout')) {
+      if (error.message.includes('timeout')) {
         return res.status(503).json({
           error: 'rpc_timeout',
           detail: 'Payment confirmation timeout',
-        });
-      }
-      if (message.includes('token_mismatch_requires_swap_client')) {
-        return res.status(400).json({
-          error: 'invalid_request',
-          detail: 'Token mismatch detected but no Jupiter swap client configured',
         });
       }
 
       // Generic error
       return res.status(400).json({
         error: 'invalid_request',
-        detail: message,
+        detail: error.message,
       });
     }
   };
@@ -103,8 +74,7 @@ export function createX402Header(
   amount: number,
   paymentAddress: string,
   nonce: string,
-  currency = 'SOL',
-  extras?: Partial<Pick<X402Request, 'payerCurrency' | 'payerAddress' | 'autoSwap'>>
+  currency = 'SOL'
 ): string {
-  return JSON.stringify({ amount, currency, paymentAddress, nonce, ...extras });
+  return JSON.stringify({ amount, currency, paymentAddress, nonce });
 }

--- a/packages/x402-solana/src/nonce.ts
+++ b/packages/x402-solana/src/nonce.ts
@@ -1,32 +1,49 @@
+import type { NonceReplayStore } from './types';
+
 /**
- * In-memory nonce store for replay protection
- * In production, this should use a persistent store (Redis, DB) with TTL
+ * In-memory nonce store for replay protection.
+ * In production, callers should provide a persistent store (Redis/DB) with TTL.
  */
 const seenNonces = new Set<string>();
 
+export class MemoryNonceReplayStore implements NonceReplayStore {
+  private readonly seen = new Set<string>();
+
+  checkAndStore(nonce: string): boolean {
+    if (this.seen.has(nonce)) return false;
+    this.seen.add(nonce);
+    return true;
+  }
+
+  clear(): void {
+    this.seen.clear();
+  }
+
+  get size(): number {
+    return this.seen.size;
+  }
+}
+
 /**
- * Check if nonce has been seen before, and store it if new
- * @param nonce The nonce to check
- * @returns true if nonce is new, false if duplicate
+ * Check if nonce has been seen before, and store it if new.
+ * @returns true if nonce is new, false if duplicate.
  */
 export function checkAndStoreNonce(nonce: string): boolean {
-  if (seenNonces.has(nonce)) {
-    return false; // Duplicate detected
-  }
+  if (seenNonces.has(nonce)) return false;
   seenNonces.add(nonce);
   return true;
 }
 
-/**
- * Clear all stored nonces (for testing)
- */
+export const defaultNonceReplayStore: NonceReplayStore = {
+  checkAndStore: checkAndStoreNonce,
+};
+
+/** Clear all stored nonces (for testing). */
 export function clearNonces(): void {
   seenNonces.clear();
 }
 
-/**
- * Get count of stored nonces (for debugging)
- */
+/** Get count of stored nonces (for debugging). */
 export function getNonceCount(): number {
   return seenNonces.size;
 }

--- a/packages/x402-solana/src/payment.ts
+++ b/packages/x402-solana/src/payment.ts
@@ -69,10 +69,7 @@ export function parseX402Header(header: string): X402Request {
 }
 
 export function parseX402PaymentHeader(header: string): unknown {
-  if (header.startsWith('demo:')) {
-    const nonce = header.slice('demo:'.length);
-    return { demo: true, token: header, nonce };
-  }
+  if (header.startsWith('demo:')) return header;
   try {
     return JSON.parse(header);
   } catch {
@@ -81,18 +78,18 @@ export function parseX402PaymentHeader(header: string): unknown {
 }
 
 function normalizeReceipt(receipt: unknown): X402PaymentReceipt | undefined {
-  if (!receipt || typeof receipt !== 'object') return undefined;
-  const record = receipt as Record<string, unknown>;
-  if (typeof record.token === 'string' && record.token.startsWith('demo:') && record.demo === true) {
+  if (typeof receipt === 'string' && receipt.startsWith('demo:')) {
     return {
       demo: true,
       network: 'solana-devnet',
       payTo: '',
       amount: '',
       currency: '',
-      nonce: typeof record.nonce === 'string' ? record.nonce : record.token.slice('demo:'.length),
+      nonce: receipt.slice('demo:'.length),
     };
   }
+  if (!receipt || typeof receipt !== 'object') return undefined;
+  const record = receipt as Record<string, unknown>;
   if (record.demo === true) return undefined;
   if (
     typeof record.network !== 'string' ||

--- a/packages/x402-solana/src/payment.ts
+++ b/packages/x402-solana/src/payment.ts
@@ -69,7 +69,10 @@ export function parseX402Header(header: string): X402Request {
 }
 
 export function parseX402PaymentHeader(header: string): unknown {
-  if (header.startsWith('demo:')) return { demo: true, token: header };
+  if (header.startsWith('demo:')) {
+    const nonce = header.slice('demo:'.length);
+    return { demo: true, token: header, nonce };
+  }
   try {
     return JSON.parse(header);
   } catch {
@@ -80,19 +83,17 @@ export function parseX402PaymentHeader(header: string): unknown {
 function normalizeReceipt(receipt: unknown): X402PaymentReceipt | undefined {
   if (!receipt || typeof receipt !== 'object') return undefined;
   const record = receipt as Record<string, unknown>;
-  if (record.demo === true || (typeof record.token === 'string' && record.token.startsWith('demo:'))) {
+  if (typeof record.token === 'string' && record.token.startsWith('demo:') && record.demo === true) {
     return {
       demo: true,
-      network: typeof record.network === 'string' ? (record.network as SolanaPaymentNetwork) : 'solana-devnet',
-      payTo: typeof record.payTo === 'string' ? record.payTo : '',
-      amount: typeof record.amount === 'string' || typeof record.amount === 'number' ? record.amount : '',
-      currency: typeof record.currency === 'string' ? record.currency : '',
-      nonce: typeof record.nonce === 'string' ? record.nonce : '',
-      signature: typeof record.signature === 'string' ? record.signature : undefined,
-      txSignature: typeof record.txSignature === 'string' ? record.txSignature : undefined,
-      payer: typeof record.payer === 'string' ? record.payer : undefined,
+      network: 'solana-devnet',
+      payTo: '',
+      amount: '',
+      currency: '',
+      nonce: typeof record.nonce === 'string' ? record.nonce : record.token.slice('demo:'.length),
     };
   }
+  if (record.demo === true) return undefined;
   if (
     typeof record.network !== 'string' ||
     typeof record.payTo !== 'string' ||
@@ -126,14 +127,14 @@ export async function verifyDemoPaymentReceipt(input: {
   }
 
   const receipt = normalizeReceipt(input.receipt);
-  if (!receipt) return { ok: false, reason: 'invalid_receipt', message: 'x402 payment receipt is not structured JSON/demo receipt' };
+  if (!receipt) return { ok: false, reason: 'invalid_receipt', message: 'x402 payment receipt is not an explicit demo receipt' };
+  if (!receipt.demo) return { ok: false, reason: 'unsupported_receipt', message: 'real Solana receipt verification is not implemented yet' };
 
   const expected = input.challenge;
-  if (receipt.demo && receipt.payTo === '' && receipt.amount === '' && receipt.currency === '' && receipt.nonce === '') {
+  if (receipt.demo && receipt.payTo === '' && receipt.amount === '' && receipt.currency === '') {
     receipt.payTo = expected.payTo;
     receipt.amount = expected.amount;
     receipt.currency = expected.currency;
-    receipt.nonce = expected.nonce;
     receipt.network = expected.network;
   }
 

--- a/packages/x402-solana/src/payment.ts
+++ b/packages/x402-solana/src/payment.ts
@@ -1,34 +1,58 @@
-import { X402Request, PaymentReceipt } from './types';
+import { PublicKey } from '@solana/web3.js';
 import { needsAutoSwap, resolveMint, SwapClient } from './jupiter';
+import { X402Request, PaymentReceipt } from './types';
+import type {
+  NonceReplayStore,
+  ReceiptVerificationResult,
+  ReceiptVerifier,
+  SolanaPaymentNetwork,
+  X402Challenge,
+  X402ChallengeInput,
+  X402PaymentReceipt,
+} from './types';
 
-export interface SendPaymentOptions {
-  swapClient?: SwapClient;
-  slippageBps?: number;
+const SUPPORTED_NETWORKS: SolanaPaymentNetwork[] = ['solana-devnet', 'solana-mainnet-beta', 'solana-testnet'];
+
+/**
+ * Strictly validate canonical Solana public-key text.
+ * Requires base58 decode to exactly 32 bytes and round-trips to the same string.
+ */
+export function isValidSolanaPublicKey(address: string): boolean {
+  if (typeof address !== 'string' || address.trim() !== address || address.length === 0) return false;
+  try {
+    const publicKey = new PublicKey(address);
+    return publicKey.toBytes().length === 32 && publicKey.toBase58() === address;
+  } catch {
+    return false;
+  }
+}
+
+/** Backwards-compatible alias for older callers. */
+export const isValidPaymentAddress = isValidSolanaPublicKey;
+
+export function buildX402Challenge(input: X402ChallengeInput): X402Challenge {
+  if (!SUPPORTED_NETWORKS.includes(input.network)) throw new Error(`unsupported Solana network: ${input.network}`);
+  if (!isValidSolanaPublicKey(input.payTo)) throw new Error('payTo must be a valid Solana public key');
+  if (!input.nonce || typeof input.nonce !== 'string') throw new Error('nonce is required');
+  if (!input.currency || typeof input.currency !== 'string') throw new Error('currency is required');
+  if (String(input.amount).length === 0 || Number(input.amount) <= 0) throw new Error('amount must be positive');
+  if (!input.endpoint || typeof input.endpoint !== 'string') throw new Error('endpoint is required');
+  return { version: input.version ?? '1', ...input };
 }
 
 /**
- * Parse x402-request header into structured request
- * Expected format: JSON string with amount, currency, paymentAddress, nonce
- * @throws Error if header is invalid
+ * Parse x402-request header into structured request.
+ * Expected format: JSON string with amount, currency, paymentAddress, nonce.
+ * @throws Error if header is invalid.
  */
 export function parseX402Header(header: string): X402Request {
   try {
     const parsed = JSON.parse(header);
-    
-    // Validate required fields
-    if (typeof parsed.amount !== 'number' || parsed.amount <= 0) {
-      throw new Error('amount must be a positive number');
-    }
-    if (!parsed.currency || typeof parsed.currency !== 'string') {
-      throw new Error('currency is required (e.g., "SOL")');
-    }
-    if (!parsed.paymentAddress || typeof parsed.paymentAddress !== 'string') {
-      throw new Error('paymentAddress is required');
-    }
-    if (!parsed.nonce || typeof parsed.nonce !== 'string') {
-      throw new Error('nonce is required');
-    }
-
+    if (typeof parsed.amount !== 'number' || parsed.amount <= 0) throw new Error('amount must be a positive number');
+    if (!parsed.currency || typeof parsed.currency !== 'string') throw new Error('currency is required (e.g., "SOL")');
+    if (!parsed.paymentAddress || typeof parsed.paymentAddress !== 'string') throw new Error('paymentAddress is required');
+    if (!parsed.nonce || typeof parsed.nonce !== 'string') throw new Error('nonce is required');
+    if (!isValidSolanaPublicKey(parsed.paymentAddress)) throw new Error('paymentAddress must be a valid Solana public key');
     return {
       amount: parsed.amount,
       currency: parsed.currency,
@@ -38,48 +62,136 @@ export function parseX402Header(header: string): X402Request {
       payerAddress: typeof parsed.payerAddress === 'string' ? parsed.payerAddress : undefined,
       autoSwap: typeof parsed.autoSwap === 'boolean' ? parsed.autoSwap : false,
     };
-  } catch (error: unknown) {
-    if (error instanceof SyntaxError) {
-      throw new Error('x402-request header is not valid JSON');
-    }
-    throw error;
+  } catch (e: any) {
+    if (e instanceof SyntaxError) throw new Error('x402-request header is not valid JSON');
+    throw e;
   }
 }
 
-/**
- * Send a payment via Solana SystemProgram.transfer
- * In Phase 1, this is a stub. Full implementation in Phase 2.
- * @param request The payment request
- * @returns Promise resolving to payment receipt
- */
-export async function sendPayment(
-  request: X402Request,
-  options: SendPaymentOptions = {}
-): Promise<PaymentReceipt> {
-  // Phase 2 implementation will:
-  // - Create a Solana connection
-  // - Load payer keypair
-  // - Create SystemProgram.transfer instruction
-  // - Send and confirm transaction with 5s timeout
-  // - Return receipt with txSignature, slot, etc.
+export function parseX402PaymentHeader(header: string): unknown {
+  if (header.startsWith('demo:')) return { demo: true, token: header };
+  try {
+    return JSON.parse(header);
+  } catch {
+    return header;
+  }
+}
 
+function normalizeReceipt(receipt: unknown): X402PaymentReceipt | undefined {
+  if (!receipt || typeof receipt !== 'object') return undefined;
+  const record = receipt as Record<string, unknown>;
+  if (record.demo === true || (typeof record.token === 'string' && record.token.startsWith('demo:'))) {
+    return {
+      demo: true,
+      network: typeof record.network === 'string' ? (record.network as SolanaPaymentNetwork) : 'solana-devnet',
+      payTo: typeof record.payTo === 'string' ? record.payTo : '',
+      amount: typeof record.amount === 'string' || typeof record.amount === 'number' ? record.amount : '',
+      currency: typeof record.currency === 'string' ? record.currency : '',
+      nonce: typeof record.nonce === 'string' ? record.nonce : '',
+      signature: typeof record.signature === 'string' ? record.signature : undefined,
+      txSignature: typeof record.txSignature === 'string' ? record.txSignature : undefined,
+      payer: typeof record.payer === 'string' ? record.payer : undefined,
+    };
+  }
+  if (
+    typeof record.network !== 'string' ||
+    typeof record.payTo !== 'string' ||
+    (typeof record.amount !== 'string' && typeof record.amount !== 'number') ||
+    typeof record.currency !== 'string' ||
+    typeof record.nonce !== 'string'
+  ) {
+    return undefined;
+  }
+  return {
+    network: record.network as SolanaPaymentNetwork,
+    payTo: record.payTo,
+    amount: record.amount,
+    currency: record.currency,
+    nonce: record.nonce,
+    signature: typeof record.signature === 'string' ? record.signature : undefined,
+    txSignature: typeof record.txSignature === 'string' ? record.txSignature : undefined,
+    payer: typeof record.payer === 'string' ? record.payer : undefined,
+    demo: record.demo === true,
+  };
+}
+
+export async function verifyDemoPaymentReceipt(input: {
+  receipt: unknown;
+  challenge: X402Challenge;
+  allowDemoPayment: boolean;
+  replayStore?: NonceReplayStore;
+}): Promise<ReceiptVerificationResult> {
+  if (!input.allowDemoPayment) {
+    return { ok: false, reason: 'demo_payment_disabled', message: 'demo x402 payments require explicit ALLOW_DEMO_X402_PAYMENT' };
+  }
+
+  const receipt = normalizeReceipt(input.receipt);
+  if (!receipt) return { ok: false, reason: 'invalid_receipt', message: 'x402 payment receipt is not structured JSON/demo receipt' };
+
+  const expected = input.challenge;
+  if (receipt.demo && receipt.payTo === '' && receipt.amount === '' && receipt.currency === '' && receipt.nonce === '') {
+    receipt.payTo = expected.payTo;
+    receipt.amount = expected.amount;
+    receipt.currency = expected.currency;
+    receipt.nonce = expected.nonce;
+    receipt.network = expected.network;
+  }
+
+  if (receipt.network !== expected.network) {
+    return { ok: false, reason: 'wrong_network', message: 'receipt network does not match challenge', expected: expected.network, actual: receipt.network };
+  }
+  if (!isValidSolanaPublicKey(receipt.payTo)) {
+    return { ok: false, reason: 'invalid_payee', message: 'receipt payTo is not a valid Solana public key', actual: receipt.payTo };
+  }
+  if (receipt.payTo !== expected.payTo) {
+    return { ok: false, reason: 'wrong_payee', message: 'receipt payee does not match challenge', expected: expected.payTo, actual: receipt.payTo };
+  }
+  if (String(receipt.amount) !== String(expected.amount)) {
+    return { ok: false, reason: 'wrong_amount', message: 'receipt amount does not match challenge', expected: expected.amount, actual: receipt.amount };
+  }
+  if (receipt.currency !== expected.currency) {
+    return { ok: false, reason: 'wrong_currency', message: 'receipt currency does not match challenge', expected: expected.currency, actual: receipt.currency };
+  }
+  if (receipt.nonce !== expected.nonce) {
+    return { ok: false, reason: 'invalid_nonce', message: 'receipt nonce does not match challenge', expected: expected.nonce, actual: receipt.nonce };
+  }
+  if (input.replayStore) {
+    const accepted = await input.replayStore.checkAndStore(receipt.nonce);
+    if (!accepted) return { ok: false, reason: 'duplicate_nonce', message: 'receipt nonce has already been used', actual: receipt.nonce };
+  }
+
+  return { ok: true, receipt, demo: true };
+}
+
+export class DemoPaymentVerifier implements ReceiptVerifier {
+  constructor(private readonly allowDemoPayment: boolean) {}
+
+  verifyReceipt(receipt: unknown, challenge: X402Challenge, replayStore?: NonceReplayStore): Promise<ReceiptVerificationResult> {
+    return verifyDemoPaymentReceipt({ receipt, challenge, allowDemoPayment: this.allowDemoPayment, replayStore });
+  }
+}
+
+export interface SendPaymentOptions {
+  swapClient?: SwapClient;
+  slippageBps?: number;
+}
+
+/**
+ * Send a payment via Solana SystemProgram.transfer.
+ * In this package version, this remains a test stub; no funding transactions are submitted.
+ */
+export async function sendPayment(request: X402Request, options: SendPaymentOptions = {}): Promise<PaymentReceipt> {
   let swapMeta: PaymentReceipt['swap'];
 
   if (needsAutoSwap(request)) {
-    if (!options.swapClient) {
-      throw new Error('token_mismatch_requires_swap_client');
-    }
-
-    const payerAddress = request.payerAddress;
-    if (!payerAddress) {
-      throw new Error('payerAddress is required when autoSwap=true');
-    }
+    if (!options.swapClient) throw new Error('token_mismatch_requires_swap_client');
+    if (!request.payerAddress) throw new Error('payerAddress is required when autoSwap=true');
 
     const swapResult = await options.swapClient.swap({
       inputMint: resolveMint(request.payerCurrency || request.currency),
       outputMint: resolveMint(request.currency),
       amount: String(request.amount),
-      userPublicKey: payerAddress,
+      userPublicKey: request.payerAddress,
       slippageBps: options.slippageBps ?? 50,
     });
 
@@ -100,7 +212,6 @@ export async function sendPayment(
     };
   }
 
-  // For now, return a mock receipt for testing
   return {
     txSignature: 'mock_tx_signature_' + Math.random().toString(36).substring(7),
     slot: Math.floor(Math.random() * 1000000),
@@ -109,12 +220,4 @@ export async function sendPayment(
     settlementCurrency: request.currency,
     swap: swapMeta,
   };
-}
-
-/**
- * Validate payment address format (basic check)
- * Real validation would use @solana/web3.js PublicKey
- */
-export function isValidPaymentAddress(address: string): boolean {
-  return address.length >= 32 && address.length <= 44; // Base58 Solana addresses
 }

--- a/packages/x402-solana/src/types.ts
+++ b/packages/x402-solana/src/types.ts
@@ -1,24 +1,58 @@
 /**
- * x402 payment request parsed from HTTP header
+ * x402 payment request parsed from HTTP header.
+ * Amount is represented as the smallest payment unit for the declared currency.
  */
 export interface X402Request {
-  amount: number;        // lamports
-  currency: string;      // "SOL"
-  paymentAddress: string; // base58 Solana address
-  nonce: string;         // UUID or random string for replay protection
-  payerCurrency?: string; // Currency currently held by payer (e.g., "SOL")
-  payerAddress?: string;  // Payer wallet used for swap/order execution
-  autoSwap?: boolean;     // If true, perform swap when payerCurrency != currency
+  amount: number;
+  currency: string;
+  paymentAddress: string;
+  nonce: string;
+  payerCurrency?: string;
+  payerAddress?: string;
+  autoSwap?: boolean;
+}
+
+export type SolanaPaymentNetwork = 'solana-devnet' | 'solana-mainnet-beta' | 'solana-testnet';
+
+export interface X402ChallengeInput {
+  version?: string;
+  network: SolanaPaymentNetwork;
+  payTo: string;
+  amount: string | number;
+  currency: string;
+  endpoint: string;
+  nonce: string;
+  memo?: string;
+}
+
+export interface X402Challenge extends X402ChallengeInput {
+  version: string;
 }
 
 /**
- * Payment receipt after successful SOL transfer
+ * Receipt shape used by specialist-side verifiers. This package deliberately
+ * does not require secrets or submit transactions.
+ */
+export interface X402PaymentReceipt {
+  network: SolanaPaymentNetwork;
+  payTo: string;
+  amount: string | number;
+  currency: string;
+  nonce: string;
+  signature?: string;
+  txSignature?: string;
+  payer?: string;
+  demo?: boolean;
+}
+
+/**
+ * Payment receipt after successful SOL transfer.
  */
 export interface PaymentReceipt {
-  txSignature: string;   // Solana transaction signature
-  slot: number;          // Solana slot when confirmed
-  lamports: number;      // Amount transferred (should match request)
-  nonce: string;         // Echo back for correlation
+  txSignature: string;
+  slot: number;
+  lamports: number;
+  nonce: string;
   settlementCurrency?: string;
   swap?: {
     performed: boolean;
@@ -31,10 +65,40 @@ export interface PaymentReceipt {
   };
 }
 
+export type ReceiptVerificationFailureReason =
+  | 'invalid_receipt'
+  | 'invalid_payee'
+  | 'invalid_nonce'
+  | 'duplicate_nonce'
+  | 'wrong_amount'
+  | 'wrong_currency'
+  | 'wrong_payee'
+  | 'wrong_network'
+  | 'demo_payment_disabled'
+  | 'unsupported_receipt';
+
+export type ReceiptVerificationResult =
+  | { ok: true; receipt: X402PaymentReceipt; demo: boolean }
+  | {
+      ok: false;
+      reason: ReceiptVerificationFailureReason;
+      message: string;
+      expected?: unknown;
+      actual?: unknown;
+    };
+
+export interface NonceReplayStore {
+  checkAndStore(nonce: string): boolean | Promise<boolean>;
+}
+
+export interface ReceiptVerifier {
+  verifyReceipt(receipt: unknown, challenge: X402Challenge, replayStore?: NonceReplayStore): Promise<ReceiptVerificationResult>;
+}
+
 /**
- * x402 error codes
+ * x402 error codes.
  */
-export type X402Error = 
+export type X402Error =
   | 'insufficient_funds'
   | 'duplicate_nonce'
   | 'invalid_request'

--- a/packages/x402-solana/tests/payment.test.ts
+++ b/packages/x402-solana/tests/payment.test.ts
@@ -1,119 +1,90 @@
 import {
+  buildX402Challenge,
+  DemoPaymentVerifier,
   parseX402Header,
   sendPayment,
   isValidPaymentAddress,
+  isValidSolanaPublicKey,
 } from '../src/payment';
-import { needsAutoSwap } from '../src/jupiter';
 import {
   checkAndStoreNonce,
   clearNonces,
   getNonceCount,
+  MemoryNonceReplayStore,
 } from '../src/nonce';
 import { createX402Middleware, createX402Header } from '../src/middleware';
 
+const validAddress = '3mL7kbtz3eK24vJ6wftjnLvhZrf93B71UEjB2DBDAddr';
+const otherValidAddress = '6uiQbwMor4UrWYiDtAJcgHKYW4vUaM3BUVChPgzdALse';
+
 describe('x402 Payment Module', () => {
   afterEach(() => {
-    clearNonces(); // Clean up between tests
+    clearNonces();
   });
 
   describe('parseX402Header', () => {
     it('should parse valid x402-request header', () => {
-      const header = JSON.stringify({
-        amount: 1000,
-        currency: 'SOL',
-        paymentAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-        nonce: 'abc123',
-      });
-
+      const header = JSON.stringify({ amount: 1000, currency: 'SOL', paymentAddress: validAddress, nonce: 'abc123' });
       const result = parseX402Header(header);
       expect(result.amount).toBe(1000);
       expect(result.currency).toBe('SOL');
-      expect(result.paymentAddress).toBe('BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv');
+      expect(result.paymentAddress).toBe(validAddress);
       expect(result.nonce).toBe('abc123');
     });
 
     it('should reject zero amount', () => {
-      const header = JSON.stringify({
-        amount: 0,
-        currency: 'SOL',
-        paymentAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-        nonce: 'abc123',
-      });
-
+      const header = JSON.stringify({ amount: 0, currency: 'SOL', paymentAddress: validAddress, nonce: 'abc123' });
       expect(() => parseX402Header(header)).toThrow('amount must be a positive number');
     });
 
     it('should reject negative amount', () => {
-      const header = JSON.stringify({
-        amount: -100,
-        currency: 'SOL',
-        paymentAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-        nonce: 'abc123',
-      });
-
+      const header = JSON.stringify({ amount: -100, currency: 'SOL', paymentAddress: validAddress, nonce: 'abc123' });
       expect(() => parseX402Header(header)).toThrow('amount must be a positive number');
     });
 
     it('should reject missing paymentAddress', () => {
-      const header = JSON.stringify({
-        amount: 1000,
-        currency: 'SOL',
-        nonce: 'abc123',
-      });
-
+      const header = JSON.stringify({ amount: 1000, currency: 'SOL', nonce: 'abc123' });
       expect(() => parseX402Header(header)).toThrow('paymentAddress is required');
     });
 
     it('should reject missing nonce', () => {
-      const header = JSON.stringify({
-        amount: 1000,
-        currency: 'SOL',
-        paymentAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-      });
-
+      const header = JSON.stringify({ amount: 1000, currency: 'SOL', paymentAddress: validAddress });
       expect(() => parseX402Header(header)).toThrow('nonce is required');
     });
 
     it('should reject invalid JSON', () => {
-      const header = '{invalid json}';
-      expect(() => parseX402Header(header)).toThrow('x402-request header is not valid JSON');
+      expect(() => parseX402Header('{invalid json}')).toThrow('x402-request header is not valid JSON');
     });
   });
 
   describe('Nonce Store', () => {
     it('should accept first nonce', () => {
-      const result = checkAndStoreNonce('nonce-1');
-      expect(result).toBe(true);
+      expect(checkAndStoreNonce('nonce-1')).toBe(true);
     });
 
     it('should reject duplicate nonce', () => {
       checkAndStoreNonce('nonce-1');
-      const result = checkAndStoreNonce('nonce-1');
-      expect(result).toBe(false);
+      expect(checkAndStoreNonce('nonce-1')).toBe(false);
     });
 
     it('should accept different nonces', () => {
       checkAndStoreNonce('nonce-1');
-      const result = checkAndStoreNonce('nonce-2');
-      expect(result).toBe(true);
+      expect(checkAndStoreNonce('nonce-2')).toBe(true);
     });
 
     it('should allow re-acceptance after clearNonces', () => {
       checkAndStoreNonce('nonce-1');
       expect(getNonceCount()).toBe(1);
-
       clearNonces();
       expect(getNonceCount()).toBe(0);
-
-      const result = checkAndStoreNonce('nonce-1');
-      expect(result).toBe(true);
+      expect(checkAndStoreNonce('nonce-1')).toBe(true);
     });
   });
 
   describe('Payment Address Validation', () => {
     it('should validate correct Solana address', () => {
-      const address = 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv';
-      expect(isValidPaymentAddress(address)).toBe(true);
+      expect(isValidPaymentAddress(validAddress)).toBe(true);
+      expect(isValidSolanaPublicKey(validAddress)).toBe(true);
     });
 
     it('should reject address that is too short', () => {
@@ -121,92 +92,79 @@ describe('x402 Payment Module', () => {
     });
 
     it('should reject address that is too long', () => {
-      const tooLong = 'a'.repeat(50);
-      expect(isValidPaymentAddress(tooLong)).toBe(false);
+      expect(isValidPaymentAddress('a'.repeat(50))).toBe(false);
     });
 
-    it('should accept 32-44 character addresses', () => {
-      expect(isValidPaymentAddress('a'.repeat(32))).toBe(true);
-      expect(isValidPaymentAddress('a'.repeat(44))).toBe(true);
+    it('should reject non-canonical 32-44 character strings', () => {
+      expect(isValidPaymentAddress('a'.repeat(32))).toBe(false);
+      expect(isValidPaymentAddress('O'.repeat(32))).toBe(false);
+    });
+  });
+
+  describe('challenge builder and demo verifier', () => {
+    const challenge = buildX402Challenge({
+      network: 'solana-devnet',
+      payTo: validAddress,
+      amount: '0.03',
+      currency: 'USDC',
+      endpoint: 'https://planning.example.test/v1/chat/completions',
+      nonce: 'nonce-123',
+    });
+
+    it('builds a strict Solana devnet challenge', () => {
+      expect(challenge.version).toBe('1');
+      expect(challenge.payTo).toBe(validAddress);
+      expect(challenge.network).toBe('solana-devnet');
+    });
+
+    it('fails closed unless demo payments are explicitly enabled', async () => {
+      const verifier = new DemoPaymentVerifier(false);
+      const result = await verifier.verifyReceipt({ demo: true, ...challenge }, challenge);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe('demo_payment_disabled');
+    });
+
+    it('accepts explicit demo receipts and stores nonce once', async () => {
+      const verifier = new DemoPaymentVerifier(true);
+      const store = new MemoryNonceReplayStore();
+      const receipt = { demo: true, ...challenge };
+      const first = await verifier.verifyReceipt(receipt, challenge, store);
+      expect(first.ok).toBe(true);
+      const second = await verifier.verifyReceipt(receipt, challenge, store);
+      expect(second.ok).toBe(false);
+      if (!second.ok) expect(second.reason).toBe('duplicate_nonce');
+    });
+
+    it('represents wrong amount, payee, and network failures', async () => {
+      const verifier = new DemoPaymentVerifier(true);
+      const wrongAmount = await verifier.verifyReceipt({ demo: true, ...challenge, amount: '0.04' }, challenge);
+      expect(wrongAmount.ok).toBe(false);
+      if (!wrongAmount.ok) expect(wrongAmount.reason).toBe('wrong_amount');
+
+      const wrongPayee = await verifier.verifyReceipt({ demo: true, ...challenge, payTo: otherValidAddress }, challenge);
+      expect(wrongPayee.ok).toBe(false);
+      if (!wrongPayee.ok) expect(wrongPayee.reason).toBe('wrong_payee');
+
+      const wrongNetwork = await verifier.verifyReceipt({ demo: true, ...challenge, network: 'solana-mainnet-beta' }, challenge);
+      expect(wrongNetwork.ok).toBe(false);
+      if (!wrongNetwork.ok) expect(wrongNetwork.reason).toBe('wrong_network');
     });
   });
 
   describe('sendPayment', () => {
     it('should return receipt with matching amount and nonce', async () => {
-      const request = {
-        amount: 5000,
-        currency: 'SOL',
-        paymentAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-        nonce: 'test-nonce-123',
-      };
-
+      const request = { amount: 5000, currency: 'SOL', paymentAddress: validAddress, nonce: 'test-nonce-123' };
       const receipt = await sendPayment(request);
       expect(receipt.lamports).toBe(5000);
       expect(receipt.nonce).toBe('test-nonce-123');
       expect(receipt.txSignature).toBeDefined();
       expect(receipt.slot).toBeDefined();
     });
-
-    it('should mark swap as performed for token mismatch with autoSwap', async () => {
-      const request = {
-        amount: 5000,
-        currency: 'USDC',
-        payerCurrency: 'SOL',
-        payerAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-        autoSwap: true,
-        paymentAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-        nonce: 'swap-nonce-1',
-      };
-
-      const receipt = await sendPayment(request, {
-        swapClient: {
-          swap: async () => ({
-            orderId: 'ord_1',
-            executeId: 'exec_1',
-            inAmount: '5000',
-            outAmount: '4990',
-          }),
-        },
-      });
-
-      expect(receipt.swap?.performed).toBe(true);
-      expect(receipt.swap?.orderId).toBe('ord_1');
-      expect(receipt.settlementCurrency).toBe('USDC');
-    });
-
-    it('should fail when token mismatch requires swap and no client configured', async () => {
-      const request = {
-        amount: 5000,
-        currency: 'USDC',
-        payerCurrency: 'SOL',
-        payerAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-        autoSwap: true,
-        paymentAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-        nonce: 'swap-nonce-2',
-      };
-
-      await expect(sendPayment(request)).rejects.toThrow('token_mismatch_requires_swap_client');
-    });
-  });
-
-  describe('needsAutoSwap', () => {
-    it('should detect mismatch when autoSwap=true', () => {
-      expect(
-        needsAutoSwap({
-          amount: 10,
-          currency: 'USDC',
-          payerCurrency: 'SOL',
-          paymentAddress: 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv',
-          nonce: 'x',
-          autoSwap: true,
-        })
-      ).toBe(true);
-    });
   });
 
   describe('Middleware Helper', () => {
     it('should create valid x402-request header', () => {
-      const header = createX402Header(1000, 'BaDZtpgWpDx6H1y8Dga2cfyxs3RXj5y2fkBo7HoT2pdv', 'nonce-123');
+      const header = createX402Header(1000, validAddress, 'nonce-123');
       const parsed = parseX402Header(header);
       expect(parsed.amount).toBe(1000);
       expect(parsed.nonce).toBe('nonce-123');

--- a/packages/x402-solana/tests/payment.test.ts
+++ b/packages/x402-solana/tests/payment.test.ts
@@ -119,7 +119,7 @@ describe('x402 Payment Module', () => {
 
     it('fails closed unless demo payments are explicitly enabled', async () => {
       const verifier = new DemoPaymentVerifier(false);
-      const result = await verifier.verifyReceipt({ demo: true, ...challenge }, challenge);
+      const result = await verifier.verifyReceipt({ demo: true, token: `demo:${challenge.nonce}`, nonce: challenge.nonce }, challenge);
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.reason).toBe('demo_payment_disabled');
     });
@@ -127,7 +127,7 @@ describe('x402 Payment Module', () => {
     it('accepts explicit demo receipts and stores nonce once', async () => {
       const verifier = new DemoPaymentVerifier(true);
       const store = new MemoryNonceReplayStore();
-      const receipt = { demo: true, ...challenge };
+      const receipt = { demo: true, token: `demo:${challenge.nonce}`, nonce: challenge.nonce };
       const first = await verifier.verifyReceipt(receipt, challenge, store);
       expect(first.ok).toBe(true);
       const second = await verifier.verifyReceipt(receipt, challenge, store);
@@ -135,19 +135,18 @@ describe('x402 Payment Module', () => {
       if (!second.ok) expect(second.reason).toBe('duplicate_nonce');
     });
 
-    it('represents wrong amount, payee, and network failures', async () => {
+    it('rejects caller-authored structured demo receipts', async () => {
       const verifier = new DemoPaymentVerifier(true);
-      const wrongAmount = await verifier.verifyReceipt({ demo: true, ...challenge, amount: '0.04' }, challenge);
-      expect(wrongAmount.ok).toBe(false);
-      if (!wrongAmount.ok) expect(wrongAmount.reason).toBe('wrong_amount');
+      const structured = await verifier.verifyReceipt({ demo: true, ...challenge }, challenge);
+      expect(structured.ok).toBe(false);
+      if (!structured.ok) expect(structured.reason).toBe('invalid_receipt');
+    });
 
-      const wrongPayee = await verifier.verifyReceipt({ demo: true, ...challenge, payTo: otherValidAddress }, challenge);
-      expect(wrongPayee.ok).toBe(false);
-      if (!wrongPayee.ok) expect(wrongPayee.reason).toBe('wrong_payee');
-
-      const wrongNetwork = await verifier.verifyReceipt({ demo: true, ...challenge, network: 'solana-mainnet-beta' }, challenge);
-      expect(wrongNetwork.ok).toBe(false);
-      if (!wrongNetwork.ok) expect(wrongNetwork.reason).toBe('wrong_network');
+    it('rejects non-demo structured receipts until real settlement verification exists', async () => {
+      const verifier = new DemoPaymentVerifier(true);
+      const unsigned = await verifier.verifyReceipt({ ...challenge, signature: 'caller-authored' }, challenge);
+      expect(unsigned.ok).toBe(false);
+      if (!unsigned.ok) expect(unsigned.reason).toBe('unsupported_receipt');
     });
   });
 

--- a/packages/x402-solana/tests/payment.test.ts
+++ b/packages/x402-solana/tests/payment.test.ts
@@ -119,7 +119,7 @@ describe('x402 Payment Module', () => {
 
     it('fails closed unless demo payments are explicitly enabled', async () => {
       const verifier = new DemoPaymentVerifier(false);
-      const result = await verifier.verifyReceipt({ demo: true, token: `demo:${challenge.nonce}`, nonce: challenge.nonce }, challenge);
+      const result = await verifier.verifyReceipt(`demo:${challenge.nonce}`, challenge);
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.reason).toBe('demo_payment_disabled');
     });
@@ -127,7 +127,7 @@ describe('x402 Payment Module', () => {
     it('accepts explicit demo receipts and stores nonce once', async () => {
       const verifier = new DemoPaymentVerifier(true);
       const store = new MemoryNonceReplayStore();
-      const receipt = { demo: true, token: `demo:${challenge.nonce}`, nonce: challenge.nonce };
+      const receipt = `demo:${challenge.nonce}`;
       const first = await verifier.verifyReceipt(receipt, challenge, store);
       expect(first.ok).toBe(true);
       const second = await verifier.verifyReceipt(receipt, challenge, store);
@@ -140,6 +140,10 @@ describe('x402 Payment Module', () => {
       const structured = await verifier.verifyReceipt({ demo: true, ...challenge }, challenge);
       expect(structured.ok).toBe(false);
       if (!structured.ok) expect(structured.reason).toBe('invalid_receipt');
+
+      const structuredToken = await verifier.verifyReceipt({ demo: true, token: `demo:${challenge.nonce}`, nonce: challenge.nonce }, challenge);
+      expect(structuredToken.ok).toBe(false);
+      if (!structuredToken.ok) expect(structuredToken.reason).toBe('invalid_receipt');
     });
 
     it('rejects non-demo structured receipts until real settlement verification exists', async () => {


### PR DESCRIPTION
## Summary
- wire `packages/openrouter-specialists` to shared `@reddi/x402-solana` challenge/demo verifier helpers
- add strict Solana public-key wallet metadata for the first five specialist profiles
- add public wallet manifest plus manifest validation and devnet balance reporting scripts
- extend x402 Solana helpers with fail-closed demo receipt verification, challenge/result types, and nonce replay contract

## Validation
- `cd packages/x402-solana && npm test` — 20/20 pass
- `cd packages/x402-solana && npm run build` — pass
- `cd packages/openrouter-specialists && npm install --ignore-scripts && npm test` — 8/8 pass
- `cd packages/openrouter-specialists && npm run validate:wallet-manifest` — pass
- `cd packages/openrouter-specialists && npm run check:devnet-balances` — exits 1 as intended because all 5 devnet wallets currently report 0 lamports, below the 1,000,000 threshold

## Notes
- Demo x402 payment remains explicit opt-in via `ALLOW_DEMO_X402_PAYMENT`.
- OpenRouter mock mode remains explicit opt-in via `OPENROUTER_MOCK`.
- No private keys, signer material, or funding transactions are included.

Closes #141
