### PR TITLE
feat: gate live delegation with budget preflight

### DIFF
--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -9,6 +9,7 @@ import {
   type X402Challenge,
 } from "@reddi/x402-solana";
 import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
+import { evaluateDelegationBudget } from "./delegation-budget.js";
 import { buildDryRunDelegationPlan, inferRequiredCapabilities } from "./marketplace-client.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "./profiles/index.js";
 import { FetchOpenRouterClient, MockOpenRouterClient } from "./openrouter.js";
@@ -181,6 +182,53 @@ export async function handleDelegationPlanning(input: {
   const delegation = typeof metadata.delegation === "object" && metadata.delegation !== null ? (metadata.delegation as Record<string, unknown>) : {};
   const dryRun = delegation.dryRun !== false && metadata.mode !== "delegation_live";
   if (!dryRun) {
+    if (!input.config.enableAgentToAgentCalls) {
+      return {
+        status: 403,
+        headers: JSON_HEADERS,
+        body: {
+          error: {
+            code: "live_delegation_disabled",
+            message: "Live agent-to-agent x402 calls are disabled until spend guards and operator approval are configured.",
+          },
+          reddi: {
+            profileId: profile.id,
+            liveCallsEnabled: false,
+            downstreamCallsExecuted: 0,
+            maxDownstreamCalls: input.config.maxDownstreamCalls ?? 0,
+            maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
+          },
+        },
+      };
+    }
+
+    const budgetPolicy = typeof delegation.budgetPolicy === "object" && delegation.budgetPolicy !== null ? delegation.budgetPolicy : undefined;
+    const budgetDecision = evaluateDelegationBudget({
+      policy: budgetPolicy,
+      estimatedLamports: budgetPolicy ? (typeof delegation.estimatedLamports === "number" ? delegation.estimatedLamports : Number.NaN) : 0,
+      usage: typeof delegation.budgetUsage === "object" && delegation.budgetUsage !== null ? delegation.budgetUsage : undefined,
+    });
+    if (!budgetDecision.allowed) {
+      return {
+        status: 403,
+        headers: JSON_HEADERS,
+        body: {
+          error: {
+            code: budgetDecision.reason,
+            message: budgetDecision.message,
+            details: budgetDecision.details,
+          },
+          reddi: {
+            profileId: profile.id,
+            liveCallsEnabled: true,
+            downstreamCallsExecuted: 0,
+            maxDownstreamCalls: input.config.maxDownstreamCalls ?? 0,
+            maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
+          },
+        },
+      };
+    }
+
     return {
       status: 501,
       headers: JSON_HEADERS,
@@ -195,6 +243,7 @@ export async function handleDelegationPlanning(input: {
           downstreamCallsExecuted: 0,
           maxDownstreamCalls: input.config.maxDownstreamCalls ?? 0,
           maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
+          budget: budgetDecision,
         },
       },
     };

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -442,11 +442,17 @@ test("deployment readiness report is public-data-only and blocks missing funding
 
 test("live delegation mode fails closed before any downstream paid call executor exists", async () => {
   const client = new MockOpenRouterClient();
+  const budgetPolicy = {
+    maxLamportsPerRequest: 1_000,
+    maxLamportsPerSession: 5_000,
+    maxLamportsPerAgent: 10_000,
+    maxDownstreamCallsPerSession: 2,
+  };
   const response = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-1" }),
     body: {
       messages: [{ role: "user", content: "Hire a code agent for this task." }],
-      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"] } },
+      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"], estimatedLamports: 500, budgetPolicy } },
     },
     config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: true, maxDownstreamCalls: 1, maxDownstreamLamports: 1000 },
     client,
@@ -456,8 +462,9 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(client.callCount, 0);
   assert.equal((response.body.error as { code: string }).code, "live_delegation_not_implemented");
   assert.equal((response.body.reddi as { downstreamCallsExecuted: number }).downstreamCallsExecuted, 0);
+  assert.equal(((response.body.reddi as { budget: { allowed: boolean } }).budget).allowed, true);
 
-  const liveWithoutDelegationObject = await handleChatCompletions({
+  const liveWithoutBudgetPolicy = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-2" }),
     body: {
       messages: [{ role: "user", content: "Hire another agent live." }],
@@ -466,22 +473,38 @@ test("live delegation mode fails closed before any downstream paid call executor
     config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: true },
     client,
   });
-  assert.equal(liveWithoutDelegationObject.status, 501);
+  assert.equal(liveWithoutBudgetPolicy.status, 403);
   assert.equal(client.callCount, 0);
-  assert.equal((liveWithoutDelegationObject.body.error as { code: string }).code, "live_delegation_not_implemented");
+  assert.equal((liveWithoutBudgetPolicy.body.error as { code: string }).code, "budget_policy_required");
+  assert.equal((liveWithoutBudgetPolicy.body.reddi as { downstreamCallsExecuted: number }).downstreamCallsExecuted, 0);
 
   const liveWithCallsDisabled = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-3" }),
     body: {
       messages: [{ role: "user", content: "Hire another agent live." }],
-      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"] } },
+      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"], estimatedLamports: 500, budgetPolicy } },
     },
     config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: false },
     client,
   });
-  assert.equal(liveWithCallsDisabled.status, 501);
+  assert.equal(liveWithCallsDisabled.status, 403);
   assert.equal(client.callCount, 0);
-  assert.equal((liveWithCallsDisabled.body.error as { code: string }).code, "live_delegation_not_implemented");
+  assert.equal((liveWithCallsDisabled.body.error as { code: string }).code, "live_delegation_disabled");
+  assert.equal((liveWithCallsDisabled.body.reddi as { downstreamCallsExecuted: number }).downstreamCallsExecuted, 0);
+
+  const liveOverBudget = await handleChatCompletions({
+    headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-4" }),
+    body: {
+      messages: [{ role: "user", content: "Hire another agent live." }],
+      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"], estimatedLamports: 2_000, budgetPolicy } },
+    },
+    config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: true },
+    client,
+  });
+  assert.equal(liveOverBudget.status, 403);
+  assert.equal(client.callCount, 0);
+  assert.equal((liveOverBudget.body.error as { code: string }).code, "request_budget_exceeded");
+  assert.equal((liveOverBudget.body.reddi as { downstreamCallsExecuted: number }).downstreamCallsExecuted, 0);
 });
 
 test("HTTP core routes expose health, models, tags, metadata, attestation, and chat", async () => {


### PR DESCRIPTION
## Summary

Implements Iteration 6 Loop 2 for OpenRouter specialists live delegation spend guards.

This wires the Loop 1 pure `evaluateDelegationBudget()` helper into the runtime live-delegation branch while preserving fail-closed behavior:

- live delegation disabled by runtime config now returns `403 live_delegation_disabled` before any budget/downstream work;
- live delegation enabled but missing/invalid/insufficient budget returns structured `403` budget denial;
- live delegation enabled with valid budget still returns `501 live_delegation_not_implemented` with `downstreamCallsExecuted: 0`;
- dry-run delegation remains unchanged.

Closes #161.

## Guardrails

- No network calls introduced.
- No signer/private-key access.
- No Coolify changes.
- No devnet transfer/registration.
- No live downstream x402/OpenRouter call.
- Normal chat completion is not used as a fallback for live delegation.

## Validation

- `npm test --prefix packages/openrouter-specialists` ✅ 34/34
- `npm run build` ✅
- `git diff --check` ✅

## Notes

During testing, missing budget policy initially got masked by invalid estimate ordering. Runtime now passes a neutral estimate when policy is absent so `budget_policy_required` is the surfaced fail-closed reason.
