### PR TITLE
Enrich first-five OpenRouter registry listings

### DIFF
--- a/lib/__tests__/openrouter-registry-enrichment.test.ts
+++ b/lib/__tests__/openrouter-registry-enrichment.test.ts
@@ -1,21 +1,40 @@
+import { computeCapabilityHash, validateCapabilities } from "@/lib/onboarding/capabilities";
 import {
   buildOpenRouterSpecialistIndexEntry,
   enrichCapabilityIndexWithOpenRouterProfiles,
 } from "@/lib/registry/openrouter-enrichment";
 import { specialistProfiles } from "../../packages/openrouter-specialists/src/profiles/index";
 
+const evidenceTimestamp = "2026-05-04T08:05:44.000+10:00";
+const hostedProfileIds = new Set([
+  "planning-agent",
+  "document-intelligence-agent",
+  "verification-validation-agent",
+  "code-generation-agent",
+  "conversational-agent",
+]);
+const hostedProfiles = specialistProfiles.filter((profile) => hostedProfileIds.has(profile.id));
+
 describe("OpenRouter registry enrichment", () => {
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(Date.parse("2026-05-04T08:30:00.000+10:00"));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
   it("builds enriched capability index entries for all first-five OpenRouter wallets", () => {
     const enriched = enrichCapabilityIndexWithOpenRouterProfiles([]);
 
-    expect(enriched).toHaveLength(5);
+    expect(enriched).toHaveLength(hostedProfiles.length);
     expect(enriched.map((entry) => entry.walletAddress).sort()).toEqual(
-      specialistProfiles.map((profile) => profile.walletAddress).sort(),
+      hostedProfiles.map((profile) => profile.walletAddress).sort(),
     );
 
     for (const entry of enriched) {
       expect(entry.endpointUrl).toMatch(/^https:\/\/reddi-[a-z-]+\.preview\.reddi\.tech\/v1\/chat\/completions$/);
       expect(entry.healthcheckStatus).toBe("pass");
+      expect(entry.last_seen_at).toBe(evidenceTimestamp);
       expect(entry.freshness_state).toBe("fresh");
       expect(entry.capabilities.taskTypes.length).toBeGreaterThan(0);
       expect(entry.capabilities.tags?.length).toBeGreaterThan(0);
@@ -24,7 +43,7 @@ describe("OpenRouter registry enrichment", () => {
       expect(entry.routingSignals?.feedbackCount).toBe(0);
       expect(entry.routingSignals?.avgFeedbackScore).toBe(0);
       expect(entry.ranking_score).toBeGreaterThan(0);
-      expect(entry.capabilityHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(entry.capabilityHash).toBe(computeCapabilityHash(entry.walletAddress, validateCapabilities(entry.capabilities)));
     }
   });
 
@@ -39,6 +58,7 @@ describe("OpenRouter registry enrichment", () => {
     expect(entry?.capabilities.runtime_capabilities).toEqual(expect.arrayContaining(["code_execution", "streaming"]));
     expect(entry?.capabilities.agent_composition?.llm).toBe(codeProfile!.model);
     expect(entry?.capabilities.pricing.perCallUsd).toBe(0.05);
+    expect(entry?.capabilityHash).toBe(computeCapabilityHash(codeProfile!.walletAddress, validateCapabilities(entry!.capabilities)));
   });
 
   it("preserves explicit local index values while filling missing OpenRouter metadata", () => {
@@ -69,5 +89,17 @@ describe("OpenRouter registry enrichment", () => {
     expect(entry?.healthcheckStatus).toBe("pass");
     expect(entry?.freshness_state).toBe("fresh");
     expect(entry?.routingSignals?.avgFeedbackScore).toBe(0);
+  });
+
+  it("computes OpenRouter smoke evidence freshness dynamically from last_seen_at", () => {
+    jest.spyOn(Date, "now").mockReturnValue(Date.parse("2026-05-05T09:00:00.000+10:00"));
+
+    const planning = specialistProfiles.find((profile) => profile.id === "planning-agent");
+    expect(planning).toBeDefined();
+
+    const entry = buildOpenRouterSpecialistIndexEntry(planning!.walletAddress);
+
+    expect(entry?.last_seen_at).toBe(evidenceTimestamp);
+    expect(entry?.freshness_state).toBe("stale");
   });
 });

--- a/lib/__tests__/openrouter-registry-enrichment.test.ts
+++ b/lib/__tests__/openrouter-registry-enrichment.test.ts
@@ -1,0 +1,73 @@
+import {
+  buildOpenRouterSpecialistIndexEntry,
+  enrichCapabilityIndexWithOpenRouterProfiles,
+} from "@/lib/registry/openrouter-enrichment";
+import { specialistProfiles } from "../../packages/openrouter-specialists/src/profiles/index";
+
+describe("OpenRouter registry enrichment", () => {
+  it("builds enriched capability index entries for all first-five OpenRouter wallets", () => {
+    const enriched = enrichCapabilityIndexWithOpenRouterProfiles([]);
+
+    expect(enriched).toHaveLength(5);
+    expect(enriched.map((entry) => entry.walletAddress).sort()).toEqual(
+      specialistProfiles.map((profile) => profile.walletAddress).sort(),
+    );
+
+    for (const entry of enriched) {
+      expect(entry.endpointUrl).toMatch(/^https:\/\/reddi-[a-z-]+\.preview\.reddi\.tech\/v1\/chat\/completions$/);
+      expect(entry.healthcheckStatus).toBe("pass");
+      expect(entry.freshness_state).toBe("fresh");
+      expect(entry.capabilities.taskTypes.length).toBeGreaterThan(0);
+      expect(entry.capabilities.tags?.length).toBeGreaterThan(0);
+      expect(entry.capabilities.pricing.perCallUsd).toBeGreaterThan(0);
+      expect(entry.capabilities.runtime_capabilities?.length).toBeGreaterThan(0);
+      expect(entry.routingSignals?.feedbackCount).toBe(0);
+      expect(entry.routingSignals?.avgFeedbackScore).toBe(0);
+      expect(entry.ranking_score).toBeGreaterThan(0);
+      expect(entry.capabilityHash).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  it("maps profile capabilities into registry taxonomy fields", () => {
+    const codeProfile = specialistProfiles.find((profile) => profile.id === "code-generation-agent");
+    expect(codeProfile).toBeDefined();
+
+    const entry = buildOpenRouterSpecialistIndexEntry(codeProfile!.walletAddress);
+
+    expect(entry?.capabilities.taskTypes).toEqual(expect.arrayContaining(["code", "review"]));
+    expect(entry?.capabilities.tags).toEqual(expect.arrayContaining(["code-generation", "debugging", "engineering"]));
+    expect(entry?.capabilities.runtime_capabilities).toEqual(expect.arrayContaining(["code_execution", "streaming"]));
+    expect(entry?.capabilities.agent_composition?.llm).toBe(codeProfile!.model);
+    expect(entry?.capabilities.pricing.perCallUsd).toBe(0.05);
+  });
+
+  it("preserves explicit local index values while filling missing OpenRouter metadata", () => {
+    const planning = specialistProfiles.find((profile) => profile.id === "planning-agent");
+    expect(planning).toBeDefined();
+
+    const enriched = enrichCapabilityIndexWithOpenRouterProfiles([
+      {
+        walletAddress: planning!.walletAddress,
+        updatedAt: "2026-05-01T00:00:00.000Z",
+        endpointUrl: "https://custom.example/v1/chat/completions",
+        capabilities: {
+          taskTypes: ["plan"],
+          inputModes: ["text"],
+          outputModes: ["text"],
+          privacyModes: ["public"],
+          pricing: { baseUsd: 0, perCallUsd: 0.01 },
+          tags: ["custom-planning"],
+          context_requirements: [],
+          runtime_capabilities: ["stateful"],
+        },
+      },
+    ]);
+
+    const entry = enriched.find((item) => item.walletAddress === planning!.walletAddress);
+    expect(entry?.endpointUrl).toBe("https://custom.example/v1/chat/completions");
+    expect(entry?.capabilities.tags).toEqual(["custom-planning"]);
+    expect(entry?.healthcheckStatus).toBe("pass");
+    expect(entry?.freshness_state).toBe("fresh");
+    expect(entry?.routingSignals?.avgFeedbackScore).toBe(0);
+  });
+});

--- a/lib/__tests__/registry-bridge-sort.test.ts
+++ b/lib/__tests__/registry-bridge-sort.test.ts
@@ -107,6 +107,9 @@ describe("registry bridge default sort", () => {
     const result = await fetchSpecialistListings();
 
     expect(result.ok).toBe(true);
-    expect(result.listings.map((l) => l.walletAddress)).toEqual(["walletB", "walletA", "walletC"]);
+    expect(result.listings
+      .map((l) => l.walletAddress)
+      .filter((wallet) => wallet.startsWith("wallet"))
+    ).toEqual(["walletB", "walletA", "walletC"]);
   });
 });

--- a/lib/registry/bridge.ts
+++ b/lib/registry/bridge.ts
@@ -29,6 +29,7 @@ import {
   computeSpecialistRankingScore,
   type SpecialistIndexEntry,
 } from "@/lib/onboarding/specialist-index";
+import { enrichCapabilityIndexWithOpenRouterProfiles } from "@/lib/registry/openrouter-enrichment";
 import type { TaskTypeId, InputModeId, OutputModeId, PrivacyModeId, RuntimeCapability, ContextRequirement } from "@/lib/capabilities/taxonomy";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -106,10 +107,11 @@ function toBase58(bytes: Buffer): string {
 
 function loadCapabilityIndex(): SpecialistIndexEntry[] {
   try {
-    return JSON.parse(
+    const entries = JSON.parse(
       readFileSync(join(process.cwd(), "data", "onboarding", "specialist-index.json"), "utf8")
     ) as SpecialistIndexEntry[];
-  } catch { return []; }
+    return enrichCapabilityIndexWithOpenRouterProfiles(entries);
+  } catch { return enrichCapabilityIndexWithOpenRouterProfiles([]); }
 }
 
 type AttestationRecord = {

--- a/lib/registry/openrouter-enrichment.ts
+++ b/lib/registry/openrouter-enrichment.ts
@@ -1,11 +1,12 @@
-import { createHash } from "crypto";
 import { specialistProfiles } from "../../packages/openrouter-specialists/src/profiles/index";
 import type { SpecialistProfile } from "../../packages/openrouter-specialists/src/types";
-import type { CapabilityInput } from "@/lib/onboarding/capabilities";
+import { computeCapabilityHash, validateCapabilities, type CapabilityInput } from "@/lib/onboarding/capabilities";
 import type { SpecialistIndexEntry } from "@/lib/onboarding/specialist-index";
-import { computeSpecialistRankingScore } from "@/lib/onboarding/specialist-index";
+import { computeFreshnessState, computeSpecialistRankingScore } from "@/lib/onboarding/specialist-index";
 
 const DEFAULT_HEALTH_STREAK = 1;
+const SMOKE_EVIDENCE_TIMESTAMP = "2026-05-04T08:05:44.000+10:00";
+const SMOKE_EVIDENCE_HEALTHCHECK_STATUS = "pass";
 
 const OPENROUTER_PROFILE_ENDPOINTS: Record<string, string> = {
   "planning-agent": "https://reddi-planning-agent.preview.reddi.tech/v1/chat/completions",
@@ -14,6 +15,8 @@ const OPENROUTER_PROFILE_ENDPOINTS: Record<string, string> = {
   "code-generation-agent": "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions",
   "conversational-agent": "https://reddi-conversational.preview.reddi.tech/v1/chat/completions",
 };
+
+const hostedOpenRouterProfiles = specialistProfiles.filter((profile) => profile.id in OPENROUTER_PROFILE_ENDPOINTS);
 
 const profileByWallet = new Map(specialistProfiles.map((profile) => [profile.walletAddress, profile]));
 
@@ -24,10 +27,12 @@ export function findOpenRouterProfile(walletAddress: string): SpecialistProfile 
 export function buildOpenRouterSpecialistIndexEntry(walletAddress: string): SpecialistIndexEntry | null {
   const profile = findOpenRouterProfile(walletAddress);
   if (!profile) return null;
+  const endpointUrl = OPENROUTER_PROFILE_ENDPOINTS[profile.id];
+  if (!endpointUrl) return null;
 
-  const capabilities = toCapabilityInput(profile);
-  const endpointUrl = OPENROUTER_PROFILE_ENDPOINTS[profile.id] ?? joinEndpoint(process.env.OPENROUTER_SPECIALISTS_PUBLIC_BASE_URL ?? "https://preview.reddi.tech", profile.endpointPath);
-  const updatedAt = "2026-05-04T08:05:44.000+10:00";
+  const capabilities = validateCapabilities(toCapabilityInput(profile));
+  const lastSeenAt = SMOKE_EVIDENCE_TIMESTAMP;
+  const updatedAt = lastSeenAt;
   const attested = false;
   const routingSignals = {
     feedbackCount: 0,
@@ -48,13 +53,13 @@ export function buildOpenRouterSpecialistIndexEntry(walletAddress: string): Spec
     schema_version: 2,
     ranking_formula_version: 1,
     endpointUrl,
-    healthcheckStatus: "pass",
-    freshness_state: "fresh",
+    healthcheckStatus: SMOKE_EVIDENCE_HEALTHCHECK_STATUS,
+    freshness_state: computeFreshnessState(lastSeenAt),
     attested,
-    capabilityHash: capabilityHash(capabilities),
+    capabilityHash: computeCapabilityHash(walletAddress, capabilities),
     capabilities,
     routingSignals,
-    last_seen_at: updatedAt,
+    last_seen_at: lastSeenAt,
     health_streak: DEFAULT_HEALTH_STREAK,
     ranking_score,
     reputation_score: 0,
@@ -84,7 +89,7 @@ export function enrichIndexEntryWithOpenRouterProfile(entry: SpecialistIndexEntr
 
 export function enrichCapabilityIndexWithOpenRouterProfiles(entries: SpecialistIndexEntry[]): SpecialistIndexEntry[] {
   const byWallet = new Map(entries.map((entry) => [entry.walletAddress, enrichIndexEntryWithOpenRouterProfile(entry)]));
-  for (const profile of specialistProfiles) {
+  for (const profile of hostedOpenRouterProfiles) {
     if (!byWallet.has(profile.walletAddress)) {
       const entry = buildOpenRouterSpecialistIndexEntry(profile.walletAddress);
       if (entry) byWallet.set(profile.walletAddress, entry);
@@ -161,12 +166,4 @@ function hasMeaningfulCapabilities(capabilities: CapabilityInput | undefined): b
 
 function hasMeaningfulRoutingSignals(signals: SpecialistIndexEntry["routingSignals"]): boolean {
   return Boolean(signals && (signals.feedbackCount > 0 || signals.avgFeedbackScore > 0 || signals.attestationAgreements > 0));
-}
-
-function joinEndpoint(baseUrl: string, endpointPath: string): string {
-  return `${baseUrl.replace(/\/$/, "")}/${endpointPath.replace(/^\//, "")}`;
-}
-
-function capabilityHash(capabilities: CapabilityInput): string {
-  return createHash("sha256").update(JSON.stringify(capabilities)).digest("hex");
 }

--- a/lib/registry/openrouter-enrichment.ts
+++ b/lib/registry/openrouter-enrichment.ts
@@ -1,0 +1,172 @@
+import { createHash } from "crypto";
+import { specialistProfiles } from "../../packages/openrouter-specialists/src/profiles/index";
+import type { SpecialistProfile } from "../../packages/openrouter-specialists/src/types";
+import type { CapabilityInput } from "@/lib/onboarding/capabilities";
+import type { SpecialistIndexEntry } from "@/lib/onboarding/specialist-index";
+import { computeSpecialistRankingScore } from "@/lib/onboarding/specialist-index";
+
+const DEFAULT_HEALTH_STREAK = 1;
+
+const OPENROUTER_PROFILE_ENDPOINTS: Record<string, string> = {
+  "planning-agent": "https://reddi-planning-agent.preview.reddi.tech/v1/chat/completions",
+  "document-intelligence-agent": "https://reddi-document-intelligence.preview.reddi.tech/v1/chat/completions",
+  "verification-validation-agent": "https://reddi-verification-agent.preview.reddi.tech/v1/chat/completions",
+  "code-generation-agent": "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions",
+  "conversational-agent": "https://reddi-conversational.preview.reddi.tech/v1/chat/completions",
+};
+
+const profileByWallet = new Map(specialistProfiles.map((profile) => [profile.walletAddress, profile]));
+
+export function findOpenRouterProfile(walletAddress: string): SpecialistProfile | undefined {
+  return profileByWallet.get(walletAddress);
+}
+
+export function buildOpenRouterSpecialistIndexEntry(walletAddress: string): SpecialistIndexEntry | null {
+  const profile = findOpenRouterProfile(walletAddress);
+  if (!profile) return null;
+
+  const capabilities = toCapabilityInput(profile);
+  const endpointUrl = OPENROUTER_PROFILE_ENDPOINTS[profile.id] ?? joinEndpoint(process.env.OPENROUTER_SPECIALISTS_PUBLIC_BASE_URL ?? "https://preview.reddi.tech", profile.endpointPath);
+  const updatedAt = "2026-05-04T08:05:44.000+10:00";
+  const attested = false;
+  const routingSignals = {
+    feedbackCount: 0,
+    avgFeedbackScore: 0,
+    attestationAgreements: 0,
+    attestationDisagreements: 0,
+  };
+  const ranking_score = computeSpecialistRankingScore({
+    reputationScore: 0,
+    healthStreak: DEFAULT_HEALTH_STREAK,
+    attested,
+    feedbackAvg: routingSignals.avgFeedbackScore,
+  });
+
+  return {
+    walletAddress,
+    updatedAt,
+    schema_version: 2,
+    ranking_formula_version: 1,
+    endpointUrl,
+    healthcheckStatus: "pass",
+    freshness_state: "fresh",
+    attested,
+    capabilityHash: capabilityHash(capabilities),
+    capabilities,
+    routingSignals,
+    last_seen_at: updatedAt,
+    health_streak: DEFAULT_HEALTH_STREAK,
+    ranking_score,
+    reputation_score: 0,
+  };
+}
+
+export function enrichIndexEntryWithOpenRouterProfile(entry: SpecialistIndexEntry): SpecialistIndexEntry {
+  const enrichment = buildOpenRouterSpecialistIndexEntry(entry.walletAddress);
+  if (!enrichment) return entry;
+
+  return {
+    ...enrichment,
+    ...entry,
+    endpointUrl: entry.endpointUrl ?? enrichment.endpointUrl,
+    healthcheckStatus: entry.healthcheckStatus === "pass" || entry.healthcheckStatus === "fail" ? entry.healthcheckStatus : enrichment.healthcheckStatus,
+    freshness_state: entry.freshness_state === "fresh" || entry.freshness_state === "warm" || entry.freshness_state === "stale" ? entry.freshness_state : enrichment.freshness_state,
+    attested: entry.attested ?? enrichment.attested,
+    capabilityHash: entry.capabilityHash ?? enrichment.capabilityHash,
+    capabilities: hasMeaningfulCapabilities(entry.capabilities) ? entry.capabilities : enrichment.capabilities,
+    routingSignals: hasMeaningfulRoutingSignals(entry.routingSignals) ? entry.routingSignals : enrichment.routingSignals,
+    last_seen_at: entry.last_seen_at ?? enrichment.last_seen_at,
+    health_streak: entry.health_streak ?? enrichment.health_streak,
+    ranking_score: entry.ranking_score ?? enrichment.ranking_score,
+    reputation_score: entry.reputation_score ?? enrichment.reputation_score,
+  };
+}
+
+export function enrichCapabilityIndexWithOpenRouterProfiles(entries: SpecialistIndexEntry[]): SpecialistIndexEntry[] {
+  const byWallet = new Map(entries.map((entry) => [entry.walletAddress, enrichIndexEntryWithOpenRouterProfile(entry)]));
+  for (const profile of specialistProfiles) {
+    if (!byWallet.has(profile.walletAddress)) {
+      const entry = buildOpenRouterSpecialistIndexEntry(profile.walletAddress);
+      if (entry) byWallet.set(profile.walletAddress, entry);
+    }
+  }
+  return [...byWallet.values()];
+}
+
+function toCapabilityInput(profile: SpecialistProfile): CapabilityInput {
+  const normalizedCapabilities = profile.capabilities.map((capability) => capability.toLowerCase());
+  return {
+    taskTypes: mapTaskTypes(normalizedCapabilities),
+    inputModes: mapInputModes(profile, normalizedCapabilities),
+    outputModes: ["text", "json", "markdown"],
+    privacyModes: profile.roles.includes("consumer") ? ["public", "per"] : ["public"],
+    pricing: { baseUsd: 0, perCallUsd: Number.parseFloat(profile.price.amount) || 0 },
+    tags: [...new Set([...profile.tags, ...normalizedCapabilities, profile.id, profile.safetyMode])],
+    context_requirements: [
+      { key: "messages", type: "json", required: true, description: "OpenAI-compatible chat messages for the specialist." },
+      { key: "metadata", type: "json", required: false, description: "Optional Reddi routing, receipt, and attestation metadata." },
+    ],
+    runtime_capabilities: runtimeCapabilitiesFor(profile, normalizedCapabilities),
+    agent_composition: {
+      llm: profile.model,
+      control_loop: "openrouter-x402-specialist-runtime",
+      tools: profile.roles.includes("attestor") ? ["receipt_review", "evidence_checks"] : ["chat_completion"],
+      memory: ["request_scoped"],
+      goals: profile.capabilities,
+    },
+    quality_claims: [profile.description],
+    attestor_checkpoints: profile.roles.includes("attestor")
+      ? ["receipt_integrity", "output_completeness", "evidence_quality", "safety_boundary"]
+      : ["requires-verification-validation-agent"],
+  };
+}
+
+function mapTaskTypes(capabilities: string[]): CapabilityInput["taskTypes"] {
+  const taskTypes = new Set<CapabilityInput["taskTypes"][number]>();
+  const addWhen = (needles: string[], taskType: CapabilityInput["taskTypes"][number]) => {
+    if (capabilities.some((capability) => needles.some((needle) => capability.includes(needle)))) taskTypes.add(taskType);
+  };
+  addWhen(["planning", "task-decomposition", "orchestration"], "plan");
+  addWhen(["risk-analysis", "document-analysis", "validation", "verification"], "analyze");
+  addWhen(["summarization", "handoff-summary"], "summarize");
+  addWhen(["evidence-extraction"], "extract");
+  addWhen(["classification"], "classify");
+  addWhen(["code", "debugging", "test-writing", "technical-design"], "code");
+  addWhen(["quality-review", "safety-review", "attestation", "test-writing", "technical-design"], "review");
+  addWhen(["conversation", "intake", "clarification"], "qa");
+  if (taskTypes.size === 0) taskTypes.add("custom");
+  return [...taskTypes];
+}
+
+function mapInputModes(profile: SpecialistProfile, capabilities: string[]): CapabilityInput["inputModes"] {
+  const inputModes = new Set<CapabilityInput["inputModes"][number]>(["text", "json"]);
+  if (capabilities.some((capability) => /document|evidence|summary|code|design/.test(capability)) || profile.tags.includes("documents")) {
+    inputModes.add("markdown");
+    inputModes.add("file");
+  }
+  return [...inputModes];
+}
+
+function runtimeCapabilitiesFor(profile: SpecialistProfile, capabilities: string[]): CapabilityInput["runtime_capabilities"] {
+  const runtime = new Set<NonNullable<CapabilityInput["runtime_capabilities"]>[number]>(["streaming", "stateful"]);
+  if (capabilities.some((capability) => /code|debug|test/.test(capability))) runtime.add("code_execution");
+  if (capabilities.some((capability) => /document|evidence|classification|summarization/.test(capability))) runtime.add("file_read");
+  if (profile.model.includes("claude")) runtime.add("long_running");
+  return [...runtime];
+}
+
+function hasMeaningfulCapabilities(capabilities: CapabilityInput | undefined): boolean {
+  return Boolean(capabilities?.taskTypes?.length || capabilities?.tags?.length || capabilities?.runtime_capabilities?.length);
+}
+
+function hasMeaningfulRoutingSignals(signals: SpecialistIndexEntry["routingSignals"]): boolean {
+  return Boolean(signals && (signals.feedbackCount > 0 || signals.avgFeedbackScore > 0 || signals.attestationAgreements > 0));
+}
+
+function joinEndpoint(baseUrl: string, endpointPath: string): string {
+  return `${baseUrl.replace(/\/$/, "")}/${endpointPath.replace(/^\//, "")}`;
+}
+
+function capabilityHash(capabilities: CapabilityInput): string {
+  return createHash("sha256").update(JSON.stringify(capabilities)).digest("hex");
+}


### PR DESCRIPTION
## Summary
- adds off-chain OpenRouter profile/readiness enrichment for the first five registered specialist wallets
- fills registry endpointUrl, capabilities/tags/pricing, health/freshness, and routing signal defaults without live downstream calls
- updates registry sort test for injected marketplace listings and adds enrichment coverage

## Validation
- npx jest
- npx eslint lib/registry/openrouter-enrichment.ts lib/registry/bridge.ts lib/__tests__/openrouter-registry-enrichment.test.ts lib/__tests__/registry-bridge-sort.test.ts
- npm run build

## Notes
- npm run lint still fails on pre-existing package/dist lint errors outside this change (x402-solana any/require rules).
