### PR TITLE
feat(openrouter): expand specialist profile registry to 30

### DIFF
--- a/packages/openrouter-specialists/src/profiles/index.ts
+++ b/packages/openrouter-specialists/src/profiles/index.ts
@@ -7,16 +7,48 @@ const wallets = {
   verificationValidation: "2EmtCTzhoSSorg2rRSnTbngGJqkqNufgtFUZRGU4iFWq",
   codeGeneration: "8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To",
   conversational: "H8U9JjaeFiyHZrPEyFF2Ku7wmk62S24GAaJMVrwNrZUn",
+  // Public placeholder addresses for Loop 1 profile metadata only. Loop 2 must rotate these to signer-backed devnet wallets before funding/registration.
+  autonomousDecision: "A3Wq5UfEVBS2cvdk3s3LioufQh6cBQkUpuLgZRQQVBke",
+  memoryAugmented: "51RozjuQ3DSUFyxaNxm2QCwy9ENaikqsLugKtsR37667",
+  knowledgeRetrieval: "C1aiKWVWEjFZSpXxipEUt2fHAeh5Mi6uPzEHYDCuVZR8",
+  scientificResearch: "DBZnDLmzL1Fmk8C1JtwKctamairXRpNN4BoGWMCqPVwx",
+  toolUsing: "6XVizkN7CPQkqDs9YNVZdFmZwRmDxBaoE94nkn9UsLpa",
+  agenticWorkflow: "2pV86kMYRenECm5ga19d675vxjfnnKHNT1F4AesSo8hh",
+  dataAnalysis: "F4wwUDHudLQZUXyvncxPQnkNuT2kWSqvi4KTcfdpntCw",
+  generalProblemSolver: "8mpXydLSxyTMRrH2GFmy5EfV5k3XG4mdzZBbTDdD3uxb",
+  securityHardened: "4Aq2cj9463VSYnefhFw1KDLBFF8xLti5C4hNyLxT2yLv",
+  selfImproving: "8fErEygQRQcfEcCJ5DhY8HnhDyiiJeaBvCdM3Drxqaiu",
+  contentCreation: "A15BENpHw1MeBWHFtEDMUUd9mv8SgQZkQtfYybhzeQMz",
+  recommendation: "GoNJYwsJuJRbbRpLBQVVPoM3ictggrvDHWZCS8QYvFpp",
+  visionLanguage: "2fErheo61Sc9DJ4WGXZuuXvk62Z4RDzqmnt98wKVMSet",
+  audioProcessing: "DNjCENkb4VG3m8QfmMQRsvYBpyd9bSvTKwBmcrrp5h7M",
+  physicalWorldSensing: "2zTbwbYrVVUzYMoqqjHnvmviVPnV7t7yquKZ6Nabco7X",
+  ethicalReasoning: "8Q2UMP6zpmB9AcL21MKrS8vJKc7cxTJLotySZboGtdGy",
+  explainable: "F4LmdHr755rm2a7HpeZb8xwjWSr2JBTnJa28oSN3ua9F",
+  healthcareIntelligence: "G4hDS9NeibhP2hPVvj7wUpnHHXti81UAZkz1RhF2i9sA",
+  scientificDiscovery: "FBHTPxynq48TMrn5sRXjWgRBfh2xMiWKRjMyMkqjaRp",
+  financialAdvisory: "HqCEoRfDse1dk4eC2mBqCeUyGgSeJUsTPjsnEM5fUL96",
+  legalIntelligence: "8Mn5YmaUWoCpxGyExGaKZaZHmgMjHu2Jv3Yo426AaJEr",
+  educationIntelligence: "HHnpsEKbQrLxdi2QyaWunA3uKULpSiFvFL1TQJ9iUAZA",
+  collectiveIntelligence: "8sm9NKwLgaEvCRV85Wcnuqc2TELuZvLtHmhC7yDGVsHJ",
+  embodiedIntelligence: "49QppkYrfKFa76PCkEWkVpFF4qdc35spRjYbRJ6qdjP9",
+  domainTransformingIntegration: "F3fT26qb4vVmKNxjQucowC2wZsA1SMJe4SQeuzcNWbF8",
 } as const;
 
 export const specialistProfiles: SpecialistProfile[] = [
   {
     id: "planning-agent",
     displayName: "Planning Agent",
-    description: "Turns broad goals into sequenced execution plans with assumptions, risks, and validation gates.",
+    description:
+      "Turns broad goals into sequenced execution plans with assumptions, risks, and validation gates.",
     walletAddress: wallets.planning,
     endpointPath: "/v1/chat/completions",
-    capabilities: ["planning", "task-decomposition", "risk-analysis", "agent-orchestration"],
+    capabilities: [
+      "planning",
+      "task-decomposition",
+      "risk-analysis",
+      "agent-orchestration",
+    ],
     roles: ["specialist", "consumer"],
     price: { currency: "USDC", amount: "0.03", unit: "request" },
     safetyMode: "standard",
@@ -29,10 +61,16 @@ export const specialistProfiles: SpecialistProfile[] = [
   {
     id: "document-intelligence-agent",
     displayName: "Document Intelligence Agent",
-    description: "Extracts, classifies, summarizes, and cross-checks document evidence.",
+    description:
+      "Extracts, classifies, summarizes, and cross-checks document evidence.",
     walletAddress: wallets.documentIntelligence,
     endpointPath: "/v1/chat/completions",
-    capabilities: ["document-analysis", "summarization", "evidence-extraction", "classification"],
+    capabilities: [
+      "document-analysis",
+      "summarization",
+      "evidence-extraction",
+      "classification",
+    ],
     roles: ["specialist"],
     price: { currency: "USDC", amount: "0.04", unit: "request" },
     safetyMode: "standard",
@@ -45,10 +83,17 @@ export const specialistProfiles: SpecialistProfile[] = [
   {
     id: "verification-validation-agent",
     displayName: "Verification & Validation Agent",
-    description: "Reviews specialist outputs for evidence quality, safety boundaries, and release/refund/dispute recommendations.",
+    description:
+      "Reviews specialist outputs for evidence quality, safety boundaries, and release/refund/dispute recommendations.",
     walletAddress: wallets.verificationValidation,
     endpointPath: "/v1/chat/completions",
-    capabilities: ["verification", "validation", "attestation", "quality-review", "safety-review"],
+    capabilities: [
+      "verification",
+      "validation",
+      "attestation",
+      "quality-review",
+      "safety-review",
+    ],
     roles: ["specialist", "attestor"],
     price: { currency: "USDC", amount: "0.025", unit: "request" },
     safetyMode: "attestation",
@@ -61,10 +106,16 @@ export const specialistProfiles: SpecialistProfile[] = [
   {
     id: "code-generation-agent",
     displayName: "Code Generation Agent",
-    description: "Builds scoped code changes, tests, migrations, and implementation notes.",
+    description:
+      "Builds scoped code changes, tests, migrations, and implementation notes.",
     walletAddress: wallets.codeGeneration,
     endpointPath: "/v1/chat/completions",
-    capabilities: ["code-generation", "debugging", "test-writing", "technical-design"],
+    capabilities: [
+      "code-generation",
+      "debugging",
+      "test-writing",
+      "technical-design",
+    ],
     roles: ["specialist"],
     price: { currency: "USDC", amount: "0.05", unit: "request" },
     safetyMode: "standard",
@@ -77,10 +128,16 @@ export const specialistProfiles: SpecialistProfile[] = [
   {
     id: "conversational-agent",
     displayName: "Conversational Agent",
-    description: "Handles general dialogue, intake, clarification, and user-friendly handoff summaries.",
+    description:
+      "Handles general dialogue, intake, clarification, and user-friendly handoff summaries.",
     walletAddress: wallets.conversational,
     endpointPath: "/v1/chat/completions",
-    capabilities: ["conversation", "intake", "clarification", "handoff-summary"],
+    capabilities: [
+      "conversation",
+      "intake",
+      "clarification",
+      "handoff-summary",
+    ],
     roles: ["specialist"],
     price: { currency: "USDC", amount: "0.015", unit: "request" },
     safetyMode: "standard",
@@ -90,6 +147,593 @@ export const specialistProfiles: SpecialistProfile[] = [
     systemPrompt:
       "You are the Reddi Conversational Agent. Be clear, warm, and useful. Clarify missing requirements and route specialized work to the proper agent when needed.",
   },
+
+  {
+    id: "autonomous-decision-agent",
+    displayName: "Autonomous Decision-Making Agent",
+    description:
+      "Compares options against goals, constraints, and evidence to recommend bounded next actions.",
+    walletAddress: wallets.autonomousDecision,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "decision-analysis",
+      "option-ranking",
+      "risk-analysis",
+      "constraint-reasoning",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.04", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "ethical-reasoning-agent",
+    ],
+    model: "openai/gpt-4.1-mini",
+    tags: ["decisions", "strategy", "risk"],
+    systemPrompt:
+      "You are the Reddi Autonomous Decision-Making Agent. Recommend bounded decisions with explicit assumptions, options considered, risks, and validation checks. Do not perform external actions.",
+  },
+  {
+    id: "memory-augmented-agent",
+    displayName: "Memory-Augmented Agent",
+    description:
+      "Uses supplied memory and context to produce continuity-aware answers, plans, and summaries.",
+    walletAddress: wallets.memoryAugmented,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "memory-grounded-answering",
+      "context-synthesis",
+      "continuity",
+      "summarization",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.025", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["memory", "context", "continuity"],
+    systemPrompt:
+      "You are the Reddi Memory-Augmented Agent. Use only caller-provided memory/context, distinguish remembered facts from inference, and cite supplied context when possible.",
+  },
+  {
+    id: "knowledge-retrieval-agent",
+    displayName: "Knowledge Retrieval Agent",
+    description:
+      "Retrieves, ranks, cites, and synthesizes knowledge from supplied corpora or search results.",
+    walletAddress: wallets.knowledgeRetrieval,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "retrieval",
+      "source-ranking",
+      "citation",
+      "knowledge-synthesis",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.03", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["retrieval", "knowledge", "citations"],
+    systemPrompt:
+      "You are the Reddi Knowledge Retrieval Agent. Retrieve from supplied sources, cite evidence, separate facts from inference, and flag missing evidence.",
+  },
+  {
+    id: "scientific-research-agent",
+    displayName: "Scientific Research Agent",
+    description:
+      "Produces literature-style research briefs, experiment plans, and evidence maps.",
+    walletAddress: wallets.scientificResearch,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "scientific-research",
+      "literature-synthesis",
+      "experiment-design",
+      "evidence-mapping",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.06", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "anthropic/claude-3.5-sonnet",
+    tags: ["science", "research", "experiments"],
+    systemPrompt:
+      "You are the Reddi Scientific Research Agent. Create evidence-grounded research briefs, cite uncertainty, distinguish established findings from hypotheses, and avoid overstating conclusions.",
+  },
+  {
+    id: "tool-using-agent",
+    displayName: "Tool-Using Agent",
+    description:
+      "Plans safe tool usage and execution sequences while leaving actual tool calls to the caller or approved runtime.",
+    walletAddress: wallets.toolUsing,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "tool-planning",
+      "workflow-decomposition",
+      "api-selection",
+      "execution-safety",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.04", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "security-hardened-agent",
+    ],
+    model: "openai/gpt-4.1-mini",
+    tags: ["tools", "workflow", "execution-plan"],
+    systemPrompt:
+      "You are the Reddi Tool-Using Agent. Recommend tool sequences with inputs, expected outputs, risks, and rollback. Do not claim tools were executed unless evidence is supplied.",
+  },
+  {
+    id: "agentic-workflow-system",
+    displayName: "Agentic Workflow System",
+    description:
+      "Plans multi-agent workflows and routes subtasks to appropriate marketplace specialists.",
+    walletAddress: wallets.agenticWorkflow,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "agent-orchestration",
+      "workflow-planning",
+      "delegation",
+      "multi-agent-coordination",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.06", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "security-hardened-agent",
+    ],
+    model: "openai/gpt-4.1-mini",
+    tags: ["workflow", "orchestration", "delegation"],
+    systemPrompt:
+      "You are the Reddi Agentic Workflow System. Decompose work across marketplace agents, preserve budgets and attestation requirements, and default to dry-run plans unless live delegation is explicitly enabled.",
+  },
+  {
+    id: "data-analysis-agent",
+    displayName: "Data Analysis Agent",
+    description:
+      "Analyzes supplied structured data, explains patterns, and reports limitations.",
+    walletAddress: wallets.dataAnalysis,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "data-analysis",
+      "statistics",
+      "table-reasoning",
+      "chart-recommendations",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.045", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["data", "analysis", "statistics"],
+    systemPrompt:
+      "You are the Reddi Data Analysis Agent. Analyze only supplied data, avoid invented statistics, explain methodology, and flag data quality limitations.",
+  },
+  {
+    id: "general-problem-solver-agent",
+    displayName: "General Problem Solver Agent",
+    description:
+      "Handles broad reasoning tasks and routes specialized subtasks when needed.",
+    walletAddress: wallets.generalProblemSolver,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "general-reasoning",
+      "problem-solving",
+      "decomposition",
+      "synthesis",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.03", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["generalist", "reasoning", "synthesis"],
+    systemPrompt:
+      "You are the Reddi General Problem Solver Agent. Solve broad tasks clearly, ask for missing critical context, and recommend specialist delegation when the task exceeds your scope.",
+  },
+  {
+    id: "security-hardened-agent",
+    displayName: "Security-Hardened Agent",
+    description:
+      "Performs threat modeling, secure-default review, and abuse-case analysis for agent workflows and code.",
+    walletAddress: wallets.securityHardened,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "security-review",
+      "threat-modeling",
+      "abuse-case-analysis",
+      "attestation",
+    ],
+    roles: ["specialist", "attestor", "consumer"],
+    price: { currency: "USDC", amount: "0.06", unit: "request" },
+    safetyMode: "attestation",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "anthropic/claude-3.5-sonnet",
+    tags: ["security", "attestation", "threat-modeling"],
+    systemPrompt:
+      "You are the Reddi Security-Hardened Agent. Review for security, abuse, payment, and runtime risks. Be conservative, evidence-based, and explicit about blockers.",
+  },
+  {
+    id: "self-improving-agent",
+    displayName: "Self-Improving Agent",
+    description:
+      "Analyzes failures and proposes durable improvements, tests, and process updates.",
+    walletAddress: wallets.selfImproving,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "retrospective",
+      "failure-analysis",
+      "improvement-planning",
+      "test-gap-analysis",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.045", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "security-hardened-agent",
+    ],
+    model: "openai/gpt-4.1-mini",
+    tags: ["improvement", "retrospective", "quality"],
+    systemPrompt:
+      "You are the Reddi Self-Improving Agent. Propose reviewable improvements and tests from observed failures. Do not self-modify production or bypass review gates.",
+  },
+  {
+    id: "content-creation-agent",
+    displayName: "Content Creation Agent",
+    description:
+      "Drafts launch copy, posts, scripts, articles, and narrative assets with factuality guardrails.",
+    walletAddress: wallets.contentCreation,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "content-writing",
+      "copywriting",
+      "scriptwriting",
+      "editorial-planning",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.025", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["content", "copy", "creative"],
+    systemPrompt:
+      "You are the Reddi Content Creation Agent. Draft clear content, preserve factual claims from supplied context, and mark unsupported claims for verification.",
+  },
+  {
+    id: "recommendation-agent",
+    displayName: "Recommendation Agent",
+    description:
+      "Ranks options, products, services, or agents based on explicit criteria and tradeoffs.",
+    walletAddress: wallets.recommendation,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "recommendation",
+      "ranking",
+      "preference-modeling",
+      "tradeoff-analysis",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.03", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "ethical-reasoning-agent",
+    ],
+    model: "openai/gpt-4.1-mini",
+    tags: ["recommendations", "ranking", "criteria"],
+    systemPrompt:
+      "You are the Reddi Recommendation Agent. Rank options using explicit criteria, explain tradeoffs, and avoid manipulative or unsupported personalization.",
+  },
+  {
+    id: "vision-language-agent",
+    displayName: "Vision Language Agent",
+    description:
+      "Analyzes supplied images, screenshots, diagrams, and visual evidence.",
+    walletAddress: wallets.visionLanguage,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "vision-language",
+      "image-analysis",
+      "diagram-understanding",
+      "screenshot-review",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.06", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["vision", "images", "screenshots"],
+    systemPrompt:
+      "You are the Reddi Vision Language Agent. Analyze supplied visual content, describe uncertainty, and do not persist or request sensitive images unnecessarily.",
+  },
+  {
+    id: "audio-processing-agent",
+    displayName: "Audio Processing Agent",
+    description:
+      "Transcribes, summarizes, and analyzes supplied audio or transcripts.",
+    walletAddress: wallets.audioProcessing,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "audio-analysis",
+      "transcription-review",
+      "speaker-summary",
+      "meeting-notes",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.05", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["audio", "transcription", "summaries"],
+    systemPrompt:
+      "You are the Reddi Audio Processing Agent. Work from supplied audio metadata or transcripts, summarize accurately, and flag when raw audio processing requires an external adapter.",
+  },
+  {
+    id: "physical-world-sensing-agent",
+    displayName: "Physical World Sensing Agent",
+    description:
+      "Interprets supplied sensor/device telemetry and produces safe situational analysis.",
+    walletAddress: wallets.physicalWorldSensing,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "sensor-analysis",
+      "telemetry-interpretation",
+      "anomaly-detection",
+      "situational-awareness",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.05", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "ethical-reasoning-agent",
+    ],
+    model: "openai/gpt-4.1-mini",
+    tags: ["sensing", "telemetry", "iot"],
+    systemPrompt:
+      "You are the Reddi Physical World Sensing Agent. Interpret supplied telemetry only. Do not control devices or claim real-world actuation.",
+  },
+  {
+    id: "ethical-reasoning-agent",
+    displayName: "Ethical Reasoning Agent",
+    description:
+      "Analyzes stakeholder impact, moral tradeoffs, policy tensions, and high-impact decision risks.",
+    walletAddress: wallets.ethicalReasoning,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "ethical-reasoning",
+      "stakeholder-analysis",
+      "policy-tradeoffs",
+      "attestation",
+    ],
+    roles: ["specialist", "attestor", "consumer"],
+    price: { currency: "USDC", amount: "0.04", unit: "request" },
+    safetyMode: "attestation",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["ethics", "policy", "attestation"],
+    systemPrompt:
+      "You are the Reddi Ethical Reasoning Agent. Analyze stakeholder impact and ethical tradeoffs. Be advisory, transparent about frameworks, and avoid coercive recommendations.",
+  },
+  {
+    id: "explainable-agent",
+    displayName: "Explainable Agent",
+    description:
+      "Explains decisions, model outputs, tradeoffs, and evidence in accessible language.",
+    walletAddress: wallets.explainable,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "explanation",
+      "traceability",
+      "decision-rationale",
+      "attestation",
+    ],
+    roles: ["specialist", "attestor", "consumer"],
+    price: { currency: "USDC", amount: "0.03", unit: "request" },
+    safetyMode: "attestation",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["explainability", "rationale", "attestation"],
+    systemPrompt:
+      "You are the Reddi Explainable Agent. Explain outputs, decisions, and tradeoffs clearly, preserving uncertainty and evidence lineage.",
+  },
+  {
+    id: "healthcare-intelligence-agent",
+    displayName: "Healthcare Intelligence Agent",
+    description:
+      "Summarizes medical literature and healthcare context for informational support only.",
+    walletAddress: wallets.healthcareIntelligence,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "healthcare-information",
+      "medical-literature-summary",
+      "care-navigation",
+      "risk-caveats",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.07", unit: "request" },
+    safetyMode: "regulated-informational",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "ethical-reasoning-agent",
+    ],
+    model: "anthropic/claude-3.5-sonnet",
+    tags: ["healthcare", "regulated", "literature"],
+    systemPrompt:
+      "You are the Reddi Healthcare Intelligence Agent. Provide informational healthcare context only, not diagnosis or treatment. Encourage qualified professional care for medical decisions and emergencies.",
+  },
+  {
+    id: "scientific-discovery-agent",
+    displayName: "Scientific Discovery Agent",
+    description:
+      "Generates hypotheses, research directions, and experiment ideas while separating speculation from evidence.",
+    walletAddress: wallets.scientificDiscovery,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "hypothesis-generation",
+      "scientific-discovery",
+      "research-roadmapping",
+      "experiment-ideation",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.06", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "ethical-reasoning-agent",
+    ],
+    model: "anthropic/claude-3.5-sonnet",
+    tags: ["science", "hypotheses", "discovery"],
+    systemPrompt:
+      "You are the Reddi Scientific Discovery Agent. Generate plausible hypotheses and experiments, clearly marking speculation, assumptions, and validation requirements.",
+  },
+  {
+    id: "financial-advisory-agent",
+    displayName: "Financial Advisory Agent",
+    description:
+      "Provides financial education, scenario analysis, and risk summaries without personalized advice or trade execution.",
+    walletAddress: wallets.financialAdvisory,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "financial-education",
+      "scenario-analysis",
+      "risk-summary",
+      "budget-analysis",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.06", unit: "request" },
+    safetyMode: "regulated-informational",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "ethical-reasoning-agent",
+    ],
+    model: "anthropic/claude-3.5-sonnet",
+    tags: ["finance", "regulated", "risk"],
+    systemPrompt:
+      "You are the Reddi Financial Advisory Agent. Provide financial education and scenario analysis only. Do not provide personalized financial advice or execute trades.",
+  },
+  {
+    id: "legal-intelligence-agent",
+    displayName: "Legal Intelligence Agent",
+    description:
+      "Provides legal information, issue spotting, and document context without legal advice.",
+    walletAddress: wallets.legalIntelligence,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "legal-information",
+      "issue-spotting",
+      "contract-context",
+      "jurisdiction-caveats",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.07", unit: "request" },
+    safetyMode: "regulated-informational",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "ethical-reasoning-agent",
+    ],
+    model: "anthropic/claude-3.5-sonnet",
+    tags: ["legal", "regulated", "documents"],
+    systemPrompt:
+      "You are the Reddi Legal Intelligence Agent. Provide legal information and issue spotting only, not legal advice. Recommend qualified counsel for legal decisions.",
+  },
+  {
+    id: "education-intelligence-agent",
+    displayName: "Education Intelligence Agent",
+    description:
+      "Creates tutoring explanations, curricula, and learning paths adapted to supplied learner context.",
+    walletAddress: wallets.educationIntelligence,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "tutoring",
+      "curriculum-design",
+      "learning-paths",
+      "assessment-design",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.03", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["education", "tutoring", "curriculum"],
+    systemPrompt:
+      "You are the Reddi Education Intelligence Agent. Teach clearly, adapt to learner context, and avoid claiming credentials or guaranteed outcomes.",
+  },
+  {
+    id: "collective-intelligence-agent",
+    displayName: "Collective Intelligence Agent",
+    description:
+      "Aggregates multiple viewpoints, agent outputs, or votes into consensus with disagreement tracking.",
+    walletAddress: wallets.collectiveIntelligence,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "collective-intelligence",
+      "consensus-building",
+      "viewpoint-synthesis",
+      "disagreement-analysis",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.05", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    model: "openai/gpt-4.1-mini",
+    tags: ["consensus", "synthesis", "collective"],
+    systemPrompt:
+      "You are the Reddi Collective Intelligence Agent. Aggregate viewpoints with provenance, expose disagreements, and avoid false consensus.",
+  },
+  {
+    id: "embodied-intelligence-agent",
+    displayName: "Embodied Intelligence Agent",
+    description:
+      "Plans embodied or robotic actions in simulation/planning mode without real-world actuation.",
+    walletAddress: wallets.embodiedIntelligence,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "embodied-planning",
+      "robotics-planning",
+      "simulation-reasoning",
+      "safety-boundaries",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.06", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "ethical-reasoning-agent",
+    ],
+    model: "openai/gpt-4.1-mini",
+    tags: ["embodied", "robotics", "planning"],
+    systemPrompt:
+      "You are the Reddi Embodied Intelligence Agent. Produce simulation/planning guidance only. Do not issue real-world actuator commands or imply physical execution.",
+  },
+  {
+    id: "domain-transforming-integration-agent",
+    displayName: "Domain-Transforming Integration Agent",
+    description:
+      "Maps workflows, data, and practices across domains, tools, and systems with integration risk notes.",
+    walletAddress: wallets.domainTransformingIntegration,
+    endpointPath: "/v1/chat/completions",
+    capabilities: [
+      "domain-translation",
+      "systems-integration",
+      "workflow-mapping",
+      "interoperability-planning",
+    ],
+    roles: ["specialist", "consumer"],
+    price: { currency: "USDC", amount: "0.055", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: [
+      "verification-validation-agent",
+      "security-hardened-agent",
+    ],
+    model: "anthropic/claude-3.5-sonnet",
+    tags: ["integration", "systems", "domain-translation"],
+    systemPrompt:
+      "You are the Reddi Domain-Transforming Integration Agent. Translate workflows across domains and systems, identify compatibility risks, and avoid silent external writes.",
+  },
 ];
 
 export function getProfile(id: string): SpecialistProfile | undefined {
@@ -98,27 +742,39 @@ export function getProfile(id: string): SpecialistProfile | undefined {
 
 export function validateProfile(profile: SpecialistProfile): string[] {
   const errors: string[] = [];
-  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(profile.id)) errors.push(`invalid id: ${profile.id}`);
-  if (!profile.displayName.trim()) errors.push(`${profile.id}: missing displayName`);
-  if (!profile.walletAddress.trim()) errors.push(`${profile.id}: missing walletAddress`);
-  else if (!isValidSolanaPublicKey(profile.walletAddress)) errors.push(`${profile.id}: invalid Solana walletAddress`);
-  if (profile.endpointPath !== "/v1/chat/completions") errors.push(`${profile.id}: unsupported endpointPath`);
-  if (profile.capabilities.length === 0) errors.push(`${profile.id}: missing capabilities`);
-  if (profile.roles.length === 0 || !profile.roles.includes("specialist")) errors.push(`${profile.id}: must include specialist role`);
-  if (!profile.price.amount || !profile.price.currency || !profile.price.unit) errors.push(`${profile.id}: invalid price`);
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(profile.id))
+    errors.push(`invalid id: ${profile.id}`);
+  if (!profile.displayName.trim())
+    errors.push(`${profile.id}: missing displayName`);
+  if (!profile.walletAddress.trim())
+    errors.push(`${profile.id}: missing walletAddress`);
+  else if (!isValidSolanaPublicKey(profile.walletAddress))
+    errors.push(`${profile.id}: invalid Solana walletAddress`);
+  if (profile.endpointPath !== "/v1/chat/completions")
+    errors.push(`${profile.id}: unsupported endpointPath`);
+  if (profile.capabilities.length === 0)
+    errors.push(`${profile.id}: missing capabilities`);
+  if (profile.roles.length === 0 || !profile.roles.includes("specialist"))
+    errors.push(`${profile.id}: must include specialist role`);
+  if (!profile.price.amount || !profile.price.currency || !profile.price.unit)
+    errors.push(`${profile.id}: invalid price`);
   if (!profile.model.trim()) errors.push(`${profile.id}: missing model`);
-  if (!profile.systemPrompt.trim()) errors.push(`${profile.id}: missing systemPrompt`);
+  if (!profile.systemPrompt.trim())
+    errors.push(`${profile.id}: missing systemPrompt`);
   return errors;
 }
 
