### PR TITLE
feat(openrouter): add default attestor verdict schema

### DIFF
--- a/packages/openrouter-specialists/README.md
+++ b/packages/openrouter-specialists/README.md
@@ -2,7 +2,7 @@
 
 Shared runtime for Reddi Agent Protocol marketplace specialists backed by OpenRouter.
 
-Iteration 1 ships the profile registry, fail-closed x402 guard, OpenAI-compatible chat completions handler, explicit mock OpenRouter mode for tests, Docker packaging, and marketplace metadata endpoints.
+Iteration 3 includes the default attestor path: `verification-validation-agent` is both a `specialist` and `attestor`, can evaluate specialist outputs plus receipt chains, and returns a structured `reddi.attestation.v1` verdict.
 
 ## Safety defaults
 
@@ -13,6 +13,30 @@ Iteration 1 ships the profile registry, fail-closed x402 guard, OpenAI-compatibl
 - Demo payment headers are accepted only when `ALLOW_DEMO_X402_PAYMENT=1` or `true`.
 - Caller-controlled strings such as `paid:` or JSON containing `signature` are not treated as payment proof.
 - Until real x402 settlement verification is wired, production deployments should leave `ALLOW_DEMO_X402_PAYMENT` unset and fail closed on unpaid requests.
+- Attestation verdicts are settlement recommendations only: `release` pays the specialist, `refund` returns funds to requester, and `dispute` holds for human/secondary review.
+
+## Attestation mode
+
+Use the attestor profile (`SPECIALIST_PROFILE_ID=verification-validation-agent`) with either route shape:
+
+- `POST /v1/attestations`
+- `POST /v1/chat/completions` with `metadata.mode="attestation"` and `metadata.attestation`
+
+Minimal request body:
+
+```json
+{
+  "mode": "attestation",
+  "subjectProfileId": "planning-agent",
+  "specialistOutput": "Specialist output to review...",
+  "receiptChain": [
+    { "id": "receipt-1", "type": "x402-payment", "status": "satisfied", "amount": "0.03", "currency": "USDC" }
+  ],
+  "domain": "general operations"
+}
+```
+
+Response body includes `verdict.schemaVersion`, `score`, `checks`, `summary`, `recommendedAction`, regulated-domain caveats when relevant, and explicit release/refund/dispute semantics.
 
 ## Validation
 

