### PR TITLE
feat(openrouter): add dry-run marketplace delegation planner

### DIFF
--- a/packages/openrouter-specialists/README.md
+++ b/packages/openrouter-specialists/README.md
@@ -4,6 +4,8 @@ Shared runtime for Reddi Agent Protocol marketplace specialists backed by OpenRo
 
 Iteration 3 includes the default attestor path: `verification-validation-agent` is both a `specialist` and `attestor`, can evaluate specialist outputs plus receipt chains, and returns a structured `reddi.attestation.v1` deterministic local settlement recommendation.
 
+Iteration 4 starts agent-to-agent composability in dry-run mode: consumer-capable specialists can return a deterministic marketplace delegation plan without performing downstream x402 negotiation or spending devnet SOL.
+
 ## Safety defaults
 
 - No private keys are stored here.
@@ -11,6 +13,7 @@ Iteration 3 includes the default attestor path: `verification-validation-agent` 
 - `OPENROUTER_MOCK` must be explicitly set to `1` or `true` to use mock mode.
 - If mock mode is disabled, `OPENROUTER_API_KEY` is required before an OpenRouter client can be created.
 - Demo payment headers are accepted only when `ALLOW_DEMO_X402_PAYMENT=1` or `true`.
+- `ENABLE_AGENT_TO_AGENT_CALLS` defaults to disabled. Iteration 4 supports dry-run delegation plans only; live delegation requests fail closed with `live_delegation_not_implemented` until a later guarded live-call iteration.
 - Caller-controlled strings such as `paid:` or JSON containing `signature` are not treated as payment proof.
 - Until real x402 settlement verification is wired, production deployments should leave `ALLOW_DEMO_X402_PAYMENT` unset and fail closed on unpaid requests.
 - Attestation verdicts are settlement recommendations only: `release` pays the specialist, `refund` returns funds to requester, and `dispute` holds for human/secondary review.
