### PR TITLE
OpenRouter 30 specialists: signer-backed wallet rotation plan

### DIFF
--- a/packages/openrouter-specialists/package.json
+++ b/packages/openrouter-specialists/package.json
@@ -24,7 +24,8 @@
     "deployment:readiness": "npm run build && node scripts/deployment-readiness.mjs",
     "delegation:noop-smoke": "npm run build && node scripts/live-noop-smoke.mjs",
     "delegation:private-smoke": "npm run build && node scripts/private-live-executor-smoke.mjs",
-    "wallet:readiness": "npm run build && NODE_PATH=$PWD/node_modules node scripts/wallet-readiness.mjs"
+    "wallet:readiness": "npm run build && NODE_PATH=$PWD/node_modules node scripts/wallet-readiness.mjs",
+    "wallet:rotation-plan": "npm run build && NODE_PATH=$PWD/node_modules node scripts/wallet-rotation-plan.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/packages/openrouter-specialists/scripts/wallet-rotation-plan.mjs
+++ b/packages/openrouter-specialists/scripts/wallet-rotation-plan.mjs
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildWalletRotationPlan } from '../dist/src/wallet-rotation-plan.js';
+
+const currentManifestPath = process.env.WALLET_MANIFEST_PATH ?? join(process.cwd(), 'public/wallet-manifest.json');
+const candidateManifestPath = process.env.SIGNER_WALLET_MANIFEST_PATH ?? process.argv[2];
+const currentManifest = JSON.parse(readFileSync(currentManifestPath, 'utf8'));
+const candidateManifest = candidateManifestPath ? JSON.parse(readFileSync(candidateManifestPath, 'utf8')) : undefined;
+
+const report = buildWalletRotationPlan({ currentManifest, candidateManifest });
+console.log(JSON.stringify(report, null, 2));
+if (report.status !== 'ready_for_operator_funding_approval') process.exitCode = 1;

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -10,3 +10,4 @@ export * from "./delegation-audit.js";
 export * from "./delegation-executor.js";
 export * from "./runtime.js";
 export * from "./wallet-readiness.js";
+export * from "./wallet-rotation-plan.js";