--- a/packages/openrouter-specialists/src/attestation.ts
+++ b/packages/openrouter-specialists/src/attestation.ts
@@ -1,0 +1,168 @@
+import type {
+  AttestationCheck,
+  AttestationPromptEnvelope,
+  AttestationReceiptLink,
+  AttestationRequest,
+  AttestationVerdict,
+  ChatMessage,
+  SpecialistProfile,
+} from "./types.js";
+
+const REGULATED_DOMAIN_TERMS = ["medical", "health", "legal", "financial", "finance", "tax", "investment", "regulated"];
+
+export const ATTESTATION_VERDICT_SEMANTICS = {
+  release: "Recommend release when specialist output is complete, receipt/payment chain is coherent, and no material safety or evidence failures are found.",
+  refund: "Recommend refund when output is missing/unsafe/unusable or receipt evidence is materially invalid.",
+  dispute: "Recommend dispute when evidence is mixed, score is borderline, or human review is needed before settlement.",
+} as const;
+
+export function normalizeAttestationRequest(input: unknown): AttestationRequest {
+  const body = isRecord(input) ? input : {};
+  const metadata = isRecord(body.metadata) ? body.metadata : {};
+  const source = isRecord(metadata.attestation) ? metadata.attestation : body;
+  return {
+    mode: source.mode === "attestation" ? "attestation" : "attestation",
+    subjectProfileId: typeof source.subjectProfileId === "string" ? source.subjectProfileId : undefined,
+    specialistOutput: stringifyUnknown(source.specialistOutput ?? source.output ?? latestUserContent(body.messages)),
+    receiptChain: normalizeReceiptChain(source.receiptChain ?? source.receipts),
+    domain: typeof source.domain === "string" ? source.domain : undefined,
+    constraints: Array.isArray(source.constraints) ? source.constraints.map(String) : undefined,
+  };
+}
+
+export function buildAttestationPromptEnvelope(profile: SpecialistProfile, request: AttestationRequest): AttestationPromptEnvelope {
+  const schema = {
+    schemaVersion: "reddi.attestation.v1",
+    score: "number 0..1",
+    recommendedAction: ["release", "refund", "dispute"],
+    checks: [{ id: "string", label: "string", status: ["pass", "warn", "fail"], score: "number 0..1", summary: "string" }],
+    summary: "string",
+    caveats: ["string"],
+  };
+  const messages: ChatMessage[] = [
+    {
+      role: "system",
+      content: `${profile.systemPrompt}\n\nAttestation mode: review the specialist output and receipt chain. Return only a structured verdict matching reddi.attestation.v1. Verdict semantics: release=pay specialist, refund=return funds to requester, dispute=hold for human/secondary review. Preserve regulated-domain caveats; do not claim legal, medical, financial, or security certification.`,
+    },
+    {
+      role: "user",
+      content: JSON.stringify({ task: "attest_specialist_output", schema, request }, null, 2),
+    },
+  ];
+  return { mode: "attestation", schemaVersion: "reddi.attestation.v1", messages };
+}
+
+export function evaluateAttestation(request: AttestationRequest, attestorProfileId: string): AttestationVerdict {
+  const checks = buildChecks(request);
+  const score = round(checks.reduce((sum, check) => sum + check.score, 0) / checks.length);
+  const hasFail = checks.some((check) => check.status === "fail");
+  const hasWarn = checks.some((check) => check.status === "warn");
+  const recommendedAction = score >= 0.8 && !hasFail && !hasWarn ? "release" : score < 0.5 || checks.some((check) => check.id === "receipt_integrity" && check.status === "fail") ? "refund" : "dispute";
+  const caveats = buildCaveats(request);
+  return {
+    schemaVersion: "reddi.attestation.v1",
+    attestorProfileId,
+    subjectProfileId: request.subjectProfileId,
+    score,
+    recommendedAction,
+    checks,
+    summary: summaryFor(recommendedAction, score),
+    caveats,
+    receiptChain: request.receiptChain,
+    semantics: ATTESTATION_VERDICT_SEMANTICS,
+  };
+}
+
+function buildChecks(request: AttestationRequest): AttestationCheck[] {
+  const output = request.specialistOutput.trim();
+  const receiptCount = request.receiptChain.length;
+  const hasReceiptEvidence = receiptCount > 0 && request.receiptChain.some((receipt) => receipt.status === "paid" || receipt.status === "satisfied" || receipt.status === "verified");
+  const regulated = isRegulatedDomain(request.domain);
+  const forbiddenClaim = /\b(guarantee|certified|definitive legal advice|medical diagnosis|private key|seed phrase)\b/i.test(output);
+  const citesEvidence = /\b(evidence|receipt|source|citation|test|validation|artifact)\b/i.test(output);
+
+  return [
+    {
+      id: "receipt_integrity",
+      label: "Receipt chain integrity",
+      status: hasReceiptEvidence ? "pass" : receiptCount > 0 ? "warn" : "fail",
+      score: hasReceiptEvidence ? 1 : receiptCount > 0 ? 0.6 : 0.2,
+      summary: hasReceiptEvidence ? "Receipt chain includes paid/satisfied/verified evidence." : receiptCount > 0 ? "Receipt chain exists but does not clearly show satisfied payment." : "No receipt chain was supplied.",
+    },
+    {
+      id: "output_completeness",
+      label: "Output completeness",
+      status: output.length >= 80 ? "pass" : output.length >= 24 ? "warn" : "fail",
+      score: output.length >= 80 ? 0.95 : output.length >= 24 ? 0.6 : 0.25,
+      summary: output.length >= 80 ? "Specialist output is substantive enough for review." : output.length >= 24 ? "Specialist output is brief and may need clarification." : "Specialist output is missing or too short to validate.",
+    },
+    {
+      id: "evidence_quality",
+      label: "Evidence quality",
+      status: citesEvidence || receiptCount > 1 ? "pass" : receiptCount > 0 ? "warn" : "fail",
+      score: citesEvidence || receiptCount > 1 ? 0.9 : receiptCount > 0 ? 0.65 : 0.3,
+      summary: citesEvidence || receiptCount > 1 ? "Output or receipts include evidence/validation signals." : receiptCount > 0 ? "Some receipt evidence exists, but output evidence is thin." : "No supporting evidence was provided.",
+    },
+    {
+      id: "safety_boundary",
+      label: "Safety and domain boundary",
+      status: forbiddenClaim ? "fail" : regulated ? "warn" : "pass",
+      score: forbiddenClaim ? 0.2 : regulated ? 0.7 : 1,
+      summary: forbiddenClaim ? "Output appears to overclaim or expose unsafe sensitive material." : regulated ? "Regulated-domain caveat required; informational review only." : "No regulated-domain or overclaim caveat detected.",
+    },
+  ];
+}
+
+function buildCaveats(request: AttestationRequest): string[] {
+  const caveats = ["Attestation is a protocol settlement recommendation, not professional certification."];
+  if (isRegulatedDomain(request.domain)) caveats.push("Regulated-domain caveat: keep this informational and route legal, medical, financial, tax, or investment decisions to qualified human review.");
+  if (request.constraints?.length) caveats.push(`Reviewed against stated constraints: ${request.constraints.join("; ")}`);
+  return caveats;
+}
+
+function summaryFor(action: AttestationVerdict["recommendedAction"], score: number): string {
+  if (action === "release") return `Recommend release: verdict score ${score} with no material failed checks.`;
+  if (action === "refund") return `Recommend refund: verdict score ${score} or receipt/output failure makes settlement unsafe.`;
+  return `Recommend dispute: verdict score ${score} requires human or secondary attestor review before settlement.`;
+}
+
+function normalizeReceiptChain(value: unknown): AttestationReceiptLink[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item, index) => {
+    const record = isRecord(item) ? item : {};
+    return {
+      id: typeof record.id === "string" ? record.id : `receipt-${index + 1}`,
+      type: typeof record.type === "string" ? record.type : "unknown",
+      status: typeof record.status === "string" ? record.status : undefined,
+      amount: typeof record.amount === "string" ? record.amount : undefined,
+      currency: typeof record.currency === "string" ? record.currency : undefined,
+      txSignature: typeof record.txSignature === "string" ? record.txSignature : undefined,
+      evidenceHash: typeof record.evidenceHash === "string" ? record.evidenceHash : undefined,
+    };
+  });
+}
+
+function latestUserContent(messages: unknown): string | undefined {
+  if (!Array.isArray(messages)) return undefined;
+  const users = messages.filter((message): message is { role: string; content: unknown } => isRecord(message) && message.role === "user");
+  const latest = users.at(-1);
+  return typeof latest?.content === "string" ? latest.content : undefined;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  return JSON.stringify(value);
+}
+
+function isRegulatedDomain(domain?: string): boolean {
+  return typeof domain === "string" && REGULATED_DOMAIN_TERMS.some((term) => domain.toLowerCase().includes(term));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types.js";
 export * from "./profiles/index.js";
 export * from "./openrouter.js";
+export * from "./attestation.js";
 export * from "./runtime.js";

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -8,9 +8,10 @@ import {
   type ReceiptVerificationResult,
   type X402Challenge,
 } from "@reddi/x402-solana";
+import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "./profiles/index.js";
 import { FetchOpenRouterClient, MockOpenRouterClient } from "./openrouter.js";
-import type { ChatCompletionRequest, OpenRouterClient, RuntimeConfig, RuntimeResponse, SpecialistProfile } from "./types.js";
+import type { AttestationRequest, ChatCompletionRequest, OpenRouterClient, RuntimeConfig, RuntimeResponse, SpecialistProfile } from "./types.js";
 
 const JSON_HEADERS = { "content-type": "application/json; charset=utf-8" };
 const PAYMENT_NETWORK = "solana-devnet" as const;
@@ -130,6 +131,76 @@ export function tagsResponse(): RuntimeResponse {
   return { status: 200, headers: JSON_HEADERS, body: { tags } };
 }
 
+export async function ensurePaid(input: {
+  headers: Headers;
+  profile: SpecialistProfile;
+  config: RuntimeConfig;
+  replayStore?: NonceReplayStore;
+}): Promise<RuntimeResponse | undefined> {
+  if (!input.config.requirePayment) return undefined;
+  const payment = await verifyPayment({ headers: input.headers, profile: input.profile, config: input.config, replayStore: input.replayStore });
+  if (payment.ok) return undefined;
+  const response = paymentRequired(buildProfileChallenge(input.profile, input.config));
+  response.body.error = {
+    code: payment.reason === "invalid_receipt" ? "payment_required" : payment.reason,
+    message: payment.message,
+  };
+  return response;
+}
+
+export function isAttestationMode(body: ChatCompletionRequest): boolean {
+  return body.metadata?.mode === "attestation" || body.metadata?.attestation !== undefined;
+}
+
+export async function handleAttestationEvaluation(input: {
+  headers: Headers;
+  body: AttestationRequest | ChatCompletionRequest | Record<string, unknown>;
+  config: RuntimeConfig;
+  client: OpenRouterClient;
+  replayStore?: NonceReplayStore;
+}): Promise<RuntimeResponse> {
+  const profile = getProfile(input.config.profileId);
+  if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };
+  if (!profile.roles.includes("attestor")) {
+    return { status: 403, headers: JSON_HEADERS, body: { error: { code: "profile_not_attestor", message: `${profile.id} is not configured for attestation.` } } };
+  }
+
+  const unpaid = await ensurePaid({ headers: input.headers, profile, config: input.config, replayStore: input.replayStore });
+  if (unpaid) return unpaid;
+
+  const requestId = randomUUID();
+  const attestationRequest = normalizeAttestationRequest(input.body);
+  const promptEnvelope = buildAttestationPromptEnvelope(profile, attestationRequest);
+  const reddi = {
+    profileId: profile.id,
+    requestId,
+    model: profile.model,
+    paymentSatisfied: input.config.requirePayment,
+    safetyMode: profile.safetyMode,
+    mockOpenRouter: input.config.mockOpenRouter,
+    mode: "attestation",
+    schemaVersion: promptEnvelope.schemaVersion,
+  };
+  const upstream = await input.client.createChatCompletion({
+    model: profile.model,
+    messages: promptEnvelope.messages,
+    temperature: 0,
+    max_tokens: 600,
+    metadata: reddi,
+  });
+  return {
+    status: 200,
+    headers: JSON_HEADERS,
+    body: {
+      object: "reddi.attestation.verdict",
+      verdict: evaluateAttestation(attestationRequest, profile.id),
+      promptEnvelope,
+      upstream,
+      reddi,
+    },
+  };
+}
+
 export async function handleChatCompletions(input: {
   headers: Headers;
   body: ChatCompletionRequest;
@@ -137,20 +208,13 @@ export async function handleChatCompletions(input: {
   client: OpenRouterClient;
   replayStore?: NonceReplayStore;
 }): Promise<RuntimeResponse> {
+  if (isAttestationMode(input.body)) return handleAttestationEvaluation(input);
+
   const profile = getProfile(input.config.profileId);
   if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };
 
-  if (input.config.requirePayment) {
-    const payment = await verifyPayment({ headers: input.headers, profile, config: input.config, replayStore: input.replayStore });
-    if (!payment.ok) {
-      const response = paymentRequired(buildProfileChallenge(profile, input.config));
-      response.body.error = {
-        code: payment.reason === "invalid_receipt" ? "payment_required" : payment.reason,
-        message: payment.message,
-      };
-      return response;
-    }
-  }
+  const unpaid = await ensurePaid({ headers: input.headers, profile, config: input.config, replayStore: input.replayStore });
+  if (unpaid) return unpaid;
 
   const requestId = randomUUID();
   const messages = input.body.messages ?? [];
@@ -195,6 +259,10 @@ export async function handleRuntimeRequest(request: Request, config = createRunt
   if (request.method === "GET" && url.pathname === "/v1/models") return toResponse(modelsResponse());
   if (request.method === "GET" && url.pathname === "/api/tags") return toResponse(tagsResponse());
   if (request.method === "GET" && url.pathname === "/.well-known/reddi-agent.json") return toResponse({ status: 200, headers: JSON_HEADERS, body: marketplaceMetadata(profile, config) });
+  if (request.method === "POST" && url.pathname === "/v1/attestations") {
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    return toResponse(await handleAttestationEvaluation({ headers: request.headers, body, config, client, replayStore: defaultNonceReplayStore }));
+  }
   if (request.method === "POST" && url.pathname === "/v1/chat/completions") {
     const body = (await request.json().catch(() => ({}))) as ChatCompletionRequest;
     return toResponse(await handleChatCompletions({ headers: request.headers, body, config, client, replayStore: defaultNonceReplayStore }));

--- a/packages/openrouter-specialists/src/types.ts
+++ b/packages/openrouter-specialists/src/types.ts
@@ -49,6 +49,56 @@ export interface ChatCompletionRequest {
   metadata?: Record<string, unknown>;
 }
 
+export type AttestationMode = "attestation";
+export type AttestationCheckStatus = "pass" | "warn" | "fail";
+export type AttestationRecommendedAction = "release" | "refund" | "dispute";
+
+export interface AttestationReceiptLink {
+  id: string;
+  type: string;
+  status?: string;
+  amount?: string;
+  currency?: string;
+  txSignature?: string;
+  evidenceHash?: string;
+}
+
+export interface AttestationRequest {
+  mode: AttestationMode;
+  subjectProfileId?: string;
+  specialistOutput: string;
+  receiptChain: AttestationReceiptLink[];
+  domain?: string;
+  constraints?: string[];
+}
+
+export interface AttestationCheck {
+  id: string;
+  label: string;
+  status: AttestationCheckStatus;
+  score: number;
+  summary: string;
+}
+
+export interface AttestationVerdict {
+  schemaVersion: "reddi.attestation.v1";
+  attestorProfileId: string;
+  subjectProfileId?: string;
+  score: number;
+  recommendedAction: AttestationRecommendedAction;
+  checks: AttestationCheck[];
+  summary: string;
+  caveats: string[];
+  receiptChain: AttestationReceiptLink[];
+  semantics: Record<AttestationRecommendedAction, string>;
+}
+
+export interface AttestationPromptEnvelope {
+  mode: AttestationMode;
+  schemaVersion: "reddi.attestation.v1";
+  messages: ChatMessage[];
+}
+
 export interface OpenRouterClient {
   readonly callCount: number;
   createChatCompletion(input: {

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { MockOpenRouterClient } from "../src/openrouter.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "../src/profiles/index.js";
-import { createRuntimeConfig, handleChatCompletions, handleRuntimeRequest, marketplaceMetadata, type RuntimeConfig } from "../src/index.js";
+import { createRuntimeConfig, evaluateAttestation, handleAttestationEvaluation, handleChatCompletions, handleRuntimeRequest, marketplaceMetadata, type RuntimeConfig } from "../src/index.js";
 
 const config: RuntimeConfig = {
   profileId: "planning-agent",
@@ -168,7 +168,96 @@ test("well-known metadata includes Reddi marketplace fields", async () => {
   assert.equal(metadata.endpoint, "https://planning.example.test/v1/chat/completions");
 });
 
-test("HTTP core routes expose health, models, tags, metadata, and chat", async () => {
+test("attestor route returns structured release verdict for sample specialist output and receipt chain", async () => {
+  const client = new MockOpenRouterClient();
+  const response = await handleAttestationEvaluation({
+    headers: new Headers({ "x402-payment": "demo:attestation-release-1" }),
+    body: {
+      mode: "attestation",
+      subjectProfileId: "planning-agent",
+      specialistOutput:
+        "Execution plan includes evidence, validation gates, artifact references, and clear risks. Receipt confirms paid specialist work and the output stays within constraints.",
+      receiptChain: [
+        { id: "challenge-1", type: "x402-challenge", status: "issued", amount: "0.03", currency: "USDC" },
+        { id: "receipt-1", type: "x402-payment", status: "satisfied", amount: "0.03", currency: "USDC", txSignature: "demo-signature" },
+      ],
+      domain: "general operations",
+    },
+    config: { ...config, profileId: "verification-validation-agent", allowDemoPayment: true },
+    client,
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(client.callCount, 1);
+  assert.equal(client.lastRequest?.metadata.mode, "attestation");
+  assert.equal(client.lastRequest?.messages[0]?.role, "system");
+  assert.match(client.lastRequest?.messages[0]?.content ?? "", /Verdict semantics: release=pay specialist, refund=return funds/);
+  const verdict = response.body.verdict as { schemaVersion: string; score: number; recommendedAction: string; checks: unknown[]; summary: string; caveats: string[] };
+  assert.equal(verdict.schemaVersion, "reddi.attestation.v1");
+  assert.equal(verdict.recommendedAction, "release");
+  assert.ok(verdict.score >= 0.8);
+  assert.ok(verdict.checks.length >= 4);
+  assert.match(verdict.summary, /Recommend release/);
+  assert.ok(verdict.caveats.some((caveat) => caveat.includes("not professional certification")));
+});
+
+test("attestation request mode on chat completions uses attestation envelope", async () => {
+  const client = new MockOpenRouterClient();
+  const response = await handleChatCompletions({
+    headers: new Headers({ "x402-payment": "demo:attestation-chat-mode-1" }),
+    body: {
+      metadata: {
+        mode: "attestation",
+        attestation: {
+          subjectProfileId: "document-intelligence-agent",
+          specialistOutput: "Short summary with no receipt evidence.",
+          receiptChain: [],
+        },
+      },
+    },
+    config: { ...config, profileId: "verification-validation-agent", allowDemoPayment: true },
+    client,
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.object, "reddi.attestation.verdict");
+  assert.equal((response.body.verdict as { recommendedAction: string }).recommendedAction, "refund");
+});
+
+test("regulated-domain caveat is preserved and borderline verdict disputes", () => {
+  const verdict = evaluateAttestation(
+    {
+      mode: "attestation",
+      subjectProfileId: "conversational-agent",
+      specialistOutput: "Financial explanation with evidence but should remain informational only.",
+      receiptChain: [{ id: "receipt-1", type: "x402-payment", status: "paid", amount: "0.015", currency: "USDC" }],
+      domain: "financial planning",
+    },
+    "verification-validation-agent",
+  );
+
+  assert.equal(verdict.recommendedAction, "dispute");
+  assert.ok(verdict.caveats.some((caveat) => caveat.includes("Regulated-domain caveat")));
+  assert.ok(verdict.semantics.release.includes("Recommend release"));
+  assert.ok(verdict.semantics.refund.includes("Recommend refund"));
+  assert.ok(verdict.semantics.dispute.includes("Recommend dispute"));
+});
+
+test("non-attestor profile cannot evaluate attestations", async () => {
+  const client = new MockOpenRouterClient();
+  const response = await handleAttestationEvaluation({
+    headers: new Headers({ "x402-payment": "demo:not-attestor-1" }),
+    body: { mode: "attestation", specialistOutput: "hello", receiptChain: [] },
+    config: { ...config, allowDemoPayment: true },
+    client,
+  });
+
+  assert.equal(response.status, 403);
+  assert.equal(client.callCount, 0);
+  assert.equal((response.body.error as { code: string }).code, "profile_not_attestor");
+});
+
+test("HTTP core routes expose health, models, tags, metadata, attestation, and chat", async () => {
   const client = new MockOpenRouterClient();
   for (const path of ["/healthz", "/x402/health", "/v1/models", "/api/tags", "/.well-known/reddi-agent.json"]) {
     const response = await handleRuntimeRequest(new Request(`https://planning.example.test${path}`), config, client);
@@ -186,4 +275,23 @@ test("HTTP core routes expose health, models, tags, metadata, and chat", async (
   );
   assert.equal(unpaid.status, 402);
   assert.equal(client.callCount, 0);
+
+  const attestation = await handleRuntimeRequest(
+    new Request("https://planning.example.test/v1/attestations", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x402-payment": "demo:http-attestation-route-1" },
+      body: JSON.stringify({
+        mode: "attestation",
+        subjectProfileId: "planning-agent",
+        specialistOutput: "Plan includes validation artifacts, test evidence, receipt references, risks, and clear settlement recommendation input.",
+        receiptChain: [{ id: "receipt-http-1", type: "x402-payment", status: "satisfied", amount: "0.03", currency: "USDC" }],
+      }),
+    }),
+    { ...config, profileId: "verification-validation-agent", allowDemoPayment: true },
+    client,
+  );
+  assert.equal(attestation.status, 200);
+  const attestationBody = (await attestation.json()) as { object: string; verdict: { recommendedAction: string } };
+  assert.equal(attestationBody.object, "reddi.attestation.verdict");
+  assert.equal(attestationBody.verdict.recommendedAction, "release");
 });


### PR DESCRIPTION
## Summary
- Adds reddi.attestation.v1 verdict schema/types and deterministic release/refund/dispute evaluator
- Adds attestation prompt envelope plus POST /v1/attestations and metadata.mode=attestation on /v1/chat/completions
- Keeps verification-validation-agent as the default attestor and rejects attestation on non-attestor profiles
- Documents attestation usage in the OpenRouter specialists README

Closes #145

## Validation
- cd packages/openrouter-specialists && npm test — PASS (15/15)
- npm run build — PASS (existing workspace-root/localstorage warnings only)

## Guardrails
- No funds, private keys, deployment, mainnet, or paid OpenRouter calls used
- Demo payment and mock OpenRouter remain explicit opt-in only