### PR TITLE
feat(openrouter): harden registry discovery readiness

### DIFF
--- a/packages/openrouter-specialists/README.md
+++ b/packages/openrouter-specialists/README.md
@@ -6,6 +6,8 @@ Iteration 3 includes the default attestor path: `verification-validation-agent` 
 
 Iteration 4 starts agent-to-agent composability in dry-run mode: consumer-capable specialists can return a deterministic marketplace delegation plan without performing downstream x402 negotiation or spending devnet SOL.
 
+Iteration 4.5 hardens dry-run discovery with a manifest-backed discovery adapter and a no-spend deployment readiness report. It still does not deploy, fund wallets, inspect secrets, sign transactions, or execute live downstream x402 calls.
+
 ## Safety defaults
 
 - No private keys are stored here.
@@ -63,6 +65,25 @@ Minimal request body:
 ```
 
 Response body includes `object="reddi.delegation.plan"`, deterministic candidate ranking by capability match, price, reputation, and freshness, estimated cost, required attestor, and guardrails. `downstreamCallsExecuted` is always `0` in this iteration. No signer/private-key material is used and no downstream paid call is attempted.
+
+The dry-run planner can use the public wallet manifest as a discovery source. Malformed manifest candidates are excluded with explicit reasons in `discoveryDiagnostics`; they are not silently ranked.
+
+## Deployment readiness preflight
+
+Generate a public-data-only readiness report:
+
+```bash
+npm run deployment:readiness
+```
+
+Optional environment inputs:
+
+- `PUBLIC_BASE_URL` — planned specialist endpoint base URL.
+- `FUNDED_PROFILE_IDS` — comma-separated profile IDs already funded/approved.
+- `DEPLOYED_PROFILE_IDS` — comma-separated profile IDs already deployed/approved.
+- `READINESS_OUT` — output path, default `artifacts/deployment-readiness.json`.
+
+The report is expected to be `blocked` before approval/funding/deployment. It reports missing endpoints, funding, and Coolify deployment as blockers while preserving guardrails: public metadata only, no private keys/signers, no devnet SOL spend, no deployment, and no live downstream x402 calls.
 
 ## Validation
 

--- a/packages/openrouter-specialists/package.json
+++ b/packages/openrouter-specialists/package.json
@@ -16,7 +16,8 @@
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test dist/tests/*.test.js",
     "validate:wallet-manifest": "node scripts/validate-wallet-manifest.mjs",
-    "check:devnet-balances": "node scripts/check-devnet-balances.mjs"
+    "check:devnet-balances": "node scripts/check-devnet-balances.mjs",
+    "deployment:readiness": "npm run build && node scripts/deployment-readiness.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/packages/openrouter-specialists/scripts/deployment-readiness.mjs
+++ b/packages/openrouter-specialists/scripts/deployment-readiness.mjs
@@ -1,0 +1,16 @@
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildDeploymentReadinessReport } from '../dist/src/index.js';
+
+const manifestPath = process.argv[2] ?? join(process.cwd(), 'public/wallet-manifest.json');
+const outPath = process.env.READINESS_OUT ?? join(process.cwd(), 'artifacts/deployment-readiness.json');
+const endpointBaseUrl = process.env.PUBLIC_BASE_URL;
+const fundedProfileIds = (process.env.FUNDED_PROFILE_IDS ?? '').split(',').map((value) => value.trim()).filter(Boolean);
+const deployedProfileIds = (process.env.DEPLOYED_PROFILE_IDS ?? '').split(',').map((value) => value.trim()).filter(Boolean);
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+const report = buildDeploymentReadinessReport({ manifest, endpointBaseUrl, fundedProfileIds, deployedProfileIds });
+
+mkdirSync(join(outPath, '..'), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify(report, null, 2));
+if (report.status !== 'ready') process.exitCode = 1;

--- a/packages/openrouter-specialists/src/deployment-readiness.ts
+++ b/packages/openrouter-specialists/src/deployment-readiness.ts
@@ -1,0 +1,85 @@
+import { candidatesFromWalletManifest, type WalletManifest } from "./marketplace-client.js";
+import { specialistProfiles } from "./profiles/index.js";
+
+export type ReadinessStatus = "ready" | "blocked";
+
+export interface SpecialistReadinessEntry {
+  profileId: string;
+  displayName: string;
+  walletAddress?: string;
+  endpoint?: string;
+  roles: string[];
+  capabilities: string[];
+  preferredAttestors: string[];
+  checks: Array<{ id: string; ok: boolean; summary: string }>;
+  blockers: string[];
+}
+
+export interface DeploymentReadinessReport {
+  schemaVersion: "reddi.openrouter.deployment-readiness.v1";
+  status: ReadinessStatus;
+  generatedAt: string;
+  network: string;
+  minimumBalanceLamports: number;
+  guardrails: string[];
+  entries: SpecialistReadinessEntry[];
+  excluded: Array<{ profileId: string; reasons: string[] }>;
+  nextApprovalRequired: string[];
+}
+
+export function buildDeploymentReadinessReport(input: {
+  manifest: WalletManifest;
+  endpointBaseUrl?: string;
+  fundedProfileIds?: string[];
+  deployedProfileIds?: string[];
+  generatedAt?: string;
+}): DeploymentReadinessReport {
+  const endpointBaseUrl = input.endpointBaseUrl;
+  const funded = new Set(input.fundedProfileIds ?? []);
+  const deployed = new Set(input.deployedProfileIds ?? []);
+  const { candidates, excluded } = candidatesFromWalletManifest(input.manifest, specialistProfiles);
+  const entries = candidates.map((candidate): SpecialistReadinessEntry => {
+    const endpoint = endpointBaseUrl ? `${endpointBaseUrl}${candidate.endpointPath}` : undefined;
+    const checks = [
+      { id: "public_wallet_present", ok: Boolean(candidate.walletAddress), summary: candidate.walletAddress ? "public wallet present" : "missing public wallet" },
+      { id: "endpoint_configured", ok: Boolean(endpoint), summary: endpoint ? `endpoint planned: ${endpoint}` : "PUBLIC_BASE_URL/endpoint not configured" },
+      { id: "funding_confirmed", ok: funded.has(candidate.profileId), summary: funded.has(candidate.profileId) ? "funding marked ready" : "funding not confirmed; approval/funding required" },
+      { id: "deployment_confirmed", ok: deployed.has(candidate.profileId), summary: deployed.has(candidate.profileId) ? "deployment marked ready" : "Coolify deployment not confirmed" },
+      { id: "attestor_configured", ok: candidate.roles.includes("attestor") || candidate.preferredAttestors.length > 0, summary: candidate.roles.includes("attestor") ? "profile is attestor" : `preferred attestor: ${candidate.preferredAttestors[0] ?? "missing"}` },
+    ];
+    return {
+      profileId: candidate.profileId,
+      displayName: candidate.displayName,
+      walletAddress: candidate.walletAddress,
+      endpoint,
+      roles: candidate.roles,
+      capabilities: candidate.capabilities,
+      preferredAttestors: candidate.preferredAttestors,
+      checks,
+      blockers: checks.filter((check) => !check.ok).map((check) => check.summary),
+    };
+  });
+  const nextApprovalRequired = [
+    "Approve/configure Coolify deployments for first five specialist profiles.",
+    "Approve/fund public devnet wallets to the minimum balance threshold if live registration is next.",
+    "Approve production secret configuration for OPENROUTER_API_KEY outside the repository.",
+    "Approve any live downstream x402 execution separately; Iteration 4.5 does not enable it.",
+  ];
+  return {
+    schemaVersion: "reddi.openrouter.deployment-readiness.v1",
+    status: entries.every((entry) => entry.blockers.length === 0) && excluded.length === 0 ? "ready" : "blocked",
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    network: input.manifest.network,
+    minimumBalanceLamports: input.manifest.minimumBalanceLamports,
+    guardrails: [
+      "public metadata only",
+      "no private keys or signer material inspected",
+      "no devnet SOL spent",
+      "no Coolify deployment performed",
+      "no live downstream x402 calls executed",
+    ],
+    entries,
+    excluded,
+    nextApprovalRequired,
+  };
+}

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -3,4 +3,5 @@ export * from "./profiles/index.js";
 export * from "./openrouter.js";
 export * from "./attestation.js";
 export * from "./marketplace-client.js";
+export * from "./deployment-readiness.js";
 export * from "./runtime.js";

--- a/packages/openrouter-specialists/src/marketplace-client.ts
+++ b/packages/openrouter-specialists/src/marketplace-client.ts
@@ -1,10 +1,12 @@
+import { isValidSolanaPublicKey } from "@reddi/x402-solana";
 import type { SpecialistPrice, SpecialistProfile } from "./types.js";
-import { specialistProfiles } from "./profiles/index.js";
+import { getProfile, specialistProfiles } from "./profiles/index.js";
 
 export interface MarketplaceCandidate {
   profileId: string;
   displayName: string;
   endpointPath: string;
+  walletAddress?: string;
   capabilities: string[];
   roles: string[];
   price: SpecialistPrice;
@@ -12,6 +14,16 @@ export interface MarketplaceCandidate {
   freshnessScore: number;
   preferredAttestors: string[];
   safetyMode: string;
+}
+
+export interface CandidateValidationResult {
+  ok: boolean;
+  reasons: string[];
+}
+
+export interface DiscoveryDiagnostics {
+  includedProfileIds: string[];
+  excluded: Array<{ profileId: string; reasons: string[] }>;
 }
 
 export interface MarketplaceDiscoveryQuery {
@@ -47,10 +59,26 @@ export interface DelegationPlan {
   estimatedCost?: SpecialistPrice;
   requiredAttestor?: string;
   guardrails: string[];
+  discoveryDiagnostics?: DiscoveryDiagnostics;
 }
 
 export interface MarketplaceDiscoveryClient {
   discover(query: MarketplaceDiscoveryQuery): Promise<MarketplaceCandidate[]>;
+  diagnostics?(): DiscoveryDiagnostics;
+}
+
+export interface WalletManifestProfile {
+  profileId: string;
+  displayName: string;
+  publicKey: string;
+}
+
+export interface WalletManifest {
+  schemaVersion: string;
+  network: "solana-devnet";
+  minimumBalanceLamports: number;
+  generatedAt?: string;
+  profiles: WalletManifestProfile[];
 }
 
 const STATIC_REPUTATION: Record<string, { reputationScore: number; freshnessScore: number }> = {
@@ -72,6 +100,98 @@ export class StaticMarketplaceDiscoveryClient implements MarketplaceDiscoveryCli
       .filter((profile) => required.length === 0 || normalizeCapabilities(profile.capabilities).some((capability) => required.includes(capability)))
       .map(toCandidate);
   }
+
+  diagnostics(): DiscoveryDiagnostics {
+    return {
+      includedProfileIds: this.profiles.map((profile) => profile.id).sort(),
+      excluded: [],
+    };
+  }
+}
+
+export class ManifestMarketplaceDiscoveryClient implements MarketplaceDiscoveryClient {
+  private readonly candidates: MarketplaceCandidate[];
+  private readonly excluded: Array<{ profileId: string; reasons: string[] }>;
+
+  constructor(manifest: WalletManifest, private readonly profiles: SpecialistProfile[] = specialistProfiles) {
+    const built = candidatesFromWalletManifest(manifest, profiles);
+    this.candidates = built.candidates;
+    this.excluded = built.excluded;
+  }
+
+  async discover(query: MarketplaceDiscoveryQuery): Promise<MarketplaceCandidate[]> {
+    const required = normalizeCapabilities(query.requiredCapabilities);
+    return this.candidates
+      .filter((candidate) => candidate.profileId !== query.requesterProfileId)
+      .filter((candidate) => candidate.roles.includes("specialist"))
+      .filter((candidate) => required.length === 0 || normalizeCapabilities(candidate.capabilities).some((capability) => required.includes(capability)));
+  }
+
+  diagnostics(): DiscoveryDiagnostics {
+    return {
+      includedProfileIds: this.candidates.map((candidate) => candidate.profileId).sort(),
+      excluded: [...this.excluded],
+    };
+  }
+}
+
+export function candidatesFromWalletManifest(
+  manifest: WalletManifest,
+  profiles: SpecialistProfile[] = specialistProfiles,
+): { candidates: MarketplaceCandidate[]; excluded: Array<{ profileId: string; reasons: string[] }> } {
+  const candidates: MarketplaceCandidate[] = [];
+  const excluded: Array<{ profileId: string; reasons: string[] }> = [];
+  const seenProfileIds = new Set<string>();
+  const seenWallets = new Set<string>();
+
+  if (manifest.network !== "solana-devnet") {
+    return {
+      candidates,
+      excluded: manifest.profiles.map((entry) => ({ profileId: entry.profileId ?? "unknown", reasons: [`unsupported network ${manifest.network}`] })),
+    };
+  }
+
+  for (const entry of manifest.profiles) {
+    const reasons: string[] = [];
+    const profile = getProfileFrom(entry.profileId, profiles);
+    if (!profile) reasons.push("profile not found in specialist registry");
+    if (seenProfileIds.has(entry.profileId)) reasons.push("duplicate profileId in wallet manifest");
+    seenProfileIds.add(entry.profileId);
+    if (!entry.publicKey || !isValidSolanaPublicKey(entry.publicKey)) reasons.push("invalid Solana public key");
+    if (seenWallets.has(entry.publicKey)) reasons.push("duplicate public key in wallet manifest");
+    seenWallets.add(entry.publicKey);
+    if (profile && profile.walletAddress !== entry.publicKey) reasons.push("manifest public key does not match specialist profile wallet");
+
+    if (!profile || reasons.length > 0) {
+      excluded.push({ profileId: entry.profileId ?? "unknown", reasons });
+      continue;
+    }
+
+    const candidate = toCandidate(profile);
+    candidate.walletAddress = entry.publicKey;
+    const validation = validateMarketplaceCandidate(candidate);
+    if (!validation.ok) {
+      excluded.push({ profileId: entry.profileId, reasons: validation.reasons });
+      continue;
+    }
+    candidates.push(candidate);
+  }
+
+  return { candidates, excluded };
+}
+
+export function validateMarketplaceCandidate(candidate: MarketplaceCandidate): CandidateValidationResult {
+  const reasons: string[] = [];
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(candidate.profileId)) reasons.push("invalid profileId");
+  if (!candidate.displayName.trim()) reasons.push("missing displayName");
+  if (!candidate.endpointPath.startsWith("/")) reasons.push("endpointPath must be relative path");
+  if (!candidate.walletAddress || !isValidSolanaPublicKey(candidate.walletAddress)) reasons.push("missing or invalid walletAddress");
+  if (!candidate.roles.includes("specialist")) reasons.push("candidate must include specialist role");
+  if (candidate.capabilities.length === 0) reasons.push("missing capabilities");
+  if (!candidate.price.amount || !candidate.price.currency || !candidate.price.unit) reasons.push("invalid price");
+  if (!Number.isFinite(candidate.reputationScore) || candidate.reputationScore < 0 || candidate.reputationScore > 1) reasons.push("reputationScore must be 0..1");
+  if (!Number.isFinite(candidate.freshnessScore) || candidate.freshnessScore < 0 || candidate.freshnessScore > 1) reasons.push("freshnessScore must be 0..1");
+  return { ok: reasons.length === 0, reasons };
 }
 
 export function normalizeCapabilities(capabilities: string[]): string[] {
@@ -135,6 +255,7 @@ export async function buildDryRunDelegationPlan(input: {
       "no signer or private-key material used",
       "set ENABLE_AGENT_TO_AGENT_CALLS=true only in a later live-call iteration",
     ],
+    discoveryDiagnostics: discoveryClient.diagnostics?.(),
   };
 }
 
@@ -144,6 +265,7 @@ function toCandidate(profile: SpecialistProfile): MarketplaceCandidate {
     profileId: profile.id,
     displayName: profile.displayName,
     endpointPath: profile.endpointPath,
+    walletAddress: profile.walletAddress,
     capabilities: profile.capabilities,
     roles: profile.roles,
     price: profile.price,
@@ -152,6 +274,10 @@ function toCandidate(profile: SpecialistProfile): MarketplaceCandidate {
     preferredAttestors: profile.preferredAttestors,
     safetyMode: profile.safetyMode,
   };
+}
+
+function getProfileFrom(id: string, profiles: SpecialistProfile[]): SpecialistProfile | undefined {
+  return profiles.find((profile) => profile.id === id) ?? getProfile(id);
 }
 
 function rankCandidate(candidate: MarketplaceCandidate, requiredCapabilities: string[]): RankedMarketplaceCandidate {

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -1,16 +1,22 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import test from "node:test";
 import { MockOpenRouterClient } from "../src/openrouter.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "../src/profiles/index.js";
 import {
   buildDryRunDelegationPlan,
+  buildDeploymentReadinessReport,
+  candidatesFromWalletManifest,
   createRuntimeConfig,
   evaluateAttestation,
   handleAttestationEvaluation,
   handleChatCompletions,
   handleRuntimeRequest,
   marketplaceMetadata,
+  ManifestMarketplaceDiscoveryClient,
   rankMarketplaceCandidates,
+  type WalletManifest,
   type RuntimeConfig,
 } from "../src/index.js";
 
@@ -22,6 +28,8 @@ const config: RuntimeConfig = {
   requirePayment: true,
   allowDemoPayment: false,
 };
+
+const walletManifest = JSON.parse(readFileSync(join(process.cwd(), "public/wallet-manifest.json"), "utf8")) as WalletManifest;
 
 test("profile registry has first five unique valid profiles with required marketplace metadata", () => {
   assert.deepEqual(validateProfileRegistry(), []);
@@ -365,6 +373,71 @@ test("dry-run marketplace ranking is deterministic for sample candidates", async
     ranked.map((candidate) => candidate.profileId),
     ["a-agent", "b-agent"],
   );
+});
+
+test("manifest marketplace discovery matches deterministic first-five ranking", async () => {
+  const discoveryClient = new ManifestMarketplaceDiscoveryClient(walletManifest);
+  const plan = await buildDryRunDelegationPlan({
+    request: {
+      requesterProfileId: "planning-agent",
+      task: "Need document evidence and code implementation",
+      requiredCapabilities: ["document-analysis", "code-generation"],
+      maxCandidates: 3,
+    },
+    discoveryClient,
+  });
+
+  assert.deepEqual(plan.discoveryDiagnostics?.excluded, []);
+  assert.deepEqual(plan.discoveryDiagnostics?.includedProfileIds, [
+    "code-generation-agent",
+    "conversational-agent",
+    "document-intelligence-agent",
+    "planning-agent",
+    "verification-validation-agent",
+  ]);
+  assert.deepEqual(
+    plan.candidates.map((candidate) => candidate.profileId),
+    ["code-generation-agent", "document-intelligence-agent"],
+  );
+  assert.equal(plan.selectedCandidate?.walletAddress, getProfile("code-generation-agent")?.walletAddress);
+});
+
+test("manifest discovery excludes malformed candidates with explicit reasons", () => {
+  const malformedManifest: WalletManifest = {
+    ...walletManifest,
+    profiles: [
+      ...walletManifest.profiles,
+      { profileId: "ghost-agent", displayName: "Ghost", publicKey: "not-a-public-key" },
+      { profileId: "planning-agent", displayName: "Duplicate Planning", publicKey: walletManifest.profiles[0]?.publicKey ?? "" },
+    ],
+  };
+  const result = candidatesFromWalletManifest(malformedManifest);
+  const ghost = result.excluded.find((entry) => entry.profileId === "ghost-agent");
+  const duplicate = result.excluded.find((entry) => entry.profileId === "planning-agent");
+  assert.ok(ghost?.reasons.includes("profile not found in specialist registry"));
+  assert.ok(ghost?.reasons.includes("invalid Solana public key"));
+  assert.ok(duplicate?.reasons.includes("duplicate profileId in wallet manifest"));
+  assert.ok(duplicate?.reasons.includes("duplicate public key in wallet manifest"));
+});
+
+test("deployment readiness report is public-data-only and blocks missing funding/deployment", () => {
+  const report = buildDeploymentReadinessReport({
+    manifest: walletManifest,
+    endpointBaseUrl: "https://planning.example.test",
+    fundedProfileIds: [],
+    deployedProfileIds: [],
+    generatedAt: "2026-05-04T00:00:00.000Z",
+  });
+
+  assert.equal(report.schemaVersion, "reddi.openrouter.deployment-readiness.v1");
+  assert.equal(report.status, "blocked");
+  assert.equal(report.entries.length, 5);
+  assert.ok(report.guardrails.includes("no private keys or signer material inspected"));
+  assert.ok(report.guardrails.includes("no devnet SOL spent"));
+  assert.ok(report.nextApprovalRequired.some((item) => item.includes("fund")));
+  assert.ok(report.entries.every((entry) => entry.endpoint?.startsWith("https://planning.example.test/")));
+  assert.ok(report.entries.every((entry) => entry.blockers.includes("funding not confirmed; approval/funding required")));
+  assert.ok(report.entries.every((entry) => entry.blockers.includes("Coolify deployment not confirmed")));
 });
 
 test("live delegation mode fails closed before any downstream paid call executor exists", async () => {


### PR DESCRIPTION
## Summary
- add manifest-backed marketplace discovery adapter with explicit malformed-candidate exclusions
- add public-data-only deployment readiness report and package script
- preserve deterministic static fixtures for dry-run delegation tests
- document Iteration 4.5 readiness flow and guardrails

## Validation
- `cd packages/openrouter-specialists && npm test` PASS (21/21)
- `cd packages/openrouter-specialists && npm run deployment:readiness` expected BLOCKED report (no approval/funding/deployment), no secrets/spend
- `npm run build` PASS
- `git diff --check` PASS

## BDD/OAD
Closes #150. Iteration 4.5 is no-spend/no-secret/no-deployment/no-live-call readiness hardening before Coolify/funding.