### PR TITLE
feat: add gated fetch live delegation executor

### DIFF
--- a/packages/openrouter-specialists/src/delegation-executor.ts
+++ b/packages/openrouter-specialists/src/delegation-executor.ts
@@ -6,22 +6,42 @@ export interface LiveDelegationExecutorInput {
   auditEnvelope: LiveDelegationAuditEnvelope;
 }
 
+export interface LiveDelegationExecutorTarget {
+  profileId: string;
+  endpoint: string;
+  walletAddress?: string;
+}
+
 export interface LiveDelegationExecutorEvidence {
   schemaVersion: "reddi.live-delegation-executor-evidence.v1";
-  executorId: "disabled-live-delegation-executor-gate" | "noop-live-delegation-executor";
-  executionStatus: "not_executed";
-  reason: "executor_disabled" | "executor_not_implemented";
+  executorId: "disabled-live-delegation-executor-gate" | "noop-live-delegation-executor" | "fetch-live-delegation-executor";
+  executionStatus: "not_executed" | "attempted";
+  reason:
+    | "executor_disabled"
+    | "executor_not_implemented"
+    | "missing_selected_candidate"
+    | "endpoint_not_allowlisted"
+    | "downstream_call_limit_exceeded"
+    | "downstream_lamport_limit_exceeded"
+    | "payment_provider_missing"
+    | "downstream_call_attempted";
   message: string;
   intentId: string;
   auditEnvelopeHash: string;
-  downstreamCallsExecuted: 0;
+  downstreamCallsExecuted: 0 | 1;
+  target?: LiveDelegationExecutorTarget;
+  downstreamResponse?: {
+    status: number;
+    ok: boolean;
+    contentType?: string;
+  };
   guardrails: {
-    noNetworkCallAttempted: true;
+    noNetworkCallAttempted: boolean;
     noSignerMaterialUsed: true;
     noSignatureAttempted: true;
     noExternalPersistence: true;
     noDevnetTransferExecuted: true;
-    noDownstreamX402Executed: true;
+    noDownstreamX402Executed: boolean;
   };
 }
 
@@ -29,9 +49,119 @@ export interface LiveDelegationExecutor {
   execute(input: LiveDelegationExecutorInput): Promise<LiveDelegationExecutorEvidence>;
 }
 
