### PR TITLE
feat(openrouter): add all-profile wallet readiness gate

### DIFF
--- a/packages/openrouter-specialists/package.json
+++ b/packages/openrouter-specialists/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node --test dist/tests/*.test.js",
+    "test": "npm run build && NODE_PATH=$PWD/node_modules node --test dist/tests/*.test.js",
     "validate:wallet-manifest": "npm run build && node scripts/validate-wallet-manifest.mjs",
     "wallet:render-signer-manifest": "npm run build && node scripts/render-signer-wallet-manifest.mjs",
     "wallet:verify-signer-provenance": "npm run build && node scripts/validate-wallet-manifest.mjs --require-signer-provenance",
@@ -23,7 +23,8 @@
     "check:devnet-balances": "node scripts/check-devnet-balances.mjs",
     "deployment:readiness": "npm run build && node scripts/deployment-readiness.mjs",
     "delegation:noop-smoke": "npm run build && node scripts/live-noop-smoke.mjs",
-    "delegation:private-smoke": "npm run build && node scripts/private-live-executor-smoke.mjs"
+    "delegation:private-smoke": "npm run build && node scripts/private-live-executor-smoke.mjs",
+    "wallet:readiness": "npm run build && NODE_PATH=$PWD/node_modules node scripts/wallet-readiness.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/packages/openrouter-specialists/scripts/wallet-readiness.mjs
+++ b/packages/openrouter-specialists/scripts/wallet-readiness.mjs
@@ -1,0 +1,13 @@
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildWalletReadinessReport } from '../dist/src/index.js';
+
+const signerManifestPath = process.argv.slice(2).find((arg) => !arg.startsWith('--')) ?? process.env.SIGNER_BACKED_WALLET_MANIFEST;
+const outPath = process.env.WALLET_READINESS_OUT ?? join(process.cwd(), 'artifacts/wallet-readiness.json');
+const signerBackedManifest = signerManifestPath ? JSON.parse(readFileSync(signerManifestPath, 'utf8')) : undefined;
+const report = buildWalletReadinessReport({ signerBackedManifest });
+
+mkdirSync(join(outPath, '..'), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify(report, null, 2));
+if (report.status !== 'ready') process.exitCode = 1;

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -9,3 +9,4 @@ export * from "./delegation-intent.js";
 export * from "./delegation-audit.js";
 export * from "./delegation-executor.js";
 export * from "./runtime.js";
+export * from "./wallet-readiness.js";

--- a/packages/openrouter-specialists/src/wallet-readiness.ts
+++ b/packages/openrouter-specialists/src/wallet-readiness.ts
@@ -1,0 +1,105 @@
+import { specialistProfiles } from "./profiles/index.js";
+import type { SpecialistProfile } from "./types.js";
+import type { SignerBackedWalletManifest } from "./wallet-provenance.js";
+
+export type WalletReadinessStatus = "ready" | "blocked";
+export type WalletProvenanceStatus =
+  | "signer_backed"
+  | "placeholder_or_unverified";
+
+export interface WalletReadinessEntry {
+  profileId: string;
+  displayName: string;
+  publicKey: string;
+  profileIndex: number;
+  firstFiveDeploymentProfile: boolean;
+  provenance: WalletProvenanceStatus;
+  signerSourceEnv?: string;
+  fundingReady: boolean;
+  registrationReady: boolean;
+  blockers: string[];
+}
+
+export interface WalletReadinessReport {
+  schemaVersion: "reddi.openrouter.wallet-readiness.v1";
+  status: WalletReadinessStatus;
+  generatedAt: string;
+  network: "solana-devnet";
+  profileCount: number;
+  signerBackedCount: number;
+  placeholderOrUnverifiedCount: number;
+  guardrails: string[];
+  entries: WalletReadinessEntry[];
+  nextApprovalRequired: string[];
+}
+
+export function buildWalletReadinessReport(input?: {
+  profiles?: SpecialistProfile[];
+  signerBackedManifest?: SignerBackedWalletManifest;
+  generatedAt?: string;
+}): WalletReadinessReport {
+  const profiles = input?.profiles ?? specialistProfiles;
+  const signerBackedByProfile = new Map(
+    (input?.signerBackedManifest?.profiles ?? []).map((entry) => [
+      entry.profileId,
+      entry,
+    ]),
+  );
+  const entries = profiles.map((profile, index): WalletReadinessEntry => {
+    const signerBacked = signerBackedByProfile.get(profile.id);
+    const signerBackedMatchesProfile =
+      signerBacked?.publicKey === profile.walletAddress;
+    const blockers: string[] = [];
+    if (!signerBacked)
+      blockers.push("wallet is not signer-backed in supplied manifest");
+    else if (!signerBackedMatchesProfile)
+      blockers.push("signer-backed public key does not match profile wallet");
+
+    const provenance: WalletProvenanceStatus =
+      signerBacked && signerBackedMatchesProfile
+        ? "signer_backed"
+        : "placeholder_or_unverified";
+    return {
+      profileId: profile.id,
+      displayName: profile.displayName,
+      publicKey: profile.walletAddress,
+      profileIndex: index,
+      firstFiveDeploymentProfile: index < 5,
+      provenance,
+      signerSourceEnv:
+        provenance === "signer_backed"
+          ? signerBacked?.signerProvenance.sourceEnv
+          : undefined,
+      fundingReady: provenance === "signer_backed",
+      registrationReady: provenance === "signer_backed",
+      blockers,
+    };
+  });
+  const signerBackedCount = entries.filter(
+    (entry) => entry.provenance === "signer_backed",
+  ).length;
+  const placeholderOrUnverifiedCount = entries.length - signerBackedCount;
+  return {
+    schemaVersion: "reddi.openrouter.wallet-readiness.v1",
+    status: placeholderOrUnverifiedCount === 0 ? "ready" : "blocked",
+    generatedAt: input?.generatedAt ?? new Date().toISOString(),
+    network: "solana-devnet",
+    profileCount: entries.length,
+    signerBackedCount,
+    placeholderOrUnverifiedCount,
+    guardrails: [
+      "public metadata only",
+      "no private keys or signer material emitted",
+      "placeholder_or_unverified wallets are not funding-ready",
+      "placeholder_or_unverified wallets are not registration-ready",
+      "devnet funding requires separate operator approval",
+    ],
+    entries,
+    nextApprovalRequired: [
+      "Generate or import signer-backed devnet wallets for every placeholder_or_unverified profile.",
+      "Rotate profile wallet constants/public manifest from signer-derived public keys before funding.",
+      "Run balance checks and request explicit devnet funding approval before any transfer.",
+      "Run devnet registration only after signer/profile/manifest wallet equality passes.",
+    ],
+  };
+}

--- a/packages/openrouter-specialists/tests/wallet-readiness.test.ts
+++ b/packages/openrouter-specialists/tests/wallet-readiness.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Keypair } from "@solana/web3.js";
+import { specialistProfiles } from "../src/profiles/index.js";
+import { buildWalletReadinessReport } from "../src/wallet-readiness.js";
+import { buildSignerBackedWalletManifest, type LoadedSignerProfile } from "../src/wallet-provenance.js";
+import type { SpecialistProfile } from "../src/types.js";
+
+function cloneProfiles(): SpecialistProfile[] {
+  return specialistProfiles.map((profile) => ({ ...profile, capabilities: [...profile.capabilities], roles: [...profile.roles], preferredAttestors: [...profile.preferredAttestors], tags: [...profile.tags] }));
+}
+
+function signerLoadedForProfile(profiles: SpecialistProfile[], index: number): LoadedSignerProfile {
+  const profile = profiles[index];
+  assert.ok(profile);
+  const keypair = Keypair.generate();
+  profile.walletAddress = keypair.publicKey.toBase58();
+  return { profile, keypair, sourceEnv: `OPENROUTER_SPECIALIST_${profile.id.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}_SIGNER_KEYPAIR_JSON` };
+}
+
+test("wallet readiness blocks all profiles without signer-backed provenance", () => {
+  const report = buildWalletReadinessReport({ generatedAt: "2026-05-04T00:00:00.000Z" });
+
+  assert.equal(report.schemaVersion, "reddi.openrouter.wallet-readiness.v1");
+  assert.equal(report.status, "blocked");
+  assert.equal(report.profileCount, 30);
+  assert.equal(report.signerBackedCount, 0);
+  assert.equal(report.placeholderOrUnverifiedCount, 30);
+  assert.equal(report.entries.length, 30);
+  assert.equal(report.entries[0]?.firstFiveDeploymentProfile, true);
+  assert.equal(report.entries[5]?.firstFiveDeploymentProfile, false);
+  assert.ok(report.entries.every((entry) => !entry.fundingReady));
+  assert.ok(report.entries.every((entry) => !entry.registrationReady));
+  assert.ok(JSON.stringify(report).includes("placeholder_or_unverified wallets are not funding-ready"));
+});
+
+test("wallet readiness marks only signer-backed matching profiles as funding and registration ready", () => {
+  const profiles = cloneProfiles();
+  const loaded = [signerLoadedForProfile(profiles, 0), signerLoadedForProfile(profiles, 1)];
+  const manifest = buildSignerBackedWalletManifest({ loaded, generatedAt: "2026-05-04T00:00:00.000Z" });
+  const report = buildWalletReadinessReport({ profiles, signerBackedManifest: manifest, generatedAt: "2026-05-04T00:00:00.000Z" });
+
+  assert.equal(report.status, "blocked");
+  assert.equal(report.profileCount, 30);
+  assert.equal(report.signerBackedCount, 2);
+  assert.equal(report.placeholderOrUnverifiedCount, 28);
+  assert.equal(report.entries[0]?.provenance, "signer_backed");
+  assert.equal(report.entries[0]?.fundingReady, true);
+  assert.equal(report.entries[0]?.registrationReady, true);
+  assert.equal(report.entries[2]?.provenance, "placeholder_or_unverified");
+  assert.equal(report.entries[2]?.fundingReady, false);
+  assert.equal(report.entries[2]?.registrationReady, false);
+});
+
+test("wallet readiness blocks signer-backed public keys that do not match profile wallets", () => {
+  const profiles = cloneProfiles();
+  const profile = profiles[0];
+  assert.ok(profile);
+  const manifest = buildSignerBackedWalletManifest({
+    loaded: [{ profile, keypair: Keypair.generate(), sourceEnv: "OPENROUTER_SPECIALIST_PLANNING_AGENT_SIGNER_KEYPAIR_JSON" }],
+    generatedAt: "2026-05-04T00:00:00.000Z",
+  });
+  const report = buildWalletReadinessReport({ profiles, signerBackedManifest: manifest, generatedAt: "2026-05-04T00:00:00.000Z" });
+
+  assert.equal(report.entries[0]?.provenance, "placeholder_or_unverified");
+  assert.equal(report.entries[0]?.fundingReady, false);
+  assert.ok(report.entries[0]?.blockers.includes("signer-backed public key does not match profile wallet"));
+});


### PR DESCRIPTION
## Summary

Loop 2 for the 30-specialist rollout.

Adds an all-profile wallet readiness gate before any funding/registration/Coolify rollout of the remaining profiles.

## Scope

- Adds `buildWalletReadinessReport()` for all 30 profiles.
- Adds `npm run wallet:readiness` to emit a public metadata-only readiness report.
- Classifies wallets as:
  - `signer_backed`; or
  - `placeholder_or_unverified`.
- Blocks funding/registration readiness unless signer-backed provenance exists and signer public key matches the profile wallet.
- Adds tests proving placeholder/unverified wallets are not funding/registration ready.

## Safety boundaries

- No funding.
- No registration.
- No Coolify mutation.
- No live downstream calls.
- No OpenRouter calls.
- No private keys or signer material emitted.
- This PR does not generate or rotate signer-backed wallets; it only adds the gate that must pass before those actions.

## Validation

- `npm run wallet:readiness --prefix packages/openrouter-specialists` ✅ expected blocked report, no secrets
- `npm test --prefix packages/openrouter-specialists` ✅ 49/49
- `npm run build` ✅
- `git diff --check` ✅

Follow-up Loop 3 should generate/import signer-backed devnet wallets and rotate public profile wallet constants/manifest only after review.

Closes #181.
