### PR TITLE
Rotate OpenRouter specialists to signer-backed devnet wallets

### DIFF
--- a/packages/openrouter-specialists/public/wallet-manifest.json
+++ b/packages/openrouter-specialists/public/wallet-manifest.json
@@ -2,32 +2,32 @@
   "schemaVersion": "1.0.0",
   "network": "solana-devnet",
   "minimumBalanceLamports": 1000000,
-  "generatedAt": "2026-05-03T00:00:00.000Z",
+  "generatedAt": "2026-05-03T21:54:00.706Z",
   "profiles": [
     {
       "profileId": "planning-agent",
       "displayName": "Planning Agent",
-      "publicKey": "3mL7kbtz3eK24vJ6wftjnLvhZrf93B71UEjB2DBDAddr"
+      "publicKey": "2wYpzbExNi2vHSdK48jBusfEx3WNVjzPFEVNcbCA5cAs"
     },
     {
       "profileId": "document-intelligence-agent",
       "displayName": "Document Intelligence Agent",
-      "publicKey": "6uiQbwMor4UrWYiDtAJcgHKYW4vUaM3BUVChPgzdALse"
+      "publicKey": "13CgDqa8K3Mw8iaoUVahbJUmKyQRrUmCRM259NC8Dmy"
     },
     {
       "profileId": "verification-validation-agent",
       "displayName": "Verification & Validation Agent",
-      "publicKey": "EqQoUabvYzHwedphRYmXhNtT1hVX7ReTTJG4NmpgXAsr"
+      "publicKey": "2EmtCTzhoSSorg2rRSnTbngGJqkqNufgtFUZRGU4iFWq"
     },
     {
       "profileId": "code-generation-agent",
       "displayName": "Code Generation Agent",
-      "publicKey": "2e39zZNWB7J6k29trdBppbPJ8pUzsELrgPtAREvUNYE7"
+      "publicKey": "8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To"
     },
     {
       "profileId": "conversational-agent",
       "displayName": "Conversational Agent",
-      "publicKey": "FZM9LeQnYQwSdQfZLUdm9VitPnKH41CaDCuaSc4EDEqM"
+      "publicKey": "H8U9JjaeFiyHZrPEyFF2Ku7wmk62S24GAaJMVrwNrZUn"
     }
   ]
 }

--- a/packages/openrouter-specialists/src/profiles/index.ts
+++ b/packages/openrouter-specialists/src/profiles/index.ts
@@ -2,11 +2,11 @@ import { isValidSolanaPublicKey } from "@reddi/x402-solana";
 import type { SpecialistProfile } from "../types.js";
 
 const wallets = {
-  planning: "3mL7kbtz3eK24vJ6wftjnLvhZrf93B71UEjB2DBDAddr",
-  documentIntelligence: "6uiQbwMor4UrWYiDtAJcgHKYW4vUaM3BUVChPgzdALse",
-  verificationValidation: "EqQoUabvYzHwedphRYmXhNtT1hVX7ReTTJG4NmpgXAsr",
-  codeGeneration: "2e39zZNWB7J6k29trdBppbPJ8pUzsELrgPtAREvUNYE7",
-  conversational: "FZM9LeQnYQwSdQfZLUdm9VitPnKH41CaDCuaSc4EDEqM",
+  planning: "2wYpzbExNi2vHSdK48jBusfEx3WNVjzPFEVNcbCA5cAs",
+  documentIntelligence: "13CgDqa8K3Mw8iaoUVahbJUmKyQRrUmCRM259NC8Dmy",
+  verificationValidation: "2EmtCTzhoSSorg2rRSnTbngGJqkqNufgtFUZRGU4iFWq",
+  codeGeneration: "8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To",
+  conversational: "H8U9JjaeFiyHZrPEyFF2Ku7wmk62S24GAaJMVrwNrZUn",
 } as const;
 
 export const specialistProfiles: SpecialistProfile[] = [


### PR DESCRIPTION
## Summary
- rotate the first-five OpenRouter specialist public wallets to newly generated signer-backed devnet addresses
- update the public wallet manifest and profile wallet constants to match
- keep secret key material outside the repository under local pending secret storage because 1Password create was not permitted from this session

## Public wallet addresses
- planning-agent: 2wYpzbExNi2vHSdK48jBusfEx3WNVjzPFEVNcbCA5cAs
- document-intelligence-agent: 13CgDqa8K3Mw8iaoUVahbJUmKyQRrUmCRM259NC8Dmy
- verification-validation-agent: 2EmtCTzhoSSorg2rRSnTbngGJqkqNufgtFUZRGU4iFWq
- code-generation-agent: 8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To
- conversational-agent: H8U9JjaeFiyHZrPEyFF2Ku7wmk62S24GAaJMVrwNrZUn

## Validation
- cd packages/openrouter-specialists && npm test (26/26)
- cd packages/openrouter-specialists && npm run validate:wallet-manifest
- cd packages/openrouter-specialists && npm run wallet:verify-signer-provenance -- ../../artifacts/openrouter-specialists-iteration5c-signer-public-20260504.json
- npm run build
- git diff --check

No faucet, registration, paid OpenRouter call, or live downstream x402 call run in this PR.