+export interface DownstreamPaymentHeaderProviderInput {
+  intentPlan: LiveDelegationIntentPlan;
+  auditEnvelope: LiveDelegationAuditEnvelope;
+  target: LiveDelegationExecutorTarget;
+}
+
+export interface DownstreamPaymentHeaderProvider {
+  paymentHeader(input: DownstreamPaymentHeaderProviderInput): Promise<string>;
+}
+
+export interface FetchLiveDelegationExecutorOptions {
+  allowlistedEndpoints: Record<string, string>;
+  paymentHeaderProvider?: DownstreamPaymentHeaderProvider;
+  fetchImpl?: typeof fetch;
+}
+
 export class NoopLiveDelegationExecutor implements LiveDelegationExecutor {
   async execute(input: LiveDelegationExecutorInput): Promise<LiveDelegationExecutorEvidence> {
     return buildNoopLiveDelegationExecutorEvidence(input);
+  }
+}
+
+export class FetchLiveDelegationExecutor implements LiveDelegationExecutor {
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private readonly options: FetchLiveDelegationExecutorOptions) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async execute(input: LiveDelegationExecutorInput): Promise<LiveDelegationExecutorEvidence> {
+    const selected = input.intentPlan.selectedCandidate;
+    if (!selected) {
+      return buildFetchExecutorNotExecutedEvidence(input, "missing_selected_candidate", "Live delegation intent has no selected candidate.");
+    }
+
+    const allowlistedEndpoint = this.options.allowlistedEndpoints[selected.profileId];
+    const candidateEndpoint = allowlistedEndpoint ? new URL(selected.endpointPath, allowlistedEndpoint).toString() : selected.endpointPath;
+    if (!allowlistedEndpoint || candidateEndpoint !== allowlistedEndpoint) {
+      return buildFetchExecutorNotExecutedEvidence(input, "endpoint_not_allowlisted", `Selected candidate ${selected.profileId} endpoint is not exactly allowlisted for live delegation.`, {
+        profileId: selected.profileId,
+        endpoint: candidateEndpoint,
+        walletAddress: selected.walletAddress,
+      });
+    }
+
+    if (input.intentPlan.guardrails.maxDownstreamCalls !== 1) {
+      return buildFetchExecutorNotExecutedEvidence(input, "downstream_call_limit_exceeded", "First live delegation smoke requires maxDownstreamCalls to be exactly 1.", {
+        profileId: selected.profileId,
+        endpoint: allowlistedEndpoint,
+        walletAddress: selected.walletAddress,
+      });
+    }
+
+    if (input.intentPlan.estimatedLamports > input.intentPlan.guardrails.maxDownstreamLamports) {
+      return buildFetchExecutorNotExecutedEvidence(input, "downstream_lamport_limit_exceeded", "Estimated downstream lamports exceed configured live delegation limit.", {
+        profileId: selected.profileId,
+        endpoint: allowlistedEndpoint,
+        walletAddress: selected.walletAddress,
+      });
+    }
+
+    const target = {
+      profileId: selected.profileId,
+      endpoint: allowlistedEndpoint,
+      walletAddress: selected.walletAddress,
+    };
+
+    if (!this.options.paymentHeaderProvider) {
+      return buildFetchExecutorNotExecutedEvidence(input, "payment_provider_missing", "Downstream payment header provider is required before any live network call.", target);
+    }
+
+    const paymentHeader = await this.options.paymentHeaderProvider.paymentHeader({ ...input, target });
+    const response = await this.fetchImpl(target.endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x402-payment": paymentHeader,
+      },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: input.intentPlan.task }],
+        metadata: {
+          mode: "delegated_live_smoke",
+          intentId: input.intentPlan.intentId,
+          auditEnvelopeHash: input.auditEnvelope.envelopeHash,
+          requesterProfileId: input.intentPlan.requesterProfileId,
+        },
+      }),
+    });
+
+    return {
+      schemaVersion: "reddi.live-delegation-executor-evidence.v1",
+      executorId: "fetch-live-delegation-executor",
+      executionStatus: "attempted",
+      reason: "downstream_call_attempted",
+      message: "Exactly one allowlisted downstream live delegation call was attempted.",
+      intentId: input.intentPlan.intentId,
+      auditEnvelopeHash: input.auditEnvelope.envelopeHash,
+      downstreamCallsExecuted: 1,
+      target,
+      downstreamResponse: {
+        status: response.status,
+        ok: response.ok,
+        contentType: response.headers.get("content-type") ?? undefined,
+      },
+      guardrails: {
+        noNetworkCallAttempted: false,
+        noSignerMaterialUsed: true,
+        noSignatureAttempted: true,
+        noExternalPersistence: true,
+        noDevnetTransferExecuted: true,
+        noDownstreamX402Executed: false,
+      },
+    };
   }
 }
 
@@ -45,14 +175,7 @@ export function buildDisabledLiveDelegationExecutorEvidence(input: LiveDelegatio
     intentId: input.intentPlan.intentId,
     auditEnvelopeHash: input.auditEnvelope.envelopeHash,
     downstreamCallsExecuted: 0,
-    guardrails: {
-      noNetworkCallAttempted: true,
-      noSignerMaterialUsed: true,
-      noSignatureAttempted: true,
-      noExternalPersistence: true,
-      noDevnetTransferExecuted: true,
-      noDownstreamX402Executed: true,
-    },
+    guardrails: nonExecutingGuardrails(),
   };
 }
 
