### PR TITLE
feat: gate live delegation executor invocation

### DIFF
--- a/packages/openrouter-specialists/src/delegation-executor.ts
+++ b/packages/openrouter-specialists/src/delegation-executor.ts
@@ -8,9 +8,9 @@ export interface LiveDelegationExecutorInput {
 
 export interface LiveDelegationExecutorEvidence {
   schemaVersion: "reddi.live-delegation-executor-evidence.v1";
-  executorId: "noop-live-delegation-executor";
+  executorId: "disabled-live-delegation-executor-gate" | "noop-live-delegation-executor";
   executionStatus: "not_executed";
-  reason: "executor_not_implemented";
+  reason: "executor_disabled" | "executor_not_implemented";
   message: string;
   intentId: string;
   auditEnvelopeHash: string;
@@ -33,6 +33,27 @@ export class NoopLiveDelegationExecutor implements LiveDelegationExecutor {
   async execute(input: LiveDelegationExecutorInput): Promise<LiveDelegationExecutorEvidence> {
     return buildNoopLiveDelegationExecutorEvidence(input);
   }
+}
+
+export function buildDisabledLiveDelegationExecutorEvidence(input: LiveDelegationExecutorInput): LiveDelegationExecutorEvidence {
+  return {
+    schemaVersion: "reddi.live-delegation-executor-evidence.v1",
+    executorId: "disabled-live-delegation-executor-gate",
+    executionStatus: "not_executed",
+    reason: "executor_disabled",
+    message: "Live downstream delegation executor invocation is disabled by configuration.",
+    intentId: input.intentPlan.intentId,
+    auditEnvelopeHash: input.auditEnvelope.envelopeHash,
+    downstreamCallsExecuted: 0,
+    guardrails: {
+      noNetworkCallAttempted: true,
+      noSignerMaterialUsed: true,
+      noSignatureAttempted: true,
+      noExternalPersistence: true,
+      noDevnetTransferExecuted: true,
+      noDownstreamX402Executed: true,
+    },
+  };
 }
 
 export function buildNoopLiveDelegationExecutorEvidence(input: LiveDelegationExecutorInput): LiveDelegationExecutorEvidence {

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -11,7 +11,7 @@ import {
 import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
 import { buildLiveDelegationAuditEnvelope } from "./delegation-audit.js";
 import { evaluateDelegationBudget } from "./delegation-budget.js";
-import { NoopLiveDelegationExecutor } from "./delegation-executor.js";
+import { buildDisabledLiveDelegationExecutorEvidence, NoopLiveDelegationExecutor, type LiveDelegationExecutor } from "./delegation-executor.js";
 import { buildLiveDelegationIntentPlan } from "./delegation-intent.js";
 import { buildDryRunDelegationPlan, inferRequiredCapabilities } from "./marketplace-client.js";
 import { getProfile, specialistProfiles, validateProfileRegistry } from "./profiles/index.js";
@@ -31,6 +31,7 @@ export function createRuntimeConfig(env: NodeJS.ProcessEnv = process.env): Runti
     requirePayment: env.REQUIRE_X402_PAYMENT !== "false",
     allowDemoPayment: env.ALLOW_DEMO_X402_PAYMENT === "1" || env.ALLOW_DEMO_X402_PAYMENT === "true",
     enableAgentToAgentCalls: env.ENABLE_AGENT_TO_AGENT_CALLS === "1" || env.ENABLE_AGENT_TO_AGENT_CALLS === "true",
+    enableLiveDelegationExecutor: env.ENABLE_LIVE_DELEGATION_EXECUTOR === "1" || env.ENABLE_LIVE_DELEGATION_EXECUTOR === "true",
     maxDownstreamCalls: env.MAX_DOWNSTREAM_CALLS ? Number.parseInt(env.MAX_DOWNSTREAM_CALLS, 10) : 0,
     maxDownstreamLamports: env.MAX_DOWNSTREAM_LAMPORTS ? Number.parseInt(env.MAX_DOWNSTREAM_LAMPORTS, 10) : 0,
   };
@@ -171,6 +172,7 @@ export async function handleDelegationPlanning(input: {
   body: ChatCompletionRequest;
   config: RuntimeConfig;
   replayStore?: NonceReplayStore;
+  liveDelegationExecutor?: LiveDelegationExecutor;
 }): Promise<RuntimeResponse> {
   const profile = getProfile(input.config.profileId);
   if (!profile) return { status: 500, headers: JSON_HEADERS, body: { error: { code: "unknown_profile" } } };
@@ -262,7 +264,9 @@ export async function handleDelegationPlanning(input: {
       maxDownstreamLamports: input.config.maxDownstreamLamports ?? 0,
     });
     const auditEnvelope = buildLiveDelegationAuditEnvelope(intentPlan);
-    const executorEvidence = await new NoopLiveDelegationExecutor().execute({ intentPlan, auditEnvelope });
+    const executorEvidence = input.config.enableLiveDelegationExecutor
+      ? await (input.liveDelegationExecutor ?? new NoopLiveDelegationExecutor()).execute({ intentPlan, auditEnvelope })
+      : buildDisabledLiveDelegationExecutorEvidence({ intentPlan, auditEnvelope });
 
     return {
       status: 501,

--- a/packages/openrouter-specialists/src/types.ts
+++ b/packages/openrouter-specialists/src/types.ts
@@ -33,6 +33,7 @@ export interface RuntimeConfig {
   requirePayment: boolean;
   allowDemoPayment?: boolean;
   enableAgentToAgentCalls?: boolean;
+  enableLiveDelegationExecutor?: boolean;
   maxDownstreamCalls?: number;
   maxDownstreamLamports?: number;
   safetyMode?: SafetyMode;

--- a/packages/openrouter-specialists/tests/delegation-executor.test.ts
+++ b/packages/openrouter-specialists/tests/delegation-executor.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { buildLiveDelegationAuditEnvelope } from "../src/delegation-audit.js";
-import { buildNoopLiveDelegationExecutorEvidence, NoopLiveDelegationExecutor } from "../src/delegation-executor.js";
+import { buildDisabledLiveDelegationExecutorEvidence, buildNoopLiveDelegationExecutorEvidence, NoopLiveDelegationExecutor } from "../src/delegation-executor.js";
 import type { LiveDelegationIntentPlan } from "../src/delegation-intent.js";
 
 const intentPlan: LiveDelegationIntentPlan = {
@@ -47,6 +47,24 @@ const intentPlan: LiveDelegationIntentPlan = {
 };
 
 const auditEnvelope = buildLiveDelegationAuditEnvelope(intentPlan);
+
+test("disabled live delegation executor evidence is non-executing and local-only", () => {
+  const evidence = buildDisabledLiveDelegationExecutorEvidence({ intentPlan, auditEnvelope });
+
+  assert.equal(evidence.schemaVersion, "reddi.live-delegation-executor-evidence.v1");
+  assert.equal(evidence.executorId, "disabled-live-delegation-executor-gate");
+  assert.equal(evidence.executionStatus, "not_executed");
+  assert.equal(evidence.reason, "executor_disabled");
+  assert.equal(evidence.intentId, intentPlan.intentId);
+  assert.equal(evidence.auditEnvelopeHash, auditEnvelope.envelopeHash);
+  assert.equal(evidence.downstreamCallsExecuted, 0);
+  assert.equal(evidence.guardrails.noNetworkCallAttempted, true);
+  assert.equal(evidence.guardrails.noSignerMaterialUsed, true);
+  assert.equal(evidence.guardrails.noSignatureAttempted, true);
+  assert.equal(evidence.guardrails.noExternalPersistence, true);
+  assert.equal(evidence.guardrails.noDevnetTransferExecuted, true);
+  assert.equal(evidence.guardrails.noDownstreamX402Executed, true);
+});
 
 test("no-op live delegation executor evidence is non-executing and local-only", () => {
   const evidence = buildNoopLiveDelegationExecutorEvidence({ intentPlan, auditEnvelope });

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -13,11 +13,14 @@ import {
   evaluateAttestation,
   handleAttestationEvaluation,
   handleChatCompletions,
+  handleDelegationPlanning,
   handleRuntimeRequest,
   marketplaceMetadata,
   ManifestMarketplaceDiscoveryClient,
   rankMarketplaceCandidates,
   type WalletManifest,
+  type LiveDelegationExecutor,
+  type LiveDelegationExecutorInput,
   type RuntimeConfig,
 } from "../src/index.js";
 
@@ -46,7 +49,9 @@ test("OpenRouter mock mode is explicit opt-in only", () => {
   assert.equal(createRuntimeConfig({}).mockOpenRouter, false);
   assert.equal(createRuntimeConfig({ OPENROUTER_MOCK: "true" }).mockOpenRouter, true);
   assert.equal(createRuntimeConfig({}).enableAgentToAgentCalls, false);
+  assert.equal(createRuntimeConfig({}).enableLiveDelegationExecutor, false);
   assert.equal(createRuntimeConfig({ ENABLE_AGENT_TO_AGENT_CALLS: "true", MAX_DOWNSTREAM_CALLS: "2", MAX_DOWNSTREAM_LAMPORTS: "5000" }).enableAgentToAgentCalls, true);
+  assert.equal(createRuntimeConfig({ ENABLE_LIVE_DELEGATION_EXECUTOR: "true" }).enableLiveDelegationExecutor, true);
   assert.equal(createRuntimeConfig({ ENABLE_AGENT_TO_AGENT_CALLS: "true", MAX_DOWNSTREAM_CALLS: "2", MAX_DOWNSTREAM_LAMPORTS: "5000" }).maxDownstreamCalls, 2);
 });
 
@@ -484,7 +489,7 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(auditEnvelope.canonicalJson, canonicalJson(JSON.parse(auditEnvelope.canonicalJson)));
   const executorEvidence = (response.body.reddi as { executorEvidence: { schemaVersion: string; executorId: string; executionStatus: string; auditEnvelopeHash: string; downstreamCallsExecuted: number; guardrails: { noNetworkCallAttempted: boolean; noSignerMaterialUsed: boolean; noSignatureAttempted: boolean; noExternalPersistence: boolean; noDevnetTransferExecuted: boolean; noDownstreamX402Executed: boolean } } }).executorEvidence;
   assert.equal(executorEvidence.schemaVersion, "reddi.live-delegation-executor-evidence.v1");
-  assert.equal(executorEvidence.executorId, "noop-live-delegation-executor");
+  assert.equal(executorEvidence.executorId, "disabled-live-delegation-executor-gate");
   assert.equal(executorEvidence.executionStatus, "not_executed");
   assert.equal(executorEvidence.auditEnvelopeHash, auditEnvelope.envelopeHash);
   assert.equal(executorEvidence.downstreamCallsExecuted, 0);
@@ -539,6 +544,87 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(client.callCount, 0);
   assert.equal((liveOverBudget.body.error as { code: string }).code, "request_budget_exceeded");
   assert.equal((liveOverBudget.body.reddi as { downstreamCallsExecuted: number }).downstreamCallsExecuted, 0);
+});
+
+test("live delegation executor gate controls invocation and remains fail-closed", async () => {
+  const budgetPolicy = {
+    maxLamportsPerRequest: 1_000,
+    maxLamportsPerSession: 5_000,
+    maxLamportsPerAgent: 10_000,
+    maxDownstreamCallsPerSession: 2,
+  };
+  let executorCalls = 0;
+  const trackingExecutor: LiveDelegationExecutor = {
+    async execute(input: LiveDelegationExecutorInput) {
+      executorCalls += 1;
+      return {
+        schemaVersion: "reddi.live-delegation-executor-evidence.v1",
+        executorId: "noop-live-delegation-executor",
+        executionStatus: "not_executed",
+        reason: "executor_not_implemented",
+        message: "tracking no-op executor was invoked",
+        intentId: input.intentPlan.intentId,
+        auditEnvelopeHash: input.auditEnvelope.envelopeHash,
+        downstreamCallsExecuted: 0,
+        guardrails: {
+          noNetworkCallAttempted: true,
+          noSignerMaterialUsed: true,
+          noSignatureAttempted: true,
+          noExternalPersistence: true,
+          noDevnetTransferExecuted: true,
+          noDownstreamX402Executed: true,
+        },
+      };
+    },
+  };
+
+  const disabledGate = await handleDelegationPlanning({
+    headers: new Headers({ "x402-payment": "demo:delegation-executor-gate-disabled" }),
+    body: {
+      messages: [{ role: "user", content: "Hire a code agent for this task." }],
+      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"], estimatedLamports: 500, budgetPolicy } },
+    },
+    config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: true, enableLiveDelegationExecutor: false, maxDownstreamCalls: 1, maxDownstreamLamports: 1000 },
+    liveDelegationExecutor: trackingExecutor,
+  });
+  assert.equal(disabledGate.status, 501);
+  assert.equal(executorCalls, 0);
+  const disabledEvidence = (disabledGate.body.reddi as { executorEvidence: { executorId: string; reason: string; downstreamCallsExecuted: number } }).executorEvidence;
+  assert.equal(disabledEvidence.executorId, "disabled-live-delegation-executor-gate");
+  assert.equal(disabledEvidence.reason, "executor_disabled");
+  assert.equal(disabledEvidence.downstreamCallsExecuted, 0);
+
+  const enabledNoop = await handleDelegationPlanning({
+    headers: new Headers({ "x402-payment": "demo:delegation-executor-gate-enabled" }),
+    body: {
+      messages: [{ role: "user", content: "Hire a code agent for this task." }],
+      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"], estimatedLamports: 500, budgetPolicy } },
+    },
+    config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: true, enableLiveDelegationExecutor: true, maxDownstreamCalls: 1, maxDownstreamLamports: 1000 },
+    liveDelegationExecutor: trackingExecutor,
+  });
+  assert.equal(enabledNoop.status, 501);
+  assert.equal(executorCalls, 1);
+  const enabledEvidence = (enabledNoop.body.reddi as { executorEvidence: { executorId: string; reason: string; executionStatus: string; downstreamCallsExecuted: number } }).executorEvidence;
+  assert.equal(enabledEvidence.executorId, "noop-live-delegation-executor");
+  assert.equal(enabledEvidence.reason, "executor_not_implemented");
+  assert.equal(enabledEvidence.executionStatus, "not_executed");
+  assert.equal(enabledEvidence.downstreamCallsExecuted, 0);
+
+  const denied = await handleDelegationPlanning({
+    headers: new Headers({ "x402-payment": "demo:delegation-executor-gate-denied" }),
+    body: {
+      messages: [{ role: "user", content: "Hire a code agent for this task." }],
+      metadata: { mode: "delegation_live", delegation: { dryRun: false, requiredCapabilities: ["code-generation"], estimatedLamports: 2_000, budgetPolicy } },
+    },
+    config: { ...config, allowDemoPayment: true, enableAgentToAgentCalls: true, enableLiveDelegationExecutor: true, maxDownstreamCalls: 1, maxDownstreamLamports: 1000 },
+    liveDelegationExecutor: trackingExecutor,
+  });
+  assert.equal(denied.status, 403);
+  assert.equal(executorCalls, 1);
+  assert.equal((denied.body.reddi as { intentPlan?: unknown; auditEnvelope?: unknown; executorEvidence?: unknown }).intentPlan, undefined);
+  assert.equal((denied.body.reddi as { auditEnvelope?: unknown }).auditEnvelope, undefined);
+  assert.equal((denied.body.reddi as { executorEvidence?: unknown }).executorEvidence, undefined);
 });
 
 test("HTTP core routes expose health, models, tags, metadata, attestation, and chat", async () => {


### PR DESCRIPTION
## Summary

Implements Iteration 6 Loop 6 for OpenRouter specialists live delegation spend guards.

Adds an explicit executor-enable gate before the live delegation executor seam can be invoked:

- new `enableLiveDelegationExecutor` runtime config;
- env gate: `ENABLE_LIVE_DELEGATION_EXECUTOR=true`;
- default remains disabled;
- disabled valid-budget live delegation returns structured `executor_disabled` evidence without invoking the executor;
- enabled test path can invoke the no-op executor, but still returns `501 live_delegation_not_implemented`, `executionStatus: "not_executed"`, and `downstreamCallsExecuted: 0`;
- denied branches still fail closed before intent/audit/executor evidence and do not invoke the executor.

Closes #169.

## Guardrails

- No real executor implementation added.
- No network calls introduced.
- No signer/private-key access.
- No signature operation.
- No external persistence.
- No Coolify changes.
- No devnet transfer/registration.
- No live downstream x402/OpenRouter call.
- All live branches retain `downstreamCallsExecuted: 0`.
- Dry-run behavior unchanged.

## Validation

- `npm test --prefix packages/openrouter-specialists` ✅ 40/40
- `npm run build` ✅
- `git diff --check` ✅