@@ -37,6 +40,29 @@ Minimal request body:
 ```
 
 Response body includes `verdictSource="deterministic_local_evaluator"`, `verdict.schemaVersion`, `score`, `checks`, `summary`, `recommendedAction`, regulated-domain caveats when relevant, and explicit release/refund/dispute semantics. The runtime still sends an attestation prompt envelope through the configured OpenRouter/mock client for auditability and future LLM attestor parsing, but the returned settlement recommendation is currently produced by the deterministic local evaluator. A future live-LLM attestor must parse and validate upstream `reddi.attestation.v1` output and fail closed/dispute on malformed output.
+
+## Dry-run marketplace delegation mode
+
+Use a consumer-capable profile such as `planning-agent` with `POST /v1/chat/completions`, a satisfied x402 payment, and `metadata.mode="delegation_plan"`.
+
+Minimal request body:
+
+```json
+{
+  "messages": [
+    { "role": "user", "content": "Plan a launch that needs document evidence extraction and code implementation." }
+  ],
+  "metadata": {
+    "mode": "delegation_plan",
+    "delegation": {
+      "requiredCapabilities": ["document-analysis", "code-generation"],
+      "maxCandidates": 3
+    }
+  }
+}
+```
+
+Response body includes `object="reddi.delegation.plan"`, deterministic candidate ranking by capability match, price, reputation, and freshness, estimated cost, required attestor, and guardrails. `downstreamCallsExecuted` is always `0` in this iteration. No signer/private-key material is used and no downstream paid call is attempted.
 
 ## Validation
 

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -2,4 +2,5 @@ export * from "./types.js";
 export * from "./profiles/index.js";
 export * from "./openrouter.js";
 export * from "./attestation.js";
+export * from "./marketplace-client.js";
 export * from "./runtime.js";

--- a/packages/openrouter-specialists/src/marketplace-client.ts
+++ b/packages/openrouter-specialists/src/marketplace-client.ts
@@ -1,0 +1,181 @@
+import type { SpecialistPrice, SpecialistProfile } from "./types.js";
+import { specialistProfiles } from "./profiles/index.js";
+
+export interface MarketplaceCandidate {
+  profileId: string;
+  displayName: string;
+  endpointPath: string;
+  capabilities: string[];
+  roles: string[];
+  price: SpecialistPrice;
+  reputationScore: number;
+  freshnessScore: number;
+  preferredAttestors: string[];
+  safetyMode: string;
+}
+
+export interface MarketplaceDiscoveryQuery {
+  requesterProfileId: string;
+  requiredCapabilities: string[];
+  maxCandidates?: number;
+}
+
+export interface RankedMarketplaceCandidate extends MarketplaceCandidate {
+  matchedCapabilities: string[];
+  missingCapabilities: string[];
+  rankScore: number;
+  rankRationale: string[];
+}
+
+export interface DelegationPlanRequest {
+  task: string;
+  requiredCapabilities: string[];
+  requesterProfileId: string;
+  maxCandidates?: number;
+}
+
+export interface DelegationPlan {
+  mode: "dry_run";
+  status: "planned" | "no_candidates";
+  requesterProfileId: string;
+  task: string;
+  requiredCapabilities: string[];
+  liveCallsEnabled: false;
+  downstreamCallsExecuted: 0;
+  candidates: RankedMarketplaceCandidate[];
+  selectedCandidate?: RankedMarketplaceCandidate;
+  estimatedCost?: SpecialistPrice;
+  requiredAttestor?: string;
+  guardrails: string[];
+}
+
+export interface MarketplaceDiscoveryClient {
+  discover(query: MarketplaceDiscoveryQuery): Promise<MarketplaceCandidate[]>;
+}
+
+const STATIC_REPUTATION: Record<string, { reputationScore: number; freshnessScore: number }> = {
+  "planning-agent": { reputationScore: 0.91, freshnessScore: 0.92 },
+  "document-intelligence-agent": { reputationScore: 0.88, freshnessScore: 0.9 },
+  "verification-validation-agent": { reputationScore: 0.93, freshnessScore: 0.91 },
+  "code-generation-agent": { reputationScore: 0.9, freshnessScore: 0.89 },
+  "conversational-agent": { reputationScore: 0.84, freshnessScore: 0.88 },
+};
+
+export class StaticMarketplaceDiscoveryClient implements MarketplaceDiscoveryClient {
+  constructor(private readonly profiles: SpecialistProfile[] = specialistProfiles) {}
+
+  async discover(query: MarketplaceDiscoveryQuery): Promise<MarketplaceCandidate[]> {
+    const required = normalizeCapabilities(query.requiredCapabilities);
+    return this.profiles
+      .filter((profile) => profile.id !== query.requesterProfileId)
+      .filter((profile) => profile.roles.includes("specialist"))
+      .filter((profile) => required.length === 0 || normalizeCapabilities(profile.capabilities).some((capability) => required.includes(capability)))
+      .map(toCandidate);
+  }
+}
+
+export function normalizeCapabilities(capabilities: string[]): string[] {
+  return [...new Set(capabilities.map((capability) => capability.trim().toLowerCase()).filter(Boolean))].sort();
+}
+
+export function inferRequiredCapabilities(task: string): string[] {
+  const normalized = task.toLowerCase();
+  const inferred = new Set<string>();
+  const addWhen = (pattern: RegExp, capability: string) => {
+    if (pattern.test(normalized)) inferred.add(capability);
+  };
+
+  addWhen(/\b(document|pdf|evidence|extract|summari[sz]e|classif)/, "document-analysis");
+  addWhen(/\b(code|bug|debug|test|typescript|api|implementation|build)\b/, "code-generation");
+  addWhen(/\b(verify|validate|attest|quality|review|evidence)\b/, "verification");
+  addWhen(/\b(plan|roadmap|sequence|milestone|orchestrat)/, "planning");
+  addWhen(/\b(intake|clarify|conversation|support|handoff)\b/, "conversation");
+
+  return [...inferred].sort();
+}
+
+export function rankMarketplaceCandidates(candidates: MarketplaceCandidate[], requiredCapabilities: string[]): RankedMarketplaceCandidate[] {
+  const required = normalizeCapabilities(requiredCapabilities);
+  return candidates
+    .map((candidate) => rankCandidate(candidate, required))
+    .sort((a, b) => b.rankScore - a.rankScore || priceAsNumber(a.price) - priceAsNumber(b.price) || b.reputationScore - a.reputationScore || a.profileId.localeCompare(b.profileId));
+}
+
+export async function buildDryRunDelegationPlan(input: {
+  request: DelegationPlanRequest;
+  discoveryClient?: MarketplaceDiscoveryClient;
+}): Promise<DelegationPlan> {
+  const requiredCapabilities = normalizeCapabilities(input.request.requiredCapabilities);
+  const discoveryClient = input.discoveryClient ?? new StaticMarketplaceDiscoveryClient();
+  const candidates = rankMarketplaceCandidates(
+    await discoveryClient.discover({
+      requesterProfileId: input.request.requesterProfileId,
+      requiredCapabilities,
+      maxCandidates: input.request.maxCandidates,
+    }),
+    requiredCapabilities,
+  ).slice(0, input.request.maxCandidates ?? 3);
+  const selectedCandidate = candidates[0];
+
+  return {
+    mode: "dry_run",
+    status: selectedCandidate ? "planned" : "no_candidates",
+    requesterProfileId: input.request.requesterProfileId,
+    task: input.request.task,
+    requiredCapabilities,
+    liveCallsEnabled: false,
+    downstreamCallsExecuted: 0,
+    candidates,
+    selectedCandidate,
+    estimatedCost: selectedCandidate?.price,
+    requiredAttestor: selectedCandidate?.preferredAttestors[0] ?? "verification-validation-agent",
+    guardrails: [
+      "dry-run only: no downstream x402 negotiation executed",
+      "no devnet SOL spent",
+      "no signer or private-key material used",
+      "set ENABLE_AGENT_TO_AGENT_CALLS=true only in a later live-call iteration",
+    ],
+  };
+}
+
+function toCandidate(profile: SpecialistProfile): MarketplaceCandidate {
+  const scores = STATIC_REPUTATION[profile.id] ?? { reputationScore: 0.75, freshnessScore: 0.75 };
+  return {
+    profileId: profile.id,
+    displayName: profile.displayName,
+    endpointPath: profile.endpointPath,
+    capabilities: profile.capabilities,
+    roles: profile.roles,
+    price: profile.price,
+    reputationScore: scores.reputationScore,
+    freshnessScore: scores.freshnessScore,
+    preferredAttestors: profile.preferredAttestors,
+    safetyMode: profile.safetyMode,
+  };
+}
+
+function rankCandidate(candidate: MarketplaceCandidate, requiredCapabilities: string[]): RankedMarketplaceCandidate {
+  const candidateCapabilities = normalizeCapabilities(candidate.capabilities);
+  const matchedCapabilities = requiredCapabilities.filter((capability) => candidateCapabilities.includes(capability));
+  const missingCapabilities = requiredCapabilities.filter((capability) => !candidateCapabilities.includes(capability));
+  const capabilityScore = requiredCapabilities.length === 0 ? 0.5 : matchedCapabilities.length / requiredCapabilities.length;
+  const affordabilityScore = Math.max(0, 1 - priceAsNumber(candidate.price));
+  const rankScore = Number((capabilityScore * 70 + candidate.reputationScore * 15 + candidate.freshnessScore * 10 + affordabilityScore * 5).toFixed(4));
+  return {
+    ...candidate,
+    matchedCapabilities,
+    missingCapabilities,
+    rankScore,
+    rankRationale: [
+      `matched ${matchedCapabilities.length}/${requiredCapabilities.length} required capabilities`,
+      `reputation=${candidate.reputationScore.toFixed(2)}`,
+      `freshness=${candidate.freshnessScore.toFixed(2)}`,
+      `price=${candidate.price.amount} ${candidate.price.currency}/${candidate.price.unit}`,
+    ],
+  };
+}
+
+function priceAsNumber(price: SpecialistPrice): number {
+  const parsed = Number.parseFloat(price.amount);
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -9,6 +9,7 @@ import {
   type X402Challenge,
 } from "@reddi/x402-solana";
 import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
+import { buildDryRunDelegationPlan, inferRequiredCapabilities } from "./marketplace-client.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "./profiles/index.js";
 import { FetchOpenRouterClient, MockOpenRouterClient } from "./openrouter.js";
 import type { AttestationRequest, ChatCompletionRequest, OpenRouterClient, RuntimeConfig, RuntimeResponse, SpecialistProfile } from "./types.js";
@@ -25,6 +26,9 @@ export function createRuntimeConfig(env: NodeJS.ProcessEnv = process.env): Runti
     mockOpenRouter: env.OPENROUTER_MOCK === "1" || env.OPENROUTER_MOCK === "true",
     requirePayment: env.REQUIRE_X402_PAYMENT !== "false",
     allowDemoPayment: env.ALLOW_DEMO_X402_PAYMENT === "1" || env.ALLOW_DEMO_X402_PAYMENT === "true",
+    enableAgentToAgentCalls: env.ENABLE_AGENT_TO_AGENT_CALLS === "1" || env.ENABLE_AGENT_TO_AGENT_CALLS === "true",
+    maxDownstreamCalls: env.MAX_DOWNSTREAM_CALLS ? Number.parseInt(env.MAX_DOWNSTREAM_CALLS, 10) : 0,
+    maxDownstreamLamports: env.MAX_DOWNSTREAM_LAMPORTS ? Number.parseInt(env.MAX_DOWNSTREAM_LAMPORTS, 10) : 0,
   };
 }
 
@@ -154,6 +158,88 @@ export function isAttestationMode(body: ChatCompletionRequest): boolean {
   return body.metadata?.mode === "attestation" || body.metadata?.attestation !== undefined;
 }
 
+export function isDelegationMode(body: ChatCompletionRequest): boolean {
+  return body.metadata?.mode === "delegation_plan" || body.metadata?.mode === "delegation_dry_run" || body.metadata?.delegation !== undefined;
+}
+
+export async function handleDelegationPlanning(input: {
+  headers: Headers;
+  body: ChatCompletionRequest;
+  config: RuntimeConfig;
+  replayStore?: NonceReplayStore;
+}): Promise<RuntimeResponse> {
+  const profile = getProfile(input.config.profileId);
+  if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };
+  if (!profile.roles.includes("consumer")) {
+    return { status: 403, headers: JSON_HEADERS, body: { error: { code: "profile_not_consumer", message: `${profile.id} cannot plan downstream marketplace delegation.` } } };
+  }
+
+  const unpaid = await ensurePaid({ headers: input.headers, profile, config: input.config, replayStore: input.replayStore });
+  if (unpaid) return unpaid;
+
+  const metadata = input.body.metadata ?? {};
+  const delegation = typeof metadata.delegation === "object" && metadata.delegation !== null ? (metadata.delegation as Record<string, unknown>) : {};
+  const dryRun = delegation.dryRun !== false && metadata.mode !== "delegation_live";
+  if (input.config.enableAgentToAgentCalls && !dryRun) {
+    return {
+      status: 501,
+      headers: JSON_HEADERS,
+      body: {
+        error: {
+          code: "live_delegation_not_implemented",
+          message: "Live agent-to-agent x402 calls are intentionally fail-closed until the guarded live-call iteration.",
+        },
+        reddi: {
+          profileId: profile.id,
+          liveCallsEnabled: true,
+          downstreamCallsExecuted: 0,
+          maxDownstreamCalls: input.config.maxDownstreamCalls ?? 0,
+          maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
+        },
+      },
+    };
+  }
+
+  const task =
+    typeof delegation.task === "string"
+      ? delegation.task
+      : input.body.messages
+          ?.filter((message) => message.role === "user")
+          .map((message) => message.content)
+          .join("\n")
+          .trim() || "";
+  const explicitCapabilities = Array.isArray(delegation.requiredCapabilities) ? delegation.requiredCapabilities.filter((value): value is string => typeof value === "string") : [];
+  const requiredCapabilities = explicitCapabilities.length > 0 ? explicitCapabilities : inferRequiredCapabilities(task);
+  const maxCandidates = typeof delegation.maxCandidates === "number" && Number.isFinite(delegation.maxCandidates) ? Math.max(1, Math.floor(delegation.maxCandidates)) : 3;
+  const plan = await buildDryRunDelegationPlan({
+    request: {
+      task,
+      requesterProfileId: profile.id,
+      requiredCapabilities,
+      maxCandidates,
+    },
+  });
+  const requestId = randomUUID();
+
+  return {
+    status: 200,
+    headers: JSON_HEADERS,
+    body: {
+      object: "reddi.delegation.plan",
+      plan,
+      reddi: {
+        profileId: profile.id,
+        requestId,
+        mode: "delegation_dry_run",
+        paymentSatisfied: input.config.requirePayment,
+        liveCallsEnabled: false,
+        downstreamCallsExecuted: 0,
+        requiredAttestor: plan.requiredAttestor,
+      },
+    },
+  };
+}
+
 export async function handleAttestationEvaluation(input: {
   headers: Headers;
   body: AttestationRequest | ChatCompletionRequest | Record<string, unknown>;
@@ -213,6 +299,7 @@ export async function handleChatCompletions(input: {
   replayStore?: NonceReplayStore;
 }): Promise<RuntimeResponse> {
   if (isAttestationMode(input.body)) return handleAttestationEvaluation({ ...input, endpointPath: "/v1/chat/completions" });
+  if (isDelegationMode(input.body)) return handleDelegationPlanning(input);
 
   const profile = getProfile(input.config.profileId);
   if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -159,7 +159,7 @@ export function isAttestationMode(body: ChatCompletionRequest): boolean {
 }
 
 export function isDelegationMode(body: ChatCompletionRequest): boolean {
-  return body.metadata?.mode === "delegation_plan" || body.metadata?.mode === "delegation_dry_run" || body.metadata?.delegation !== undefined;
+  return body.metadata?.mode === "delegation_plan" || body.metadata?.mode === "delegation_dry_run" || body.metadata?.mode === "delegation_live" || body.metadata?.delegation !== undefined;
 }
 
 export async function handleDelegationPlanning(input: {
@@ -180,7 +180,7 @@ export async function handleDelegationPlanning(input: {
   const metadata = input.body.metadata ?? {};
   const delegation = typeof metadata.delegation === "object" && metadata.delegation !== null ? (metadata.delegation as Record<string, unknown>) : {};
   const dryRun = delegation.dryRun !== false && metadata.mode !== "delegation_live";
-  if (input.config.enableAgentToAgentCalls && !dryRun) {
+  if (!dryRun) {
     return {
       status: 501,
       headers: JSON_HEADERS,

--- a/packages/openrouter-specialists/src/types.ts
+++ b/packages/openrouter-specialists/src/types.ts
@@ -32,6 +32,9 @@ export interface RuntimeConfig {
   mockOpenRouter: boolean;
   requirePayment: boolean;
   allowDemoPayment?: boolean;
+  enableAgentToAgentCalls?: boolean;
+  maxDownstreamCalls?: number;
+  maxDownstreamLamports?: number;
   safetyMode?: SafetyMode;
 }
 

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -2,7 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { MockOpenRouterClient } from "../src/openrouter.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "../src/profiles/index.js";
-import { createRuntimeConfig, evaluateAttestation, handleAttestationEvaluation, handleChatCompletions, handleRuntimeRequest, marketplaceMetadata, type RuntimeConfig } from "../src/index.js";
+import {
+  buildDryRunDelegationPlan,
+  createRuntimeConfig,
+  evaluateAttestation,
+  handleAttestationEvaluation,
+  handleChatCompletions,
+  handleRuntimeRequest,
+  marketplaceMetadata,
+  rankMarketplaceCandidates,
+  type RuntimeConfig,
+} from "../src/index.js";
 
 const config: RuntimeConfig = {
   profileId: "planning-agent",
@@ -26,6 +36,9 @@ test("profile registry has first five unique valid profiles with required market
 test("OpenRouter mock mode is explicit opt-in only", () => {
   assert.equal(createRuntimeConfig({}).mockOpenRouter, false);
   assert.equal(createRuntimeConfig({ OPENROUTER_MOCK: "true" }).mockOpenRouter, true);
+  assert.equal(createRuntimeConfig({}).enableAgentToAgentCalls, false);
+  assert.equal(createRuntimeConfig({ ENABLE_AGENT_TO_AGENT_CALLS: "true", MAX_DOWNSTREAM_CALLS: "2", MAX_DOWNSTREAM_LAMPORTS: "5000" }).enableAgentToAgentCalls, true);
+  assert.equal(createRuntimeConfig({ ENABLE_AGENT_TO_AGENT_CALLS: "true", MAX_DOWNSTREAM_CALLS: "2", MAX_DOWNSTREAM_LAMPORTS: "5000" }).maxDownstreamCalls, 2);
 });
 
 test("unpaid completion returns 402 challenge before OpenRouter client call", async () => {
@@ -256,6 +269,120 @@ test("non-attestor profile cannot evaluate attestations", async () => {
   assert.equal(response.status, 403);
   assert.equal(client.callCount, 0);
   assert.equal((response.body.error as { code: string }).code, "profile_not_attestor");
+});
+
+test("dry-run marketplace delegation ranks candidates deterministically without downstream paid calls", async () => {
+  const client = new MockOpenRouterClient();
+  const response = await handleChatCompletions({
+    headers: new Headers({ "x402-payment": "demo:delegation-dry-run-1" }),
+    body: {
+      messages: [{ role: "user", content: "Plan a launch that needs document evidence extraction and code implementation." }],
+      metadata: {
+        mode: "delegation_plan",
+        delegation: {
+          requiredCapabilities: ["document-analysis", "code-generation"],
+          maxCandidates: 3,
+        },
+      },
+    },
+    config: { ...config, allowDemoPayment: true },
+    client,
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(client.callCount, 0);
+  assert.equal(response.body.object, "reddi.delegation.plan");
+  const plan = response.body.plan as {
+    mode: string;
+    liveCallsEnabled: boolean;
+    downstreamCallsExecuted: number;
+    requiredCapabilities: string[];
+    candidates: Array<{ profileId: string; matchedCapabilities: string[]; rankScore: number }>;
+    selectedCandidate: { profileId: string };
+    estimatedCost: { amount: string; currency: string };
+    requiredAttestor: string;
+    guardrails: string[];
+  };
+  assert.equal(plan.mode, "dry_run");
+  assert.equal(plan.liveCallsEnabled, false);
+  assert.equal(plan.downstreamCallsExecuted, 0);
+  assert.deepEqual(plan.requiredCapabilities, ["code-generation", "document-analysis"]);
+  assert.deepEqual(
+    plan.candidates.map((candidate) => candidate.profileId),
+    ["code-generation-agent", "document-intelligence-agent"],
+  );
+  assert.equal(plan.selectedCandidate.profileId, "code-generation-agent");
+  assert.deepEqual(plan.candidates.map((candidate) => candidate.rankScore), [...plan.candidates.map((candidate) => candidate.rankScore)].sort((a, b) => b - a));
+  assert.equal(plan.estimatedCost.currency, "USDC");
+  assert.equal(plan.requiredAttestor, "verification-validation-agent");
+  assert.ok(plan.guardrails.some((guardrail) => guardrail.includes("no devnet SOL spent")));
+  assert.equal((response.body.reddi as { downstreamCallsExecuted: number; liveCallsEnabled: boolean }).downstreamCallsExecuted, 0);
+  assert.equal((response.body.reddi as { downstreamCallsExecuted: number; liveCallsEnabled: boolean }).liveCallsEnabled, false);
+});
+
+test("dry-run marketplace ranking is deterministic for sample candidates", async () => {
+  const plan = await buildDryRunDelegationPlan({
+    request: {
+      requesterProfileId: "planning-agent",
+      task: "Need code and tests",
+      requiredCapabilities: ["code-generation"],
+      maxCandidates: 3,
+    },
+  });
+  assert.equal(plan.candidates[0]?.profileId, "code-generation-agent");
+  assert.equal(plan.selectedCandidate?.profileId, "code-generation-agent");
+
+  const ranked = rankMarketplaceCandidates(
+    [
+      {
+        profileId: "b-agent",
+        displayName: "B",
+        endpointPath: "/v1/chat/completions",
+        capabilities: ["code-generation"],
+        roles: ["specialist"],
+        price: { currency: "USDC", amount: "0.02", unit: "request" },
+        reputationScore: 0.8,
+        freshnessScore: 0.8,
+        preferredAttestors: ["verification-validation-agent"],
+        safetyMode: "standard",
+      },
+      {
+        profileId: "a-agent",
+        displayName: "A",
+        endpointPath: "/v1/chat/completions",
+        capabilities: ["code-generation"],
+        roles: ["specialist"],
+        price: { currency: "USDC", amount: "0.02", unit: "request" },
+        reputationScore: 0.8,
+        freshnessScore: 0.8,
+        preferredAttestors: ["verification-validation-agent"],
+        safetyMode: "standard",
+      },
+    ],
+    ["code-generation"],
+  );
+  assert.deepEqual(
+    ranked.map((candidate) => candidate.profileId),
+    ["a-agent", "b-agent"],
+  );
+});
+
+test("live delegation mode fails closed before any downstream paid call executor exists", async () => {
+  const client = new MockOpenRouterClient();
+  const response = await handleChatCompletions({
+    headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-1" }),
+    body: {
+      messages: [{ role: "user", content: "Hire a code agent for this task." }],
+      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"] } },
+    },
+    config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: true, maxDownstreamCalls: 1, maxDownstreamLamports: 1000 },
+    client,
+  });
+
+  assert.equal(response.status, 501);
+  assert.equal(client.callCount, 0);
+  assert.equal((response.body.error as { code: string }).code, "live_delegation_not_implemented");
+  assert.equal((response.body.reddi as { downstreamCallsExecuted: number }).downstreamCallsExecuted, 0);
 });
 
 test("HTTP core routes expose health, models, tags, metadata, attestation, and chat", async () => {

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -383,6 +383,32 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(client.callCount, 0);
   assert.equal((response.body.error as { code: string }).code, "live_delegation_not_implemented");
   assert.equal((response.body.reddi as { downstreamCallsExecuted: number }).downstreamCallsExecuted, 0);
+
+  const liveWithoutDelegationObject = await handleChatCompletions({
+    headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-2" }),
+    body: {
+      messages: [{ role: "user", content: "Hire another agent live." }],
+      metadata: { mode: "delegation_live" },
+    },
+    config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: true },
+    client,
+  });
+  assert.equal(liveWithoutDelegationObject.status, 501);
+  assert.equal(client.callCount, 0);
+  assert.equal((liveWithoutDelegationObject.body.error as { code: string }).code, "live_delegation_not_implemented");
+
+  const liveWithCallsDisabled = await handleChatCompletions({
+    headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-3" }),
+    body: {
+      messages: [{ role: "user", content: "Hire another agent live." }],
+      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"] } },
+    },
+    config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: false },
+    client,
+  });
+  assert.equal(liveWithCallsDisabled.status, 501);
+  assert.equal(client.callCount, 0);
+  assert.equal((liveWithCallsDisabled.body.error as { code: string }).code, "live_delegation_not_implemented");
 });
 
 test("HTTP core routes expose health, models, tags, metadata, attestation, and chat", async () => {


### PR DESCRIPTION
## Summary
- add deterministic dry-run marketplace discovery/ranking for OpenRouter specialists
- add delegation-plan mode on `/v1/chat/completions` for consumer-capable profiles
- keep live agent-to-agent calls fail-closed until a later guarded iteration
- document Iteration 4 dry-run behavior and guardrails

## Validation
- `cd packages/openrouter-specialists && npm test` PASS (18/18)
- `npm run build` PASS
- `git diff --check` PASS

## BDD/OAD
Closes #147. Iteration 4 is dry-run only: no devnet SOL spend, no signer/private-key material, no Coolify deployment, and no live downstream x402 call.