### PR TITLE
feat: add live delegation intent plan

### DIFF
--- a/packages/openrouter-specialists/src/delegation-intent.ts
+++ b/packages/openrouter-specialists/src/delegation-intent.ts
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import type { DelegationBudgetDecisionAllowed } from "./delegation-budget.js";
+import type { DelegationPlan, RankedMarketplaceCandidate } from "./marketplace-client.js";
+
+export interface LiveDelegationIntentPlanInput {
+  requesterProfileId: string;
+  task: string;
+  requiredCapabilities: string[];
+  selectedCandidate?: RankedMarketplaceCandidate;
+  delegationPlan: DelegationPlan;
+  budget: DelegationBudgetDecisionAllowed;
+  maxDownstreamCalls: number;
+  maxDownstreamLamports: number;
+}
+
+export interface LiveDelegationIntentPlan {
+  schemaVersion: "reddi.live-delegation-intent.v1";
+  intentId: string;
+  executionStatus: "not_executed";
+  requesterProfileId: string;
+  selectedCandidate?: {
+    profileId: string;
+    displayName: string;
+    endpointPath: string;
+    walletAddress?: string;
+    matchedCapabilities: string[];
+    price: RankedMarketplaceCandidate["price"];
+    safetyMode: string;
+  };
+  task: string;
+  requiredCapabilities: string[];
+  estimatedLamports: number;
+  budget: DelegationBudgetDecisionAllowed;
+  guardrails: {
+    liveCallsEnabled: true;
+    downstreamCallsExecuted: 0;
+    maxDownstreamCalls: number;
+    maxDownstreamLamports: number;
+    noSignerMaterialUsed: true;
+    noDevnetTransferExecuted: true;
+    noDownstreamX402Executed: true;
+  };
+  requiredAttestor?: string;
+  candidateCount: number;
+}
+
+export function buildLiveDelegationIntentPlan(input: LiveDelegationIntentPlanInput): LiveDelegationIntentPlan {
+  const selectedCandidate = input.selectedCandidate;
+  const identityPayload = JSON.stringify({
+    requesterProfileId: input.requesterProfileId,
+    selectedCandidateProfileId: selectedCandidate?.profileId ?? null,
+    task: input.task,
+    requiredCapabilities: input.requiredCapabilities,
+    estimatedLamports: input.budget.estimatedLamports,
+    candidateCount: input.delegationPlan.candidates.length,
+  });
+  const intentId = `intent_${createHash("sha256").update(identityPayload).digest("hex").slice(0, 24)}`;
+
+  return {
+    schemaVersion: "reddi.live-delegation-intent.v1",
+    intentId,
+    executionStatus: "not_executed",
+    requesterProfileId: input.requesterProfileId,
+    selectedCandidate: selectedCandidate
+      ? {
+          profileId: selectedCandidate.profileId,
+          displayName: selectedCandidate.displayName,
+          endpointPath: selectedCandidate.endpointPath,
+          walletAddress: selectedCandidate.walletAddress,
+          matchedCapabilities: selectedCandidate.matchedCapabilities,
+          price: selectedCandidate.price,
+          safetyMode: selectedCandidate.safetyMode,
+        }
+      : undefined,
+    task: input.task,
+    requiredCapabilities: input.requiredCapabilities,
+    estimatedLamports: input.budget.estimatedLamports,
+    budget: input.budget,
+    guardrails: {
+      liveCallsEnabled: true,
+      downstreamCallsExecuted: 0,
+      maxDownstreamCalls: input.maxDownstreamCalls,
+      maxDownstreamLamports: input.maxDownstreamLamports,
+      noSignerMaterialUsed: true,
+      noDevnetTransferExecuted: true,
+      noDownstreamX402Executed: true,
+    },
+    requiredAttestor: input.delegationPlan.requiredAttestor,
+    candidateCount: input.delegationPlan.candidates.length,
+  };
+}

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -5,4 +5,5 @@ export * from "./attestation.js";
 export * from "./marketplace-client.js";
 export * from "./deployment-readiness.js";
 export * from "./delegation-budget.js";
+export * from "./delegation-intent.js";
 export * from "./runtime.js";

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -10,6 +10,7 @@ import {
 } from "@reddi/x402-solana";
 import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
 import { evaluateDelegationBudget } from "./delegation-budget.js";
+import { buildLiveDelegationIntentPlan } from "./delegation-intent.js";
 import { buildDryRunDelegationPlan, inferRequiredCapabilities } from "./marketplace-client.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "./profiles/index.js";
 import { FetchOpenRouterClient, MockOpenRouterClient } from "./openrouter.js";
