### PR TITLE
test: add live noop executor smoke report

### DIFF
--- a/packages/openrouter-specialists/artifacts/live-noop-executor-smoke.json
+++ b/packages/openrouter-specialists/artifacts/live-noop-executor-smoke.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": "reddi.live-noop-executor-smoke.v1",
+  "generatedAt": "2026-05-04T00:00:00.000Z",
+  "status": "pass",
+  "scope": "local controlled smoke for enabled no-op live delegation executor path",
+  "guardrails": {
+    "localRuntimeFixturesOnly": true,
+    "noRealExecutorImplementation": true,
+    "noNetworkCallsIntroduced": true,
+    "noSignerMaterialAccessed": true,
+    "noSignatureOperation": true,
+    "noExternalPersistenceExceptLocalArtifact": true,
+    "noCoolifyChanges": true,
+    "noDevnetTransferOrRegistration": true,
+    "noLiveDownstreamX402OrOpenRouterCall": true
+  },
+  "configProof": {
+    "enableAgentToAgentCalls": true,
+    "enableLiveDelegationExecutor": true,
+    "mockOpenRouter": true,
+    "maxDownstreamCalls": 1,
+    "maxDownstreamLamports": 1000
+  },
+  "cases": {
+    "validBudgetEnabledNoop": {
+      "status": 501,
+      "errorCode": "live_delegation_not_implemented",
+      "profileId": "planning-agent",
+      "liveCallsEnabled": true,
+      "downstreamCallsExecuted": 0,
+      "budgetAllowed": true,
+      "intent": {
+        "schemaVersion": "reddi.live-delegation-intent.v1",
+        "intentId": "intent_f7e1cb143f459640ce8ce017",
+        "executionStatus": "not_executed",
+        "selectedCandidateProfileId": "code-generation-agent",
+        "downstreamCallsExecuted": 0,
+        "noDevnetTransferExecuted": true,
+        "noDownstreamX402Executed": true
+      },
+      "auditEnvelope": {
+        "schemaVersion": "reddi.live-delegation-audit-envelope.v1",
+        "hashAlgorithm": "sha256",
+        "envelopeHash": "sha256:1af0ba9fd0ba716ef55d3e66f9ee8326600adb28ca5c9804e4796e4d5c0f09f7",
+        "signatureStatus": "unsigned",
+        "persistenceStatus": "not_persisted",
+        "executionStatus": "not_executed"
+      },
+      "executorEvidence": {
+        "schemaVersion": "reddi.live-delegation-executor-evidence.v1",
+        "executorId": "noop-live-delegation-executor",
+        "executionStatus": "not_executed",
+        "reason": "executor_not_implemented",
+        "downstreamCallsExecuted": 0,
+        "guardrails": {
+          "noNetworkCallAttempted": true,
+          "noSignerMaterialUsed": true,
+          "noSignatureAttempted": true,
+          "noExternalPersistence": true,
+          "noDevnetTransferExecuted": true,
+          "noDownstreamX402Executed": true
+        }
+      }
+    },
+    "budgetDenied": {
+      "status": 403,
+      "errorCode": "request_budget_exceeded",
+      "profileId": "planning-agent",
+      "liveCallsEnabled": true,
+      "downstreamCallsExecuted": 0
+    }
+  }
+}

--- a/packages/openrouter-specialists/package.json
+++ b/packages/openrouter-specialists/package.json
@@ -21,7 +21,8 @@
     "wallet:airdrop-devnet": "npm run build && node scripts/airdrop-devnet-wallets.mjs",
     "wallet:register-devnet": "npm run build && node scripts/register-devnet-specialists.mjs",
     "check:devnet-balances": "node scripts/check-devnet-balances.mjs",