@@ -66,13 +189,37 @@ export function buildNoopLiveDelegationExecutorEvidence(input: LiveDelegationExe
     intentId: input.intentPlan.intentId,
     auditEnvelopeHash: input.auditEnvelope.envelopeHash,
     downstreamCallsExecuted: 0,
-    guardrails: {
-      noNetworkCallAttempted: true,
-      noSignerMaterialUsed: true,
-      noSignatureAttempted: true,
-      noExternalPersistence: true,
-      noDevnetTransferExecuted: true,
-      noDownstreamX402Executed: true,
-    },
+    guardrails: nonExecutingGuardrails(),
+  };
+}
+
+function buildFetchExecutorNotExecutedEvidence(
+  input: LiveDelegationExecutorInput,
+  reason: LiveDelegationExecutorEvidence["reason"],
+  message: string,
+  target?: LiveDelegationExecutorTarget,
+): LiveDelegationExecutorEvidence {
+  return {
+    schemaVersion: "reddi.live-delegation-executor-evidence.v1",
+    executorId: "fetch-live-delegation-executor",
+    executionStatus: "not_executed",
+    reason,
+    message,
+    intentId: input.intentPlan.intentId,
+    auditEnvelopeHash: input.auditEnvelope.envelopeHash,
+    downstreamCallsExecuted: 0,
+    target,
+    guardrails: nonExecutingGuardrails(),
+  };
+}
+
+function nonExecutingGuardrails(): LiveDelegationExecutorEvidence["guardrails"] {
+  return {
+    noNetworkCallAttempted: true,
+    noSignerMaterialUsed: true,
+    noSignatureAttempted: true,
+    noExternalPersistence: true,
+    noDevnetTransferExecuted: true,
+    noDownstreamX402Executed: true,
   };
 }

