### PR TITLE
feat: add noop live delegation executor contract

### DIFF
--- a/packages/openrouter-specialists/src/delegation-executor.ts
+++ b/packages/openrouter-specialists/src/delegation-executor.ts
@@ -1,0 +1,57 @@
+import type { LiveDelegationAuditEnvelope } from "./delegation-audit.js";
+import type { LiveDelegationIntentPlan } from "./delegation-intent.js";
+
+export interface LiveDelegationExecutorInput {
+  intentPlan: LiveDelegationIntentPlan;
+  auditEnvelope: LiveDelegationAuditEnvelope;
+}
+
+export interface LiveDelegationExecutorEvidence {
+  schemaVersion: "reddi.live-delegation-executor-evidence.v1";
+  executorId: "noop-live-delegation-executor";
+  executionStatus: "not_executed";
+  reason: "executor_not_implemented";
+  message: string;
+  intentId: string;
+  auditEnvelopeHash: string;
+  downstreamCallsExecuted: 0;
+  guardrails: {
+    noNetworkCallAttempted: true;
+    noSignerMaterialUsed: true;
+    noSignatureAttempted: true;
+    noExternalPersistence: true;
+    noDevnetTransferExecuted: true;
+    noDownstreamX402Executed: true;
+  };
+}
+
+export interface LiveDelegationExecutor {
+  execute(input: LiveDelegationExecutorInput): Promise<LiveDelegationExecutorEvidence>;
+}
+
+export class NoopLiveDelegationExecutor implements LiveDelegationExecutor {
+  async execute(input: LiveDelegationExecutorInput): Promise<LiveDelegationExecutorEvidence> {
+    return buildNoopLiveDelegationExecutorEvidence(input);
+  }
+}
+
+export function buildNoopLiveDelegationExecutorEvidence(input: LiveDelegationExecutorInput): LiveDelegationExecutorEvidence {
+  return {
+    schemaVersion: "reddi.live-delegation-executor-evidence.v1",
+    executorId: "noop-live-delegation-executor",
+    executionStatus: "not_executed",
+    reason: "executor_not_implemented",
+    message: "Live downstream delegation executor is intentionally not implemented in this guarded iteration.",
+    intentId: input.intentPlan.intentId,
+    auditEnvelopeHash: input.auditEnvelope.envelopeHash,
+    downstreamCallsExecuted: 0,
+    guardrails: {
+      noNetworkCallAttempted: true,
+      noSignerMaterialUsed: true,
+      noSignatureAttempted: true,
+      noExternalPersistence: true,
+      noDevnetTransferExecuted: true,
+      noDownstreamX402Executed: true,
+    },
+  };
+}

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -7,4 +7,5 @@ export * from "./deployment-readiness.js";
 export * from "./delegation-budget.js";
 export * from "./delegation-intent.js";
 export * from "./delegation-audit.js";