--- a/packages/openrouter-specialists/src/wallet-rotation-plan.ts
+++ b/packages/openrouter-specialists/src/wallet-rotation-plan.ts
@@ -1,0 +1,154 @@
+import { PublicKey } from "@solana/web3.js";
+import { specialistProfiles } from "./profiles/index.js";
+import type { WalletManifest } from "./marketplace-client.js";
+import type { SpecialistProfile } from "./types.js";
+
+export type WalletRotationAction =
+  | "generate_or_import_signer"
+  | "rotate_profile_and_manifest_wallet"
+  | "verify_signer_backed_readiness"
+  | "ready_for_operator_funding_approval";
+
+export interface WalletRotationPlanEntry {
+  profileId: string;
+  displayName: string;
+  currentProfileWallet: string;
+  currentManifestWallet?: string;
+  candidateSignerWallet?: string;
+  signerBacked: boolean;
+  profileManifestMatch: boolean;
+  candidateMatchesProfile: boolean;
+  fundingReadyAfterRotation: boolean;
+  registrationReadyAfterRotation: boolean;
+  actions: WalletRotationAction[];
+  blockers: string[];
+}
+
+export interface WalletRotationPlan {
+  schemaVersion: "reddi.openrouter.wallet-rotation-plan.v1";
+  status: "ready_for_operator_funding_approval" | "blocked";
+  generatedAt: string;
+  network: "solana-devnet";
+  profileCount: number;
+  signerBackedCandidateCount: number;
+  profileManifestMismatchCount: number;
+  candidateRotationRequiredCount: number;
+  guardrails: string[];
+  entries: WalletRotationPlanEntry[];
+  nextApprovalRequired: string[];
+}
+
+export interface SignerBackedCandidateManifestProfile {
+  profileId: string;
+  displayName?: string;
+  publicKey: string;
+  signerProvenance?: {
+    sourceEnv?: string;
+    derivedFromSigner?: boolean;
+  };
+}
+
+export interface SignerBackedCandidateManifest {
+  schemaVersion?: string;
+  network?: string;
+  profiles?: SignerBackedCandidateManifestProfile[];
+}
+
+export function buildWalletRotationPlan(input?: {
+  profiles?: SpecialistProfile[];
+  currentManifest?: WalletManifest;
+  candidateManifest?: SignerBackedCandidateManifest;
+  generatedAt?: string;
+}): WalletRotationPlan {
+  const profiles = input?.profiles ?? specialistProfiles;
+  const currentManifestById = new Map((input?.currentManifest?.profiles ?? []).map((entry) => [entry.profileId, entry]));
+  const candidateById = new Map((input?.candidateManifest?.profiles ?? []).map((entry) => [entry.profileId, entry]));
+
+  const entries = profiles.map((profile): WalletRotationPlanEntry => {
+    const currentManifestWallet = currentManifestById.get(profile.id)?.publicKey;
+    const candidate = candidateById.get(profile.id);
+    const candidateSignerWallet = candidate?.publicKey;
+    const signerBacked = isSignerBackedCandidate(candidate);
+    const profileManifestMatch = currentManifestWallet === profile.walletAddress;
+    const candidateMatchesProfile = signerBacked && candidateSignerWallet === profile.walletAddress;
+    const actions: WalletRotationAction[] = [];
+    const blockers: string[] = [];
+
+    if (!profileManifestMatch) {
+      blockers.push("current public manifest wallet does not match profile wallet");
+    }
+    if (!signerBacked) {
+      actions.push("generate_or_import_signer");
+      blockers.push("missing signer-backed candidate public key");
+    } else if (!candidateMatchesProfile) {
+      actions.push("rotate_profile_and_manifest_wallet");
+      blockers.push("signer-backed candidate wallet has not yet replaced profile/manifest wallet");
+    }
+
+    if (signerBacked) actions.push("verify_signer_backed_readiness");
+    if (profileManifestMatch && candidateMatchesProfile) actions.push("ready_for_operator_funding_approval");
+
+    return {
+      profileId: profile.id,
+      displayName: profile.displayName,
+      currentProfileWallet: profile.walletAddress,
+      currentManifestWallet,
+      candidateSignerWallet,
+      signerBacked,
+      profileManifestMatch,
+      candidateMatchesProfile,
+      fundingReadyAfterRotation: profileManifestMatch && candidateMatchesProfile,
+      registrationReadyAfterRotation: profileManifestMatch && candidateMatchesProfile,
+      actions,
+      blockers,
+    };
+  });
+
+  const signerBackedCandidateCount = entries.filter((entry) => entry.signerBacked).length;
+  const profileManifestMismatchCount = entries.filter((entry) => !entry.profileManifestMatch).length;
+  const candidateRotationRequiredCount = entries.filter((entry) => entry.signerBacked && !entry.candidateMatchesProfile).length;
+  const ready = entries.every((entry) => entry.fundingReadyAfterRotation && entry.registrationReadyAfterRotation);
+
+  return {
+    schemaVersion: "reddi.openrouter.wallet-rotation-plan.v1",
+    status: ready ? "ready_for_operator_funding_approval" : "blocked",
+    generatedAt: input?.generatedAt ?? new Date().toISOString(),
+    network: "solana-devnet",
+    profileCount: profiles.length,
+    signerBackedCandidateCount,
+    profileManifestMismatchCount,
+    candidateRotationRequiredCount,
+    guardrails: [
+      "public metadata only",
+      "no private keys or signer material emitted",
+      "no devnet funding executed",
+      "no devnet registration executed",
+      "no Coolify mutation executed",
+      "operator approval required before any transfer or registration",
+    ],
+    entries,
+    nextApprovalRequired: ready
+      ? [
+          "Operator approval to fund signer-backed devnet wallets.",
+          "Operator approval to run devnet registration after balances pass.",
+          "Operator approval to mutate Coolify environment and redeploy hosted specialists.",
+        ]
+      : [
+          "Generate or import signer-backed devnet wallets for every blocked profile.",
+          "Rotate profile wallet constants and public manifest to signer-derived public keys.",
+          "Re-run wallet readiness and rotation plan until all profiles are signer-backed and equality-verified.",
+        ],
+  };
+}
+
+function isSignerBackedCandidate(candidate: SignerBackedCandidateManifestProfile | undefined): boolean {
+  if (!candidate) return false;
+  if (!candidate.signerProvenance || candidate.signerProvenance.derivedFromSigner !== true) return false;
+  if (typeof candidate.publicKey !== "string") return false;
+  try {
+    const publicKey = new PublicKey(candidate.publicKey);
+    return publicKey.toBase58() === candidate.publicKey;
+  } catch {
+    return false;
+  }
+}