--- a/packages/openrouter-specialists/tests/delegation-executor.test.ts
+++ b/packages/openrouter-specialists/tests/delegation-executor.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { buildLiveDelegationAuditEnvelope } from "../src/delegation-audit.js";
-import { buildDisabledLiveDelegationExecutorEvidence, buildNoopLiveDelegationExecutorEvidence, NoopLiveDelegationExecutor } from "../src/delegation-executor.js";
+import {
+  buildDisabledLiveDelegationExecutorEvidence,
+  buildNoopLiveDelegationExecutorEvidence,
+  FetchLiveDelegationExecutor,
+  NoopLiveDelegationExecutor,
+  type DownstreamPaymentHeaderProvider,
+} from "../src/delegation-executor.js";
 import type { LiveDelegationIntentPlan } from "../src/delegation-intent.js";
 
 const intentPlan: LiveDelegationIntentPlan = {
@@ -9,6 +15,15 @@ const intentPlan: LiveDelegationIntentPlan = {
   intentId: "intent_executor_test",
   executionStatus: "not_executed",
   requesterProfileId: "planning-agent",
+  selectedCandidate: {
+    profileId: "code-generation-agent",
+    displayName: "Code Generation Agent",
+    endpointPath: "/v1/chat/completions",
+    walletAddress: "8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To",
+    matchedCapabilities: ["code-generation"],
+    price: { currency: "USDC", amount: "0.05", unit: "request" },
+    safetyMode: "standard",
+  },
   task: "Write tests",
   requiredCapabilities: ["code-generation"],
   estimatedLamports: 500,
@@ -47,6 +62,11 @@ const intentPlan: LiveDelegationIntentPlan = {
 };
 
 const auditEnvelope = buildLiveDelegationAuditEnvelope(intentPlan);
+const allowlistedEndpoint = "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions";
+
+function withIntentPatch(patch: Partial<LiveDelegationIntentPlan>): LiveDelegationIntentPlan {
+  return { ...intentPlan, ...patch };
+}
 
 test("disabled live delegation executor evidence is non-executing and local-only", () => {
   const evidence = buildDisabledLiveDelegationExecutorEvidence({ intentPlan, auditEnvelope });
@@ -89,4 +109,156 @@ test("default no-op live delegation executor returns the same fail-closed eviden
   const evidence = await executor.execute({ intentPlan, auditEnvelope });
 
   assert.deepEqual(evidence, buildNoopLiveDelegationExecutorEvidence({ intentPlan, auditEnvelope }));
+});
+
+test("fetch live delegation executor fails closed before network when payment provider is missing", async () => {
+  let fetchCalls = 0;
+  const executor = new FetchLiveDelegationExecutor({
+    allowlistedEndpoints: { "code-generation-agent": allowlistedEndpoint },
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response("{}", { status: 200 });
+    },
+  });
+
+  const evidence = await executor.execute({ intentPlan, auditEnvelope });
+
+  assert.equal(fetchCalls, 0);
+  assert.equal(evidence.executorId, "fetch-live-delegation-executor");
+  assert.equal(evidence.executionStatus, "not_executed");
+  assert.equal(evidence.reason, "payment_provider_missing");
+  assert.equal(evidence.downstreamCallsExecuted, 0);
+  assert.equal(evidence.guardrails.noNetworkCallAttempted, true);
+  assert.equal(evidence.target?.profileId, "code-generation-agent");
+});
+
+test("fetch live delegation executor fails closed before network when endpoint is not allowlisted", async () => {
+  let fetchCalls = 0;
+  const paymentHeaderProvider: DownstreamPaymentHeaderProvider = { paymentHeader: async () => "demo:downstream-live-smoke" };
+  const executor = new FetchLiveDelegationExecutor({
+    allowlistedEndpoints: {},
+    paymentHeaderProvider,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response("{}", { status: 200 });
+    },
+  });
+
+  const evidence = await executor.execute({ intentPlan, auditEnvelope });
+
+  assert.equal(fetchCalls, 0);
+  assert.equal(evidence.executorId, "fetch-live-delegation-executor");
+  assert.equal(evidence.executionStatus, "not_executed");
+  assert.equal(evidence.reason, "endpoint_not_allowlisted");
+  assert.equal(evidence.downstreamCallsExecuted, 0);
+  assert.equal(evidence.guardrails.noNetworkCallAttempted, true);
+});
+
+test("fetch live delegation executor fails closed before network when selected path does not exactly match allowlist", async () => {
+  let fetchCalls = 0;
+  const paymentHeaderProvider: DownstreamPaymentHeaderProvider = { paymentHeader: async () => "demo:downstream-live-smoke" };
+  const executor = new FetchLiveDelegationExecutor({
+    allowlistedEndpoints: { "code-generation-agent": allowlistedEndpoint },
+    paymentHeaderProvider,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response("{}", { status: 200 });
+    },
+  });
+  const mismatchedIntent = withIntentPatch({
+    selectedCandidate: intentPlan.selectedCandidate ? { ...intentPlan.selectedCandidate, endpointPath: "/not-allowlisted" } : undefined,
+  });
+
+  const evidence = await executor.execute({ intentPlan: mismatchedIntent, auditEnvelope });
+
+  assert.equal(fetchCalls, 0);
+  assert.equal(evidence.executorId, "fetch-live-delegation-executor");
+  assert.equal(evidence.executionStatus, "not_executed");
+  assert.equal(evidence.reason, "endpoint_not_allowlisted");
+  assert.equal(evidence.target?.endpoint, "https://reddi-code-generation.preview.reddi.tech/not-allowlisted");
+  assert.equal(evidence.downstreamCallsExecuted, 0);
+  assert.equal(evidence.guardrails.noNetworkCallAttempted, true);
+});
+
+test("fetch live delegation executor fails closed before network when call count guard is not exactly one", async () => {
+  let fetchCalls = 0;
+  const paymentHeaderProvider: DownstreamPaymentHeaderProvider = { paymentHeader: async () => "demo:downstream-live-smoke" };
+  const executor = new FetchLiveDelegationExecutor({
+    allowlistedEndpoints: { "code-generation-agent": allowlistedEndpoint },
+    paymentHeaderProvider,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response("{}", { status: 200 });
+    },
+  });
+  const badCallCountIntent = withIntentPatch({
+    guardrails: { ...intentPlan.guardrails, maxDownstreamCalls: 2 },
+  });
+
+  const evidence = await executor.execute({ intentPlan: badCallCountIntent, auditEnvelope });
+
+  assert.equal(fetchCalls, 0);
+  assert.equal(evidence.executorId, "fetch-live-delegation-executor");
+  assert.equal(evidence.executionStatus, "not_executed");
+  assert.equal(evidence.reason, "downstream_call_limit_exceeded");
+  assert.equal(evidence.downstreamCallsExecuted, 0);
+  assert.equal(evidence.guardrails.noNetworkCallAttempted, true);
+});
+
+test("fetch live delegation executor fails closed before network when lamport guard is exceeded", async () => {
+  let fetchCalls = 0;
+  const paymentHeaderProvider: DownstreamPaymentHeaderProvider = { paymentHeader: async () => "demo:downstream-live-smoke" };
+  const executor = new FetchLiveDelegationExecutor({
+    allowlistedEndpoints: { "code-generation-agent": allowlistedEndpoint },
+    paymentHeaderProvider,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response("{}", { status: 200 });
+    },
+  });
+  const overLamportIntent = withIntentPatch({
+    estimatedLamports: 1_500,
+    guardrails: { ...intentPlan.guardrails, maxDownstreamLamports: 1_000 },
+  });
+
+  const evidence = await executor.execute({ intentPlan: overLamportIntent, auditEnvelope });
+
+  assert.equal(fetchCalls, 0);
+  assert.equal(evidence.executorId, "fetch-live-delegation-executor");
+  assert.equal(evidence.executionStatus, "not_executed");
+  assert.equal(evidence.reason, "downstream_lamport_limit_exceeded");
+  assert.equal(evidence.downstreamCallsExecuted, 0);
+  assert.equal(evidence.guardrails.noNetworkCallAttempted, true);
+});
+
+test("fetch live delegation executor attempts exactly one allowlisted downstream call with bounded evidence", async () => {
+  const requests: Request[] = [];
+  const paymentHeaderProvider: DownstreamPaymentHeaderProvider = { paymentHeader: async () => "demo:downstream-live-smoke" };
+  const executor = new FetchLiveDelegationExecutor({
+    allowlistedEndpoints: { "code-generation-agent": allowlistedEndpoint },
+    paymentHeaderProvider,
+    fetchImpl: async (input, init) => {
+      requests.push(new Request(input, init));
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    },
+  });
+
+  const evidence = await executor.execute({ intentPlan, auditEnvelope });
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0]?.url, allowlistedEndpoint);
+  assert.equal(requests[0]?.method, "POST");
+  assert.equal(requests[0]?.headers.get("x402-payment"), "demo:downstream-live-smoke");
+  assert.equal(evidence.executorId, "fetch-live-delegation-executor");
+  assert.equal(evidence.executionStatus, "attempted");
+  assert.equal(evidence.reason, "downstream_call_attempted");
+  assert.equal(evidence.downstreamCallsExecuted, 1);
+  assert.equal(evidence.downstreamResponse?.status, 200);
+  assert.equal(evidence.downstreamResponse?.ok, true);
+  assert.equal(evidence.guardrails.noNetworkCallAttempted, false);
+  assert.equal(evidence.guardrails.noSignerMaterialUsed, true);
+  assert.equal(evidence.guardrails.noSignatureAttempted, true);
+  assert.equal(evidence.guardrails.noExternalPersistence, true);
+  assert.equal(evidence.guardrails.noDevnetTransferExecuted, true);
+  assert.equal(evidence.guardrails.noDownstreamX402Executed, false);
 });


### PR DESCRIPTION
## Summary

Implements Iteration 6 Loop 9 for OpenRouter specialists live delegation spend guards.

Adds a minimal real executor implementation class, still gated/injectable and not wired as the default runtime executor:

- `FetchLiveDelegationExecutor`
- static allowlisted endpoint map required by constructor
- payment header provider required before any network call
- exactly-one-call guard via `maxDownstreamCalls === 1`
- lamport limit guard before network call
- bounded public executor evidence for attempted/skipped outcomes
- no signer/private-key handling inside executor
- no external persistence

Default runtime remains disabled/no-op unless caller explicitly injects an executor behind the existing gates.

Closes #175.

## Guardrails

- No private keys committed/logged.
- No Coolify changes.
- No real devnet transfer/registration during PR implementation.
- No live downstream x402/OpenRouter smoke run in this PR.
- Missing payment provider fails closed before network calls.
- Non-allowlisted endpoint fails closed before network calls.
- Over call/lamport limits fail closed before network calls.
- Tests use mock fetch/payment provider only.

## Validation

- `npm test --prefix packages/openrouter-specialists` ✅ 43/43
- `npm run build` ✅
- `git diff --check` ✅
