### PR TITLE
Add signer-safe OpenRouter wallet tooling

### DIFF
--- a/packages/openrouter-specialists/README.md
+++ b/packages/openrouter-specialists/README.md
@@ -8,10 +8,14 @@ Iteration 4 starts agent-to-agent composability in dry-run mode: consumer-capabl
 
 Iteration 4.5 hardens dry-run discovery with a manifest-backed discovery adapter and a no-spend deployment readiness report. It still does not deploy, fund wallets, inspect secrets, sign transactions, or execute live downstream x402 calls.
 
+Iteration 5b adds signer-safe wallet provenance, devnet-only funding helpers, and idempotent devnet registration helpers for the first five specialists. These tools load signer keypairs from environment variables only, derive public keys, and write public-only artifacts. They fail closed when signer env is absent and reject non-devnet RPC endpoints.
+
 ## Safety defaults
 
 - No private keys are stored here.
 - Wallet values are public devnet addresses only; Iteration 2 replaces static profile values with a public wallet manifest and balance verifier.
+- Iteration 5b signer tooling loads keypairs from env only and writes public keys, env var names, balances, PDAs, and transaction signatures only — never secret key bytes.
+- Funding and registration scripts are devnet-only and fail before sending transactions if pointed at a non-devnet RPC endpoint.
 - `OPENROUTER_MOCK` must be explicitly set to `1` or `true` to use mock mode.
 - If mock mode is disabled, `OPENROUTER_API_KEY` is required before an OpenRouter client can be created.
 - Demo payment headers are accepted only when `ALLOW_DEMO_X402_PAYMENT=1` or `true`.
@@ -67,6 +71,63 @@ Minimal request body:
 Response body includes `object="reddi.delegation.plan"`, deterministic candidate ranking by capability match, price, reputation, and freshness, estimated cost, required attestor, and guardrails. `downstreamCallsExecuted` is always `0` in this iteration. No signer/private-key material is used and no downstream paid call is attempted.
 
 The dry-run planner can use the public wallet manifest as a discovery source. Malformed manifest candidates are excluded with explicit reasons in `discoveryDiagnostics`; they are not silently ranked.
+
+## Iteration 5b wallet provenance, funding, and registration
+
+### Signer env format
+
+Signer material must come from environment variables. Do not write these values to files or commit them.
+
+Bulk env, keyed by profile ID:
+
+```bash
+export OPENROUTER_SPECIALIST_SIGNER_KEYPAIRS_JSON='{
+  "planning-agent": [64, byte, secret, key, ...],
+  "document-intelligence-agent": {"secretKey": [64, byte, secret, key, ...]}
+}'
+```
+
+Or per-profile env vars:
+
+```bash
+export OPENROUTER_SPECIALIST_PLANNING_AGENT_SIGNER_KEYPAIR_JSON='[64, byte, secret, key, ...]'
+export OPENROUTER_SPECIALIST_DOCUMENT_INTELLIGENCE_AGENT_SIGNER_KEYPAIR_JSON='{"secretKey":[64, byte, secret, key, ...]}'
+export OPENROUTER_SPECIALIST_VERIFICATION_VALIDATION_AGENT_SIGNER_KEYPAIR_JSON='[64, byte, secret, key, ...]'
+export OPENROUTER_SPECIALIST_CODE_GENERATION_AGENT_SIGNER_KEYPAIR_JSON='[64, byte, secret, key, ...]'
+export OPENROUTER_SPECIALIST_CONVERSATIONAL_AGENT_SIGNER_KEYPAIR_JSON='[64, byte, secret, key, ...]'
+```
+
+Supported JSON material shapes are a 64-byte secret-key array, `{ "secretKey": [...] }`, `{ "privateKey": [...] }`, or `{ "keypair": [...] }`. The scripts derive public keys from the signer and never persist the secret-key array.
+
+### Render and verify a signer-backed public manifest
+
+```bash
+npm run wallet:render-signer-manifest
+npm run wallet:verify-signer-provenance -- artifacts/signer-wallet-manifest.json
+```
+
+The rendered manifest contains `profileId`, `displayName`, derived `publicKey`, and `signerProvenance.sourceEnv` only. It is safe to publish after review. The existing static `public/wallet-manifest.json` remains public-only; use `--require-signer-provenance` when gating a signer-backed replacement.
+
+### Request devnet airdrops
+
+```bash
+WALLET_MANIFEST_PATH=artifacts/signer-wallet-manifest.json \
+AIRDROP_ARTIFACT_OUT=artifacts/devnet-airdrop-report.json \
+npm run wallet:airdrop-devnet
+```
+
+Defaults: `SOLANA_DEVNET_RPC_URL=https://api.devnet.solana.com`, `AIRDROP_MAX_ATTEMPTS=3`, exponential backoff, and a public-only artifact containing profile IDs, public keys, balances, requested lamports, and tx signatures. Faucet rate limits are expected; failures are recorded without leaking signer material.
+
+### Register the first five specialists on devnet
+
+```bash
+REGISTRATION_ARTIFACT_OUT=artifacts/devnet-registration-report.json \
+npm run wallet:register-devnet
+```
+
+Registration requires signer env for all first-five profiles. It checks the agent PDA before sending, skips already-registered specialists, refuses to register underfunded signers, and writes a public-only artifact with owner public keys, PDAs, balances, status, and tx signatures. Program ID defaults to the devnet escrow program and can be overridden with `OPENROUTER_SPECIALIST_ESCROW_PROGRAM_ID` or `DEMO_ESCROW_PROGRAM_ID`.
+
+Guardrails: devnet only, no mainnet RPC, no committed private keys, no OpenRouter/live downstream calls.
 
 ## Deployment readiness preflight
 

