### PR TITLE
fix(openrouter): bind attestation x402 challenges to route

### DIFF
--- a/packages/openrouter-specialists/README.md
+++ b/packages/openrouter-specialists/README.md
@@ -2,7 +2,7 @@
 
 Shared runtime for Reddi Agent Protocol marketplace specialists backed by OpenRouter.
 
-Iteration 3 includes the default attestor path: `verification-validation-agent` is both a `specialist` and `attestor`, can evaluate specialist outputs plus receipt chains, and returns a structured `reddi.attestation.v1` verdict.
+Iteration 3 includes the default attestor path: `verification-validation-agent` is both a `specialist` and `attestor`, can evaluate specialist outputs plus receipt chains, and returns a structured `reddi.attestation.v1` deterministic local settlement recommendation.
 
 ## Safety defaults
 
@@ -36,7 +36,7 @@ Minimal request body:
 }
 ```
 
-Response body includes `verdict.schemaVersion`, `score`, `checks`, `summary`, `recommendedAction`, regulated-domain caveats when relevant, and explicit release/refund/dispute semantics.
+Response body includes `verdictSource="deterministic_local_evaluator"`, `verdict.schemaVersion`, `score`, `checks`, `summary`, `recommendedAction`, regulated-domain caveats when relevant, and explicit release/refund/dispute semantics. The runtime still sends an attestation prompt envelope through the configured OpenRouter/mock client for auditability and future LLM attestor parsing, but the returned settlement recommendation is currently produced by the deterministic local evaluator. A future live-LLM attestor must parse and validate upstream `reddi.attestation.v1` output and fail closed/dispute on malformed output.
 
 ## Validation
 

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -34,16 +34,16 @@ export function createOpenRouterClient(config: RuntimeConfig): OpenRouterClient 
   return new FetchOpenRouterClient(config.openRouterApiKey, config.openRouterBaseUrl);
 }
 
-export function buildProfileChallenge(profile: SpecialistProfile, config: RuntimeConfig, nonce: string = randomUUID()): X402Challenge {
+export function buildProfileChallenge(profile: SpecialistProfile, config: RuntimeConfig, nonce: string = randomUUID(), endpointPath = profile.endpointPath): X402Challenge {
   return buildX402Challenge({
     version: "1",
     network: PAYMENT_NETWORK,
     payTo: profile.walletAddress,
     amount: profile.price.amount,
     currency: profile.price.currency,
-    endpoint: `${config.endpointBaseUrl}${profile.endpointPath}`,
+    endpoint: `${config.endpointBaseUrl}${endpointPath}`,
     nonce,
-    memo: `reddi:${profile.id}`,
+    memo: `reddi:${profile.id}:${endpointPath}`,
   });
 }
 
@@ -64,8 +64,8 @@ function paymentRequired(challenge: X402Challenge): RuntimeResponse {
   };
 }
 
-export function x402Challenge(profile: SpecialistProfile, config: RuntimeConfig): RuntimeResponse {
-  return paymentRequired(buildProfileChallenge(profile, config));
+export function x402Challenge(profile: SpecialistProfile, config: RuntimeConfig, endpointPath = profile.endpointPath): RuntimeResponse {
+  return paymentRequired(buildProfileChallenge(profile, config, randomUUID(), endpointPath));
 }
 
 export async function verifyPayment(input: {
@@ -73,6 +73,7 @@ export async function verifyPayment(input: {
   profile: SpecialistProfile;
   config: RuntimeConfig;
   replayStore?: NonceReplayStore;
+  endpointPath?: string;
 }): Promise<ReceiptVerificationResult> {
   const value = input.headers.get("x402-payment") ?? input.headers.get("x-payment");
   if (!value) return { ok: false, reason: "invalid_receipt", message: "missing x402-payment header" };
@@ -85,7 +86,7 @@ export async function verifyPayment(input: {
         ? (parsed as { nonce: string }).nonce
         : randomUUID();
   if (!receiptNonce) return { ok: false, reason: "invalid_nonce", message: "x402 payment nonce is required" };
-  const challenge = buildProfileChallenge(input.profile, input.config, receiptNonce);
+  const challenge = buildProfileChallenge(input.profile, input.config, receiptNonce, input.endpointPath);
   const verifier = new DemoPaymentVerifier(input.config.allowDemoPayment === true);
   return verifier.verifyReceipt(parsed, challenge, input.replayStore);
 }
@@ -136,11 +137,12 @@ export async function ensurePaid(input: {
   profile: SpecialistProfile;
   config: RuntimeConfig;
   replayStore?: NonceReplayStore;
+  endpointPath?: string;
 }): Promise<RuntimeResponse | undefined> {
   if (!input.config.requirePayment) return undefined;
-  const payment = await verifyPayment({ headers: input.headers, profile: input.profile, config: input.config, replayStore: input.replayStore });
+  const payment = await verifyPayment({ headers: input.headers, profile: input.profile, config: input.config, replayStore: input.replayStore, endpointPath: input.endpointPath });
   if (payment.ok) return undefined;
-  const response = paymentRequired(buildProfileChallenge(input.profile, input.config));
+  const response = paymentRequired(buildProfileChallenge(input.profile, input.config, randomUUID(), input.endpointPath));
   response.body.error = {
     code: payment.reason === "invalid_receipt" ? "payment_required" : payment.reason,
     message: payment.message,
@@ -158,6 +160,7 @@ export async function handleAttestationEvaluation(input: {
   config: RuntimeConfig;
   client: OpenRouterClient;
   replayStore?: NonceReplayStore;
+  endpointPath?: string;
 }): Promise<RuntimeResponse> {
   const profile = getProfile(input.config.profileId);
   if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };
@@ -165,7 +168,7 @@ export async function handleAttestationEvaluation(input: {
     return { status: 403, headers: JSON_HEADERS, body: { error: { code: "profile_not_attestor", message: `${profile.id} is not configured for attestation.` } } };
   }
 
-  const unpaid = await ensurePaid({ headers: input.headers, profile, config: input.config, replayStore: input.replayStore });
+  const unpaid = await ensurePaid({ headers: input.headers, profile, config: input.config, replayStore: input.replayStore, endpointPath: input.endpointPath ?? "/v1/attestations" });
   if (unpaid) return unpaid;
 
   const requestId = randomUUID();
@@ -193,6 +196,7 @@ export async function handleAttestationEvaluation(input: {
     headers: JSON_HEADERS,
     body: {
       object: "reddi.attestation.verdict",
+      verdictSource: "deterministic_local_evaluator",
       verdict: evaluateAttestation(attestationRequest, profile.id),
       promptEnvelope,
       upstream,
@@ -208,7 +212,7 @@ export async function handleChatCompletions(input: {
   client: OpenRouterClient;
   replayStore?: NonceReplayStore;
 }): Promise<RuntimeResponse> {
-  if (isAttestationMode(input.body)) return handleAttestationEvaluation(input);
+  if (isAttestationMode(input.body)) return handleAttestationEvaluation({ ...input, endpointPath: "/v1/chat/completions" });
 
   const profile = getProfile(input.config.profileId);
   if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };
@@ -261,7 +265,7 @@ export async function handleRuntimeRequest(request: Request, config = createRunt
   if (request.method === "GET" && url.pathname === "/.well-known/reddi-agent.json") return toResponse({ status: 200, headers: JSON_HEADERS, body: marketplaceMetadata(profile, config) });
   if (request.method === "POST" && url.pathname === "/v1/attestations") {
     const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
-    return toResponse(await handleAttestationEvaluation({ headers: request.headers, body, config, client, replayStore: defaultNonceReplayStore }));
+    return toResponse(await handleAttestationEvaluation({ headers: request.headers, body, config, client, replayStore: defaultNonceReplayStore, endpointPath: "/v1/attestations" }));
   }
   if (request.method === "POST" && url.pathname === "/v1/chat/completions") {
     const body = (await request.json().catch(() => ({}))) as ChatCompletionRequest;

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -189,6 +189,7 @@ test("attestor route returns structured release verdict for sample specialist ou
 
   assert.equal(response.status, 200);
   assert.equal(client.callCount, 1);
+  assert.equal(response.body.verdictSource, "deterministic_local_evaluator");
   assert.equal(client.lastRequest?.metadata.mode, "attestation");
   assert.equal(client.lastRequest?.messages[0]?.role, "system");
   assert.match(client.lastRequest?.messages[0]?.content ?? "", /Verdict semantics: release=pay specialist, refund=return funds/);
@@ -276,6 +277,20 @@ test("HTTP core routes expose health, models, tags, metadata, attestation, and c
   assert.equal(unpaid.status, 402);
   assert.equal(client.callCount, 0);
 
+  const unpaidAttestation = await handleRuntimeRequest(
+    new Request("https://planning.example.test/v1/attestations", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mode: "attestation", specialistOutput: "hello", receiptChain: [] }),
+    }),
+    { ...config, profileId: "verification-validation-agent", allowDemoPayment: true },
+    client,
+  );
+  assert.equal(unpaidAttestation.status, 402);
+  const unpaidAttestationChallenge = JSON.parse(unpaidAttestation.headers.get("x402-request") ?? "{}") as { endpoint?: string; memo?: string };
+  assert.equal(unpaidAttestationChallenge.endpoint, "https://planning.example.test/v1/attestations");
+  assert.equal(unpaidAttestationChallenge.memo, "reddi:verification-validation-agent:/v1/attestations");
+
   const attestation = await handleRuntimeRequest(
     new Request("https://planning.example.test/v1/attestations", {
       method: "POST",
@@ -291,7 +306,8 @@ test("HTTP core routes expose health, models, tags, metadata, attestation, and c
     client,
   );
   assert.equal(attestation.status, 200);
-  const attestationBody = (await attestation.json()) as { object: string; verdict: { recommendedAction: string } };
+  const attestationBody = (await attestation.json()) as { object: string; verdictSource: string; verdict: { recommendedAction: string } };
   assert.equal(attestationBody.object, "reddi.attestation.verdict");
+  assert.equal(attestationBody.verdictSource, "deterministic_local_evaluator");
   assert.equal(attestationBody.verdict.recommendedAction, "release");
 });


### PR DESCRIPTION
## Summary
- bind x402 challenges for `/v1/attestations` to the actual attestation route
- keep chat-completions challenges scoped to `/v1/chat/completions`
- clarify docs that deterministic verdicts are local settlement recommendations

## Validation
- `cd packages/openrouter-specialists && npm test` PASS (15/15)
- `npm run build` PASS

## BDD loop
Follow-up hardening from Iteration 3 retrospective before Iteration 4 dry-run marketplace delegation. No funds, private keys, deployment, or paid OpenRouter calls.