### PR TITLE
feat: add OpenRouter delegation budget evaluator

### DIFF
--- a/packages/openrouter-specialists/src/delegation-budget.ts
+++ b/packages/openrouter-specialists/src/delegation-budget.ts
@@ -1,0 +1,155 @@
+export type DelegationBudgetDenialReason =
+  | "budget_policy_required"
+  | "invalid_budget_policy"
+  | "invalid_estimated_cost"
+  | "request_budget_exceeded"
+  | "session_budget_exceeded"
+  | "agent_budget_exceeded"
+  | "downstream_call_limit_exceeded";
+
+export interface DelegationBudgetPolicy {
+  /** Maximum lamports this single delegation request may spend. */
+  maxLamportsPerRequest: number;
+  /** Maximum total lamports allowed for the caller's current session. */
+  maxLamportsPerSession: number;
+  /** Maximum total lamports allowed for the caller agent within the policy window. */
+  maxLamportsPerAgent: number;
+  /** Maximum downstream calls allowed for the caller's current session. */
+  maxDownstreamCallsPerSession: number;
+}
+
+export interface DelegationBudgetUsage {
+  sessionLamportsSpent: number;
+  agentLamportsSpent: number;
+  downstreamCallsUsed: number;
+}
+
+export interface DelegationBudgetEvaluationInput {
+  policy?: Partial<DelegationBudgetPolicy> | null;
+  estimatedLamports: number;
+  usage?: Partial<DelegationBudgetUsage> | null;
+}
+
+export interface DelegationBudgetDecisionAllowed {
+  allowed: true;
+  policy: DelegationBudgetPolicy;
+  usage: DelegationBudgetUsage;
+  estimatedLamports: number;
+  remaining: {
+    requestLamports: number;
+    sessionLamports: number;
+    agentLamports: number;
+    downstreamCalls: number;
+  };
+}
+
+export interface DelegationBudgetDecisionDenied {
+  allowed: false;
+  reason: DelegationBudgetDenialReason;
+  message: string;
+  details: Record<string, unknown>;
+}
+
+export type DelegationBudgetDecision = DelegationBudgetDecisionAllowed | DelegationBudgetDecisionDenied;
+
+const POLICY_FIELDS: Array<keyof DelegationBudgetPolicy> = ["maxLamportsPerRequest", "maxLamportsPerSession", "maxLamportsPerAgent", "maxDownstreamCallsPerSession"];
+
+function deny(reason: DelegationBudgetDenialReason, message: string, details: Record<string, unknown> = {}): DelegationBudgetDecisionDenied {
+  return { allowed: false, reason, message, details };
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function validateDelegationBudgetPolicy(policy?: Partial<DelegationBudgetPolicy> | null): DelegationBudgetPolicy | DelegationBudgetDecisionDenied {
+  if (!policy) {
+    return deny("budget_policy_required", "Live delegation requires an explicit budget policy.");
+  }
+
+  const invalidFields = POLICY_FIELDS.filter((field) => !isNonNegativeSafeInteger(policy[field]));
+  if (invalidFields.length > 0) {
+    return deny("invalid_budget_policy", "Budget policy fields must be non-negative safe integers.", { invalidFields });
+  }
+
+  return {
+    maxLamportsPerRequest: policy.maxLamportsPerRequest as number,
+    maxLamportsPerSession: policy.maxLamportsPerSession as number,
+    maxLamportsPerAgent: policy.maxLamportsPerAgent as number,
+    maxDownstreamCallsPerSession: policy.maxDownstreamCallsPerSession as number,
+  };
+}
+
+export function normalizeDelegationBudgetUsage(usage?: Partial<DelegationBudgetUsage> | null): DelegationBudgetUsage | DelegationBudgetDecisionDenied {
+  const normalized = {
+    sessionLamportsSpent: usage?.sessionLamportsSpent ?? 0,
+    agentLamportsSpent: usage?.agentLamportsSpent ?? 0,
+    downstreamCallsUsed: usage?.downstreamCallsUsed ?? 0,
+  };
+  const invalidFields = (Object.keys(normalized) as Array<keyof DelegationBudgetUsage>).filter((field) => !isNonNegativeSafeInteger(normalized[field]));
+  if (invalidFields.length > 0) {
+    return deny("invalid_budget_policy", "Budget usage fields must be non-negative safe integers.", { invalidFields });
+  }
+  return normalized;
+}
+
+export function evaluateDelegationBudget(input: DelegationBudgetEvaluationInput): DelegationBudgetDecision {
+  if (!isNonNegativeSafeInteger(input.estimatedLamports)) {
+    return deny("invalid_estimated_cost", "Estimated downstream cost must be a non-negative safe integer.", { estimatedLamports: input.estimatedLamports });
+  }
+
+  const policy = validateDelegationBudgetPolicy(input.policy);
+  if ("allowed" in policy) return policy;
+
+  const usage = normalizeDelegationBudgetUsage(input.usage);
+  if ("allowed" in usage) return usage;
+
+  if (input.estimatedLamports > policy.maxLamportsPerRequest) {
+    return deny("request_budget_exceeded", "Estimated downstream cost exceeds the per-request budget.", {
+      estimatedLamports: input.estimatedLamports,
+      maxLamportsPerRequest: policy.maxLamportsPerRequest,
+    });
+  }
+
+  const projectedSessionLamports = usage.sessionLamportsSpent + input.estimatedLamports;
+  if (projectedSessionLamports > policy.maxLamportsPerSession) {
+    return deny("session_budget_exceeded", "Estimated downstream cost exceeds the remaining session budget.", {
+      estimatedLamports: input.estimatedLamports,
+      sessionLamportsSpent: usage.sessionLamportsSpent,
+      maxLamportsPerSession: policy.maxLamportsPerSession,
+      projectedSessionLamports,
+    });
+  }
+
+  const projectedAgentLamports = usage.agentLamportsSpent + input.estimatedLamports;
+  if (projectedAgentLamports > policy.maxLamportsPerAgent) {
+    return deny("agent_budget_exceeded", "Estimated downstream cost exceeds the remaining agent budget.", {
+      estimatedLamports: input.estimatedLamports,
+      agentLamportsSpent: usage.agentLamportsSpent,
+      maxLamportsPerAgent: policy.maxLamportsPerAgent,
+      projectedAgentLamports,
+    });
+  }
+
+  const projectedDownstreamCalls = usage.downstreamCallsUsed + 1;
+  if (projectedDownstreamCalls > policy.maxDownstreamCallsPerSession) {
+    return deny("downstream_call_limit_exceeded", "Live delegation would exceed the session downstream call limit.", {
+      downstreamCallsUsed: usage.downstreamCallsUsed,
+      maxDownstreamCallsPerSession: policy.maxDownstreamCallsPerSession,
+      projectedDownstreamCalls,
+    });
+  }
+
+  return {
+    allowed: true,
+    policy,
+    usage,
+    estimatedLamports: input.estimatedLamports,
+    remaining: {
+      requestLamports: policy.maxLamportsPerRequest - input.estimatedLamports,
+      sessionLamports: policy.maxLamportsPerSession - projectedSessionLamports,
+      agentLamports: policy.maxLamportsPerAgent - projectedAgentLamports,
+      downstreamCalls: policy.maxDownstreamCallsPerSession - projectedDownstreamCalls,
+    },
+  };
+}

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -4,4 +4,5 @@ export * from "./openrouter.js";
 export * from "./attestation.js";
 export * from "./marketplace-client.js";
 export * from "./deployment-readiness.js";
+export * from "./delegation-budget.js";
 export * from "./runtime.js";

--- a/packages/openrouter-specialists/tests/delegation-budget.test.ts
+++ b/packages/openrouter-specialists/tests/delegation-budget.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluateDelegationBudget, validateDelegationBudgetPolicy } from "../src/delegation-budget.js";
+
+const policy = {
+  maxLamportsPerRequest: 100_000,
+  maxLamportsPerSession: 300_000,
+  maxLamportsPerAgent: 1_000_000,
+  maxDownstreamCallsPerSession: 3,
+};
+
+test("missing live delegation budget policy fails closed", () => {
+  const decision = evaluateDelegationBudget({ estimatedLamports: 1_000 });
+
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.reason, "budget_policy_required");
+});
+
+test("malformed budget policy fails closed with invalid fields", () => {
+  const decision = validateDelegationBudgetPolicy({
+    maxLamportsPerRequest: 100,
+    maxLamportsPerSession: -1,
+    maxLamportsPerAgent: Number.NaN,
+  });
+
+  assert.ok("allowed" in decision);
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.reason, "invalid_budget_policy");
+  assert.deepEqual(decision.details.invalidFields, ["maxLamportsPerSession", "maxLamportsPerAgent", "maxDownstreamCallsPerSession"]);
+});
+
+test("invalid estimated cost fails closed", () => {
+  const decision = evaluateDelegationBudget({ policy, estimatedLamports: 1.5 });
+
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.reason, "invalid_estimated_cost");
+});
+
+test("request over per-request spend cap fails closed", () => {
+  const decision = evaluateDelegationBudget({ policy, estimatedLamports: 100_001 });
+
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.reason, "request_budget_exceeded");
+  assert.equal(decision.details.maxLamportsPerRequest, 100_000);
+});
+
+test("request over remaining session budget fails closed", () => {
+  const decision = evaluateDelegationBudget({
+    policy,
+    estimatedLamports: 75_000,
+    usage: { sessionLamportsSpent: 250_001 },
+  });
+
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.reason, "session_budget_exceeded");
+  assert.equal(decision.details.projectedSessionLamports, 325_001);
+});
+
+test("request over remaining agent budget fails closed", () => {
+  const decision = evaluateDelegationBudget({
+    policy,
+    estimatedLamports: 75_000,
+    usage: { agentLamportsSpent: 950_001 },
+  });
+
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.reason, "agent_budget_exceeded");
+  assert.equal(decision.details.projectedAgentLamports, 1_025_001);
+});
+
+test("request over downstream call count fails closed", () => {
+  const decision = evaluateDelegationBudget({
+    policy,
+    estimatedLamports: 1_000,
+    usage: { downstreamCallsUsed: 3 },
+  });
+
+  assert.equal(decision.allowed, false);
+  assert.equal(decision.reason, "downstream_call_limit_exceeded");
+  assert.equal(decision.details.projectedDownstreamCalls, 4);
+});
+
+test("request within all budget limits is allowed with remaining budget snapshot", () => {
+  const decision = evaluateDelegationBudget({
+    policy,
+    estimatedLamports: 25_000,
+    usage: { sessionLamportsSpent: 50_000, agentLamportsSpent: 100_000, downstreamCallsUsed: 1 },
+  });
+
+  assert.equal(decision.allowed, true);
+  assert.deepEqual(decision.remaining, {
+    requestLamports: 75_000,
+    sessionLamports: 225_000,
+    agentLamports: 875_000,
+    downstreamCalls: 1,
+  });
+});


### PR DESCRIPTION
## Summary

Loop 1 for live delegation spend guards. Adds a pure, deterministic budget policy evaluator for OpenRouter specialist live delegation preflight.

Linked issue: #159

## What changed

- Added `delegation-budget.ts` with:
  - `DelegationBudgetPolicy`
  - usage normalization
  - policy validation
  - `evaluateDelegationBudget()` allow/deny decisions
  - structured denial reasons for missing/malformed budget, invalid estimated cost, over-spend, and call-count exhaustion
- Exported evaluator from package index.
- Added tests for missing policy, malformed policy, invalid estimate, request/session/agent spend caps, call-count cap, and allowed-within-budget snapshot.

## Guardrails

- No network calls.
- No signer/private-key access.
- No Coolify changes.
- No devnet transfers/registration.
- No live downstream x402/OpenRouter calls.

## Validation

- `cd packages/openrouter-specialists && npm test` → 34/34 passing
- `npm run build` → passing
- `git diff --check` → passing

## Retrospective to complete after review/merge

Update the Iteration 6 log and refine Loop 2: runtime live-delegation preflight gate.