--- a/packages/openrouter-specialists/package.json
+++ b/packages/openrouter-specialists/package.json
@@ -15,7 +15,11 @@
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test dist/tests/*.test.js",
-    "validate:wallet-manifest": "node scripts/validate-wallet-manifest.mjs",
+    "validate:wallet-manifest": "npm run build && node scripts/validate-wallet-manifest.mjs",
+    "wallet:render-signer-manifest": "npm run build && node scripts/render-signer-wallet-manifest.mjs",
+    "wallet:verify-signer-provenance": "npm run build && node scripts/validate-wallet-manifest.mjs --require-signer-provenance",
+    "wallet:airdrop-devnet": "npm run build && node scripts/airdrop-devnet-wallets.mjs",
+    "wallet:register-devnet": "npm run build && node scripts/register-devnet-specialists.mjs",
     "check:devnet-balances": "node scripts/check-devnet-balances.mjs",
     "deployment:readiness": "npm run build && node scripts/deployment-readiness.mjs"
   },

--- a/packages/openrouter-specialists/scripts/airdrop-devnet-wallets.mjs
+++ b/packages/openrouter-specialists/scripts/airdrop-devnet-wallets.mjs
@@ -1,0 +1,77 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { Connection, LAMPORTS_PER_SOL, PublicKey, clusterApiUrl } from '@solana/web3.js';
+import { validateSignerBackedManifest } from '../dist/src/wallet-provenance.js';
+
+const manifestPath = process.argv[2] ?? process.env.WALLET_MANIFEST_PATH ?? join(process.cwd(), 'public/wallet-manifest.json');
+const outPath = process.env.AIRDROP_ARTIFACT_OUT ?? join(process.cwd(), 'artifacts/devnet-airdrop-report.json');
+const endpoint = process.env.SOLANA_DEVNET_RPC_URL ?? clusterApiUrl('devnet');
+const targetLamports = Number(process.env.MIN_DEVNET_BALANCE_LAMPORTS ?? process.env.AIRDROP_TARGET_LAMPORTS ?? 1_000_000);
+const requestLamports = Number(process.env.AIRDROP_LAMPORTS ?? Math.max(targetLamports, Math.floor(0.05 * LAMPORTS_PER_SOL)));
+const maxAttempts = Number(process.env.AIRDROP_MAX_ATTEMPTS ?? 3);
+const baseDelayMs = Number(process.env.AIRDROP_RETRY_BASE_MS ?? 2_000);
+
+if (!endpoint.includes('devnet')) throw new Error('airdrop script is devnet-only; SOLANA_DEVNET_RPC_URL must point at devnet');
+for (const [name, value] of Object.entries({ targetLamports, requestLamports, maxAttempts, baseDelayMs })) {
+  if (!Number.isFinite(value) || value < 0) throw new Error(`${name} must be a non-negative number`);
+}
+
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+const errors = validateSignerBackedManifest(manifest, { requireSignerProvenance: false });
+if (errors.length > 0) throw new Error(`manifest failed validation:\n- ${errors.join('\n- ')}`);
+if (manifest.network !== 'solana-devnet') throw new Error('airdrop script is devnet-only');
+
+const connection = new Connection(endpoint, 'confirmed');
+const report = [];
+for (const profile of manifest.profiles) {
+  const publicKey = new PublicKey(profile.publicKey);
+  const beforeLamports = await connection.getBalance(publicKey, 'confirmed');
+  const entry = {
+    profileId: profile.profileId,
+    publicKey: profile.publicKey,
+    beforeLamports,
+    requestedLamports: 0,
+    afterLamports: beforeLamports,
+    txSignatures: [],
+    status: beforeLamports >= targetLamports ? 'already_funded' : 'pending',
+    errors: [],
+  };
+
+  for (let attempt = 1; entry.afterLamports < targetLamports && attempt <= maxAttempts; attempt += 1) {
+    try {
+      const signature = await connection.requestAirdrop(publicKey, requestLamports);
+      await connection.confirmTransaction(signature, 'confirmed');
+      entry.txSignatures.push(signature);
+      entry.requestedLamports += requestLamports;
+      entry.afterLamports = await connection.getBalance(publicKey, 'confirmed');
+      entry.status = entry.afterLamports >= targetLamports ? 'funded' : 'below_threshold';
+    } catch (error) {
+      entry.errors.push(String(error?.message ?? error));
+      if (attempt < maxAttempts) await delay(baseDelayMs * 2 ** (attempt - 1));
+      entry.afterLamports = await connection.getBalance(publicKey, 'confirmed').catch(() => entry.afterLamports);
+      entry.status = 'airdrop_failed';
+    }
+  }
+  if (entry.afterLamports < targetLamports && entry.status !== 'airdrop_failed') entry.status = 'below_threshold';
+  report.push(entry);
+}
+
+const artifact = {
+  schemaVersion: '1.0.0',
+  network: 'solana-devnet',
+  endpoint,
+  manifestPath,
+  targetLamports,
+  requestLamports,
+  maxAttempts,
+  generatedAt: new Date().toISOString(),
+  report,
+};
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(artifact, null, 2)}\n`, { mode: 0o644 });
+console.log(JSON.stringify(artifact, null, 2));
+if (report.some((entry) => entry.afterLamports < targetLamports)) process.exitCode = 1;
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/openrouter-specialists/scripts/register-devnet-specialists.mjs
+++ b/packages/openrouter-specialists/scripts/register-devnet-specialists.mjs
@@ -1,0 +1,141 @@
+import crypto from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  Connection,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  clusterApiUrl,
+} from '@solana/web3.js';
+import { loadSignerKeypairsFromEnv, profileEnvSlug } from '../dist/src/wallet-provenance.js';
+import { specialistProfiles } from '../dist/src/profiles/index.js';
+
+const DEFAULT_PROGRAM_ID = '794nTFNyJknzDrR13ApSfVyNCRvcvnCN3BVDfic8dcZD';
+const AGENT_SEED = Buffer.from('agent');
+const INCINERATOR = new PublicKey('1nc1nerator11111111111111111111111111111111');
+const AgentType = { Primary: 0, Attestation: 1, Both: 2 };
+
+const endpoint = process.env.SOLANA_DEVNET_RPC_URL ?? clusterApiUrl('devnet');
+const programId = new PublicKey(process.env.OPENROUTER_SPECIALIST_ESCROW_PROGRAM_ID ?? process.env.DEMO_ESCROW_PROGRAM_ID ?? DEFAULT_PROGRAM_ID);
+const outPath = process.env.REGISTRATION_ARTIFACT_OUT ?? join(process.cwd(), 'artifacts/devnet-registration-report.json');
+const minBalanceLamports = Number(process.env.MIN_DEVNET_BALANCE_LAMPORTS ?? 500_000);
+
+if (!endpoint.includes('devnet')) throw new Error('registration script is devnet-only; SOLANA_DEVNET_RPC_URL must point at devnet');
+if (!Number.isFinite(minBalanceLamports) || minBalanceLamports < 0) throw new Error('MIN_DEVNET_BALANCE_LAMPORTS must be non-negative');
+
+const signerLoad = loadSignerKeypairsFromEnv({ profiles: specialistProfiles.slice(0, 5), requireAll: true });
+const connection = new Connection(endpoint, 'confirmed');
+const report = [];
+
+for (const { profile, keypair, sourceEnv } of signerLoad.loaded) {
+  const owner = keypair.publicKey;
+  const agentPda = PublicKey.findProgramAddressSync([AGENT_SEED, owner.toBytes()], programId)[0];
+  const existing = await connection.getAccountInfo(agentPda, 'confirmed');
+  const balanceLamports = await connection.getBalance(owner, 'confirmed');
+  const entry = {
+    profileId: profile.id,
+    displayName: profile.displayName,
+    ownerPublicKey: owner.toBase58(),
+    profileWalletAddress: profile.walletAddress,
+    signerSourceEnv: sourceEnv,
+    agentPda: agentPda.toBase58(),
+    programId: programId.toBase58(),
+    balanceLamports,
+    status: 'pending',
+    txSignature: null,
+    errors: [],
+  };
+
+  if (existing) {
+    entry.status = 'already_registered';
+    report.push(entry);
+    continue;
+  }
+  if (balanceLamports < minBalanceLamports) {
+    entry.status = 'insufficient_balance';
+    entry.errors.push(`balance ${balanceLamports} below threshold ${minBalanceLamports}`);
+    report.push(entry);
+    continue;
+  }
+
+  const instruction = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: agentPda, isSigner: false, isWritable: true },
+      { pubkey: owner, isSigner: true, isWritable: true },
+      { pubkey: INCINERATOR, isSigner: false, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: encodeRegisterAgent(agentTypeFor(profile), profile.model, rateLamportsFor(profile), 0),
+  });
+
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash('confirmed');
+  const tx = new Transaction({ feePayer: owner, blockhash, lastValidBlockHeight }).add(instruction);
+  tx.sign(keypair);
+
+  try {
+    const signature = await connection.sendRawTransaction(tx.serialize(), { skipPreflight: false });
+    await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, 'confirmed');
+    entry.status = 'registered';
+    entry.txSignature = signature;
+  } catch (error) {
+    const message = String(error?.message ?? error);
+    if (/already in use|AlreadyInUse|0x0/i.test(message)) entry.status = 'already_registered';
+    else {
+      entry.status = 'registration_failed';
+      entry.errors.push(message);
+    }
+  }
+  report.push(entry);
+}
+
+const artifact = {
+  schemaVersion: '1.0.0',
+  network: 'solana-devnet',
+  endpoint,
+  programId: programId.toBase58(),
+  generatedAt: new Date().toISOString(),
+  report,
+};
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(artifact, null, 2)}\n`, { mode: 0o644 });
+console.log(JSON.stringify(artifact, null, 2));
+if (report.some((entry) => entry.status === 'registration_failed' || entry.status === 'insufficient_balance')) process.exitCode = 1;
+
+function disc(ixName) {
+  return crypto.createHash('sha256').update(`global:${ixName}`).digest().subarray(0, 8);
+}
+
+function encodeRegisterAgent(agentType, model, rateLamports, minReputation) {
+  const modelBytes = Buffer.from(model, 'utf8');
+  const buf = Buffer.alloc(8 + 1 + 4 + modelBytes.length + 8 + 1);
+  let offset = 0;
+  disc('register_agent').copy(buf, offset); offset += 8;
+  buf.writeUInt8(agentType, offset); offset += 1;
+  buf.writeUInt32LE(modelBytes.length, offset); offset += 4;
+  modelBytes.copy(buf, offset); offset += modelBytes.length;
+  buf.writeBigUInt64LE(rateLamports, offset); offset += 8;
+  buf.writeUInt8(minReputation, offset);
+  return buf;
+}
+
+function agentTypeFor(profile) {
+  const primary = profile.roles.includes('specialist');
+  const attestor = profile.roles.includes('attestor');
+  if (primary && attestor) return AgentType.Both;
+  if (attestor) return AgentType.Attestation;
+  return AgentType.Primary;
+}
+
+function rateLamportsFor(profile) {
+  const envName = `OPENROUTER_SPECIALIST_${profileEnvSlug(profile.id)}_RATE_LAMPORTS`;
+  const raw = process.env[envName] ?? process.env.OPENROUTER_SPECIALIST_DEFAULT_RATE_LAMPORTS;
+  if (raw !== undefined) {
+    const parsed = BigInt(raw);
+    if (parsed < 0n) throw new Error(`${envName} must be non-negative`);
+    return parsed;
+  }
+  return profile.roles.includes('attestor') ? 500_000n : 1_000_000n;
+}

--- a/packages/openrouter-specialists/scripts/render-signer-wallet-manifest.mjs
+++ b/packages/openrouter-specialists/scripts/render-signer-wallet-manifest.mjs
@@ -1,0 +1,25 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  buildSignerBackedWalletManifest,
+  loadSignerKeypairsFromEnv,
+  validateSignerBackedManifest,
+} from '../dist/src/wallet-provenance.js';
+import { specialistProfiles } from '../dist/src/profiles/index.js';
+
+const outPath = process.env.WALLET_MANIFEST_OUT ?? process.argv[2] ?? join(process.cwd(), 'artifacts/signer-wallet-manifest.json');
+const minimumBalanceLamports = Number(process.env.MIN_DEVNET_BALANCE_LAMPORTS ?? 1_000_000);
+
+if (!Number.isFinite(minimumBalanceLamports) || minimumBalanceLamports < 0) {
+  throw new Error('MIN_DEVNET_BALANCE_LAMPORTS must be a non-negative number');
+}
+
+const result = loadSignerKeypairsFromEnv({ profiles: specialistProfiles.slice(0, 5), requireAll: true });
+const manifest = buildSignerBackedWalletManifest({ loaded: result.loaded, minimumBalanceLamports });
+const errors = validateSignerBackedManifest(manifest, { requireSignerProvenance: true });
+if (errors.length > 0) throw new Error(`rendered manifest failed validation:\n- ${errors.join('\n- ')}`);
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o644 });
+console.log(`rendered signer-backed public wallet manifest: ${outPath}`);
+console.log(`profiles=${manifest.profiles.length}; network=${manifest.network}; secrets=redacted/not-written`);

--- a/packages/openrouter-specialists/scripts/validate-wallet-manifest.mjs
+++ b/packages/openrouter-specialists/scripts/validate-wallet-manifest.mjs
@@ -1,43 +1,15 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { PublicKey } from '@solana/web3.js';
+import { validateSignerBackedManifest } from '../dist/src/wallet-provenance.js';
 
-const manifestPath = process.argv[2] ?? join(process.cwd(), 'public/wallet-manifest.json');
+const args = new Set(process.argv.slice(2).filter((arg) => arg.startsWith('--')));
+const manifestPath = process.argv.slice(2).find((arg) => !arg.startsWith('--')) ?? join(process.cwd(), 'public/wallet-manifest.json');
+const requireSignerProvenance = args.has('--require-signer-provenance');
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 
-function isValidPublicKey(value) {
-  try {
-    const key = new PublicKey(value);
-    return key.toBytes().length === 32 && key.toBase58() === value;
-  } catch {
-    return false;
-  }
-}
-
-assert.equal(manifest.schemaVersion, '1.0.0');
-assert.equal(manifest.network, 'solana-devnet');
-assert.equal(typeof manifest.minimumBalanceLamports, 'number');
-assert.ok(manifest.minimumBalanceLamports >= 0);
-assert.ok(Array.isArray(manifest.profiles));
+const errors = validateSignerBackedManifest(manifest, { requireSignerProvenance });
+assert.deepEqual(errors, [], `wallet manifest failed validation:\n- ${errors.join('\n- ')}`);
 assert.equal(manifest.profiles.length, 5, 'manifest must publish first five specialist wallets');
 
-const ids = new Set();
-const publicKeys = new Set();
-for (const profile of manifest.profiles) {
-  assert.equal(typeof profile.profileId, 'string');
-  assert.match(profile.profileId, /^[a-z0-9]+(?:-[a-z0-9]+)*$/);
-  assert.equal(typeof profile.displayName, 'string');
-  assert.ok(profile.displayName.length > 0);
-  assert.equal(typeof profile.publicKey, 'string');
-  assert.ok(isValidPublicKey(profile.publicKey), `${profile.profileId} publicKey must be a strict Solana public key`);
-  assert.equal(profile.privateKey, undefined, `${profile.profileId} must not include privateKey`);
-  assert.equal(profile.secretKey, undefined, `${profile.profileId} must not include secretKey`);
-  assert.equal(profile.mnemonic, undefined, `${profile.profileId} must not include mnemonic`);
-  assert.ok(!ids.has(profile.profileId), `duplicate profileId ${profile.profileId}`);
-  assert.ok(!publicKeys.has(profile.publicKey), `duplicate publicKey ${profile.publicKey}`);
-  ids.add(profile.profileId);
-  publicKeys.add(profile.publicKey);
-}
-
-console.log(`wallet manifest valid: ${manifest.profiles.length} ${manifest.network} public keys, no secrets`);
+console.log(`wallet manifest valid: ${manifest.profiles.length} ${manifest.network} public keys, no secrets${requireSignerProvenance ? ', signer provenance present' : ''}`);

--- a/packages/openrouter-specialists/src/wallet-provenance.ts
+++ b/packages/openrouter-specialists/src/wallet-provenance.ts
@@ -1,0 +1,221 @@
+import { Keypair, PublicKey } from "@solana/web3.js";
+import type { SpecialistProfile } from "./types.js";
+import { specialistProfiles } from "./profiles/index.js";
+
+export interface SignerBackedWalletManifestProfile {
+  profileId: string;
+  displayName: string;
+  publicKey: string;
+  signerProvenance: {
+    sourceEnv: string;
+    derivedFromSigner: true;
+  };
+}
+
+export interface SignerBackedWalletManifest {
+  schemaVersion: "1.0.0";
+  network: "solana-devnet";
+  minimumBalanceLamports: number;
+  generatedAt: string;
+  profiles: SignerBackedWalletManifestProfile[];
+}
+
+export interface LoadedSignerProfile {
+  profile: SpecialistProfile;
+  keypair: Keypair;
+  sourceEnv: string;
+}
+
+export interface SignerEnvLoadResult {
+  loaded: LoadedSignerProfile[];
+  missingProfileIds: string[];
+}
+
+const BULK_SIGNER_ENV = "OPENROUTER_SPECIALIST_SIGNER_KEYPAIRS_JSON";
+const SECRET_FIELD_PATTERN = /(secret|private|mnemonic|seed|keypair)/i;
+
+export function profileEnvSlug(profileId: string): string {
+  return profileId.toUpperCase().replace(/[^A-Z0-9]+/g, "_");
+}
+
+export function perProfileSignerEnvNames(profileId: string): string[] {
+  const slug = profileEnvSlug(profileId);
+  return [
+    `OPENROUTER_SPECIALIST_${slug}_SIGNER_KEYPAIR_JSON`,
+    `OPENROUTER_SPECIALIST_${slug}_SECRET_KEY_JSON`,
+  ];
+}
+
+export function signerEnvNamesFor(profileId: string): string[] {
+  return [BULK_SIGNER_ENV, ...perProfileSignerEnvNames(profileId)];
+}
+
+export function parseSignerKeypairMaterial(material: unknown): Keypair {
+  let candidate = material;
+  if (typeof candidate === "string") {
+    candidate = JSON.parse(candidate);
+  }
+  if (candidate && typeof candidate === "object" && !Array.isArray(candidate)) {
+    const record = candidate as Record<string, unknown>;
+    candidate = record.secretKey ?? record.privateKey ?? record.keypair;
+    if (typeof candidate === "string") candidate = JSON.parse(candidate);
+  }
+  if (!Array.isArray(candidate)) {
+    throw new Error("signer keypair material must be a JSON array or object with secretKey/privateKey/keypair array");
+  }
+  const bytes = candidate.map((value) => {
+    if (!Number.isInteger(value) || Number(value) < 0 || Number(value) > 255) throw new Error("signer keypair bytes must be integers 0..255");
+    return Number(value);
+  });
+  if (bytes.length !== 64) throw new Error("signer keypair secret key must contain 64 bytes");
+  return Keypair.fromSecretKey(Uint8Array.from(bytes));
+}
+
+export function loadSignerKeypairsFromEnv(options?: {
+  env?: NodeJS.ProcessEnv;
+  profiles?: SpecialistProfile[];
+  requireAll?: boolean;
+}): SignerEnvLoadResult {
+  const env = options?.env ?? process.env;
+  const profiles = options?.profiles ?? specialistProfiles.slice(0, 5);
+  const loaded: LoadedSignerProfile[] = [];
+  const missingProfileIds: string[] = [];
+  const bulk = loadBulkSignerEnv(env[BULK_SIGNER_ENV]);
+
+  for (const profile of profiles) {
+    const fromBulk = bulk.get(profile.id);
+    if (fromBulk !== undefined) {
+      loaded.push({ profile, keypair: parseSignerKeypairMaterial(fromBulk), sourceEnv: BULK_SIGNER_ENV });
+      continue;
+    }
+
+    const perProfile = perProfileSignerEnvNames(profile.id).find((name) => env[name]?.trim());
+    if (perProfile) {
+      loaded.push({ profile, keypair: parseSignerKeypairMaterial(env[perProfile]), sourceEnv: perProfile });
+    } else {
+      missingProfileIds.push(profile.id);
+    }
+  }
+
+  if (options?.requireAll && missingProfileIds.length > 0) {
+    throw new Error(`missing signer env for profiles: ${missingProfileIds.join(", ")}`);
+  }
+
+  return { loaded, missingProfileIds };
+}
+
+export function buildSignerBackedWalletManifest(input: {
+  loaded: LoadedSignerProfile[];
+  minimumBalanceLamports?: number;
+  generatedAt?: string;
+}): SignerBackedWalletManifest {
+  return {
+    schemaVersion: "1.0.0",
+    network: "solana-devnet",
+    minimumBalanceLamports: input.minimumBalanceLamports ?? 1_000_000,
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    profiles: input.loaded.map(({ profile, keypair, sourceEnv }) => ({
+      profileId: profile.id,
+      displayName: profile.displayName,
+      publicKey: keypair.publicKey.toBase58(),
+      signerProvenance: {
+        sourceEnv,
+        derivedFromSigner: true,
+      },
+    })),
+  };
+}
+
+export function validateSignerBackedManifest(manifest: unknown, options?: { requireSignerProvenance?: boolean }): string[] {
+  const errors: string[] = [];
+  if (!manifest || typeof manifest !== "object") return ["manifest must be an object"];
+  const record = manifest as Record<string, unknown>;
+  if (record.schemaVersion !== "1.0.0") errors.push("schemaVersion must be 1.0.0");
+  if (record.network !== "solana-devnet") errors.push("manifest must be solana-devnet only");
+  if (typeof record.minimumBalanceLamports !== "number" || record.minimumBalanceLamports < 0) errors.push("minimumBalanceLamports must be a non-negative number");
+  if (!Array.isArray(record.profiles)) errors.push("profiles must be an array");
+
+  const ids = new Set<string>();
+  const publicKeys = new Set<string>();
+  for (const entry of Array.isArray(record.profiles) ? record.profiles : []) {
+    if (!entry || typeof entry !== "object") {
+      errors.push("profile entry must be an object");
+      continue;
+    }
+    const profile = entry as Record<string, unknown>;
+    const profileId = String(profile.profileId ?? "unknown");
+    if (typeof profile.profileId !== "string" || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(profile.profileId)) errors.push(`${profileId}: invalid profileId`);
+    if (ids.has(profileId)) errors.push(`${profileId}: duplicate profileId`);
+    ids.add(profileId);
+    if (typeof profile.publicKey !== "string" || !isStrictPublicKey(profile.publicKey)) errors.push(`${profileId}: invalid publicKey`);
+    if (typeof profile.publicKey === "string" && publicKeys.has(profile.publicKey)) errors.push(`${profileId}: duplicate publicKey`);
+    if (typeof profile.publicKey === "string") publicKeys.add(profile.publicKey);
+
+    for (const key of Object.keys(profile)) {
+      if (SECRET_FIELD_PATTERN.test(key) && key !== "signerProvenance") errors.push(`${profileId}: public manifest contains secret-like field ${key}`);
+    }
+
+    const provenance = profile.signerProvenance as Record<string, unknown> | undefined;
+    if (options?.requireSignerProvenance) {
+      if (!provenance || typeof provenance !== "object") errors.push(`${profileId}: missing signerProvenance`);
+      else {
+        if (provenance.derivedFromSigner !== true) errors.push(`${profileId}: signerProvenance.derivedFromSigner must be true`);
+        if (typeof provenance.sourceEnv !== "string" || !signerEnvNamesFor(profileId).includes(provenance.sourceEnv)) {
+          errors.push(`${profileId}: signerProvenance.sourceEnv must be an approved env var name`);
+        }
+      }
+    }
+  }
+
+  if (containsSecretLikeValue(record)) errors.push("public manifest contains secret-like value material");
+  return errors;
+}
+
+export function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) return "[REDACTED_ARRAY]";
+  if (!value || typeof value !== "object") return value;
+  const output: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    output[key] = SECRET_FIELD_PATTERN.test(key) ? "[REDACTED]" : redactSecrets(nested);
+  }
+  return output;
+}
+
+function loadBulkSignerEnv(raw: string | undefined): Map<string, unknown> {
+  const out = new Map<string, unknown>();
+  if (!raw?.trim()) return out;
+  const parsed = JSON.parse(raw);
+  if (Array.isArray(parsed)) {
+    for (const entry of parsed) {
+      if (!entry || typeof entry !== "object") continue;
+      const record = entry as Record<string, unknown>;
+      if (typeof record.profileId === "string") out.set(record.profileId, record.secretKey ?? record.privateKey ?? record.keypair ?? record);
+    }
+    return out;
+  }
+  if (parsed && typeof parsed === "object") {
+    for (const [profileId, material] of Object.entries(parsed as Record<string, unknown>)) out.set(profileId, material);
+  }
+  return out;
+}
+
+function isStrictPublicKey(value: string): boolean {
+  try {
+    const publicKey = new PublicKey(value);
+    return publicKey.toBytes().length === 32 && publicKey.toBase58() === value;
+  } catch {
+    return false;
+  }
+}
+
+function containsSecretLikeValue(value: unknown): boolean {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (/^(\[\s*\d{1,3}\s*,){20,}/.test(trimmed)) return true;
+    if (/BEGIN (?:RSA |EC |OPENSSH |)PRIVATE KEY/.test(trimmed)) return true;
+    if (/\b(?:secretKey|privateKey|mnemonic|seed phrase)\b/i.test(trimmed)) return true;
+  }
+  if (Array.isArray(value)) return value.length >= 32 && value.every((entry) => Number.isInteger(entry));
+  if (value && typeof value === "object") return Object.values(value as Record<string, unknown>).some(containsSecretLikeValue);
+  return false;
+}

--- a/packages/openrouter-specialists/tests/wallet-provenance.test.ts
+++ b/packages/openrouter-specialists/tests/wallet-provenance.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Keypair } from "@solana/web3.js";
+import {
+  buildSignerBackedWalletManifest,
+  loadSignerKeypairsFromEnv,
+  profileEnvSlug,
+  redactSecrets,
+  validateSignerBackedManifest,
+} from "../src/wallet-provenance.js";
+import type { SpecialistProfile } from "../src/types.js";
+
+function profile(id: string): SpecialistProfile {
+  return {
+    id,
+    displayName: id,
+    description: "test",
+    walletAddress: Keypair.generate().publicKey.toBase58(),
+    endpointPath: "/v1/chat/completions",
+    capabilities: ["test"],
+    roles: ["specialist"],
+    price: { currency: "USDC", amount: "0.01", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [],
+    model: "test-model",
+    tags: [],
+    systemPrompt: "test",
+  };
+}
+
+test("profileEnvSlug converts profile IDs to per-profile env slugs", () => {
+  assert.equal(profileEnvSlug("document-intelligence-agent"), "DOCUMENT_INTELLIGENCE_AGENT");
+});
+
+test("loads signer keypairs from env and renders public-only provenance manifest", () => {
+  const profiles = [profile("planning-agent"), profile("code-generation-agent")];
+  const planning = Keypair.generate();
+  const code = Keypair.generate();
+  const env = {
+    OPENROUTER_SPECIALIST_SIGNER_KEYPAIRS_JSON: JSON.stringify({
+      "planning-agent": Array.from(planning.secretKey),
+    }),
+    OPENROUTER_SPECIALIST_CODE_GENERATION_AGENT_SIGNER_KEYPAIR_JSON: JSON.stringify({
+      secretKey: Array.from(code.secretKey),
+    }),
+  };
+
+  const loaded = loadSignerKeypairsFromEnv({ env, profiles, requireAll: true });
+  const manifest = buildSignerBackedWalletManifest({ loaded: loaded.loaded, generatedAt: "2026-05-04T00:00:00.000Z" });
+  const serialized = JSON.stringify(manifest);
+
+  assert.equal(manifest.profiles[0].publicKey, planning.publicKey.toBase58());
+  assert.equal(manifest.profiles[0].signerProvenance.sourceEnv, "OPENROUTER_SPECIALIST_SIGNER_KEYPAIRS_JSON");
+  assert.equal(manifest.profiles[1].publicKey, code.publicKey.toBase58());
+  assert.equal(manifest.profiles[1].signerProvenance.sourceEnv, "OPENROUTER_SPECIALIST_CODE_GENERATION_AGENT_SIGNER_KEYPAIR_JSON");
+  assert.ok(!serialized.includes(String(planning.secretKey[0]) + "," + String(planning.secretKey[1])));
+  assert.deepEqual(validateSignerBackedManifest(manifest, { requireSignerProvenance: true }), []);
+});
+
+test("signer loading fails closed when required signer env is missing", () => {
+  assert.throws(
+    () => loadSignerKeypairsFromEnv({ env: {}, profiles: [profile("planning-agent")], requireAll: true }),
+    /missing signer env/,
+  );
+});
+
+test("provenance validation rejects secrets and missing signer provenance", () => {
+  const manifest = {
+    schemaVersion: "1.0.0",
+    network: "solana-devnet",
+    minimumBalanceLamports: 1,
+    profiles: [
+      {
+        profileId: "planning-agent",
+        displayName: "Planning Agent",
+        publicKey: Keypair.generate().publicKey.toBase58(),
+        secretKey: [1, 2, 3],
+      },
+    ],
+  };
+
+  const errors = validateSignerBackedManifest(manifest, { requireSignerProvenance: true });
+  assert.ok(errors.some((error) => error.includes("secret-like field secretKey")));
+  assert.ok(errors.some((error) => error.includes("missing signerProvenance")));
+});
+
+test("redactSecrets removes nested key material before logging", () => {
+  assert.deepEqual(redactSecrets({ publicKey: "abc", secretKey: [1, 2, 3], nested: { privateKey: "nope" } }), {
+    publicKey: "abc",
+    secretKey: "[REDACTED]",
+    nested: { privateKey: "[REDACTED]" },
+  });
+});


### PR DESCRIPTION
## Summary
- add env-only signer loading and public-only wallet provenance manifest rendering/validation
- add devnet-only airdrop and idempotent specialist registration scripts with public artifacts
- document Iteration 5b guardrails and add secret-redaction/provenance tests

## Validation
- npm test (packages/openrouter-specialists)
- npm run validate:wallet-manifest (packages/openrouter-specialists)
- signer manifest render+verify using generated in-memory test keypairs; artifact removed
- root npm run build

## Notes
- Did not run real faucet or devnet registration. Signer env is absent and scripts fail closed; faucet was previously rate-limited.