### PR TITLE
feat: add live delegation audit envelope

### DIFF
--- a/packages/openrouter-specialists/src/delegation-audit.ts
+++ b/packages/openrouter-specialists/src/delegation-audit.ts
@@ -1,0 +1,67 @@
+import { createHash } from "node:crypto";
+import type { LiveDelegationIntentPlan } from "./delegation-intent.js";
+
+export interface LiveDelegationAuditEnvelope {
+  schemaVersion: "reddi.live-delegation-audit-envelope.v1";
+  canonicalization: "json-stable-sort-v1";
+  hashAlgorithm: "sha256";
+  envelopeHash: string;
+  canonicalJson: string;
+  intentPlan: LiveDelegationIntentPlan;
+  signatureStatus: "unsigned";
+  persistenceStatus: "not_persisted";
+  executionStatus: "not_executed";
+  guardrails: {
+    noSignerMaterialUsed: true;
+    noExternalPersistence: true;
+    noDevnetTransferExecuted: true;
+    noDownstreamX402Executed: true;
+  };
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortForCanonicalJson(value));
+}
+
+export function buildLiveDelegationAuditEnvelope(intentPlan: LiveDelegationIntentPlan): LiveDelegationAuditEnvelope {
+  const canonicalPayload = canonicalJson({
+    schemaVersion: "reddi.live-delegation-audit-envelope.v1",
+    intentPlan,
+    signatureStatus: "unsigned",
+    persistenceStatus: "not_persisted",
+    executionStatus: "not_executed",
+  });
+  return {
+    schemaVersion: "reddi.live-delegation-audit-envelope.v1",
+    canonicalization: "json-stable-sort-v1",
+    hashAlgorithm: "sha256",
+    envelopeHash: `sha256:${createHash("sha256").update(canonicalPayload).digest("hex")}`,
+    canonicalJson: canonicalPayload,
+    intentPlan,
+    signatureStatus: "unsigned",
+    persistenceStatus: "not_persisted",
+    executionStatus: "not_executed",
+    guardrails: {
+      noSignerMaterialUsed: true,
+      noExternalPersistence: true,
+      noDevnetTransferExecuted: true,
+      noDownstreamX402Executed: true,
+    },
+  };
+}
+
+function sortForCanonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortForCanonicalJson);
+  if (!isPlainObject(value)) return value;
+
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    const child = value[key];
+    if (child !== undefined) sorted[key] = sortForCanonicalJson(child);
+  }
+  return sorted;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype;
+}

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -6,4 +6,5 @@ export * from "./marketplace-client.js";
 export * from "./deployment-readiness.js";
 export * from "./delegation-budget.js";
 export * from "./delegation-intent.js";
+export * from "./delegation-audit.js";
 export * from "./runtime.js";

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -9,6 +9,7 @@ import {
   type X402Challenge,
 } from "@reddi/x402-solana";
 import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
+import { buildLiveDelegationAuditEnvelope } from "./delegation-audit.js";
 import { evaluateDelegationBudget } from "./delegation-budget.js";
 import { buildLiveDelegationIntentPlan } from "./delegation-intent.js";
 import { buildDryRunDelegationPlan, inferRequiredCapabilities } from "./marketplace-client.js";
@@ -259,6 +260,7 @@ export async function handleDelegationPlanning(input: {
       maxDownstreamCalls: input.config.maxDownstreamCalls ?? 0,
       maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
     });
+    const auditEnvelope = buildLiveDelegationAuditEnvelope(intentPlan);
 
     return {
       status: 501,
@@ -276,6 +278,7 @@ export async function handleDelegationPlanning(input: {
           maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
           budget: budgetDecision,
           intentPlan,
+          auditEnvelope,
         },
       },
     };

