### PR TITLE
Use all-30 hosted endpoint evidence for economic demo dry-run

### DIFF
--- a/app/api/economic-demo/balances/route.ts
+++ b/app/api/economic-demo/balances/route.ts
@@ -1,0 +1,14 @@
+import { buildBalanceSnapshotReport, createDevnetConnection } from "@/lib/economic-demo/balances";
+import { buildEconomicDemoDryRunPlan, isEconomicDemoScenarioId } from "@/lib/economic-demo/dry-run";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const scenario = url.searchParams.get("scenario") ?? "webpage";
+  if (!isEconomicDemoScenarioId(scenario)) {
+    return Response.json({ ok: false, error: "unknown_scenario" }, { status: 400 });
+  }
+
+  const plan = buildEconomicDemoDryRunPlan(scenario);
+  const report = await buildBalanceSnapshotReport(plan, createDevnetConnection());
+  return Response.json({ ok: true, report });
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -8,6 +8,7 @@ import {
   lamportsDelta,
   type EconomicDemoScenario,
 } from "@/lib/economic-demo/fixture";
+import type { EconomicDemoBalanceReport } from "@/lib/economic-demo/balances";
 import type { DryRunEconomicPlan } from "@/lib/economic-demo/dry-run";
 
 function shortWallet(wallet: string) {
@@ -25,12 +26,15 @@ export default function EconomicDemoPage() {
   const [scenarioId, setScenarioId] = useState(economicDemoScenarios[0].id);
   const [dryRunPlan, setDryRunPlan] = useState<DryRunEconomicPlan | null>(null);
   const [dryRunStatus, setDryRunStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [balanceReport, setBalanceReport] = useState<EconomicDemoBalanceReport | null>(null);
+  const [balanceStatus, setBalanceStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const scenario = useMemo(
     () => economicDemoScenarios.find((candidate) => candidate.id === scenarioId) ?? economicDemoScenarios[0],
     [scenarioId],
   );
   const totalPlanned = scenario.edges.reduce((sum, edge) => sum + edge.amountLamports, 0);
   const activeDryRunPlan = dryRunPlan?.scenarioId === scenario.id ? dryRunPlan : null;
+  const activeBalanceReport = balanceReport?.scenarioId === scenario.id ? balanceReport : null;
 
   async function loadDryRunPlan() {
     setDryRunStatus("loading");
@@ -39,9 +43,24 @@ export default function EconomicDemoPage() {
       const payload = (await res.json()) as { ok?: boolean; plan?: DryRunEconomicPlan };
       if (!res.ok || !payload.ok || !payload.plan) throw new Error("dry_run_plan_failed");
       setDryRunPlan(payload.plan);
+      setBalanceReport(null);
+      setBalanceStatus("idle");
       setDryRunStatus("loaded");
     } catch {
       setDryRunStatus("error");
+    }
+  }
+
+  async function loadBalanceSnapshot() {
+    setBalanceStatus("loading");
+    try {
+      const res = await fetch(`/api/economic-demo/balances?scenario=${scenario.id}`);
+      const payload = (await res.json()) as { ok?: boolean; report?: EconomicDemoBalanceReport };
+      if (!res.ok || !payload.ok || !payload.report) throw new Error("balance_snapshot_failed");
+      setBalanceReport(payload.report);
+      setBalanceStatus("loaded");
+    } catch {
+      setBalanceStatus("error");
     }
   }
 
@@ -94,6 +113,13 @@ export default function EconomicDemoPage() {
                 >
                   {dryRunStatus === "loading" ? "Building dry-run plan…" : "Build dry-run economic graph"}
                 </button>
+                <button
+                  onClick={loadBalanceSnapshot}
+                  disabled={balanceStatus === "loading"}
+                  className="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-gray-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {balanceStatus === "loading" ? "Reading balances…" : "Read devnet balances"}
+                </button>
                 <span className="text-xs text-gray-500">
                   Uses deployed 30-agent profile metadata · zero downstream calls
                 </span>
@@ -101,6 +127,11 @@ export default function EconomicDemoPage() {
               {dryRunStatus === "error" && (
                 <p className="mt-3 rounded-lg border border-red-400/30 bg-red-400/10 p-3 text-sm text-red-200">
                   Dry-run plan failed. Fixture view is still available.
+                </p>
+              )}
+              {balanceStatus === "error" && (
+                <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+                  Balance snapshot failed. No transfer was attempted.
                 </p>
               )}
               <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
@@ -235,6 +266,35 @@ export default function EconomicDemoPage() {
                 ))}
               </div>
             </div>
+
+
+              {activeBalanceReport && (
+                <div className="mt-6 rounded-xl border border-white/10 bg-black/20 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-gray-500">Read-only balance snapshot</p>
+                      <p className="mt-1 text-sm text-gray-300">No transfers attempted · downstream calls executed: {activeBalanceReport.downstreamCallsExecuted}</p>
+                    </div>
+                    <span className="rounded-full border border-white/15 bg-white/5 px-2 py-0.5 text-xs text-gray-300">{activeBalanceReport.mode}</span>
+                  </div>
+                  <div className="mt-4 space-y-2">
+                    {activeBalanceReport.snapshots.map((snapshot) => (
+                      <div key={`${snapshot.profileId}-${snapshot.walletAddress}`} className="grid gap-2 rounded-lg border border-white/10 bg-white/5 p-3 text-sm sm:grid-cols-[1fr_auto]">
+                        <div>
+                          <p className="font-mono text-white">{snapshot.profileId}</p>
+                          <p className="mt-1 font-mono text-xs text-gray-500">{shortWallet(snapshot.walletAddress)}</p>
+                        </div>
+                        <div className="text-left sm:text-right">
+                          <p className={snapshot.status === "available" ? "font-mono text-[#14F195]" : "font-mono text-yellow-200"}>
+                            {snapshot.status === "available" && snapshot.lamports !== null ? formatLamports(snapshot.lamports).replace(/^\+/, "") : "balance unavailable"}
+                          </p>
+                          <p className="mt-1 text-xs text-gray-500">{snapshot.status}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
 
             <div className="rounded-2xl border border-white/10 bg-card/70 p-6 shadow-card">
               <p className="section-label">Wallet balance ledger</p>

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -109,3 +109,33 @@ Before Phase 4 balance snapshots, add Phase 3 slice B: exact all-30 endpoint evi
 
 - Phase 3 remains zero-spend: no x402 payment header generation and no downstream fetch.
 - Dry-run graph should become evidence-backed by all-30 hosted smoke data before live edges.
+
+### Phase 3 implementation reflection — dry-run endpoint evidence slice B
+
+**Date:** 2026-05-04 AEST  
+**Scope shipped:** Promoted all-30 hosted smoke endpoint evidence into committed public-data helper and removed naming-convention fallback from dry-run planning.  
+**BDD scenarios touched:** Dry-run orchestration builds a real planned economic graph.  
+**Validation:** `npx jest lib/__tests__/economic-demo-dry-run.test.ts --runInBand`; targeted lint; `npm run build`.  
+**Result:** PASS.
+**Evidence artifacts:** `lib/economic-demo/openrouter-endpoints.ts` generated from local public smoke artifact `artifacts/openrouter-specialists-all30-hosted-smoke-20260504.json`.
+
+#### What worked
+
+Dry-run planning now requires smoke-proven endpoint evidence for every selected specialist. Tests assert the evidence covers exactly all 30 specialist profiles and that each endpoint is a chat-completions endpoint.
+
+#### What failed or surprised us
+
+One assumption was corrected by evidence: `agentic-workflow-system` is deployed at `reddi-agentic-workflow-system.preview.reddi.tech`, not the shorter derived hostname. This validates the need for committed endpoint evidence before later phases.
+
+#### Drift check
+
+This improves payload flow accuracy and keeps the planned graph aligned with deployed infrastructure. Still zero spend.
+
+#### Next phase adjustment
+
+Phase 4 can now fetch balances against wallet addresses from the smoke-proven profile/evidence map. The next step should add balance snapshot types/route/tests with mocked RPC first, then one optional live devnet read-only smoke.
+
+#### Decision log additions
+
+- Dry-run endpoint resolution must fail closed if a profile lacks committed hosted endpoint evidence.
+- Do not use naming-convention-derived endpoints for live or rehearsal planning.

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -139,3 +139,33 @@ Phase 4 can now fetch balances against wallet addresses from the smoke-proven pr
 
 - Dry-run endpoint resolution must fail closed if a profile lacks committed hosted endpoint evidence.
 - Do not use naming-convention-derived endpoints for live or rehearsal planning.
+
+## Phase 4 implementation reflection — read-only balance snapshot slice A
+
+**Date:** 2026-05-04 AEST  
+**Scope shipped:** Added read-only balance snapshot builder, API route, and mocked-RPC unit tests.  
+**BDD scenarios touched:** Real devnet balance snapshots, no spend.  
+**Validation:** `npx jest lib/__tests__/economic-demo-balances.test.ts lib/__tests__/economic-demo-dry-run.test.ts --runInBand`; targeted lint; `npm run build`.  
+**Result:** PASS for mocked-RPC slice A.
+**Evidence artifacts:** `lib/economic-demo/balances.ts`, `app/api/economic-demo/balances/route.ts`, `lib/__tests__/economic-demo-balances.test.ts`.
+
+### What worked
+
+The balance report is read-only, deduplicates orchestrator/specialist wallets, preserves `downstreamCallsExecuted: 0`, and fails soft per wallet with `balance_unavailable` instead of breaking the whole report.
+
+### What failed or surprised us
+
+The picture workflow currently includes `tool-using-agent` as both orchestrator and planned adapter orchestrator edge, so wallet deduplication matters. The report correctly snapshots the wallet once.
+
+### Drift check
+
+This improves wallet-impact proof while remaining no-spend. It does not yet compare before/after deltas because no local transfers occur until the Surfpool phase.
+
+### Next phase adjustment
+
+Add UI rendering for the read-only balance snapshot and optionally run one live devnet read-only smoke. Then proceed to Surfpool rehearsal design with deterministic local wallets.
+
+### Decision log additions
+
+- Balance snapshot failures are per-wallet soft failures, not whole-demo failures.
+- Balance snapshot mode must always report zero downstream calls and no transfer attempts.

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -169,3 +169,33 @@ Add UI rendering for the read-only balance snapshot and optionally run one live 
 
 - Balance snapshot failures are per-wallet soft failures, not whole-demo failures.
 - Balance snapshot mode must always report zero downstream calls and no transfer attempts.
+
+### Phase 4 implementation reflection — balance snapshot UI slice B
+
+**Date:** 2026-05-04 AEST  
+**Scope shipped:** Added `/economic-demo` UI control and render panel for read-only balance snapshots.  
+**BDD scenarios touched:** Real devnet balance snapshots, no spend.  
+**Validation:** focused Jest for balances + dry-run; targeted lint; `npm run build`.  
+**Result:** PASS.
+**Evidence artifacts:** `/economic-demo` now has `Read devnet balances` action and a read-only snapshot panel.
+
+#### What worked
+
+The UI now distinguishes fixture ledger economics from live read-only balance reads. Snapshot rendering explicitly says no transfers were attempted and shows `downstreamCallsExecuted: 0`.
+
+#### What failed or surprised us
+
+The balance UI can expose RPC availability issues. That is useful, but we should avoid treating RPC read failures as economic failures; the route already marks them per-wallet.
+
+#### Drift check
+
+Improves wallet-impact visibility without spend. Still not transfer proof; Surfpool remains the transfer-semantics gate.
+
+#### Next phase adjustment
+
+Run/record an optional live read-only devnet balance smoke or proceed directly into Surfpool rehearsal implementation if CI is green and the preview page is enough for review.
+
+#### Decision log additions
+
+- Fixture ledger and read-only live balance panel are separate proof layers.
+- Read-only devnet balance reads are allowed; they are not payment execution.

--- a/lib/__tests__/economic-demo-balances.test.ts
+++ b/lib/__tests__/economic-demo-balances.test.ts
@@ -1,0 +1,39 @@
+import { PublicKey } from "@solana/web3.js";
+import { buildBalanceSnapshotReport } from "@/lib/economic-demo/balances";
+import { buildEconomicDemoDryRunPlan } from "@/lib/economic-demo/dry-run";
+
+describe("economic demo balance snapshots", () => {
+  it("reads balances for orchestrator and planned downstream participants without executing calls", async () => {
+    const plan = buildEconomicDemoDryRunPlan("webpage");
+    const getBalance = jest.fn(async (wallet: PublicKey) => wallet.toBase58().length);
+
+    const report = await buildBalanceSnapshotReport(plan, { getBalance });
+
+    expect(report.mode).toBe("read_only_balance_snapshot");
+    expect(report.scenarioId).toBe("webpage");
+    expect(report.downstreamCallsExecuted).toBe(0);
+    expect(report.snapshots.map((snapshot) => snapshot.profileId)).toEqual([
+      "agentic-workflow-system",
+      "planning-agent",
+      "content-creation-agent",
+      "code-generation-agent",
+      "verification-validation-agent",
+    ]);
+    expect(report.snapshots.every((snapshot) => snapshot.status === "available" && snapshot.lamports !== null)).toBe(true);
+    expect(getBalance).toHaveBeenCalledTimes(5);
+  });
+
+  it("marks unavailable balances without failing the whole report", async () => {
+    const plan = buildEconomicDemoDryRunPlan("picture");
+    const getBalance = jest.fn(async (wallet: PublicKey) => {
+      if (wallet.toBase58() === plan.orchestrator.walletAddress) throw new Error("rpc unavailable");
+      return 123;
+    });
+
+    const report = await buildBalanceSnapshotReport(plan, { getBalance });
+
+    expect(report.downstreamCallsExecuted).toBe(0);
+    expect(report.snapshots.find((snapshot) => snapshot.profileId === "tool-using-agent")?.status).toBe("balance_unavailable");
+    expect(report.snapshots.some((snapshot) => snapshot.status === "available")).toBe(true);
+  });
+});

--- a/lib/__tests__/economic-demo-dry-run.test.ts
+++ b/lib/__tests__/economic-demo-dry-run.test.ts
@@ -1,4 +1,6 @@
+import { specialistProfiles } from "../../packages/openrouter-specialists/src/profiles/index";
 import { buildEconomicDemoDryRunPlan, endpointForProfile } from "@/lib/economic-demo/dry-run";
+import { openRouterAll30EndpointEvidence } from "@/lib/economic-demo/openrouter-endpoints";
 
 describe("economic demo dry-run planning", () => {
   it("builds a zero-spend webpage plan from deployed specialist profile metadata", () => {
@@ -32,8 +34,13 @@ describe("economic demo dry-run planning", () => {
     expect(plan.notes.join(" ")).toContain("Dry-run only");
   });
 
-  it("uses exact known endpoints for first-five live deployed routes", () => {
+  it("uses smoke-proven endpoint evidence for all 30 deployed specialist routes", () => {
+    expect(openRouterAll30EndpointEvidence).toHaveLength(30);
+    expect(openRouterAll30EndpointEvidence.map((entry) => entry.profileId).sort()).toEqual(
+      specialistProfiles.map((profile) => profile.id).sort(),
+    );
     expect(endpointForProfile("code-generation-agent")).toBe("https://reddi-code-generation.preview.reddi.tech/v1/chat/completions");
     expect(endpointForProfile("agentic-workflow-system")).toBe("https://reddi-agentic-workflow-system.preview.reddi.tech/v1/chat/completions");
+    expect(openRouterAll30EndpointEvidence.every((entry) => entry.smokePassed && entry.endpoint.endsWith("/v1/chat/completions"))).toBe(true);
   });
 });

--- a/lib/economic-demo/balances.ts
+++ b/lib/economic-demo/balances.ts
@@ -1,0 +1,63 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+import type { DryRunEconomicPlan } from "@/lib/economic-demo/dry-run";
+
+export type BalanceSnapshot = {
+  profileId: string;
+  walletAddress: string;
+  lamports: number | null;
+  status: "available" | "balance_unavailable";
+  error?: string;
+};
+
+export type EconomicDemoBalanceReport = {
+  mode: "read_only_balance_snapshot";
+  scenarioId: DryRunEconomicPlan["scenarioId"];
+  downstreamCallsExecuted: 0;
+  snapshots: BalanceSnapshot[];
+};
+
+type BalanceConnection = Pick<Connection, "getBalance">;
+
+function uniqueParticipants(plan: DryRunEconomicPlan) {
+  const byWallet = new Map<string, { profileId: string; walletAddress: string }>();
+  byWallet.set(plan.orchestrator.walletAddress, {
+    profileId: plan.orchestrator.id,
+    walletAddress: plan.orchestrator.walletAddress,
+  });
+  for (const edge of plan.edges) {
+    byWallet.set(edge.walletAddress, { profileId: edge.toProfileId, walletAddress: edge.walletAddress });
+  }
+  return [...byWallet.values()];
+}
+
+export async function buildBalanceSnapshotReport(
+  plan: DryRunEconomicPlan,
+  connection: BalanceConnection,
+): Promise<EconomicDemoBalanceReport> {
+  const snapshots = await Promise.all(
+    uniqueParticipants(plan).map(async (participant): Promise<BalanceSnapshot> => {
+      try {
+        const lamports = await connection.getBalance(new PublicKey(participant.walletAddress));
+        return { ...participant, lamports, status: "available" };
+      } catch (error) {
+        return {
+          ...participant,
+          lamports: null,
+          status: "balance_unavailable",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+
+  return {
+    mode: "read_only_balance_snapshot",
+    scenarioId: plan.scenarioId,
+    downstreamCallsExecuted: 0,
+    snapshots,
+  };
+}
+
+export function createDevnetConnection(rpcUrl = process.env.SOLANA_RPC_URL ?? "https://api.devnet.solana.com") {
+  return new Connection(rpcUrl, "confirmed");
+}

--- a/lib/economic-demo/dry-run.ts
+++ b/lib/economic-demo/dry-run.ts
@@ -1,5 +1,6 @@
 import { specialistProfiles } from "../../packages/openrouter-specialists/src/profiles/index";
 import type { EconomicDemoScenarioId } from "@/lib/economic-demo/fixture";
+import { openRouterEndpointByProfileId } from "@/lib/economic-demo/openrouter-endpoints";
 
 type Profile = (typeof specialistProfiles)[number];
 
@@ -52,14 +53,6 @@ const SCENARIO_EDGE_PROFILES: Record<EconomicDemoScenarioId, Array<{ id: string;
   ],
 };
 
-const EXACT_ENDPOINTS: Record<string, string> = {
-  "planning-agent": "https://reddi-planning-agent.preview.reddi.tech/v1/chat/completions",
-  "document-intelligence-agent": "https://reddi-document-intelligence.preview.reddi.tech/v1/chat/completions",
-  "verification-validation-agent": "https://reddi-verification-agent.preview.reddi.tech/v1/chat/completions",
-  "code-generation-agent": "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions",
-  "conversational-agent": "https://reddi-conversational.preview.reddi.tech/v1/chat/completions",
-};
-
 function profileById(id: string): Profile {
   const profile = specialistProfiles.find((candidate) => candidate.id === id);
   if (!profile) throw new Error(`unknown_profile:${id}`);
@@ -67,7 +60,9 @@ function profileById(id: string): Profile {
 }
 
 export function endpointForProfile(profileId: string): string {
-  return EXACT_ENDPOINTS[profileId] ?? `https://reddi-${profileId.replace(/-agent$/, "")}.preview.reddi.tech/v1/chat/completions`;
+  const endpoint = openRouterEndpointByProfileId[profileId];
+  if (!endpoint) throw new Error(`missing_hosted_endpoint_evidence:${profileId}`);
+  return endpoint;
 }
 
 function priceUsd(profile: Profile): number {

--- a/lib/economic-demo/openrouter-endpoints.ts
+++ b/lib/economic-demo/openrouter-endpoints.ts
@@ -1,0 +1,52 @@
+// Generated from public smoke evidence: artifacts/openrouter-specialists-all30-hosted-smoke-20260504.json
+// Contains endpoint URLs and public wallet addresses only. No secrets or signer material.
+
+export type OpenRouterHostedEndpointEvidence = {
+  profileId: string;
+  endpoint: string;
+  walletAddress: string;
+  smokePassed: true;
+};
+
+export const OPENROUTER_ALL30_SMOKE_GENERATED_AT = "2026-05-04T04:30:42Z";
+
+export const openRouterAll30EndpointEvidence = [
+  { profileId: "agentic-workflow-system", endpoint: "https://reddi-agentic-workflow-system.preview.reddi.tech/v1/chat/completions", walletAddress: "9qbchEAHxg2iTMJTQNV5KrLUxXgqFT7HJMUGKMGUt17G", smokePassed: true },
+  { profileId: "audio-processing-agent", endpoint: "https://reddi-audio-processing.preview.reddi.tech/v1/chat/completions", walletAddress: "Fo6iQZNuHPgXMHQntnZouyqGdjoQDvNktwPeNMc7bZMp", smokePassed: true },
+  { profileId: "autonomous-decision-agent", endpoint: "https://reddi-autonomous-decision.preview.reddi.tech/v1/chat/completions", walletAddress: "61SdRxMi23cHfQpMDs9fvyjKaiFKoYfgXBZzAqxx6Vb5", smokePassed: true },
+  { profileId: "code-generation-agent", endpoint: "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions", walletAddress: "8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To", smokePassed: true },
+  { profileId: "collective-intelligence-agent", endpoint: "https://reddi-collective-intelligence.preview.reddi.tech/v1/chat/completions", walletAddress: "5R7snV8st2mi3wnRx8eVMvxLHW91VtZznzNe1xh9Q69y", smokePassed: true },
+  { profileId: "content-creation-agent", endpoint: "https://reddi-content-creation.preview.reddi.tech/v1/chat/completions", walletAddress: "4RfVeJp8si1KunYbvf41i5cDjr2SEjNEHEknUMXSEvEE", smokePassed: true },
+  { profileId: "conversational-agent", endpoint: "https://reddi-conversational.preview.reddi.tech/v1/chat/completions", walletAddress: "H8U9JjaeFiyHZrPEyFF2Ku7wmk62S24GAaJMVrwNrZUn", smokePassed: true },
+  { profileId: "data-analysis-agent", endpoint: "https://reddi-data-analysis.preview.reddi.tech/v1/chat/completions", walletAddress: "CischZ2HZBazNPJJLdc5yYr9u8ith1vn5V2pQZUPQqEF", smokePassed: true },
+  { profileId: "document-intelligence-agent", endpoint: "https://reddi-document-intelligence.preview.reddi.tech/v1/chat/completions", walletAddress: "13CgDqa8K3Mw8iaoUVahbJUmKyQRrUmCRM259NC8Dmy", smokePassed: true },
+  { profileId: "domain-transforming-integration-agent", endpoint: "https://reddi-domain-transforming-integration.preview.reddi.tech/v1/chat/completions", walletAddress: "C7SyDdJnUMtJ9YRQyvsFqjYTLibuDB3vQevjpoQsTNZr", smokePassed: true },
+  { profileId: "education-intelligence-agent", endpoint: "https://reddi-education-intelligence.preview.reddi.tech/v1/chat/completions", walletAddress: "9cNPPapLEUucKnw8kx7ZmcZF1xxW2nb5yatYJ77HJGcs", smokePassed: true },
+  { profileId: "embodied-intelligence-agent", endpoint: "https://reddi-embodied-intelligence.preview.reddi.tech/v1/chat/completions", walletAddress: "J4QXByEJs2VKiAqisDwxTi6kEp8pipET7zGr4bqBkPfv", smokePassed: true },
+  { profileId: "ethical-reasoning-agent", endpoint: "https://reddi-ethical-reasoning.preview.reddi.tech/v1/chat/completions", walletAddress: "CyY7MVqCYEtkq4R6dntpp4AfYetH2Hjjr5bLx5vJNbMG", smokePassed: true },
+  { profileId: "explainable-agent", endpoint: "https://reddi-explainable.preview.reddi.tech/v1/chat/completions", walletAddress: "5Hrogoh4rwfp3UdQ1HZKHfUFcfQ4cYojzTqLswt7i4vG", smokePassed: true },
+  { profileId: "financial-advisory-agent", endpoint: "https://reddi-financial-advisory.preview.reddi.tech/v1/chat/completions", walletAddress: "GpEERKh7TEyaRSQ4c5gsD7ZKFufrdcG5n3KrXVdNbYJd", smokePassed: true },
+  { profileId: "general-problem-solver-agent", endpoint: "https://reddi-general-problem-solver.preview.reddi.tech/v1/chat/completions", walletAddress: "4WzsVzdmCDjqZ5Ab63hCntNHoz6L2ziQ9Jmat3satHzD", smokePassed: true },
+  { profileId: "healthcare-intelligence-agent", endpoint: "https://reddi-healthcare-intelligence.preview.reddi.tech/v1/chat/completions", walletAddress: "9qisw2PSPcwYT789d8BsR8F8TZK1i4M7zbAECYotvLBG", smokePassed: true },
+  { profileId: "knowledge-retrieval-agent", endpoint: "https://reddi-knowledge-retrieval.preview.reddi.tech/v1/chat/completions", walletAddress: "8U6cFDvibNtaFFkNGC3gPTUbcjETLg1gxHiDeefar39v", smokePassed: true },
+  { profileId: "legal-intelligence-agent", endpoint: "https://reddi-legal-intelligence.preview.reddi.tech/v1/chat/completions", walletAddress: "9f4g632hwzSE8Zpu5vs4k5WiLVxv48ZMmvnLekdY6NS", smokePassed: true },
+  { profileId: "memory-augmented-agent", endpoint: "https://reddi-memory-augmented.preview.reddi.tech/v1/chat/completions", walletAddress: "Hdnghqbm8jva9N8L4e5NjpKj9chbxDp8jD2qqCGCujEu", smokePassed: true },
+  { profileId: "physical-world-sensing-agent", endpoint: "https://reddi-physical-world-sensing.preview.reddi.tech/v1/chat/completions", walletAddress: "5xFsPLvyapAzFJBEw1SaztfEV8xvwfw8w9wooA5AJXAw", smokePassed: true },
+  { profileId: "planning-agent", endpoint: "https://reddi-planning-agent.preview.reddi.tech/v1/chat/completions", walletAddress: "2wYpzbExNi2vHSdK48jBusfEx3WNVjzPFEVNcbCA5cAs", smokePassed: true },
+  { profileId: "recommendation-agent", endpoint: "https://reddi-recommendation.preview.reddi.tech/v1/chat/completions", walletAddress: "51okYwLPbbGGpsDXsG4SDU4EZhCfk1USQLtyJUp7Wd9e", smokePassed: true },
+  { profileId: "scientific-discovery-agent", endpoint: "https://reddi-scientific-discovery.preview.reddi.tech/v1/chat/completions", walletAddress: "GsY5rLp3Ry2CuQddWFB7iPUTHXYiAqMWCPh5ZEEznFhC", smokePassed: true },
+  { profileId: "scientific-research-agent", endpoint: "https://reddi-scientific-research.preview.reddi.tech/v1/chat/completions", walletAddress: "EtKBLuMftRiSnax5eQQyFsu7QTruujmHxspQBX5FDbSL", smokePassed: true },
+  { profileId: "security-hardened-agent", endpoint: "https://reddi-security-hardened.preview.reddi.tech/v1/chat/completions", walletAddress: "CkAE6suBXoLamDJcZkhmTkS3c3VNkfecuCFd1yKRpc4b", smokePassed: true },
+  { profileId: "self-improving-agent", endpoint: "https://reddi-self-improving.preview.reddi.tech/v1/chat/completions", walletAddress: "4PTbsovCzDrNPc44p2LUsu6GbuEwwNZKkFy9335djv8b", smokePassed: true },
+  { profileId: "tool-using-agent", endpoint: "https://reddi-tool-using.preview.reddi.tech/v1/chat/completions", walletAddress: "GFkP1kmrCG4JAt4miD5zHHaUDNZpUx1N5dK6g3NK9Y2", smokePassed: true },
+  { profileId: "verification-validation-agent", endpoint: "https://reddi-verification-agent.preview.reddi.tech/v1/chat/completions", walletAddress: "2EmtCTzhoSSorg2rRSnTbngGJqkqNufgtFUZRGU4iFWq", smokePassed: true },
+  { profileId: "vision-language-agent", endpoint: "https://reddi-vision-language.preview.reddi.tech/v1/chat/completions", walletAddress: "HsuJYNDcNFi9SzyG73TG3fwvAbPpkKho8UooTb4BHYnq", smokePassed: true },
+] as const satisfies readonly OpenRouterHostedEndpointEvidence[];
+
+export const openRouterEndpointByProfileId = Object.fromEntries(
+  openRouterAll30EndpointEvidence.map((entry) => [entry.profileId, entry.endpoint]),
+) as Record<string, string>;
+
+export const openRouterWalletByProfileId = Object.fromEntries(
+  openRouterAll30EndpointEvidence.map((entry) => [entry.profileId, entry.walletAddress]),
+) as Record<string, string>;


### PR DESCRIPTION
## Summary\n- Promotes all-30 hosted smoke endpoint evidence into a committed public-data helper\n- Updates economic demo dry-run planning to fail closed if endpoint evidence is missing\n- Adds/updates tests so the dry-run plan covers exactly the deployed 30 specialist profiles and no longer relies on hostname guesses\n- Appends Phase 3 slice B retrospective to the economic demo iteration log\n\n## Validation\n- npx jest lib/__tests__/economic-demo-dry-run.test.ts --runInBand\n- npm run lint -- lib/economic-demo/dry-run.ts lib/economic-demo/openrouter-endpoints.ts app/api/economic-demo/dry-run/route.ts lib/__tests__/economic-demo-dry-run.test.ts\n- npm run build\n\n## Drift check\nImproves payload-flow accuracy and aligns planned economic graph edges to smoke-proven deployed endpoints. Still zero spend.