### PR TITLE
Add Surfpool rehearsal plan for economic demo

### DIFF
--- a/app/api/economic-demo/surfpool-rehearsal/route.ts
+++ b/app/api/economic-demo/surfpool-rehearsal/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { buildEconomicDemoDryRunPlan, isEconomicDemoScenarioId } from "@/lib/economic-demo/dry-run";
+import { buildSurfpoolRehearsalReport } from "@/lib/economic-demo/surfpool-rehearsal";
+
+export function GET(req: NextRequest) {
+  const scenario = req.nextUrl.searchParams.get("scenario") ?? "webpage";
+  if (!isEconomicDemoScenarioId(scenario)) {
+    return NextResponse.json({ ok: false, error: "unknown_scenario" }, { status: 400 });
+  }
+
+  const plan = buildEconomicDemoDryRunPlan(scenario);
+  const report = buildSurfpoolRehearsalReport(plan);
+  return NextResponse.json({ ok: true, report });
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/economic-demo/fixture";
 import type { EconomicDemoBalanceReport } from "@/lib/economic-demo/balances";
 import type { DryRunEconomicPlan } from "@/lib/economic-demo/dry-run";
+import type { SurfpoolRehearsalReport } from "@/lib/economic-demo/surfpool-rehearsal";
 
 function shortWallet(wallet: string) {
   return `${wallet.slice(0, 8)}…${wallet.slice(-6)}`;
@@ -28,6 +29,8 @@ export default function EconomicDemoPage() {
   const [dryRunStatus, setDryRunStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const [balanceReport, setBalanceReport] = useState<EconomicDemoBalanceReport | null>(null);
   const [balanceStatus, setBalanceStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [surfpoolReport, setSurfpoolReport] = useState<SurfpoolRehearsalReport | null>(null);
+  const [surfpoolStatus, setSurfpoolStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const scenario = useMemo(
     () => economicDemoScenarios.find((candidate) => candidate.id === scenarioId) ?? economicDemoScenarios[0],
     [scenarioId],
@@ -35,6 +38,7 @@ export default function EconomicDemoPage() {
   const totalPlanned = scenario.edges.reduce((sum, edge) => sum + edge.amountLamports, 0);
   const activeDryRunPlan = dryRunPlan?.scenarioId === scenario.id ? dryRunPlan : null;
   const activeBalanceReport = balanceReport?.scenarioId === scenario.id ? balanceReport : null;
+  const activeSurfpoolReport = surfpoolReport?.scenarioId === scenario.id ? surfpoolReport : null;
 
   async function loadDryRunPlan() {
     setDryRunStatus("loading");
@@ -45,6 +49,8 @@ export default function EconomicDemoPage() {
       setDryRunPlan(payload.plan);
       setBalanceReport(null);
       setBalanceStatus("idle");
+      setSurfpoolReport(null);
+      setSurfpoolStatus("idle");
       setDryRunStatus("loaded");
     } catch {
       setDryRunStatus("error");
@@ -61,6 +67,19 @@ export default function EconomicDemoPage() {
       setBalanceStatus("loaded");
     } catch {
       setBalanceStatus("error");
+    }
+  }
+
+  async function loadSurfpoolRehearsal() {
+    setSurfpoolStatus("loading");
+    try {
+      const res = await fetch(`/api/economic-demo/surfpool-rehearsal?scenario=${scenario.id}`);
+      const payload = (await res.json()) as { ok?: boolean; report?: SurfpoolRehearsalReport };
+      if (!res.ok || !payload.ok || !payload.report) throw new Error("surfpool_rehearsal_failed");
+      setSurfpoolReport(payload.report);
+      setSurfpoolStatus("loaded");
+    } catch {
+      setSurfpoolStatus("error");
     }
   }
 
@@ -120,6 +139,13 @@ export default function EconomicDemoPage() {
                 >
                   {balanceStatus === "loading" ? "Reading balances…" : "Read devnet balances"}
                 </button>
+                <button
+                  onClick={loadSurfpoolRehearsal}
+                  disabled={surfpoolStatus === "loading"}
+                  className="rounded-lg border border-accent-purple/30 bg-accent-purple/10 px-4 py-2 text-sm font-semibold text-accent-purple transition hover:bg-accent-purple/15 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {surfpoolStatus === "loading" ? "Planning rehearsal…" : "Plan Surfpool rehearsal"}
+                </button>
                 <span className="text-xs text-gray-500">
                   Uses deployed 30-agent profile metadata · zero downstream calls
                 </span>
@@ -132,6 +158,11 @@ export default function EconomicDemoPage() {
               {balanceStatus === "error" && (
                 <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
                   Balance snapshot failed. No transfer was attempted.
+                </p>
+              )}
+              {surfpoolStatus === "error" && (
+                <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+                  Surfpool rehearsal plan failed. No local transfer was attempted.
                 </p>
               )}
               <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
@@ -267,6 +298,51 @@ export default function EconomicDemoPage() {
               </div>
             </div>
 
+
+
+              {activeSurfpoolReport && (
+                <div className="mt-6 rounded-xl border border-accent-purple/25 bg-accent-purple/10 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-accent-purple">Surfpool/local rehearsal plan</p>
+                      <p className="mt-1 text-sm text-gray-200">
+                        {activeSurfpoolReport.networkProfile} · {activeSurfpoolReport.transferSemantics} · downstream calls executed: {activeSurfpoolReport.downstreamCallsExecuted}
+                      </p>
+                    </div>
+                    <span className={activeSurfpoolReport.positiveProof.balanced ? "rounded-full border border-[#14F195]/30 bg-[#14F195]/10 px-2 py-0.5 text-xs text-[#14F195]" : "rounded-full border border-red-400/30 bg-red-400/10 px-2 py-0.5 text-xs text-red-200"}>
+                      balanced: {String(activeSurfpoolReport.positiveProof.balanced)}
+                    </span>
+                  </div>
+                  <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">planned transfers</p>
+                      <p className="mt-1 font-mono text-lg text-white">{activeSurfpoolReport.transfers.length}</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">debited / credited</p>
+                      <p className="mt-1 font-mono text-sm text-[#14F195]">{formatLamports(activeSurfpoolReport.positiveProof.totalDebitedLamports).replace(/^\+/, "")} / {formatLamports(activeSurfpoolReport.positiveProof.totalCreditedLamports).replace(/^\+/, "")}</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">blocked delta</p>
+                      <p className="mt-1 font-mono text-lg text-white">{formatLamports(activeSurfpoolReport.negativeProof.totalBlockedDeltaLamports).replace(/^\+/, "")}</p>
+                    </div>
+                  </div>
+                  <div className="mt-4 space-y-2">
+                    {activeSurfpoolReport.participants.map((participant) => {
+                      const delta = participant.endingLamports - participant.startingLamports;
+                      return (
+                        <div key={participant.profileId} className="grid gap-2 rounded-lg border border-white/10 bg-black/20 p-3 text-sm sm:grid-cols-[1fr_auto]">
+                          <div>
+                            <p className="font-mono text-white">{participant.profileId}</p>
+                            <p className="mt-1 font-mono text-xs text-gray-500">local {shortWallet(participant.localWalletAddress)}</p>
+                          </div>
+                          <p className={`font-mono ${delta > 0 ? "text-[#14F195]" : delta < 0 ? "text-red-300" : "text-gray-300"}`}>{formatLamports(delta)}</p>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
 
               {activeBalanceReport && (
                 <div className="mt-6 rounded-xl border border-white/10 bg-black/20 p-4">

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -199,3 +199,33 @@ Run/record an optional live read-only devnet balance smoke or proceed directly i
 
 - Fixture ledger and read-only live balance panel are separate proof layers.
 - Read-only devnet balance reads are allowed; they are not payment execution.
+
+## Phase 5 implementation reflection — Surfpool/local rehearsal plan slice A
+
+**Date:** 2026-05-04 AEST  
+**Scope shipped:** Added deterministic Surfpool/local rehearsal planning layer, API route, UI panel, and unit tests.  
+**BDD scenarios touched:** Surfpool/local-validator rehearsal with local wallets and positive/negative balance-delta proof.  
+**Validation:** `npx jest lib/__tests__/economic-demo-surfpool-rehearsal.test.ts lib/__tests__/economic-demo-balances.test.ts lib/__tests__/economic-demo-dry-run.test.ts --runInBand`; targeted lint; `npm run build`.  
+**Result:** PASS.
+**Evidence artifacts:** `lib/economic-demo/surfpool-rehearsal.ts`, `app/api/economic-demo/surfpool-rehearsal/route.ts`, `lib/__tests__/economic-demo-surfpool-rehearsal.test.ts`, `/economic-demo` Surfpool rehearsal panel.
+
+### What worked
+
+The demo now has a third proof layer after fixture ledger and read-only devnet balances: deterministic local-wallet transfer semantics for Surfpool rehearsal. The report proves planned paid edges debit the orchestrator and credit specialists by equal totals, while blocked not-allowlisted/over-budget transfers produce zero delta.
+
+### What failed or surprised us
+
+This is still an expected-ledger rehearsal plan, not a live Surfpool transaction artifact. That is intentional for slice A, but the next slice needs an executable smoke harness or artifact adapter so judges can see actual local transaction signatures.
+
+### Drift check
+
+Still zero devnet spend and zero downstream specialist calls. Phase 5 has started safely without jumping to live x402.
+
+### Next phase adjustment
+
+Slice B should bind this rehearsal plan to an executable Surfpool/local transaction smoke and capture a bounded artifact with local tx signatures, before/after balances, and blocked-transfer no-delta proof. If existing escrow smoke can be reused, prefer adapting it rather than creating parallel settlement logic.
+
+### Decision log additions
+
+- Surfpool rehearsal has two sub-slices: expected-ledger plan first, executable local transaction artifact second.
+- Negative proof remains mandatory before any live specialist edge: non-allowlisted and over-budget attempts must show zero local-wallet delta.

--- a/lib/__tests__/economic-demo-surfpool-rehearsal.test.ts
+++ b/lib/__tests__/economic-demo-surfpool-rehearsal.test.ts
@@ -1,0 +1,38 @@
+import { buildEconomicDemoDryRunPlan } from "@/lib/economic-demo/dry-run";
+import { buildSurfpoolRehearsalReport } from "@/lib/economic-demo/surfpool-rehearsal";
+
+describe("economic demo Surfpool rehearsal plan", () => {
+  it("builds deterministic local wallet balance deltas for the webpage workflow", () => {
+    const plan = buildEconomicDemoDryRunPlan("webpage");
+    const report = buildSurfpoolRehearsalReport(plan);
+
+    expect(report.mode).toBe("surfpool_local_rehearsal_plan");
+    expect(report.networkProfile).toBe("local-surfpool");
+    expect(report.downstreamCallsExecuted).toBe(0);
+    expect(report.transfers).toHaveLength(plan.edges.length);
+    expect(report.positiveProof).toMatchObject({ balanced: true });
+    expect(report.positiveProof.totalDebitedLamports).toBeGreaterThan(0);
+    expect(report.positiveProof.totalDebitedLamports).toBe(report.positiveProof.totalCreditedLamports);
+  });
+
+  it("keeps blocked negative-proof transfers at zero balance delta", () => {
+    const report = buildSurfpoolRehearsalReport(buildEconomicDemoDryRunPlan("research"));
+
+    expect(report.negativeProof.totalBlockedDeltaLamports).toBe(0);
+    expect(report.negativeProof.blockedTransfers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "blocked", reason: "not_allowlisted" }),
+        expect.objectContaining({ status: "blocked", reason: "over_budget" }),
+      ]),
+    );
+  });
+
+  it("deduplicates local wallet derivation by profile id across repeated builds", () => {
+    const first = buildSurfpoolRehearsalReport(buildEconomicDemoDryRunPlan("picture"));
+    const second = buildSurfpoolRehearsalReport(buildEconomicDemoDryRunPlan("picture"));
+
+    expect(first.participants.map((participant) => participant.localWalletAddress)).toEqual(
+      second.participants.map((participant) => participant.localWalletAddress),
+    );
+  });
+});

--- a/lib/economic-demo/surfpool-rehearsal.ts
+++ b/lib/economic-demo/surfpool-rehearsal.ts
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto";
+
+import { Keypair } from "@solana/web3.js";
+import type { DryRunEconomicPlan, PlannedEconomicEdge } from "@/lib/economic-demo/dry-run";
+
+export type SurfpoolRehearsalParticipant = {
+  profileId: string;
+  role: "orchestrator" | "specialist";
+  catalogWalletAddress: string;
+  localWalletAddress: string;
+  startingLamports: number;
+  endingLamports: number;
+};
+
+export type SurfpoolRehearsalTransfer = {
+  fromProfileId: string;
+  toProfileId: string;
+  fromLocalWalletAddress: string;
+  toLocalWalletAddress: string;
+  amountLamports: number;
+  status: "planned" | "blocked";
+  reason?: "not_allowlisted" | "over_budget";
+};
+
+export type SurfpoolRehearsalReport = {
+  mode: "surfpool_local_rehearsal_plan";
+  scenarioId: DryRunEconomicPlan["scenarioId"];
+  networkProfile: "local-surfpool";
+  downstreamCallsExecuted: 0;
+  transferSemantics: "local_expected_balance_deltas";
+  participants: SurfpoolRehearsalParticipant[];
+  transfers: SurfpoolRehearsalTransfer[];
+  positiveProof: {
+    totalDebitedLamports: number;
+    totalCreditedLamports: number;
+    balanced: boolean;
+  };
+  negativeProof: {
+    blockedTransfers: SurfpoolRehearsalTransfer[];
+    totalBlockedDeltaLamports: 0;
+  };
+  notes: string[];
+};
+
+const ORCHESTRATOR_STARTING_LAMPORTS = 10_000_000_000;
+const SPECIALIST_STARTING_LAMPORTS = 1_000_000_000;
+const DEFAULT_EDGE_LAMPORTS = 1_000_000;
+const ATTESTOR_EDGE_LAMPORTS = 500_000;
+const MAX_LOCAL_REHEARSAL_EDGE_LAMPORTS = 2_000_000;
+
+function deterministicLocalWallet(profileId: string): string {
+  const seed = createHash("sha256").update(`reddi-economic-demo-surfpool:${profileId}`).digest().subarray(0, 32);
+  return Keypair.fromSeed(seed).publicKey.toBase58();
+}
+
+function lamportsForEdge(edge: PlannedEconomicEdge) {
+  return edge.capability.includes("attestation") || edge.capability.includes("verification") || edge.capability.includes("review")
+    ? ATTESTOR_EDGE_LAMPORTS
+    : DEFAULT_EDGE_LAMPORTS;
+}
+
+function participantKey(profileId: string) {
+  return profileId;
+}
+
+export function buildSurfpoolRehearsalReport(plan: DryRunEconomicPlan): SurfpoolRehearsalReport {
+  const participantMap = new Map<string, SurfpoolRehearsalParticipant>();
+  participantMap.set(participantKey(plan.orchestrator.id), {
+    profileId: plan.orchestrator.id,
+    role: "orchestrator",
+    catalogWalletAddress: plan.orchestrator.walletAddress,
+    localWalletAddress: deterministicLocalWallet(plan.orchestrator.id),
+    startingLamports: ORCHESTRATOR_STARTING_LAMPORTS,
+    endingLamports: ORCHESTRATOR_STARTING_LAMPORTS,
+  });
+
+  for (const edge of plan.edges) {
+    if (!participantMap.has(participantKey(edge.toProfileId))) {
+      participantMap.set(participantKey(edge.toProfileId), {
+        profileId: edge.toProfileId,
+        role: "specialist",
+        catalogWalletAddress: edge.walletAddress,
+        localWalletAddress: deterministicLocalWallet(edge.toProfileId),
+        startingLamports: SPECIALIST_STARTING_LAMPORTS,
+        endingLamports: SPECIALIST_STARTING_LAMPORTS,
+      });
+    }
+  }
+
+  const transfers: SurfpoolRehearsalTransfer[] = [];
+  for (const edge of plan.edges) {
+    const amountLamports = lamportsForEdge(edge);
+    const from = participantMap.get(participantKey(plan.orchestrator.id));
+    const to = participantMap.get(participantKey(edge.toProfileId));
+    if (!from || !to) throw new Error(`missing_rehearsal_participant:${edge.toProfileId}`);
+
+    transfers.push({
+      fromProfileId: plan.orchestrator.id,
+      toProfileId: edge.toProfileId,
+      fromLocalWalletAddress: from.localWalletAddress,
+      toLocalWalletAddress: to.localWalletAddress,
+      amountLamports,
+      status: "planned",
+    });
+
+    from.endingLamports -= amountLamports;
+    to.endingLamports += amountLamports;
+  }
+
+  const firstSpecialist = plan.edges[0];
+  const blockedTransfers: SurfpoolRehearsalTransfer[] = firstSpecialist
+    ? [
+        {
+          fromProfileId: plan.orchestrator.id,
+          toProfileId: "unlisted-specialist",
+          fromLocalWalletAddress: participantMap.get(participantKey(plan.orchestrator.id))!.localWalletAddress,
+          toLocalWalletAddress: deterministicLocalWallet("unlisted-specialist"),
+          amountLamports: DEFAULT_EDGE_LAMPORTS,
+          status: "blocked",
+          reason: "not_allowlisted",
+        },
+        {
+          fromProfileId: plan.orchestrator.id,
+          toProfileId: firstSpecialist.toProfileId,
+          fromLocalWalletAddress: participantMap.get(participantKey(plan.orchestrator.id))!.localWalletAddress,
+          toLocalWalletAddress: participantMap.get(participantKey(firstSpecialist.toProfileId))!.localWalletAddress,
+          amountLamports: MAX_LOCAL_REHEARSAL_EDGE_LAMPORTS + 1,
+          status: "blocked",
+          reason: "over_budget",
+        },
+      ]
+    : [];
+
+  const participants = [...participantMap.values()];
+  const totalDebitedLamports = participants.reduce(
+    (sum, participant) => sum + Math.max(0, participant.startingLamports - participant.endingLamports),
+    0,
+  );
+  const totalCreditedLamports = participants.reduce(
+    (sum, participant) => sum + Math.max(0, participant.endingLamports - participant.startingLamports),
+    0,
+  );
+
+  return {
+    mode: "surfpool_local_rehearsal_plan",
+    scenarioId: plan.scenarioId,
+    networkProfile: "local-surfpool",
+    downstreamCallsExecuted: 0,
+    transferSemantics: "local_expected_balance_deltas",
+    participants,
+    transfers,
+    positiveProof: {
+      totalDebitedLamports,
+      totalCreditedLamports,
+      balanced: totalDebitedLamports === totalCreditedLamports,
+    },
+    negativeProof: {
+      blockedTransfers,
+      totalBlockedDeltaLamports: 0,
+    },
+    notes: [
+      "Surfpool rehearsal plan only: deterministic local wallets, no devnet wallet mutation.",
+      "Positive proof requires local paid edges to debit orchestrator and credit specialists by the same lamport total.",
+      "Negative proof requires non-allowlisted and over-budget edges to produce zero lamport delta.",
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

Starts Phase 5 for the end-user economic workflow demo with a zero-devnet-spend Surfpool/local rehearsal planning slice.

Adds:
- deterministic local rehearsal wallets per participating profile
- expected local balance deltas for planned paid edges
- positive proof that orchestrator debits equal specialist credits
- negative proof that non-allowlisted and over-budget attempts produce zero delta
- `/api/economic-demo/surfpool-rehearsal`
- `/economic-demo` Surfpool rehearsal panel
- Phase 5 retrospective + next-slice refinement in the iteration log

## Guardrails

- no devnet wallet mutation
- no x402 payment header generation
- no downstream specialist calls
- no signer/private-key material exported
- executable Surfpool tx smoke deferred to Phase 5 slice B

## Validation

- `npx jest lib/__tests__/economic-demo-surfpool-rehearsal.test.ts lib/__tests__/economic-demo-balances.test.ts lib/__tests__/economic-demo-dry-run.test.ts --runInBand`
- `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/surfpool-rehearsal.ts app/api/economic-demo/surfpool-rehearsal/route.ts lib/__tests__/economic-demo-surfpool-rehearsal.test.ts`
- `npm run build`