--- a/packages/openrouter-specialists/tests/delegation-audit.test.ts
+++ b/packages/openrouter-specialists/tests/delegation-audit.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildLiveDelegationAuditEnvelope, canonicalJson } from "../src/delegation-audit.js";
+import type { LiveDelegationIntentPlan } from "../src/delegation-intent.js";
+
+const intentPlan: LiveDelegationIntentPlan = {
+  schemaVersion: "reddi.live-delegation-intent.v1",
+  intentId: "intent_test",
+  executionStatus: "not_executed",
+  requesterProfileId: "planning-agent",
+  selectedCandidate: {
+    profileId: "code-generation-agent",
+    displayName: "Code Generation Agent",
+    endpointPath: "/v1/chat/completions",
+    walletAddress: "11111111111111111111111111111111",
+    matchedCapabilities: ["code-generation"],
+    price: { currency: "USDC", amount: "0.02", unit: "request" },
+    safetyMode: "standard",
+  },
+  task: "Write tests",
+  requiredCapabilities: ["code-generation"],
+  estimatedLamports: 500,
+  budget: {
+    allowed: true,
+    estimatedLamports: 500,
+    policy: {
+      maxLamportsPerRequest: 1000,
+      maxLamportsPerSession: 5000,
+      maxLamportsPerAgent: 10000,
+      maxDownstreamCallsPerSession: 2,
+    },
+    usage: {
+      sessionLamportsSpent: 0,
+      agentLamportsSpent: 0,
+      downstreamCallsUsed: 0,
+    },
+    remaining: {
+      requestLamports: 500,
+      sessionLamports: 4500,
+      agentLamports: 9500,
+      downstreamCalls: 1,
+    },
+  },
+  guardrails: {
+    liveCallsEnabled: true,
+    downstreamCallsExecuted: 0,
+    maxDownstreamCalls: 1,
+    maxDownstreamLamports: 1000,
+    noSignerMaterialUsed: true,
+    noDevnetTransferExecuted: true,
+    noDownstreamX402Executed: true,
+  },
+  requiredAttestor: "verification-validation-agent",
+  candidateCount: 1,
+};
+
+test("canonicalJson sorts object keys recursively and omits undefined", () => {
+  assert.equal(canonicalJson({ b: 2, a: { d: undefined, c: 1 } }), '{"a":{"c":1},"b":2}');
+});
+
+test("live delegation audit envelope is deterministic, unsigned, and local-only", () => {
+  const first = buildLiveDelegationAuditEnvelope(intentPlan);
+  const second = buildLiveDelegationAuditEnvelope({ ...intentPlan, selectedCandidate: intentPlan.selectedCandidate ? { ...intentPlan.selectedCandidate } : undefined });
+
+  assert.equal(first.envelopeHash, second.envelopeHash);
+  assert.match(first.envelopeHash, /^sha256:[a-f0-9]{64}$/);
+  assert.equal(first.signatureStatus, "unsigned");
+  assert.equal(first.persistenceStatus, "not_persisted");
+  assert.equal(first.executionStatus, "not_executed");
+  assert.equal(first.guardrails.noSignerMaterialUsed, true);
+  assert.equal(first.guardrails.noExternalPersistence, true);
+  assert.equal(first.guardrails.noDevnetTransferExecuted, true);
+  assert.equal(first.guardrails.noDownstreamX402Executed, true);
+  assert.equal(first.canonicalJson, canonicalJson(JSON.parse(first.canonicalJson)));
+  assert.equal(JSON.parse(first.canonicalJson).intentPlan.intentId, "intent_test");
+});

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
+import { canonicalJson } from "../src/delegation-audit.js";
 import { MockOpenRouterClient } from "../src/openrouter.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "../src/profiles/index.js";
 import {
@@ -470,6 +471,17 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(intentPlan.estimatedLamports, 500);
   assert.equal(intentPlan.guardrails.downstreamCallsExecuted, 0);
   assert.equal(intentPlan.guardrails.noDownstreamX402Executed, true);
+  const auditEnvelope = (response.body.reddi as { auditEnvelope: { schemaVersion: string; hashAlgorithm: string; envelopeHash: string; canonicalJson: string; signatureStatus: string; persistenceStatus: string; executionStatus: string; guardrails: { noSignerMaterialUsed: boolean; noExternalPersistence: boolean; noDownstreamX402Executed: boolean } } }).auditEnvelope;
+  assert.equal(auditEnvelope.schemaVersion, "reddi.live-delegation-audit-envelope.v1");
+  assert.equal(auditEnvelope.hashAlgorithm, "sha256");
+  assert.match(auditEnvelope.envelopeHash, /^sha256:[a-f0-9]{64}$/);
+  assert.equal(auditEnvelope.signatureStatus, "unsigned");
+  assert.equal(auditEnvelope.persistenceStatus, "not_persisted");
+  assert.equal(auditEnvelope.executionStatus, "not_executed");
+  assert.equal(auditEnvelope.guardrails.noSignerMaterialUsed, true);
+  assert.equal(auditEnvelope.guardrails.noExternalPersistence, true);
+  assert.equal(auditEnvelope.guardrails.noDownstreamX402Executed, true);
+  assert.equal(auditEnvelope.canonicalJson, canonicalJson(JSON.parse(auditEnvelope.canonicalJson)));
 
   const liveWithoutBudgetPolicy = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-2" }),
@@ -483,8 +495,9 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(liveWithoutBudgetPolicy.status, 403);
   assert.equal(client.callCount, 0);
   assert.equal((liveWithoutBudgetPolicy.body.error as { code: string }).code, "budget_policy_required");
-  assert.equal((liveWithoutBudgetPolicy.body.reddi as { downstreamCallsExecuted: number; intentPlan?: unknown }).downstreamCallsExecuted, 0);
+  assert.equal((liveWithoutBudgetPolicy.body.reddi as { downstreamCallsExecuted: number; intentPlan?: unknown; auditEnvelope?: unknown }).downstreamCallsExecuted, 0);
   assert.equal((liveWithoutBudgetPolicy.body.reddi as { intentPlan?: unknown }).intentPlan, undefined);
+  assert.equal((liveWithoutBudgetPolicy.body.reddi as { auditEnvelope?: unknown }).auditEnvelope, undefined);
 
   const liveWithCallsDisabled = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-3" }),


### PR DESCRIPTION
## Summary

Implements Iteration 6 Loop 4 for OpenRouter specialists live delegation spend guards.

Adds a deterministic, local-only `reddi.live-delegation-audit-envelope.v1` around the Loop 3 intent plan:

- canonical JSON via stable recursive key sorting;
- deterministic `sha256:` envelope hash;
- explicit `signatureStatus: "unsigned"`;
- explicit `persistenceStatus: "not_persisted"`;
- explicit `executionStatus: "not_executed"`;
- local-only guardrails embedded in the envelope.

The envelope is included only in the existing valid-budget fail-closed live response. Denied branches do not create an envelope or intent plan.

Closes #165.

## Guardrails

- No network calls introduced.
- No signer/private-key access.
- No signature operation.
- No external persistence.
- No Coolify changes.
- No devnet transfer/registration.
- No live downstream x402/OpenRouter call.
- All live branches retain `downstreamCallsExecuted: 0`.
- Dry-run behavior unchanged.

## Validation

- `npm test --prefix packages/openrouter-specialists` ✅ 36/36
- `npm run build` ✅
- `git diff --check` ✅