--- a/packages/openrouter-specialists/tests/wallet-rotation-plan.test.ts
+++ b/packages/openrouter-specialists/tests/wallet-rotation-plan.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Keypair } from "@solana/web3.js";
+import { buildWalletRotationPlan } from "../src/wallet-rotation-plan.js";
+import type { WalletManifest } from "../src/marketplace-client.js";
+import type { SpecialistProfile } from "../src/types.js";
+
+function profile(id: string, walletAddress = Keypair.generate().publicKey.toBase58()): SpecialistProfile {
+  return {
+    id,
+    displayName: id,
+    description: "test",
+    walletAddress,
+    endpointPath: "/v1/chat/completions",
+    capabilities: ["test"],
+    tags: ["test"],
+    model: "openrouter/test",
+    roles: ["specialist"],
+    price: { currency: "USDC", amount: "0.01", unit: "request" },
+    safetyMode: "standard",
+    preferredAttestors: ["verification-validation-agent"],
+    systemPrompt: "test",
+  };
+}
+
+function manifestFor(profiles: SpecialistProfile[]): WalletManifest {
+  return {
+    schemaVersion: "1.0.0",
+    network: "solana-devnet",
+    minimumBalanceLamports: 1_000_000,
+    profiles: profiles.map((entry) => ({
+      profileId: entry.id,
+      displayName: entry.displayName,
+      publicKey: entry.walletAddress,
+    })),
+  };
+}
+
+test("rotation plan blocks placeholder-only current wallets before funding approval", () => {
+  const profiles = [profile("planning-agent"), profile("document-intelligence-agent")];
+  const report = buildWalletRotationPlan({
+    profiles,
+    currentManifest: manifestFor(profiles),
+    generatedAt: "2026-05-04T00:00:00.000Z",
+  });
+
+  assert.equal(report.status, "blocked");
+  assert.equal(report.profileCount, 2);
+  assert.equal(report.signerBackedCandidateCount, 0);
+  assert.equal(report.candidateRotationRequiredCount, 0);
+  assert.deepEqual(report.entries.map((entry) => entry.fundingReadyAfterRotation), [false, false]);
+  assert.deepEqual(report.entries.map((entry) => entry.registrationReadyAfterRotation), [false, false]);
+  assert.ok(report.entries.every((entry) => entry.actions.includes("generate_or_import_signer")));
+  assert.ok(report.guardrails.includes("no devnet funding executed"));
+  assert.ok(report.guardrails.includes("no private keys or signer material emitted"));
+});
+
+test("rotation plan requires profile and manifest rotation when signer-backed candidates differ", () => {
+  const profiles = [profile("planning-agent"), profile("code-generation-agent")];
+  const candidates = profiles.map((entry) => ({
+    profileId: entry.id,
+    displayName: entry.displayName,
+    publicKey: Keypair.generate().publicKey.toBase58(),
+    signerProvenance: { sourceEnv: "OPENROUTER_SPECIALIST_SIGNER_KEYPAIRS_JSON", derivedFromSigner: true },
+  }));
+
+  const report = buildWalletRotationPlan({
+    profiles,
+    currentManifest: manifestFor(profiles),
+    candidateManifest: { schemaVersion: "1.0.0", network: "solana-devnet", profiles: candidates },
+  });
+
+  assert.equal(report.status, "blocked");
+  assert.equal(report.signerBackedCandidateCount, 2);
+  assert.equal(report.candidateRotationRequiredCount, 2);
+  assert.ok(report.entries.every((entry) => entry.signerBacked));
+  assert.ok(report.entries.every((entry) => entry.actions.includes("rotate_profile_and_manifest_wallet")));
+  assert.ok(report.entries.every((entry) => entry.actions.includes("verify_signer_backed_readiness")));
+  assert.ok(report.entries.every((entry) => !entry.fundingReadyAfterRotation));
+});
+
+test("rotation plan becomes funding-approval-ready only after signer/profile/manifest equality", () => {
+  const walletA = Keypair.generate().publicKey.toBase58();
+  const walletB = Keypair.generate().publicKey.toBase58();
+  const profiles = [profile("planning-agent", walletA), profile("verification-validation-agent", walletB)];
+  const candidateProfiles = profiles.map((entry) => ({
+    profileId: entry.id,
+    displayName: entry.displayName,
+    publicKey: entry.walletAddress,
+    signerProvenance: { sourceEnv: "OPENROUTER_SPECIALIST_SIGNER_KEYPAIRS_JSON", derivedFromSigner: true },
+  }));
+
+  const report = buildWalletRotationPlan({
+    profiles,
+    currentManifest: manifestFor(profiles),
+    candidateManifest: { schemaVersion: "1.0.0", network: "solana-devnet", profiles: candidateProfiles },
+  });
+
+  assert.equal(report.status, "ready_for_operator_funding_approval");
+  assert.equal(report.signerBackedCandidateCount, 2);
+  assert.equal(report.candidateRotationRequiredCount, 0);
+  assert.equal(report.profileManifestMismatchCount, 0);
+  assert.ok(report.entries.every((entry) => entry.fundingReadyAfterRotation));
+  assert.ok(report.entries.every((entry) => entry.registrationReadyAfterRotation));
+  assert.ok(report.entries.every((entry) => entry.actions.includes("ready_for_operator_funding_approval")));
+  assert.match(report.nextApprovalRequired.join("\n"), /Operator approval to fund/);
+});
+
+test("rotation plan blocks malformed signer candidate public keys", () => {
+  const profiles = [profile("planning-agent")];
+  const report = buildWalletRotationPlan({
+    profiles,
+    currentManifest: manifestFor(profiles),
+    candidateManifest: {
+      schemaVersion: "1.0.0",
+      network: "solana-devnet",
+      profiles: [{ profileId: profiles[0].id, publicKey: "not-a-public-key", signerProvenance: { derivedFromSigner: true } }],
+    },
+  });
+
+  assert.equal(report.status, "blocked");
+  assert.equal(report.signerBackedCandidateCount, 0);
+  assert.ok(report.entries[0].actions.includes("generate_or_import_signer"));
+});


### PR DESCRIPTION
Closes #183.

## Summary
- Adds a public-data-only all-profile wallet rotation plan builder and `npm run wallet:rotation-plan`.
- Covers all 30 OpenRouter specialist profiles and blocks funding/registration until signer-backed candidates exist and profile/manifest equality is proven.
- Adds tests for placeholder-only, signer-backed-but-not-rotated, equality-ready, and malformed candidate cases.

## Guardrails
- No funding execution.
- No registration execution.
- No Coolify mutation.
- No live downstream/OpenRouter calls.
- No private keys or signer material emitted.

## Validation
- `npm run wallet:rotation-plan --prefix packages/openrouter-specialists` exits blocked as expected for current public state.
- `npm test --prefix packages/openrouter-specialists` passes 53/53.
- `npm run build` passes.
- `git diff --check` passes.