+export * from "./delegation-executor.js";
 export * from "./runtime.js";

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -11,6 +11,7 @@ import {
 import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
 import { buildLiveDelegationAuditEnvelope } from "./delegation-audit.js";
 import { evaluateDelegationBudget } from "./delegation-budget.js";
+import { NoopLiveDelegationExecutor } from "./delegation-executor.js";
 import { buildLiveDelegationIntentPlan } from "./delegation-intent.js";
 import { buildDryRunDelegationPlan, inferRequiredCapabilities } from "./marketplace-client.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "./profiles/index.js";
@@ -261,6 +262,7 @@ export async function handleDelegationPlanning(input: {
       maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
     });
     const auditEnvelope = buildLiveDelegationAuditEnvelope(intentPlan);
+    const executorEvidence = await new NoopLiveDelegationExecutor().execute({ intentPlan, auditEnvelope });
 
     return {
       status: 501,
@@ -279,6 +281,7 @@ export async function handleDelegationPlanning(input: {
           budget: budgetDecision,
           intentPlan,
           auditEnvelope,
+          executorEvidence,
         },
       },
     };

--- a/packages/openrouter-specialists/tests/delegation-executor.test.ts
+++ b/packages/openrouter-specialists/tests/delegation-executor.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildLiveDelegationAuditEnvelope } from "../src/delegation-audit.js";
+import { buildNoopLiveDelegationExecutorEvidence, NoopLiveDelegationExecutor } from "../src/delegation-executor.js";
+import type { LiveDelegationIntentPlan } from "../src/delegation-intent.js";
+
+const intentPlan: LiveDelegationIntentPlan = {
+  schemaVersion: "reddi.live-delegation-intent.v1",
+  intentId: "intent_executor_test",
+  executionStatus: "not_executed",
+  requesterProfileId: "planning-agent",
+  task: "Write tests",
+  requiredCapabilities: ["code-generation"],
+  estimatedLamports: 500,
+  budget: {
+    allowed: true,
+    estimatedLamports: 500,
+    policy: {
+      maxLamportsPerRequest: 1000,
+      maxLamportsPerSession: 5000,
+      maxLamportsPerAgent: 10000,
+      maxDownstreamCallsPerSession: 2,
+    },
+    usage: {
+      sessionLamportsSpent: 0,
+      agentLamportsSpent: 0,
+      downstreamCallsUsed: 0,
+    },
+    remaining: {
+      requestLamports: 500,
+      sessionLamports: 4500,
+      agentLamports: 9500,
+      downstreamCalls: 1,
+    },
+  },
+  guardrails: {
+    liveCallsEnabled: true,
+    downstreamCallsExecuted: 0,
+    maxDownstreamCalls: 1,
+    maxDownstreamLamports: 1000,
+    noSignerMaterialUsed: true,
+    noDevnetTransferExecuted: true,
+    noDownstreamX402Executed: true,
+  },
+  requiredAttestor: "verification-validation-agent",
+  candidateCount: 1,
+};
+
+const auditEnvelope = buildLiveDelegationAuditEnvelope(intentPlan);
+
+test("no-op live delegation executor evidence is non-executing and local-only", () => {
+  const evidence = buildNoopLiveDelegationExecutorEvidence({ intentPlan, auditEnvelope });
+
+  assert.equal(evidence.schemaVersion, "reddi.live-delegation-executor-evidence.v1");
+  assert.equal(evidence.executorId, "noop-live-delegation-executor");
+  assert.equal(evidence.executionStatus, "not_executed");
+  assert.equal(evidence.reason, "executor_not_implemented");
+  assert.equal(evidence.intentId, intentPlan.intentId);
+  assert.equal(evidence.auditEnvelopeHash, auditEnvelope.envelopeHash);
+  assert.equal(evidence.downstreamCallsExecuted, 0);
+  assert.equal(evidence.guardrails.noNetworkCallAttempted, true);
+  assert.equal(evidence.guardrails.noSignerMaterialUsed, true);
+  assert.equal(evidence.guardrails.noSignatureAttempted, true);
+  assert.equal(evidence.guardrails.noExternalPersistence, true);
+  assert.equal(evidence.guardrails.noDevnetTransferExecuted, true);
+  assert.equal(evidence.guardrails.noDownstreamX402Executed, true);
+});
+
+test("default no-op live delegation executor returns the same fail-closed evidence", async () => {
+  const executor = new NoopLiveDelegationExecutor();
+  const evidence = await executor.execute({ intentPlan, auditEnvelope });
+
+  assert.deepEqual(evidence, buildNoopLiveDelegationExecutorEvidence({ intentPlan, auditEnvelope }));
+});

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -482,6 +482,18 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(auditEnvelope.guardrails.noExternalPersistence, true);
   assert.equal(auditEnvelope.guardrails.noDownstreamX402Executed, true);
   assert.equal(auditEnvelope.canonicalJson, canonicalJson(JSON.parse(auditEnvelope.canonicalJson)));