@@ -180,6 +181,17 @@ export async function handleDelegationPlanning(input: {
 
   const metadata = input.body.metadata ?? {};
   const delegation = typeof metadata.delegation === "object" && metadata.delegation !== null ? (metadata.delegation as Record<string, unknown>) : {};
+  const task =
+    typeof delegation.task === "string"
+      ? delegation.task
+      : input.body.messages
+          ?.filter((message) => message.role === "user")
+          .map((message) => message.content)
+          .join("\n")
+          .trim() || "";
+  const explicitCapabilities = Array.isArray(delegation.requiredCapabilities) ? delegation.requiredCapabilities.filter((value): value is string => typeof value === "string") : [];
+  const requiredCapabilities = explicitCapabilities.length > 0 ? explicitCapabilities : inferRequiredCapabilities(task);
+  const maxCandidates = typeof delegation.maxCandidates === "number" && Number.isFinite(delegation.maxCandidates) ? Math.max(1, Math.floor(delegation.maxCandidates)) : 3;
   const dryRun = delegation.dryRun !== false && metadata.mode !== "delegation_live";
   if (!dryRun) {
     if (!input.config.enableAgentToAgentCalls) {
@@ -229,6 +241,25 @@ export async function handleDelegationPlanning(input: {
       };
     }
 
+    const plan = await buildDryRunDelegationPlan({
+      request: {
+        task,
+        requesterProfileId: profile.id,
+        requiredCapabilities,
+        maxCandidates,
+      },
+    });
+    const intentPlan = buildLiveDelegationIntentPlan({
+      requesterProfileId: profile.id,
+      task,
+      requiredCapabilities,
+      selectedCandidate: plan.selectedCandidate,
+      delegationPlan: plan,
+      budget: budgetDecision,
+      maxDownstreamCalls: input.config.maxDownstreamCalls ?? 0,
+      maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
+    });
+
     return {
       status: 501,
       headers: JSON_HEADERS,
@@ -244,22 +275,12 @@ export async function handleDelegationPlanning(input: {
           maxDownstreamCalls: input.config.maxDownstreamCalls ?? 0,
           maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
           budget: budgetDecision,
+          intentPlan,
         },
       },
     };
   }
 
-  const task =
-    typeof delegation.task === "string"
-      ? delegation.task
-      : input.body.messages
-          ?.filter((message) => message.role === "user")
-          .map((message) => message.content)
-          .join("\n")
-          .trim() || "";
-  const explicitCapabilities = Array.isArray(delegation.requiredCapabilities) ? delegation.requiredCapabilities.filter((value): value is string => typeof value === "string") : [];
-  const requiredCapabilities = explicitCapabilities.length > 0 ? explicitCapabilities : inferRequiredCapabilities(task);
-  const maxCandidates = typeof delegation.maxCandidates === "number" && Number.isFinite(delegation.maxCandidates) ? Math.max(1, Math.floor(delegation.maxCandidates)) : 3;
   const plan = await buildDryRunDelegationPlan({
     request: {
       task,

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -463,6 +463,13 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal((response.body.error as { code: string }).code, "live_delegation_not_implemented");
   assert.equal((response.body.reddi as { downstreamCallsExecuted: number }).downstreamCallsExecuted, 0);
   assert.equal(((response.body.reddi as { budget: { allowed: boolean } }).budget).allowed, true);
+  const intentPlan = (response.body.reddi as { intentPlan: { schemaVersion: string; executionStatus: string; selectedCandidate?: { profileId: string }; guardrails: { downstreamCallsExecuted: number; noDownstreamX402Executed: boolean }; estimatedLamports: number } }).intentPlan;
+  assert.equal(intentPlan.schemaVersion, "reddi.live-delegation-intent.v1");
+  assert.equal(intentPlan.executionStatus, "not_executed");
+  assert.equal(intentPlan.selectedCandidate?.profileId, "code-generation-agent");
+  assert.equal(intentPlan.estimatedLamports, 500);
+  assert.equal(intentPlan.guardrails.downstreamCallsExecuted, 0);
+  assert.equal(intentPlan.guardrails.noDownstreamX402Executed, true);
 
   const liveWithoutBudgetPolicy = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-2" }),
@@ -476,7 +483,8 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(liveWithoutBudgetPolicy.status, 403);
   assert.equal(client.callCount, 0);
   assert.equal((liveWithoutBudgetPolicy.body.error as { code: string }).code, "budget_policy_required");
-  assert.equal((liveWithoutBudgetPolicy.body.reddi as { downstreamCallsExecuted: number }).downstreamCallsExecuted, 0);
+  assert.equal((liveWithoutBudgetPolicy.body.reddi as { downstreamCallsExecuted: number; intentPlan?: unknown }).downstreamCallsExecuted, 0);
+  assert.equal((liveWithoutBudgetPolicy.body.reddi as { intentPlan?: unknown }).intentPlan, undefined);
 
   const liveWithCallsDisabled = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-3" }),


### PR DESCRIPTION
## Summary

Implements Iteration 6 Loop 3 for OpenRouter specialists live delegation spend guards.

Adds a deterministic, public-data-only `reddi.live-delegation-intent.v1` plan object after live budget preflight passes, while preserving fail-closed behavior:

- no downstream execution is added;
- valid-budget live delegation still returns `501 live_delegation_not_implemented`;
- the response includes an `intentPlan` with requester, candidate, capabilities, budget snapshot, guardrails, attestor expectation, and `executionStatus: "not_executed"`;
- denied live branches do not create an intent plan;
- dry-run behavior remains unchanged.

Closes #163.

## Guardrails

- No network calls introduced.
- No signer/private-key access.
- No Coolify changes.
- No devnet transfer/registration.
- No live downstream x402/OpenRouter call.
- All live branches retain `downstreamCallsExecuted: 0`.

## Validation

- `npm test --prefix packages/openrouter-specialists` ✅ 34/34
- `npm run build` ✅
- `git diff --check` ✅