-export function validateProfileRegistry(profiles = specialistProfiles): string[] {
+export function validateProfileRegistry(
+  profiles = specialistProfiles,
+): string[] {
   const ids = new Set<string>();
   const wallets = new Set<string>();
   const errors = profiles.flatMap(validateProfile);
   for (const profile of profiles) {
     if (ids.has(profile.id)) errors.push(`duplicate id: ${profile.id}`);
     ids.add(profile.id);
-    if (wallets.has(profile.walletAddress)) errors.push(`duplicate wallet: ${profile.walletAddress}`);
+    if (wallets.has(profile.walletAddress))
+      errors.push(`duplicate wallet: ${profile.walletAddress}`);
     wallets.add(profile.walletAddress);
   }
   return errors;

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -35,14 +35,59 @@ const config: RuntimeConfig = {
 
 const walletManifest = JSON.parse(readFileSync(join(process.cwd(), "public/wallet-manifest.json"), "utf8")) as WalletManifest;
 
-test("profile registry has first five unique valid profiles with required marketplace metadata", () => {
+test("profile registry has all 30 unique valid profiles with required marketplace metadata", () => {
   assert.deepEqual(validateProfileRegistry(), []);
-  assert.equal(specialistProfiles.length, 5);
+  assert.equal(specialistProfiles.length, 30);
   assert.deepEqual(
-    specialistProfiles.map((profile) => profile.id),
+    specialistProfiles.slice(0, 5).map((profile) => profile.id),
     ["planning-agent", "document-intelligence-agent", "verification-validation-agent", "code-generation-agent", "conversational-agent"],
   );
-  assert.ok(getProfile("verification-validation-agent")?.roles.includes("attestor"));
+  assert.deepEqual(
+    specialistProfiles.map((profile) => profile.id).sort(),
+    [
+      "agentic-workflow-system",
+      "audio-processing-agent",
+      "autonomous-decision-agent",
+      "code-generation-agent",
+      "collective-intelligence-agent",
+      "content-creation-agent",
+      "conversational-agent",
+      "data-analysis-agent",
+      "document-intelligence-agent",
+      "domain-transforming-integration-agent",
+      "education-intelligence-agent",
+      "embodied-intelligence-agent",
+      "ethical-reasoning-agent",
+      "explainable-agent",
+      "financial-advisory-agent",
+      "general-problem-solver-agent",
+      "healthcare-intelligence-agent",
+      "knowledge-retrieval-agent",
+      "legal-intelligence-agent",
+      "memory-augmented-agent",
+      "physical-world-sensing-agent",
+      "planning-agent",
+      "recommendation-agent",
+      "scientific-discovery-agent",
+      "scientific-research-agent",
+      "security-hardened-agent",
+      "self-improving-agent",
+      "tool-using-agent",
+      "verification-validation-agent",
+      "vision-language-agent",
+    ],
+  );
+  for (const attestorId of ["verification-validation-agent", "security-hardened-agent", "ethical-reasoning-agent", "explainable-agent"]) {
+    assert.ok(getProfile(attestorId)?.roles.includes("attestor"), `${attestorId} must be attestor-capable`);
+  }
+  const profileIds = new Set(specialistProfiles.map((profile) => profile.id));
+  const attestorIds = new Set(specialistProfiles.filter((profile) => profile.roles.includes("attestor")).map((profile) => profile.id));
+  for (const profile of specialistProfiles) {
+    for (const attestorId of profile.preferredAttestors) {
+      assert.ok(profileIds.has(attestorId), `${profile.id} references unknown attestor ${attestorId}`);
+      assert.ok(attestorIds.has(attestorId), `${profile.id} references non-attestor profile ${attestorId}`);
+    }
+  }
 });
 
 test("OpenRouter mock mode is explicit opt-in only", () => {


### PR DESCRIPTION
## Summary

Loop 1 for the 30-specialist rollout.

Adds the remaining 25 requested specialist profiles to `packages/openrouter-specialists`, bringing the registry to 30 total marketplace-native profile definitions.

## Scope

- Adds profile metadata only: IDs, names, descriptions, capabilities, roles, safety modes, prices, OpenRouter model policy, tags, prompts, and preferred attestors.
- Marks `security-hardened-agent`, `ethical-reasoning-agent`, and `explainable-agent` as attestor-capable alongside the existing `verification-validation-agent`.
- Keeps first-five profile order intact for existing first-five wallet manifest/deployment scripts.
- Adds registry test coverage for all 30 IDs and preferred-attestor references.

## Safety boundaries

- No funding.
- No Coolify changes.
- No devnet registration.
- No live downstream calls.
- No OpenRouter calls.
- No private keys or signer material.
- Added non-first-five wallet addresses are public placeholder metadata only; Loop 2 must rotate them to signer-backed devnet wallets before funding/registration.

## Validation

- `npm test --prefix packages/openrouter-specialists` ✅ 46/46
- `npm run build` ✅
- `git diff --check` ✅

Closes #179 for Loop 1 profile-registry expansion scope only; follow-up loops remain for signer-backed wallets, Coolify deployment, funding, registration, attestor smokes, and agent-to-agent discovery across all 30.
