### PR TITLE
Add end-user economic workflow demo fixture

### DIFF
--- a/app/api/economic-demo/dry-run/route.ts
+++ b/app/api/economic-demo/dry-run/route.ts
@@ -1,0 +1,18 @@
+import { buildEconomicDemoDryRunPlan, isEconomicDemoScenarioId } from "@/lib/economic-demo/dry-run";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const scenario = url.searchParams.get("scenario") ?? "webpage";
+  if (!isEconomicDemoScenarioId(scenario)) {
+    return Response.json({ ok: false, error: "unknown_scenario" }, { status: 400 });
+  }
+  return Response.json({ ok: true, plan: buildEconomicDemoDryRunPlan(scenario) });
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as { scenario?: unknown };
+  if (!isEconomicDemoScenarioId(body.scenario)) {
+    return Response.json({ ok: false, error: "unknown_scenario" }, { status: 400 });
+  }
+  return Response.json({ ok: true, plan: buildEconomicDemoDryRunPlan(body.scenario) });
+}

--- a/app/api/economic-demo/image/route.ts
+++ b/app/api/economic-demo/image/route.ts
@@ -1,0 +1,27 @@
+import { generateEconomicDemoImage, imageAdapterReadiness, type ImageProvider } from "@/lib/economic-demo/image-adapter";
+
+function isProvider(value: unknown): value is ImageProvider {
+  return value === "openai" || value === "fal";
+}
+
+export async function GET() {
+  return Response.json({ ok: true, readiness: imageAdapterReadiness() });
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as { prompt?: unknown; provider?: unknown };
+    if (typeof body.prompt !== "string" || !body.prompt.trim()) {
+      return Response.json({ ok: false, error: "prompt_required" }, { status: 400 });
+    }
+    const result = await generateEconomicDemoImage({
+      prompt: body.prompt,
+      provider: isProvider(body.provider) ? body.provider : undefined,
+    });
+    return Response.json({ ok: true, result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status = message === "image_generation_disabled" ? 403 : 502;
+    return Response.json({ ok: false, error: message, readiness: imageAdapterReadiness() }, { status });
+  }
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  economicDemoScenarios,
+  formatLamports,
+  lamportsDelta,
+  type EconomicDemoScenario,
+} from "@/lib/economic-demo/fixture";
+
+function shortWallet(wallet: string) {
+  return `${wallet.slice(0, 8)}…${wallet.slice(-6)}`;
+}
+
+function statusClass(status: EconomicDemoScenario["edges"][number]["status"]) {
+  if (status === "blocked") return "border-red-400/40 bg-red-400/10 text-red-200";
+  if (status === "attested") return "border-[#14F195]/40 bg-[#14F195]/10 text-[#14F195]";
+  if (status === "paid") return "border-accent-purple/40 bg-accent-purple/10 text-accent-purple";
+  return "border-white/15 bg-white/5 text-gray-300";
+}
+
+export default function EconomicDemoPage() {
+  const [scenarioId, setScenarioId] = useState(economicDemoScenarios[0].id);
+  const scenario = useMemo(
+    () => economicDemoScenarios.find((candidate) => candidate.id === scenarioId) ?? economicDemoScenarios[0],
+    [scenarioId],
+  );
+  const totalPlanned = scenario.edges.reduce((sum, edge) => sum + edge.amountLamports, 0);
+
+  return (
+    <main className="min-h-screen bg-page">
+      <section className="relative overflow-hidden border-b border-white/5">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(153,69,255,0.22),transparent_35%),radial-gradient(circle_at_80%_10%,rgba(20,241,149,0.16),transparent_28%)]" />
+        <div className="relative mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
+          <div className="max-w-4xl space-y-5">
+            <span className="section-label">End-user economic demo · issue #187</span>
+            <h1 className="font-display text-4xl font-bold text-white sm:text-5xl">
+              Watch one user request become a paid agent workflow
+            </h1>
+            <p className="max-w-3xl text-base leading-7 text-gray-400">
+              This fixture slice shows the demo we are wiring next: an end user asks for work, a consumer-capable specialist hires other specialists through Reddi/x402, attestors verify the result, and the ledger shows the before/after impact for every wallet.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              {economicDemoScenarios.map((candidate) => (
+                <button
+                  key={candidate.id}
+                  onClick={() => setScenarioId(candidate.id)}
+                  className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
+                    candidate.id === scenario.id
+                      ? "border-[#14F195]/50 bg-[#14F195]/15 text-[#14F195]"
+                      : "border-white/10 bg-white/5 text-gray-300 hover:border-white/25 hover:text-white"
+                  }`}
+                >
+                  {candidate.title}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="grid gap-6 lg:grid-cols-[1.05fr_1.5fr]">
+          <div className="space-y-6">
+            <div className="rounded-2xl border border-white/10 bg-card/70 p-6 shadow-card">
+              <p className="section-label">User request</p>
+              <h2 className="mt-2 text-2xl font-semibold text-white">{scenario.title}</h2>
+              <p className="mt-3 rounded-xl border border-white/10 bg-black/20 p-4 text-sm leading-6 text-gray-200">
+                “{scenario.prompt}”
+              </p>
+              <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <dt className="text-gray-500">Orchestrator</dt>
+                  <dd className="mt-1 font-mono text-[#14F195]">{scenario.orchestrator}</dd>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <dt className="text-gray-500">Mode now</dt>
+                  <dd className="mt-1 font-mono text-gray-200">{scenario.mode}</dd>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <dt className="text-gray-500">Edges</dt>
+                  <dd className="mt-1 text-gray-200">{scenario.edges.length}</dd>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <dt className="text-gray-500">Planned flow</dt>
+                  <dd className="mt-1 text-gray-200">{formatLamports(totalPlanned)}</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-card/70 p-6 shadow-card">
+              <p className="section-label">Final output</p>
+              <h3 className="mt-2 text-xl font-semibold text-white">{scenario.finalOutputType}</h3>
+              <p className="mt-3 text-sm leading-6 text-gray-300">{scenario.finalOutputSummary}</p>
+              <div className="mt-5 rounded-xl border border-[#14F195]/20 bg-[#14F195]/10 p-4 text-sm text-[#14F195]">
+                Next live loop: replace fixture receipts with exact allowlisted devnet x402 receipts and balance snapshots.
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-card/70 p-6 shadow-card">
+              <p className="section-label">Guardrails</p>
+              <ul className="mt-3 space-y-2 text-sm text-gray-300">
+                {scenario.guardrails.map((guardrail) => (
+                  <li key={guardrail} className="flex gap-2">
+                    <span className="text-[#14F195]">•</span>
+                    <span>{guardrail}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="rounded-2xl border border-white/10 bg-card/70 p-6 shadow-card">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="section-label">Payload + money graph</p>
+                  <h2 className="mt-2 text-2xl font-semibold text-white">Agent workflow</h2>
+                </div>
+                <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-400">
+                  fixture · zero spend
+                </span>
+              </div>
+
+              <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                {scenario.agents.map((agent) => (
+                  <div key={agent.profileId} className="rounded-xl border border-white/10 bg-black/20 p-4">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="rounded-full border border-accent-purple/30 bg-accent-purple/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-accent-purple">
+                        {agent.role}
+                      </span>
+                    </div>
+                    <h3 className="mt-3 break-words font-mono text-sm text-white">{agent.profileId}</h3>
+                    <p className="mt-2 text-xs leading-5 text-gray-400">{agent.description}</p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-6 space-y-3">
+                {scenario.edges.map((edge, index) => (
+                  <div key={`${edge.from}-${edge.to}-${edge.capability}`} className="rounded-xl border border-white/10 bg-black/20 p-4">
+                    <div className="flex flex-wrap items-center gap-2 text-sm">
+                      <span className="font-mono text-white">{edge.from}</span>
+                      <span className="text-gray-500">→</span>
+                      <span className="font-mono text-white">{edge.to}</span>
+                      <span className={`rounded-full border px-2 py-0.5 text-xs ${statusClass(edge.status)}`}>{edge.status}</span>
+                    </div>
+                    <div className="mt-3 grid gap-3 md:grid-cols-[1fr_auto]">
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-gray-500">Payload {index + 1} · {edge.capability}</p>
+                        <p className="mt-1 text-sm leading-6 text-gray-300">{edge.payloadSummary}</p>
+                        <p className="mt-2 break-all font-mono text-xs text-gray-500">{edge.receipt}</p>
+                      </div>
+                      <div className="rounded-lg border border-[#14F195]/20 bg-[#14F195]/10 px-3 py-2 text-right">
+                        <p className="text-xs text-gray-400">x402 amount</p>
+                        <p className="font-mono text-sm text-[#14F195]">{formatLamports(edge.amountLamports)}</p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-card/70 p-6 shadow-card">
+              <p className="section-label">Wallet balance ledger</p>
+              <h2 className="mt-2 text-2xl font-semibold text-white">Start → end balances</h2>
+              <div className="mt-5 overflow-hidden rounded-xl border border-white/10">
+                <div className="grid grid-cols-[1.1fr_0.7fr_0.7fr_0.7fr] gap-3 bg-white/5 px-4 py-3 text-xs uppercase tracking-wide text-gray-500">
+                  <span>Wallet</span>
+                  <span>Start</span>
+                  <span>End</span>
+                  <span>Delta</span>
+                </div>
+                {scenario.balances.map((balance) => {
+                  const delta = lamportsDelta(balance);
+                  return (
+                    <div key={`${balance.profileId}-${balance.wallet}`} className="grid grid-cols-[1.1fr_0.7fr_0.7fr_0.7fr] gap-3 border-t border-white/10 px-4 py-3 text-sm">
+                      <div>
+                        <p className="font-mono text-white">{balance.profileId}</p>
+                        <p className="mt-1 font-mono text-xs text-gray-500">{shortWallet(balance.wallet)}</p>
+                      </div>
+                      <span className="font-mono text-gray-300">{formatLamports(balance.startingLamports).replace(/^\+/, "")}</span>
+                      <span className="font-mono text-gray-300">{formatLamports(balance.endingLamports).replace(/^\+/, "")}</span>
+                      <span className={`font-mono ${delta > 0 ? "text-[#14F195]" : delta < 0 ? "text-red-300" : "text-gray-400"}`}>
+                        {formatLamports(delta)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -8,6 +8,7 @@ import {
   lamportsDelta,
   type EconomicDemoScenario,
 } from "@/lib/economic-demo/fixture";
+import type { DryRunEconomicPlan } from "@/lib/economic-demo/dry-run";
 
 function shortWallet(wallet: string) {
   return `${wallet.slice(0, 8)}…${wallet.slice(-6)}`;
@@ -22,11 +23,27 @@ function statusClass(status: EconomicDemoScenario["edges"][number]["status"]) {
 
 export default function EconomicDemoPage() {
   const [scenarioId, setScenarioId] = useState(economicDemoScenarios[0].id);
+  const [dryRunPlan, setDryRunPlan] = useState<DryRunEconomicPlan | null>(null);
+  const [dryRunStatus, setDryRunStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const scenario = useMemo(
     () => economicDemoScenarios.find((candidate) => candidate.id === scenarioId) ?? economicDemoScenarios[0],
     [scenarioId],
   );
   const totalPlanned = scenario.edges.reduce((sum, edge) => sum + edge.amountLamports, 0);
+  const activeDryRunPlan = dryRunPlan?.scenarioId === scenario.id ? dryRunPlan : null;
+
+  async function loadDryRunPlan() {
+    setDryRunStatus("loading");
+    try {
+      const res = await fetch(`/api/economic-demo/dry-run?scenario=${scenario.id}`);
+      const payload = (await res.json()) as { ok?: boolean; plan?: DryRunEconomicPlan };
+      if (!res.ok || !payload.ok || !payload.plan) throw new Error("dry_run_plan_failed");
+      setDryRunPlan(payload.plan);
+      setDryRunStatus("loaded");
+    } catch {
+      setDryRunStatus("error");
+    }
+  }
 
   return (
     <main className="min-h-screen bg-page">
@@ -69,6 +86,23 @@ export default function EconomicDemoPage() {
               <p className="mt-3 rounded-xl border border-white/10 bg-black/20 p-4 text-sm leading-6 text-gray-200">
                 “{scenario.prompt}”
               </p>
+              <div className="mt-5 flex flex-wrap items-center gap-3">
+                <button
+                  onClick={loadDryRunPlan}
+                  disabled={dryRunStatus === "loading"}
+                  className="rounded-lg border border-[#14F195]/30 bg-[#14F195]/10 px-4 py-2 text-sm font-semibold text-[#14F195] transition hover:bg-[#14F195]/15 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {dryRunStatus === "loading" ? "Building dry-run plan…" : "Build dry-run economic graph"}
+                </button>
+                <span className="text-xs text-gray-500">
+                  Uses deployed 30-agent profile metadata · zero downstream calls
+                </span>
+              </div>
+              {dryRunStatus === "error" && (
+                <p className="mt-3 rounded-lg border border-red-400/30 bg-red-400/10 p-3 text-sm text-red-200">
+                  Dry-run plan failed. Fixture view is still available.
+                </p>
+              )}
               <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
                 <div className="rounded-xl border border-white/10 bg-white/5 p-3">
                   <dt className="text-gray-500">Orchestrator</dt>
@@ -147,6 +181,35 @@ export default function EconomicDemoPage() {
                   </div>
                 ))}
               </div>
+
+              {activeDryRunPlan && (
+                <div className="mt-6 rounded-xl border border-[#14F195]/25 bg-[#14F195]/10 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-[#14F195]">Dry-run orchestration plan</p>
+                      <p className="mt-1 font-mono text-sm text-white">{activeDryRunPlan.orchestrator.id}</p>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-xs text-gray-400">downstream calls executed</p>
+                      <p className="font-mono text-lg text-[#14F195]">{activeDryRunPlan.downstreamCallsExecuted}</p>
+                    </div>
+                  </div>
+                  <div className="mt-4 space-y-2">
+                    {activeDryRunPlan.edges.map((edge) => (
+                      <div key={`${edge.toProfileId}-${edge.capability}`} className="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <div className="flex flex-wrap items-center gap-2 text-sm">
+                          <span className="font-mono text-white">{edge.fromProfileId}</span>
+                          <span className="text-gray-500">→</span>
+                          <span className="font-mono text-white">{edge.toProfileId}</span>
+                          <span className="rounded-full border border-white/15 bg-white/5 px-2 py-0.5 text-xs text-gray-300">planned</span>
+                        </div>
+                        <p className="mt-2 text-sm text-gray-300">{edge.payloadSummary}</p>
+                        <p className="mt-2 break-all font-mono text-xs text-gray-500">{edge.endpoint}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
 
               <div className="mt-6 space-y-3">
                 {scenario.edges.map((edge, index) => (

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -109,6 +109,17 @@ export default function EconomicDemoPage() {
                 ))}
               </ul>
             </div>
+
+            {scenario.id === "picture" && (
+              <div className="rounded-2xl border border-accent-purple/25 bg-accent-purple/10 p-6 shadow-card">
+                <p className="section-label">Image adapter path</p>
+                <h3 className="mt-2 text-xl font-semibold text-white">OpenAI first · Fal.ai fallback</h3>
+                <p className="mt-3 text-sm leading-6 text-gray-300">
+                  The picture scenario is now modeled as a gated tool adapter: `tool-using-agent` can call OpenAI image generation when configured, or Fal.ai as fallback. The live route stays disabled until `ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION=true`.
+                </p>
+                <p className="mt-3 font-mono text-xs text-gray-500">/api/economic-demo/image · GET readiness · POST generate</p>
+              </div>
+            )}
           </div>
 
           <div className="space-y-6">

--- a/docs/END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md
@@ -1,0 +1,312 @@
+# End-User Economic Workflow Demo — BDD Delivery Plan
+
+_Date:_ 2026-05-04 AEST  
+_Issue:_ #187  
+_PR:_ #188  
+_Status:_ Phase 0/1 started on `feature/end-user-economic-demo-187`
+
+## Intended outcome
+
+A judge can open one page, submit or select an end-user request, and watch Reddi Agent Protocol turn it into a visible agent economy:
+
+1. request payload moves from user → orchestrator → specialists → attestors;
+2. x402 challenge/payment/receipt evidence moves with each paid edge;
+3. the final output is returned to the user;
+4. the page shows starting balance, ending balance, and net delta for every participating wallet.
+
+This is the north star. Any implementation phase that does not improve proof of payload flow, money flow, attestation, final output, or wallet impact should be treated as drift.
+
+## Non-negotiable guardrails
+
+- Devnet only for live economic runs.
+- Fixture/dry-run phases must execute zero paid API calls and zero wallet mutations.
+- Image generation is disabled unless `ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION=true`.
+- Live image generation uses OpenAI first, Fal.ai fallback, through the adapter route only.
+- No private keys, signer material, OpenAI/Fal keys, or payment secrets in UI, logs, fixtures, artifacts, or PR text.
+- Live downstream specialist calls require exact endpoint allowlist, max call count, lamport cap, and bounded evidence artifact.
+- No automatic spend retries.
+- Each phase ends with reflection before expanding scope.
+
+## Phase map
+
+### Phase 0 — Planning contract and BDD scenarios
+
+**Status:** complete in project plan; repo docs added in PR #188.
+
+**Goal:** lock the end-user demo outcome and prevent drift.
+
+**Acceptance criteria:**
+
+- Three user scenarios are named: webpage, research article, picture.
+- Demo evidence schema includes agents, edges, receipts, final output, and wallet balances.
+- Reflection template exists.
+- Picture case has explicit OpenAI/Fal adapter path and disabled-by-default guardrail.
+
+**Validation:** direct doc inspection.
+
+**Reflection prompt:** Did the plan preserve the economic proof, or just add another product demo?
+
+---
+
+### Phase 1 — Static economic fixture UI
+
+**Status:** implemented in PR #188 (`/economic-demo`).
+
+**Goal:** make the intended demo visible immediately without spend.
+
+**Acceptance criteria:**
+
+- `/economic-demo` renders all three scenarios.
+- User request, orchestrator, specialists, attestors, payload edges, x402 amount placeholders, receipt placeholders, final output summary, and wallet balance deltas are visible.
+- Fixture mode is clearly labeled as zero-spend.
+- No network calls are required to render the page.
+
+**Validation:**
+
+- `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/fixture.ts`
+- `npm run build`
+
+**Reflection prompt:** Is the static view understandable to a judge in under 30 seconds?
+
+---
+
+### Phase 2 — Gated image-generation adapter readiness
+
+**Status:** implemented as disabled-by-default route in PR #188.
+
+**Goal:** turn the picture case from “missing capability” into an explicit provider adapter path.
+
+**Acceptance criteria:**
+
+- `GET /api/economic-demo/image` reports readiness without exposing secrets.
+- `POST /api/economic-demo/image` returns `403 image_generation_disabled` unless `ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION=true`.
+- When enabled, provider selection is OpenAI first if configured, otherwise Fal.ai if configured.
+- OpenAI model and Fal model are configurable by env.
+- No provider is called during normal build/static demo.
+
+**Validation:**
+
+- targeted lint for route + adapter;
+- `npm run build`;
+- optional local readiness smoke with generation disabled.
+
+**Reflection prompt:** Did we add capability without creating a hidden external-spend path?
+
+---
+
+### Phase 3 — Dry-run orchestrator integration
+
+**Status:** next implementation phase.
+
+**Goal:** replace fixture edges with real delegation plans while still executing zero downstream paid calls.
+
+**Acceptance criteria:**
+
+- User scenario maps to a consumer-capable orchestrator:
+  - webpage → `agentic-workflow-system` or `planning-agent`;
+  - research → `scientific-research-agent` or `agentic-workflow-system`;
+  - picture → `tool-using-agent`.
+- Orchestrator returns candidate specialist edges from the marketplace profile data.
+- UI renders actual plan edges with candidate endpoint, wallet, price, and required attestors.
+- `downstreamCallsExecuted` remains `0`.
+- Ledger is labeled `planned`, not paid.
+
+**Validation:**
+
+- unit tests for scenario → plan mapping;
+- route test for dry-run graph generation;
+- build.
+
+**Reflection prompt:** Are selected specialists explainable and aligned with the user task, or just hardcoded decorations?
+
+---
+
+### Phase 4 — Real devnet balance snapshots, no spend
+
+**Status:** pending.
+
+**Goal:** prove the wallet ledger plumbing against live devnet balances before payments.
+
+**Acceptance criteria:**
+
+- Before/after balance fetch works for all wallets in a dry-run plan.
+- Deltas remain zero in no-spend mode.
+- RPC failures fail soft with explicit `balance_unavailable` markers.
+- No private signer access is required.
+
+**Validation:**
+
+- route tests with mocked RPC;
+- one manual devnet snapshot smoke if RPC available;
+- build.
+
+**Reflection prompt:** Does the ledger use real wallet addresses and balances, or fixture economics?
+
+---
+
+### Phase 5 — One live x402 specialist edge
+
+**Status:** pending; requires explicit go decision before execution.
+
+**Goal:** execute exactly one paid devnet specialist edge and show the resulting economic delta.
+
+**Recommended first edge:** `agentic-workflow-system` → `code-generation-agent` for the webpage case.
+
+**Acceptance criteria:**
+
+- Exact endpoint allowlist contains only the selected specialist endpoint.
+- `MAX_DOWNSTREAM_CALLS=1`.
+- Lamport cap enforced.
+- x402 challenge/payment/receipt or fail-closed reason captured.
+- Before/after balances are captured for payer and payee.
+- No automatic retry.
+
+**Validation:**
+
+- tests proving non-allowlisted endpoints fail before payment;
+- one bounded private devnet smoke with artifact;
+- reflection before any second live edge.
+
+**Reflection prompt:** Did the run produce real economic evidence, or just reach a protected endpoint?
+
+---
+
+### Phase 6 — Multi-edge webpage workflow with attestation
+
+**Status:** pending.
+
+**Goal:** complete the most demo-friendly workflow end-to-end.
+
+**Acceptance criteria:**
+
+- Webpage request triggers 2–3 specialist calls plus one attestor call.
+- Final output is a page/spec/code artifact.
+- UI shows receipt chain and balance deltas for each participant.
+- Attestor recommendation is visible: release, refund, or dispute.
+- Evidence artifact is downloadable/savable.
+
+**Validation:** bounded devnet run + evidence artifact inspection.
+
+**Reflection prompt:** Is the final output useful enough to justify the economic path shown?
+
+---
+
+### Phase 7 — Research article workflow with evidence/attestation
+
+**Status:** pending.
+
+**Goal:** prove a non-code knowledge workflow with citations/evidence caveats.
+
+**Acceptance criteria:**
+
+- Research request triggers retrieval/synthesis/drafting/review roles.
+- Final output includes citations or explicit evidence caveats.
+- Explainability and verification attestors are represented.
+- Ledger and receipts show all paid edges.
+
+**Validation:** bounded devnet run + evidence artifact inspection.
+
+**Reflection prompt:** Are citations/evidence meaningful, or is the article just fluent text?
+
+---
+
+### Phase 8 — Picture workflow with OpenAI/Fal adapter + vision validation
+
+**Status:** pending; requires image-generation env enablement and cost approval.
+
+**Goal:** produce an actual image, then pay/route validation work.
+
+**Acceptance criteria:**
+
+- Image generation goes through `/api/economic-demo/image` only.
+- Provider is recorded as OpenAI or Fal.ai with model name.
+- Generated image URL/data is displayed or safely persisted as an artifact.
+- `vision-language-agent` validates against the prompt.
+- `verification-validation-agent` attests the run.
+- Ledger includes adapter/specialist/attestor deltas.
+
+**Validation:** one bounded image-generation run + artifact inspection.
+
+**Reflection prompt:** Did image generation stay inside the economic protocol story, or become a disconnected API demo?
+
+---
+
+### Phase 9 — Evidence pack, judge script, and regression sweep
+
+**Status:** pending.
+
+**Goal:** make the demo repeatable and reviewable.
+
+**Acceptance criteria:**
+
+- Evidence pack links latest fixture, dry-run, balance, and live artifacts.
+- Judge walkthrough script explains the three scenarios and guardrails.
+- BDD feature index includes this demo bucket.
+- Representative tests/build pass.
+- Known gaps are explicit.
+
+**Validation:** `npm run test:bdd:index`, targeted tests, `npm run build`, manual page inspection.
+
+**Reflection prompt:** Can a fresh reviewer understand what is real, what is fixture, and what remains gated?
+
+## Iteration reflection template
+
+Append this after each phase/loop in the PR or repo iteration log:
+
+```md
+## Phase N reflection — <name>
+
+**Date:** YYYY-MM-DD AEST  
+**Scope shipped:**  
+**BDD scenarios touched:**  
+**Validation:**  
+**Result:** PASS / PARTIAL / FAIL / BLOCKED  
+**Evidence artifacts:**
+
+### What worked
+
+### What failed or surprised us
+
+### Drift check
+
+Did this phase improve at least one intended outcome: payload flow, money flow, attestation, final output, wallet impact?
+
+### Next phase adjustment
+
+### Decision log additions
+```
+
+## Current next action
+
+Proceed to **Phase 3 — Dry-run orchestrator integration** after PR #188 review/merge or continue in the same PR if speed is more important than PR size.
+
+## Phase 0/1/2 reflection — initial plan, fixture UI, gated image adapter
+
+**Date:** 2026-05-04 AEST  
+**Scope shipped:** delivery plan, BDD feature bucket, static `/economic-demo` fixture, disabled-by-default OpenAI/Fal image adapter route.  
+**BDD scenarios touched:** static fixture, disabled image generation gate, OpenAI/Fal adapter readiness.  
+**Validation:** `npm run test:bdd:index`; targeted lint for economic demo files; `npm run build`.  
+**Result:** PASS  
+**Evidence artifacts:** PR #188, commits `7a442cba`, `e54e8d4c`, plus this docs update.
+
+### What worked
+
+The phases now separate fixture storytelling, dry-run planning, balance plumbing, live x402 edges, multi-edge workflows, image generation, and evidence-pack work. That should make progress reviewable instead of letting the demo sprawl.
+
+### What failed or surprised us
+
+The picture case looked like a capability gap until we reframed it as a gated provider adapter. OpenAI and Fal.ai can both fit, but only if the adapter remains explicit and disabled by default.
+
+### Drift check
+
+This phase improves payload flow, money-flow explanation, final-output framing, and wallet-impact visualization. It does not yet prove real paid flow; that starts at Phase 5.
+
+### Next phase adjustment
+
+Phase 3 should not add live calls. It should replace hardcoded fixture edges with real dry-run plans selected from marketplace profile/capability metadata.
+
+### Decision log additions
+
+- Add Bucket J for end-user economic demo tracking.
+- Treat `/economic-demo` as the judge-facing proof surface for the remaining live-delegation work.
+- Treat image generation as an adapter/tool edge owned by `tool-using-agent`, not as an untracked external shortcut.

--- a/docs/END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md
@@ -144,7 +144,36 @@ This is the north star. Any implementation phase that does not improve proof of 
 
 ---
 
-### Phase 5 — One live x402 specialist edge
+### Phase 5 — Full Surfpool dress rehearsal with local validator wallets
+
+**Status:** pending.
+
+**Goal:** run the complete economic workflow against a Surfpool local validator using local test wallets, so we can prove real SOL transfers, balance deltas, receipt capture, and rollback behavior before touching devnet live edges.
+
+**Acceptance criteria:**
+
+- Surfpool/local validator starts from a deterministic funded wallet fixture.
+- End-user, orchestrator, specialist, and attestor wallets are created or loaded as local-only test wallets.
+- Marketplace registration/identity data is seeded or replayed locally enough for the demo graph.
+- At least one full workflow executes local SOL transfers for specialist consumption.
+- Before/after balances prove lamports moved exactly as expected.
+- Transfer ledger matches the UI edge ledger.
+- Failure path proves non-allowlisted or over-budget calls produce zero balance delta.
+- Evidence artifact includes validator mode, wallet public keys, tx signatures, edge receipts, balance deltas, and final output summary.
+- No devnet/mainnet spend, no Coolify mutation, no external provider spend unless separately enabled for the image adapter.
+
+**Validation:**
+
+- local Surfpool rehearsal script/test;
+- artifact inspection;
+- UI import/render of the rehearsal artifact;
+- reflection before devnet live edge.
+
+**Reflection prompt:** Did the local rehearsal prove real money movement semantics, or only simulate them in UI?
+
+---
+
+### Phase 6 — One live x402 specialist edge
 
 **Status:** pending; requires explicit go decision before execution.
 
@@ -171,7 +200,7 @@ This is the north star. Any implementation phase that does not improve proof of 
 
 ---
 
-### Phase 6 — Multi-edge webpage workflow with attestation
+### Phase 7 — Multi-edge webpage workflow with attestation
 
 **Status:** pending.
 
@@ -191,7 +220,7 @@ This is the north star. Any implementation phase that does not improve proof of 
 
 ---
 
-### Phase 7 — Research article workflow with evidence/attestation
+### Phase 8 — Research article workflow with evidence/attestation
 
 **Status:** pending.
 
@@ -210,7 +239,7 @@ This is the north star. Any implementation phase that does not improve proof of 
 
 ---
 
-### Phase 8 — Picture workflow with OpenAI/Fal adapter + vision validation
+### Phase 9 — Picture workflow with OpenAI/Fal adapter + vision validation
 
 **Status:** pending; requires image-generation env enablement and cost approval.
 
@@ -231,7 +260,7 @@ This is the north star. Any implementation phase that does not improve proof of 
 
 ---
 
-### Phase 9 — Evidence pack, judge script, and regression sweep
+### Phase 10 — Evidence pack, judge script, and regression sweep
 
 **Status:** pending.
 
@@ -278,7 +307,7 @@ Did this phase improve at least one intended outcome: payload flow, money flow, 
 
 ## Current next action
 
-Proceed to **Phase 3 — Dry-run orchestrator integration** after PR #188 review/merge or continue in the same PR if speed is more important than PR size.
+Proceed to **Phase 3 — Dry-run orchestrator integration** after PR #188 review/merge or continue in the same PR if speed is more important than PR size. Before devnet live edges, insert **Phase 5 — Surfpool dress rehearsal** as the mandatory proof gate for real local SOL transfers.
 
 ## Phase 0/1/2 reflection — initial plan, fixture UI, gated image adapter
 

--- a/docs/END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md
@@ -173,13 +173,13 @@ This is the north star. Any implementation phase that does not improve proof of 
 
 ---
 
-### Phase 6 — One live x402 specialist edge
+### Phase 6 — First controlled live x402 edge against the deployed 30-agent network
 
 **Status:** pending; requires explicit go decision before execution.
 
-**Goal:** execute exactly one paid devnet specialist edge and show the resulting economic delta.
+**Goal:** execute exactly one paid devnet orchestrator-to-specialist edge against the already deployed 30-agent network, then show the resulting economic delta. This is a safety ramp for live consumer-agent payment execution, not a statement that only one specialist is deployed.
 
-**Recommended first edge:** `agentic-workflow-system` → `code-generation-agent` for the webpage case.
+**Recommended first edge:** `agentic-workflow-system` → `code-generation-agent` for the webpage case, selected from the deployed 30-agent catalog.
 
 **Acceptance criteria:**
 

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -1,0 +1,111 @@
+# End-User Economic Workflow Demo — BDD Iteration Log
+
+_Date started:_ 2026-05-04 AEST  
+_Plan:_ `docs/END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md`  
+_Feature:_ `docs/bdd/features/bucket-j-end-user-economic-demo.feature`  
+_Issue:_ #187  
+_PR:_ #188
+
+## Loop rules
+
+Each phase follows:
+
+```text
+scope slice → BDD scenario/check → implementation → validation → retrospective → refine next phase
+```
+
+Do not expand from fixture/dry-run to live spend without a completed retrospective and explicit next-phase go decision.
+
+## Phase 0/1/2 — Plan, fixture UI, gated image adapter
+
+**Date:** 2026-05-04 AEST  
+**Scope shipped:** Static `/economic-demo` page, OpenAI/Fal image adapter route disabled by default, delivery plan and Bucket J BDD feature.  
+**BDD scenarios touched:** static fixture, image disabled gate, OpenAI/Fal adapter readiness.  
+**Validation:** `npm run test:bdd:index`; targeted lint; `npm run build`.  
+**Result:** PASS  
+**Evidence artifacts:** commits `7a442cba`, `e54e8d4c`, `9a568adf`.
+
+### What worked
+
+The demo now has a visible judge-facing proof surface and a disabled-by-default image adapter path without external spend.
+
+### What failed or surprised us
+
+The phrase “one live x402 specialist edge” was ambiguous and sounded like only one specialist was live. Nissan caught this; the plan was corrected to say first controlled live edge against the already deployed 30-agent network.
+
+### Drift check
+
+Improved payload flow, money-flow visualization, final-output framing, and wallet impact. No live economic proof yet.
+
+### Next phase adjustment
+
+Before live devnet edges, add Surfpool/local-validator rehearsal to prove real SOL transfer semantics safely.
+
+### Decision log additions
+
+- `/economic-demo` is the judge-facing proof surface.
+- Image generation is an explicit adapter edge, not an untracked API shortcut.
+- Surfpool rehearsal is mandatory before devnet live payment expansion.
+
+## Phase 5 planning addendum — Surfpool rehearsal gate
+
+**Date:** 2026-05-04 AEST  
+**Scope shipped:** Phase 5 inserted into plan and Bucket J scenario.  
+**Validation:** `npm run test:bdd:index`; `git diff --check`.  
+**Result:** PASS  
+**Evidence artifacts:** commit `6c1147ac`.
+
+### What worked
+
+The local-validator rehearsal makes the money-transfer proof safer and more convincing before a real devnet run.
+
+### What failed or surprised us
+
+The phase order needed adjustment: balance snapshots alone are insufficient before live devnet execution; we need local transfer semantics first.
+
+### Drift check
+
+Improves money-flow and wallet-impact proof directly.
+
+### Next phase adjustment
+
+Proceed to Phase 3 dry-run orchestrator integration, then Phase 4 balance snapshots, then Phase 5 Surfpool rehearsal.
+
+### Decision log additions
+
+- Surfpool/local validator is the required dress rehearsal environment for full transfer semantics.
+- Negative path must prove over-budget/non-allowlisted calls produce zero balance delta.
+
+## Phase 3 — Dry-run orchestrator integration
+
+**Status:** in progress.
+
+### Phase 3 implementation reflection — dry-run orchestrator integration slice A
+
+**Date:** 2026-05-04 AEST  
+**Scope shipped:** Added dry-run economic planner, API route, UI button/render path, and unit coverage.  
+**BDD scenarios touched:** Dry-run orchestration builds a real planned economic graph.  
+**Validation:** `npx jest lib/__tests__/economic-demo-dry-run.test.ts --runInBand`; targeted lint; `npm run build`.  
+**Result:** PASS for slice A.
+**Evidence artifacts:** `lib/economic-demo/dry-run.ts`, `app/api/economic-demo/dry-run/route.ts`, `lib/__tests__/economic-demo-dry-run.test.ts`, `/economic-demo` dry-run graph button.
+
+#### What worked
+
+The page can now ask the app for a dry-run economic graph. Plans are built from the deployed 30-profile specialist catalog metadata: orchestrator, downstream specialist IDs, wallets, endpoint URLs, prices, and required attestors. The route guarantees `downstreamCallsExecuted: 0`.
+
+#### What failed or surprised us
+
+The repo's exact endpoint enrichment map only covers the first five in committed code. For non-first-five profiles, this slice derives URLs from the deployed naming convention. That is acceptable for dry-run visualization, but Phase 3 slice B should promote the all-30 endpoint map/evidence into a committed public-data artifact or helper so dry-run plans use exact smoke-proven endpoints for every profile.
+
+#### Drift check
+
+This improves payload flow and planned money flow without introducing spend. It does not yet prove wallet balances or transfers.
+
+#### Next phase adjustment
+
+Before Phase 4 balance snapshots, add Phase 3 slice B: exact all-30 endpoint evidence map + UI plan/fixture reconciliation so the dry-run graph and static ledger cannot drift apart.
+
+#### Decision log additions
+
+- Phase 3 remains zero-spend: no x402 payment header generation and no downstream fetch.
+- Dry-run graph should become evidence-backed by all-30 hosted smoke data before live edges.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -68,7 +68,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Verify:
   - `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/fixture.ts lib/economic-demo/image-adapter.ts app/api/economic-demo/image/route.ts`
   - `npm run build`
-  - Future targeted route tests for dry-run graph, image disabled gate, balance snapshots, Surfpool local transfer rehearsal, and one-live-edge guardrails
+  - Future targeted route tests for dry-run graph, image disabled gate, balance snapshots, Surfpool local transfer rehearsal, and first-live-edge guardrails
 
 ## Drift guard
 - Validate index coverage against feature files:

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -1,6 +1,6 @@
 # BDD Feature Index
 
-_Last updated: 2026-04-22 AEST_
+_Last updated: 2026-05-04 AEST_
 
 Purpose: single lookup from BDD feature file -> bucket -> executable verification command(s).
 
@@ -61,6 +61,14 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
   - `npx jest lib/__tests__/manager-readiness-route.test.ts lib/__tests__/manager-evidence-pack.test.ts lib/__tests__/manager-evidence-route.test.ts --runInBand`
   - `npm run test:bdd:index`
   - E2E target: manager launchpad Playwright smoke once added to representative sweep
+
+
+### Bucket J — End-User Economic Demo
+- Feature: `docs/bdd/features/bucket-j-end-user-economic-demo.feature`
+- Verify:
+  - `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/fixture.ts lib/economic-demo/image-adapter.ts app/api/economic-demo/image/route.ts`
+  - `npm run build`
+  - Future targeted route tests for dry-run graph, image disabled gate, balance snapshots, and one-live-edge guardrails
 
 ## Drift guard
 - Validate index coverage against feature files:

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -68,7 +68,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Verify:
   - `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/fixture.ts lib/economic-demo/image-adapter.ts app/api/economic-demo/image/route.ts`
   - `npm run build`
-  - Future targeted route tests for dry-run graph, image disabled gate, balance snapshots, and one-live-edge guardrails
+  - Future targeted route tests for dry-run graph, image disabled gate, balance snapshots, Surfpool local transfer rehearsal, and one-live-edge guardrails
 
 ## Drift guard
 - Validate index coverage against feature files:

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -1,0 +1,58 @@
+Feature: End-user economic workflow demo
+
+  Background:
+    Given the Reddi Agent Protocol marketplace is running on Solana devnet
+    And live downstream specialist calls are disabled unless explicit spend gates are enabled
+    And demo artifacts must not expose private keys, signer material, provider API keys, or payment secrets
+
+  Scenario: Static fixture explains the economic workflow without spending
+    Given the user opens /economic-demo
+    When they select the webpage, research article, or picture scenario
+    Then the page shows the end-user request
+    And it shows the orchestrator, downstream specialists, and attestors
+    And it shows payload summaries flowing between participants
+    And it shows planned x402 amounts and receipt placeholders
+    And it shows starting balances, ending balances, and wallet deltas
+    And it performs zero wallet mutations
+
+  Scenario: Image generation stays disabled until explicitly enabled
+    Given ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION is not true
+    When a caller posts to /api/economic-demo/image
+    Then the response is 403
+    And the error is image_generation_disabled
+    And no OpenAI or Fal.ai generation request is made
+
+  Scenario: Picture workflow uses OpenAI first and Fal.ai fallback when enabled
+    Given ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION is true
+    And OpenAI image generation or Fal.ai is configured
+    When the picture scenario requests an image
+    Then the request goes through the economic demo image adapter
+    And the provider and model are recorded
+    And the generated image is available to the workflow
+    And vision validation and verification attestation can be attached afterward
+
+  Scenario: Dry-run orchestration builds a real planned economic graph
+    Given dry-run marketplace delegation is enabled
+    When the user submits an end-user scenario
+    Then the orchestrator returns selected specialist candidates
+    And every edge includes endpoint, wallet, price, capability, and required attestors
+    And downstreamCallsExecuted is 0
+    And the ledger is marked planned rather than paid
+
+  Scenario: One live specialist edge is bounded and reviewable
+    Given live demo mode is explicitly approved for one devnet edge
+    And the endpoint allowlist contains exactly one specialist endpoint
+    And max downstream calls is 1
+    And the lamport cap is set for the one edge
+    When the orchestrator executes the approved edge
+    Then it captures an x402 receipt or fail-closed reason
+    And it captures before and after balances for payer and payee
+    And it does not retry automatically
+
+  Scenario: Multi-edge demo returns output and economic impact
+    Given multi-edge demo mode is explicitly approved
+    When the webpage or research article workflow completes
+    Then the final output is shown to the user
+    And attestor guidance is shown
+    And each participating wallet has a start balance, end balance, and delta
+    And a bounded evidence artifact is produced

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -39,6 +39,16 @@ Feature: End-user economic workflow demo
     And downstreamCallsExecuted is 0
     And the ledger is marked planned rather than paid
 
+  Scenario: Surfpool dress rehearsal proves local SOL transfer semantics
+    Given a Surfpool local validator is running with deterministic funded test wallets
+    And end-user, orchestrator, specialist, and attestor wallets are available locally
+    When the economic demo workflow runs against the local validator
+    Then SOL transfers occur for approved specialist consumption edges
+    And the before and after balances match the expected edge ledger
+    And transaction signatures or local validator receipts are recorded
+    And a non-allowlisted or over-budget edge produces zero balance delta
+    And no devnet or mainnet wallet is mutated
+
   Scenario: One live specialist edge is bounded and reviewable
     Given live demo mode is explicitly approved for one devnet edge
     And the endpoint allowlist contains exactly one specialist endpoint

--- a/lib/__tests__/economic-demo-dry-run.test.ts
+++ b/lib/__tests__/economic-demo-dry-run.test.ts
@@ -1,0 +1,39 @@
+import { buildEconomicDemoDryRunPlan, endpointForProfile } from "@/lib/economic-demo/dry-run";
+
+describe("economic demo dry-run planning", () => {
+  it("builds a zero-spend webpage plan from deployed specialist profile metadata", () => {
+    const plan = buildEconomicDemoDryRunPlan("webpage");
+
+    expect(plan.mode).toBe("delegation_dry_run");
+    expect(plan.downstreamCallsExecuted).toBe(0);
+    expect(plan.orchestrator.id).toBe("agentic-workflow-system");
+    expect(plan.orchestrator.roles).toContain("consumer");
+    expect(plan.edges.map((edge) => edge.toProfileId)).toEqual([
+      "planning-agent",
+      "content-creation-agent",
+      "code-generation-agent",
+      "verification-validation-agent",
+    ]);
+    expect(plan.edges.every((edge) => edge.status === "planned")).toBe(true);
+    expect(plan.edges.every((edge) => edge.walletAddress.length > 20)).toBe(true);
+    expect(plan.edges.every((edge) => edge.endpoint.endsWith("/v1/chat/completions"))).toBe(true);
+    expect(plan.plannedTotalUsd).toBeGreaterThan(0);
+  });
+
+  it("keeps the picture path inside the tool-using adapter and validation chain", () => {
+    const plan = buildEconomicDemoDryRunPlan("picture");
+
+    expect(plan.orchestrator.id).toBe("tool-using-agent");
+    expect(plan.edges.map((edge) => edge.toProfileId)).toEqual([
+      "tool-using-agent",
+      "vision-language-agent",
+      "verification-validation-agent",
+    ]);
+    expect(plan.notes.join(" ")).toContain("Dry-run only");
+  });
+
+  it("uses exact known endpoints for first-five live deployed routes", () => {
+    expect(endpointForProfile("code-generation-agent")).toBe("https://reddi-code-generation.preview.reddi.tech/v1/chat/completions");
+    expect(endpointForProfile("agentic-workflow-system")).toBe("https://reddi-agentic-workflow-system.preview.reddi.tech/v1/chat/completions");
+  });
+});

--- a/lib/economic-demo/dry-run.ts
+++ b/lib/economic-demo/dry-run.ts
@@ -1,0 +1,120 @@
+import { specialistProfiles } from "../../packages/openrouter-specialists/src/profiles/index";
+import type { EconomicDemoScenarioId } from "@/lib/economic-demo/fixture";
+
+type Profile = (typeof specialistProfiles)[number];
+
+export type PlannedEconomicEdge = {
+  fromProfileId: string;
+  toProfileId: string;
+  capability: string;
+  endpoint: string;
+  walletAddress: string;
+  price: Profile["price"];
+  requiredAttestors: string[];
+  payloadSummary: string;
+  status: "planned";
+};
+
+export type DryRunEconomicPlan = {
+  scenarioId: EconomicDemoScenarioId;
+  mode: "delegation_dry_run";
+  downstreamCallsExecuted: 0;
+  orchestrator: Pick<Profile, "id" | "displayName" | "walletAddress" | "capabilities" | "roles" | "price"> & { endpoint: string };
+  edges: PlannedEconomicEdge[];
+  plannedTotalUsd: number;
+  notes: string[];
+};
+
+const ORCHESTRATORS: Record<EconomicDemoScenarioId, string> = {
+  webpage: "agentic-workflow-system",
+  research: "scientific-research-agent",
+  picture: "tool-using-agent",
+};
+
+const SCENARIO_EDGE_PROFILES: Record<EconomicDemoScenarioId, Array<{ id: string; capability: string; payloadSummary: string }>> = {
+  webpage: [
+    { id: "planning-agent", capability: "task-decomposition", payloadSummary: "Clarify page sections, user goal, and acceptance criteria." },
+    { id: "content-creation-agent", capability: "marketing-copy", payloadSummary: "Draft page copy, calls-to-action, and positioning." },
+    { id: "code-generation-agent", capability: "webpage-code", payloadSummary: "Produce implementation-ready webpage/component code." },
+    { id: "verification-validation-agent", capability: "attestation", payloadSummary: "Check final webpage output against user request and receipt chain." },
+  ],
+  research: [
+    { id: "knowledge-retrieval-agent", capability: "knowledge-retrieval", payloadSummary: "Gather source summaries, evidence candidates, and citation map." },
+    { id: "scientific-research-agent", capability: "research-synthesis", payloadSummary: "Synthesize evidence into claims, caveats, and structure." },
+    { id: "content-creation-agent", capability: "article-drafting", payloadSummary: "Convert synthesis into a reader-ready article draft." },
+    { id: "explainable-agent", capability: "explainability-review", payloadSummary: "Check traceability, readability, and reasoning clarity." },
+    { id: "verification-validation-agent", capability: "claim-verification", payloadSummary: "Verify claims against evidence and recommend release/refund/dispute." },
+  ],
+  picture: [
+    { id: "tool-using-agent", capability: "image-adapter-orchestration", payloadSummary: "Prepare gated OpenAI/Fal image adapter call with budget and safety constraints." },
+    { id: "vision-language-agent", capability: "image-validation", payloadSummary: "Validate generated visual output against the original prompt." },
+    { id: "verification-validation-agent", capability: "attestation", payloadSummary: "Verify prompt adherence, receipt chain, and release/refund/dispute guidance." },
+  ],
+};
+
+const EXACT_ENDPOINTS: Record<string, string> = {
+  "planning-agent": "https://reddi-planning-agent.preview.reddi.tech/v1/chat/completions",
+  "document-intelligence-agent": "https://reddi-document-intelligence.preview.reddi.tech/v1/chat/completions",
+  "verification-validation-agent": "https://reddi-verification-agent.preview.reddi.tech/v1/chat/completions",
+  "code-generation-agent": "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions",
+  "conversational-agent": "https://reddi-conversational.preview.reddi.tech/v1/chat/completions",
+};
+
+function profileById(id: string): Profile {
+  const profile = specialistProfiles.find((candidate) => candidate.id === id);
+  if (!profile) throw new Error(`unknown_profile:${id}`);
+  return profile;
+}
+
+export function endpointForProfile(profileId: string): string {
+  return EXACT_ENDPOINTS[profileId] ?? `https://reddi-${profileId.replace(/-agent$/, "")}.preview.reddi.tech/v1/chat/completions`;
+}
+
+function priceUsd(profile: Profile): number {
+  return Number.parseFloat(profile.price.amount) || 0;
+}
+
+export function buildEconomicDemoDryRunPlan(scenarioId: EconomicDemoScenarioId): DryRunEconomicPlan {
+  const orchestratorProfile = profileById(ORCHESTRATORS[scenarioId]);
+  const edgeInputs = SCENARIO_EDGE_PROFILES[scenarioId];
+  const edges = edgeInputs.map((edge): PlannedEconomicEdge => {
+    const target = profileById(edge.id);
+    return {
+      fromProfileId: orchestratorProfile.id,
+      toProfileId: target.id,
+      capability: edge.capability,
+      endpoint: endpointForProfile(target.id),
+      walletAddress: target.walletAddress,
+      price: target.price,
+      requiredAttestors: target.roles.includes("attestor") ? [] : target.preferredAttestors,
+      payloadSummary: edge.payloadSummary,
+      status: "planned",
+    };
+  });
+
+  return {
+    scenarioId,
+    mode: "delegation_dry_run",
+    downstreamCallsExecuted: 0,
+    orchestrator: {
+      id: orchestratorProfile.id,
+      displayName: orchestratorProfile.displayName,
+      walletAddress: orchestratorProfile.walletAddress,
+      capabilities: orchestratorProfile.capabilities,
+      roles: orchestratorProfile.roles,
+      price: orchestratorProfile.price,
+      endpoint: endpointForProfile(orchestratorProfile.id),
+    },
+    edges,
+    plannedTotalUsd: edges.reduce((sum, edge) => sum + priceUsd(profileById(edge.toProfileId)), 0),
+    notes: [
+      "Dry-run only: no x402 payment header generated.",
+      "Dry-run only: downstreamCallsExecuted remains 0.",
+      "Prices and wallets come from the deployed 30-profile OpenRouter specialist catalog.",
+    ],
+  };
+}
+
+export function isEconomicDemoScenarioId(value: unknown): value is EconomicDemoScenarioId {
+  return value === "webpage" || value === "research" || value === "picture";
+}

--- a/lib/economic-demo/fixture.ts
+++ b/lib/economic-demo/fixture.ts
@@ -150,7 +150,7 @@ export const economicDemoScenarios: EconomicDemoScenario[] = [
     ],
     edges: [
       { from: "end-user", to: "tool-using-agent", capability: "visual-workflow-planning", payloadSummary: "Prompt, style, safety constraints, and budget cap.", amountLamports: 1_000_000, status: "planned", receipt: "fixture:x402:challenge:picture-orchestrator" },
-      { from: "tool-using-agent", to: "image-generation-adapter", capability: "image-generation", payloadSummary: "Blocked pending approved adapter and exact endpoint allowlist.", amountLamports: 0, status: "blocked", receipt: "blocked:adapter-not-approved" },
+      { from: "tool-using-agent", to: "image-generation-adapter", capability: "image-generation", payloadSummary: "Adapter gated by env flag, provider key, and exact OpenAI/Fal provider route.", amountLamports: 0, status: "blocked", receipt: "blocked:image-generation-disabled" },
       { from: "tool-using-agent", to: "vision-language-agent", capability: "image-validation", payloadSummary: "Generated image or storyboard plus prompt criteria.", amountLamports: 500_000, status: "planned", receipt: "fixture:x402:challenge:vision-validation" },
     ],
     balances: [
@@ -160,7 +160,7 @@ export const economicDemoScenarios: EconomicDemoScenario[] = [
       { profileId: "vision-language-agent", role: "specialist", wallet: "VisionLanguage11111111111111111111111111", startingLamports: 2_000_000, endingLamports: 2_000_000 },
       { profileId: "verification-validation-agent", role: "attestor", wallet: "VerifyValidate11111111111111111111111111", startingLamports: 3_000_000, endingLamports: 3_000_000 },
     ],
-    guardrails: ["Actual image generation blocked until adapter approval", "No unapproved external generation services", "Vision validation follows adapter approval"],
+    guardrails: ["OpenAI/Fal image adapter route exists but is disabled until ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION=true", "Provider order: OpenAI first when configured, Fal.ai fallback when configured", "Vision validation follows generated image receipt capture"],
   },
 ];
 

--- a/lib/economic-demo/fixture.ts
+++ b/lib/economic-demo/fixture.ts
@@ -1,0 +1,174 @@
+export type EconomicDemoScenarioId = "webpage" | "research" | "picture";
+
+export type WalletBalance = {
+  profileId: string;
+  role: "end-user" | "orchestrator" | "specialist" | "attestor" | "adapter";
+  wallet: string;
+  startingLamports: number;
+  endingLamports: number;
+};
+
+export type EconomicEdge = {
+  from: string;
+  to: string;
+  capability: string;
+  payloadSummary: string;
+  amountLamports: number;
+  status: "planned" | "paid" | "attested" | "blocked";
+  receipt: string;
+};
+
+export type EconomicDemoScenario = {
+  id: EconomicDemoScenarioId;
+  title: string;
+  prompt: string;
+  orchestrator: string;
+  mode: "fixture-zero-spend" | "planned-dry-run" | "adapter-required";
+  finalOutputType: "webpage" | "article" | "image-brief";
+  finalOutputSummary: string;
+  agents: Array<{ profileId: string; role: WalletBalance["role"]; description: string }>;
+  edges: EconomicEdge[];
+  balances: WalletBalance[];
+  guardrails: string[];
+};
+
+const USER_WALLET = "UserDevnet111111111111111111111111111111111";
+
+export const economicDemoScenarios: EconomicDemoScenario[] = [
+  {
+    id: "webpage",
+    title: "Design me a webpage for X",
+    prompt: "Design me a webpage for a solar-powered bakery.",
+    orchestrator: "agentic-workflow-system",
+    mode: "fixture-zero-spend",
+    finalOutputType: "webpage",
+    finalOutputSummary:
+      "A responsive landing page plan with hero copy, menu sections, sustainability proof points, and implementation-ready component notes.",
+    agents: [
+      { profileId: "end-user", role: "end-user", description: "Submits the goal and funds the run budget." },
+      { profileId: "agentic-workflow-system", role: "orchestrator", description: "Breaks the request into paid specialist jobs." },
+      { profileId: "content-creation-agent", role: "specialist", description: "Writes page copy and calls-to-action." },
+      { profileId: "code-generation-agent", role: "specialist", description: "Turns the approved structure into webpage code." },
+      { profileId: "verification-validation-agent", role: "attestor", description: "Checks the output against acceptance criteria." },
+    ],
+    edges: [
+      {
+        from: "end-user",
+        to: "agentic-workflow-system",
+        capability: "workflow-orchestration",
+        payloadSummary: "Goal, audience, tone, run budget, and desired output type.",
+        amountLamports: 1_000_000,
+        status: "planned",
+        receipt: "fixture:x402:challenge:webpage-orchestrator",
+      },
+      {
+        from: "agentic-workflow-system",
+        to: "content-creation-agent",
+        capability: "marketing-copy",
+        payloadSummary: "Bakery positioning, section list, and CTA requirements.",
+        amountLamports: 1_000_000,
+        status: "planned",
+        receipt: "fixture:x402:challenge:webpage-copy",
+      },
+      {
+        from: "agentic-workflow-system",
+        to: "code-generation-agent",
+        capability: "webpage-code",
+        payloadSummary: "Approved copy plus responsive layout constraints.",
+        amountLamports: 1_000_000,
+        status: "planned",
+        receipt: "fixture:x402:challenge:webpage-code",
+      },
+      {
+        from: "agentic-workflow-system",
+        to: "verification-validation-agent",
+        capability: "attestation",
+        payloadSummary: "Final page draft, acceptance criteria, and receipt chain.",
+        amountLamports: 500_000,
+        status: "attested",
+        receipt: "fixture:attestation:release-recommended",
+      },
+    ],
+    balances: [
+      { profileId: "end-user", role: "end-user", wallet: USER_WALLET, startingLamports: 10_000_000, endingLamports: 6_500_000 },
+      { profileId: "agentic-workflow-system", role: "orchestrator", wallet: "AgenticWorkflow111111111111111111111111111", startingLamports: 4_000_000, endingLamports: 4_000_000 },
+      { profileId: "content-creation-agent", role: "specialist", wallet: "ContentCreation11111111111111111111111111", startingLamports: 2_000_000, endingLamports: 3_000_000 },
+      { profileId: "code-generation-agent", role: "specialist", wallet: "CodeGeneration111111111111111111111111111", startingLamports: 2_000_000, endingLamports: 3_000_000 },
+      { profileId: "verification-validation-agent", role: "attestor", wallet: "VerifyValidate11111111111111111111111111", startingLamports: 2_000_000, endingLamports: 2_500_000 },
+    ],
+    guardrails: ["Fixture mode only", "No wallet mutation", "Next live loop allows one exact downstream edge"],
+  },
+  {
+    id: "research",
+    title: "Write me a research article on Y",
+    prompt: "Write me a research article on decentralized agent marketplaces.",
+    orchestrator: "scientific-research-agent",
+    mode: "fixture-zero-spend",
+    finalOutputType: "article",
+    finalOutputSummary:
+      "A structured article outline with evidence-gathering, synthesis, drafting, explainability, and verification steps.",
+    agents: [
+      { profileId: "end-user", role: "end-user", description: "Requests a research-backed article." },
+      { profileId: "scientific-research-agent", role: "orchestrator", description: "Owns evidence synthesis and hires support specialists." },
+      { profileId: "knowledge-retrieval-agent", role: "specialist", description: "Collects source summaries and citation candidates." },
+      { profileId: "content-creation-agent", role: "specialist", description: "Turns synthesis into an article draft." },
+      { profileId: "explainable-agent", role: "attestor", description: "Checks traceability and readability." },
+      { profileId: "verification-validation-agent", role: "attestor", description: "Checks claims against evidence." },
+    ],
+    edges: [
+      { from: "end-user", to: "scientific-research-agent", capability: "research-orchestration", payloadSummary: "Topic, desired audience, and evidence standard.", amountLamports: 1_000_000, status: "planned", receipt: "fixture:x402:challenge:research-orchestrator" },
+      { from: "scientific-research-agent", to: "knowledge-retrieval-agent", capability: "knowledge-retrieval", payloadSummary: "Search questions, source criteria, and citation requirements.", amountLamports: 1_000_000, status: "planned", receipt: "fixture:x402:challenge:research-retrieval" },
+      { from: "scientific-research-agent", to: "content-creation-agent", capability: "article-drafting", payloadSummary: "Evidence synthesis, angle, outline, and caveats.", amountLamports: 1_000_000, status: "planned", receipt: "fixture:x402:challenge:research-draft" },
+      { from: "scientific-research-agent", to: "explainable-agent", capability: "explainability-review", payloadSummary: "Draft plus traceability checklist.", amountLamports: 500_000, status: "attested", receipt: "fixture:attestation:traceable" },
+      { from: "scientific-research-agent", to: "verification-validation-agent", capability: "claim-verification", payloadSummary: "Final article and cited evidence map.", amountLamports: 500_000, status: "attested", receipt: "fixture:attestation:release-recommended" },
+    ],
+    balances: [
+      { profileId: "end-user", role: "end-user", wallet: USER_WALLET, startingLamports: 12_000_000, endingLamports: 8_000_000 },
+      { profileId: "scientific-research-agent", role: "orchestrator", wallet: "ScientificResearch111111111111111111111111", startingLamports: 3_000_000, endingLamports: 3_000_000 },
+      { profileId: "knowledge-retrieval-agent", role: "specialist", wallet: "KnowledgeRetrieval11111111111111111111111", startingLamports: 2_000_000, endingLamports: 3_000_000 },
+      { profileId: "content-creation-agent", role: "specialist", wallet: "ContentCreation11111111111111111111111111", startingLamports: 3_000_000, endingLamports: 4_000_000 },
+      { profileId: "explainable-agent", role: "attestor", wallet: "Explainable1111111111111111111111111111", startingLamports: 2_000_000, endingLamports: 2_500_000 },
+      { profileId: "verification-validation-agent", role: "attestor", wallet: "VerifyValidate11111111111111111111111111", startingLamports: 2_500_000, endingLamports: 3_000_000 },
+    ],
+    guardrails: ["Fixture mode only", "Citations are represented as payload summaries", "No live retrieval or inference in this slice"],
+  },
+  {
+    id: "picture",
+    title: "Give me a picture that shows Z",
+    prompt: "Give me a picture that shows autonomous agents cooking Malatang.",
+    orchestrator: "tool-using-agent",
+    mode: "adapter-required",
+    finalOutputType: "image-brief",
+    finalOutputSummary:
+      "A visual brief/storyboard until an image-generation adapter is explicitly approved and allowlisted.",
+    agents: [
+      { profileId: "end-user", role: "end-user", description: "Requests a visual output." },
+      { profileId: "tool-using-agent", role: "orchestrator", description: "Would call an allowlisted image adapter after approval." },
+      { profileId: "image-generation-adapter", role: "adapter", description: "Not yet part of the 30-agent catalog; requires explicit approval." },
+      { profileId: "vision-language-agent", role: "specialist", description: "Validates visual output against the prompt after generation." },
+      { profileId: "verification-validation-agent", role: "attestor", description: "Issues release/refund/dispute guidance." },
+    ],
+    edges: [
+      { from: "end-user", to: "tool-using-agent", capability: "visual-workflow-planning", payloadSummary: "Prompt, style, safety constraints, and budget cap.", amountLamports: 1_000_000, status: "planned", receipt: "fixture:x402:challenge:picture-orchestrator" },
+      { from: "tool-using-agent", to: "image-generation-adapter", capability: "image-generation", payloadSummary: "Blocked pending approved adapter and exact endpoint allowlist.", amountLamports: 0, status: "blocked", receipt: "blocked:adapter-not-approved" },
+      { from: "tool-using-agent", to: "vision-language-agent", capability: "image-validation", payloadSummary: "Generated image or storyboard plus prompt criteria.", amountLamports: 500_000, status: "planned", receipt: "fixture:x402:challenge:vision-validation" },
+    ],
+    balances: [
+      { profileId: "end-user", role: "end-user", wallet: USER_WALLET, startingLamports: 10_000_000, endingLamports: 9_000_000 },
+      { profileId: "tool-using-agent", role: "orchestrator", wallet: "ToolUsing111111111111111111111111111111", startingLamports: 3_000_000, endingLamports: 3_000_000 },
+      { profileId: "image-generation-adapter", role: "adapter", wallet: "PendingAdapter11111111111111111111111111", startingLamports: 0, endingLamports: 0 },
+      { profileId: "vision-language-agent", role: "specialist", wallet: "VisionLanguage11111111111111111111111111", startingLamports: 2_000_000, endingLamports: 2_000_000 },
+      { profileId: "verification-validation-agent", role: "attestor", wallet: "VerifyValidate11111111111111111111111111", startingLamports: 3_000_000, endingLamports: 3_000_000 },
+    ],
+    guardrails: ["Actual image generation blocked until adapter approval", "No unapproved external generation services", "Vision validation follows adapter approval"],
+  },
+];
+
+export function lamportsDelta(balance: WalletBalance) {
+  return balance.endingLamports - balance.startingLamports;
+}
+
+export function formatLamports(lamports: number) {
+  const sign = lamports > 0 ? "+" : "";
+  return `${sign}${(lamports / 1_000_000_000).toFixed(6)} SOL`;
+}

--- a/lib/economic-demo/image-adapter.ts
+++ b/lib/economic-demo/image-adapter.ts
@@ -1,0 +1,129 @@
+export type ImageProvider = "openai" | "fal";
+
+export type ImageGenerationRequest = {
+  prompt: string;
+  provider?: ImageProvider;
+};
+
+export type ImageGenerationResult = {
+  provider: ImageProvider;
+  model: string;
+  imageUrl: string;
+  receipt: string;
+};
+
+const DEFAULT_OPENAI_IMAGE_MODEL = process.env.OPENAI_IMAGE_MODEL ?? "gpt-image-1";
+const DEFAULT_FAL_IMAGE_MODEL = process.env.FAL_IMAGE_MODEL ?? "fal-ai/flux/schnell";
+
+function requireEnabled() {
+  if (process.env.ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION !== "true") {
+    throw new Error("image_generation_disabled");
+  }
+}
+
+function pickProvider(requested?: ImageProvider): ImageProvider {
+  if (requested) return requested;
+  if (process.env.OPENAI_API_KEY) return "openai";
+  if (process.env.FAL_KEY || process.env.FAL_API_KEY) return "fal";
+  return "openai";
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+async function generateWithOpenAI(prompt: string): Promise<ImageGenerationResult> {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) throw new Error("openai_key_missing");
+
+  const res = await fetch("https://api.openai.com/v1/images/generations", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: DEFAULT_OPENAI_IMAGE_MODEL,
+      prompt,
+      size: process.env.OPENAI_IMAGE_SIZE ?? "1024x1024",
+      response_format: "b64_json",
+    }),
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  const data = (await res.json().catch(() => ({}))) as {
+    data?: Array<{ b64_json?: string; url?: string }>;
+    error?: { message?: string };
+  };
+  if (!res.ok) throw new Error(data.error?.message ?? `openai_image_error_${res.status}`);
+
+  const first = data.data?.[0];
+  const imageUrl = first?.b64_json ? `data:image/png;base64,${first.b64_json}` : asString(first?.url);
+  if (!imageUrl) throw new Error("openai_image_missing");
+
+  return {
+    provider: "openai",
+    model: DEFAULT_OPENAI_IMAGE_MODEL,
+    imageUrl,
+    receipt: `openai:image:${Date.now()}`,
+  };
+}
+
+async function generateWithFal(prompt: string): Promise<ImageGenerationResult> {
+  const key = process.env.FAL_KEY ?? process.env.FAL_API_KEY;
+  if (!key) throw new Error("fal_key_missing");
+
+  const res = await fetch(`https://fal.run/${DEFAULT_FAL_IMAGE_MODEL}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Key ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      prompt,
+      image_size: process.env.FAL_IMAGE_SIZE ?? "square_hd",
+      num_images: 1,
+    }),
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  const data = (await res.json().catch(() => ({}))) as {
+    images?: Array<{ url?: string }>;
+    image?: { url?: string };
+    error?: string | { message?: string };
+  };
+  if (!res.ok) {
+    const detail = typeof data.error === "string" ? data.error : data.error?.message;
+    throw new Error(detail ?? `fal_image_error_${res.status}`);
+  }
+
+  const imageUrl = asString(data.images?.[0]?.url) ?? asString(data.image?.url);
+  if (!imageUrl) throw new Error("fal_image_missing");
+
+  return {
+    provider: "fal",
+    model: DEFAULT_FAL_IMAGE_MODEL,
+    imageUrl,
+    receipt: `fal:image:${Date.now()}`,
+  };
+}
+
+export async function generateEconomicDemoImage(request: ImageGenerationRequest): Promise<ImageGenerationResult> {
+  requireEnabled();
+  const prompt = request.prompt.trim();
+  if (!prompt) throw new Error("prompt_required");
+
+  const provider = pickProvider(request.provider);
+  if (provider === "openai") return generateWithOpenAI(prompt);
+  return generateWithFal(prompt);
+}
+
+export function imageAdapterReadiness() {
+  return {
+    enabled: process.env.ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION === "true",
+    openaiConfigured: Boolean(process.env.OPENAI_API_KEY),
+    falConfigured: Boolean(process.env.FAL_KEY || process.env.FAL_API_KEY),
+    defaultOpenAIModel: DEFAULT_OPENAI_IMAGE_MODEL,
+    defaultFalModel: DEFAULT_FAL_IMAGE_MODEL,
+  };
+}


### PR DESCRIPTION
## Summary\n- Adds a static /economic-demo page for issue #187\n- Provides three end-user scenarios: webpage, research article, and picture/visual brief\n- Visualizes orchestrator/specialist/attestor payload edges, x402 amounts/receipts, final output summary, and start/end wallet deltas\n\n## Guardrails\n- Fixture-only slice: no live calls, no wallet mutation, no private key or signer material\n- Picture case is blocked/brief-only until an image-generation adapter is explicitly approved and allowlisted\n\n## Validation\n- npm run lint -- app/economic-demo/page.tsx lib/economic-demo/fixture.ts\n- npm run build\n\nCloses #187