-    "deployment:readiness": "npm run build && node scripts/deployment-readiness.mjs"
+    "deployment:readiness": "npm run build && node scripts/deployment-readiness.mjs",
+    "delegation:noop-smoke": "npm run build && node scripts/live-noop-smoke.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/packages/openrouter-specialists/scripts/live-noop-smoke.mjs
+++ b/packages/openrouter-specialists/scripts/live-noop-smoke.mjs
@@ -1,0 +1,163 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { handleDelegationPlanning } from '../dist/src/index.js';
+
+const outPath = process.env.LIVE_NOOP_SMOKE_OUT ?? join(process.cwd(), 'artifacts/live-noop-executor-smoke.json');
+const generatedAt = process.env.LIVE_NOOP_SMOKE_GENERATED_AT ?? '2026-05-04T00:00:00.000Z';
+
+const budgetPolicy = {
+  maxLamportsPerRequest: 1_000,
+  maxLamportsPerSession: 5_000,
+  maxLamportsPerAgent: 10_000,
+  maxDownstreamCallsPerSession: 2,
+};
+
+const baseConfig = {
+  profileId: 'planning-agent',
+  endpointBaseUrl: 'https://planning.example.test',
+  openRouterBaseUrl: 'https://openrouter.ai/api/v1',
+  mockOpenRouter: true,
+  requirePayment: true,
+  allowDemoPayment: true,
+  enableAgentToAgentCalls: true,
+  enableLiveDelegationExecutor: true,
+  maxDownstreamCalls: 1,
+  maxDownstreamLamports: 1_000,
+};
+
+function assertCondition(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function publicEvidenceFrom(response) {
+  const reddi = response.body.reddi ?? {};
+  return {
+    status: response.status,
+    errorCode: response.body.error?.code,
+    profileId: reddi.profileId,
+    liveCallsEnabled: reddi.liveCallsEnabled,
+    downstreamCallsExecuted: reddi.downstreamCallsExecuted,
+    budgetAllowed: reddi.budget?.allowed,
+    intent: reddi.intentPlan
+      ? {
+          schemaVersion: reddi.intentPlan.schemaVersion,
+          intentId: reddi.intentPlan.intentId,
+          executionStatus: reddi.intentPlan.executionStatus,
+          selectedCandidateProfileId: reddi.intentPlan.selectedCandidate?.profileId,
+          downstreamCallsExecuted: reddi.intentPlan.guardrails?.downstreamCallsExecuted,
+          noDevnetTransferExecuted: reddi.intentPlan.guardrails?.noDevnetTransferExecuted,
+          noDownstreamX402Executed: reddi.intentPlan.guardrails?.noDownstreamX402Executed,
+        }
+      : undefined,
+    auditEnvelope: reddi.auditEnvelope
+      ? {
+          schemaVersion: reddi.auditEnvelope.schemaVersion,
+          hashAlgorithm: reddi.auditEnvelope.hashAlgorithm,
+          envelopeHash: reddi.auditEnvelope.envelopeHash,
+          signatureStatus: reddi.auditEnvelope.signatureStatus,
+          persistenceStatus: reddi.auditEnvelope.persistenceStatus,
+          executionStatus: reddi.auditEnvelope.executionStatus,
+        }
+      : undefined,
+    executorEvidence: reddi.executorEvidence
+      ? {
+          schemaVersion: reddi.executorEvidence.schemaVersion,
+          executorId: reddi.executorEvidence.executorId,
+          executionStatus: reddi.executorEvidence.executionStatus,
+          reason: reddi.executorEvidence.reason,
+          downstreamCallsExecuted: reddi.executorEvidence.downstreamCallsExecuted,
+          guardrails: reddi.executorEvidence.guardrails,
+        }
+      : undefined,
+  };
+}
+
+const validResponse = await handleDelegationPlanning({
+  headers: new Headers({ 'x402-payment': 'demo:live-noop-smoke-valid' }),
+  body: {
+    messages: [{ role: 'user', content: 'Hire a code agent for this task.' }],
+    metadata: {
+      mode: 'delegation_live',
+      delegation: {
+        dryRun: false,
+        requiredCapabilities: ['code-generation'],
+        estimatedLamports: 500,
+        budgetPolicy,
+      },
+    },
+  },
+  config: baseConfig,
+});
+
+assertCondition(validResponse.status === 501, 'valid enabled no-op path must remain 501');
+assertCondition(validResponse.body.error?.code === 'live_delegation_not_implemented', 'valid enabled no-op path must remain not implemented');
+assertCondition(validResponse.body.reddi?.downstreamCallsExecuted === 0, 'valid enabled no-op path must execute zero downstream calls');
+assertCondition(validResponse.body.reddi?.intentPlan?.executionStatus === 'not_executed', 'intent must be not_executed');
+assertCondition(validResponse.body.reddi?.auditEnvelope?.signatureStatus === 'unsigned', 'audit envelope must remain unsigned');
+assertCondition(validResponse.body.reddi?.auditEnvelope?.persistenceStatus === 'not_persisted', 'audit envelope must not be externally persisted');
+assertCondition(validResponse.body.reddi?.executorEvidence?.executorId === 'noop-live-delegation-executor', 'enabled smoke must invoke only the no-op executor');
+assertCondition(validResponse.body.reddi?.executorEvidence?.executionStatus === 'not_executed', 'executor evidence must be not_executed');
+assertCondition(validResponse.body.reddi?.executorEvidence?.downstreamCallsExecuted === 0, 'executor evidence must execute zero downstream calls');
+assertCondition(validResponse.body.reddi?.executorEvidence?.guardrails?.noNetworkCallAttempted === true, 'executor must not attempt network calls');
+assertCondition(validResponse.body.reddi?.executorEvidence?.guardrails?.noSignerMaterialUsed === true, 'executor must not use signer material');
+assertCondition(validResponse.body.reddi?.executorEvidence?.guardrails?.noSignatureAttempted === true, 'executor must not attempt signatures');
+assertCondition(validResponse.body.reddi?.executorEvidence?.guardrails?.noExternalPersistence === true, 'executor must not persist externally');
+assertCondition(validResponse.body.reddi?.executorEvidence?.guardrails?.noDevnetTransferExecuted === true, 'executor must not execute devnet transfers');
+assertCondition(validResponse.body.reddi?.executorEvidence?.guardrails?.noDownstreamX402Executed === true, 'executor must not execute downstream x402');
+
+const deniedResponse = await handleDelegationPlanning({
+  headers: new Headers({ 'x402-payment': 'demo:live-noop-smoke-denied' }),
+  body: {
+    messages: [{ role: 'user', content: 'Hire a code agent for this over-budget task.' }],
+    metadata: {
+      mode: 'delegation_live',
+      delegation: {
+        dryRun: false,
+        requiredCapabilities: ['code-generation'],
+        estimatedLamports: 2_000,
+        budgetPolicy,
+      },
+    },
+  },
+  config: baseConfig,
+});
+
+assertCondition(deniedResponse.status === 403, 'denied branch must remain 403');
+assertCondition(deniedResponse.body.error?.code === 'request_budget_exceeded', 'denied branch must report request_budget_exceeded');
+assertCondition(deniedResponse.body.reddi?.downstreamCallsExecuted === 0, 'denied branch must execute zero downstream calls');
+assertCondition(deniedResponse.body.reddi?.intentPlan === undefined, 'denied branch must not create intent plan');
+assertCondition(deniedResponse.body.reddi?.auditEnvelope === undefined, 'denied branch must not create audit envelope');
+assertCondition(deniedResponse.body.reddi?.executorEvidence === undefined, 'denied branch must not create executor evidence');
+
+const report = {
+  schemaVersion: 'reddi.live-noop-executor-smoke.v1',
+  generatedAt,
+  status: 'pass',
+  scope: 'local controlled smoke for enabled no-op live delegation executor path',
+  guardrails: {
+    localRuntimeFixturesOnly: true,
+    noRealExecutorImplementation: true,
+    noNetworkCallsIntroduced: true,
+    noSignerMaterialAccessed: true,
+    noSignatureOperation: true,
+    noExternalPersistenceExceptLocalArtifact: true,
+    noCoolifyChanges: true,
+    noDevnetTransferOrRegistration: true,
+    noLiveDownstreamX402OrOpenRouterCall: true,
+  },
+  configProof: {
+    enableAgentToAgentCalls: baseConfig.enableAgentToAgentCalls,
+    enableLiveDelegationExecutor: baseConfig.enableLiveDelegationExecutor,
+    mockOpenRouter: baseConfig.mockOpenRouter,
+    maxDownstreamCalls: baseConfig.maxDownstreamCalls,
+    maxDownstreamLamports: baseConfig.maxDownstreamLamports,
+  },
+  cases: {
+    validBudgetEnabledNoop: publicEvidenceFrom(validResponse),
+    budgetDenied: publicEvidenceFrom(deniedResponse),
+  },
+};
+
+mkdirSync(join(outPath, '..'), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify(report, null, 2));


### PR DESCRIPTION
## Summary

Implements Iteration 6 Loop 7 for OpenRouter specialists live delegation spend guards.

Adds a local controlled smoke harness/report for the enabled no-op live delegation executor path:

- new package script: `npm run delegation:noop-smoke`;
- local runtime fixture sets `enableLiveDelegationExecutor: true` but uses only the no-op executor;
- writes public-data-only artifact `packages/openrouter-specialists/artifacts/live-noop-executor-smoke.json`;
- proves valid-budget live delegation still returns `501 live_delegation_not_implemented`;
- proves executor evidence remains `not_executed` and `noop-live-delegation-executor`;
- proves `downstreamCallsExecuted: 0`;
- proves budget-denied branch creates no intent/audit/executor evidence.

Closes #171.

## Guardrails

- No real executor implementation added.
- No network calls introduced.
- No signer/private-key access.
- No signature operation.
- No external persistence except the local repo artifact/report.
- No Coolify changes.
- No devnet transfer/registration.
- No live downstream x402/OpenRouter call.
- Dry-run behavior unchanged.

## Validation

- `npm run delegation:noop-smoke --prefix packages/openrouter-specialists` ✅
- `npm test --prefix packages/openrouter-specialists` ✅ 40/40
- `npm run build` ✅
- `git diff --check` ✅