+  const executorEvidence = (response.body.reddi as { executorEvidence: { schemaVersion: string; executorId: string; executionStatus: string; auditEnvelopeHash: string; downstreamCallsExecuted: number; guardrails: { noNetworkCallAttempted: boolean; noSignerMaterialUsed: boolean; noSignatureAttempted: boolean; noExternalPersistence: boolean; noDevnetTransferExecuted: boolean; noDownstreamX402Executed: boolean } } }).executorEvidence;
+  assert.equal(executorEvidence.schemaVersion, "reddi.live-delegation-executor-evidence.v1");
+  assert.equal(executorEvidence.executorId, "noop-live-delegation-executor");
+  assert.equal(executorEvidence.executionStatus, "not_executed");
+  assert.equal(executorEvidence.auditEnvelopeHash, auditEnvelope.envelopeHash);
+  assert.equal(executorEvidence.downstreamCallsExecuted, 0);
+  assert.equal(executorEvidence.guardrails.noNetworkCallAttempted, true);
+  assert.equal(executorEvidence.guardrails.noSignerMaterialUsed, true);
+  assert.equal(executorEvidence.guardrails.noSignatureAttempted, true);
+  assert.equal(executorEvidence.guardrails.noExternalPersistence, true);
+  assert.equal(executorEvidence.guardrails.noDevnetTransferExecuted, true);
+  assert.equal(executorEvidence.guardrails.noDownstreamX402Executed, true);
 
   const liveWithoutBudgetPolicy = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-2" }),
@@ -495,9 +507,10 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(liveWithoutBudgetPolicy.status, 403);
   assert.equal(client.callCount, 0);
   assert.equal((liveWithoutBudgetPolicy.body.error as { code: string }).code, "budget_policy_required");
-  assert.equal((liveWithoutBudgetPolicy.body.reddi as { downstreamCallsExecuted: number; intentPlan?: unknown; auditEnvelope?: unknown }).downstreamCallsExecuted, 0);
+  assert.equal((liveWithoutBudgetPolicy.body.reddi as { downstreamCallsExecuted: number; intentPlan?: unknown; auditEnvelope?: unknown; executorEvidence?: unknown }).downstreamCallsExecuted, 0);
   assert.equal((liveWithoutBudgetPolicy.body.reddi as { intentPlan?: unknown }).intentPlan, undefined);
   assert.equal((liveWithoutBudgetPolicy.body.reddi as { auditEnvelope?: unknown }).auditEnvelope, undefined);
+  assert.equal((liveWithoutBudgetPolicy.body.reddi as { executorEvidence?: unknown }).executorEvidence, undefined);
 
   const liveWithCallsDisabled = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-3" }),


### PR DESCRIPTION
## Summary

Implements Iteration 6 Loop 5 for OpenRouter specialists live delegation spend guards.

Adds a live delegation executor seam with a default no-op/fail-closed implementation:

- `LiveDelegationExecutor` interface;
- `NoopLiveDelegationExecutor` default adapter;
- structured `reddi.live-delegation-executor-evidence.v1` with `executionStatus: "not_executed"`;
- explicit guardrails showing no network/signing/persistence/devnet/downstream x402 attempt;
- valid-budget live response still returns `501 live_delegation_not_implemented` with `downstreamCallsExecuted: 0`.

Denied branches do not create intent/audit/executor evidence. Dry-run behavior remains unchanged.

Closes #167.

## Guardrails

- No network calls introduced.
- No signer/private-key access.
- No signature operation.
- No external persistence.
- No Coolify changes.
- No devnet transfer/registration.
- No live downstream x402/OpenRouter call.
- All live branches retain `downstreamCallsExecuted: 0`.
- Dry-run behavior unchanged.

## Validation

- `npm test --prefix packages/openrouter-specialists` ✅ 38/38
- `npm run build` ✅
- `git diff --check` ✅
