### PR TITLE
fix(openrouter): repair specialist Docker deployment build

### DIFF
--- a/packages/openrouter-specialists/Dockerfile
+++ b/packages/openrouter-specialists/Dockerfile
@@ -1,13 +1,25 @@
-FROM node:22-alpine AS build
-WORKDIR /app
-COPY packages/openrouter-specialists/package*.json ./
+FROM node:24-alpine AS build
+WORKDIR /workspace
+
+COPY packages/x402-solana/package*.json packages/x402-solana/
+WORKDIR /workspace/packages/x402-solana
+RUN npm ci --ignore-scripts
+COPY packages/x402-solana/ ./
+RUN npm run build
+
+WORKDIR /workspace
+COPY packages/openrouter-specialists/package*.json packages/openrouter-specialists/
+WORKDIR /workspace/packages/openrouter-specialists
 RUN npm ci --ignore-scripts
 COPY packages/openrouter-specialists/ ./
 RUN npm run build
 
-FROM node:22-alpine
-WORKDIR /app
+FROM node:24-alpine
+WORKDIR /workspace/packages/openrouter-specialists
 ENV NODE_ENV=production
-COPY --from=build /app/dist ./dist
-COPY --from=build /app/package.json ./package.json
+ENV HOST=0.0.0.0
+ENV PORT=8080
+COPY --from=build /workspace/packages/x402-solana /workspace/packages/x402-solana
+COPY --from=build /workspace/packages/openrouter-specialists /workspace/packages/openrouter-specialists
+EXPOSE 8080
 CMD ["node", "dist/src/server.js"]


### PR DESCRIPTION
## Summary\n- Fixes the OpenRouter specialist Dockerfile for the current workspace dependency on @reddi/x402-solana.\n- Builds @reddi/x402-solana inside the image before building @reddi/openrouter-specialists.\n- Moves the runtime to Node 24 Alpine and exposes the Coolify target port 8080.\n\n## Issue\nCloses #152 for the deploy-runtime blocker slice.\n\n## Validation\n- docker build -f packages/openrouter-specialists/Dockerfile -t reddi-openrouter-specialists:iter5-preflight .\n- cd packages/openrouter-specialists && npm test — PASS 21/21\n- cd packages/openrouter-specialists && npm run deployment:readiness — expected BLOCKED no-spend report\n- npm run build — PASS\n- git diff --check — PASS\n\n## Guardrails\n- No private keys/signers.\n- No secrets committed.\n- No devnet spend in this PR.\n- No Coolify deployment in this PR.\n- No live downstream x402 calls.