### PR TITLE
Add live x402 payment readiness probe

### DIFF
--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -288,3 +288,32 @@ Before Phase 7 multi-edge webpage workflow, add or configure a valid devnet paym
 
 - Phase 6 acceptance splits into two states: live x402 challenge reached (done) vs paid specialist completion (blocked until valid devnet payment provider/signing path exists).
 - Do not retry live edges repeatedly while payment provider is unavailable; the one-call proof is enough until the payment path is configured.
+
+## Phase 6 implementation reflection — paid-retry readiness probe
+
+**Date:** 2026-05-04 AEST
+**Scope executed:** Added and ran a bounded live x402 readiness probe that captures the unpaid challenge and makes one demo-paid retry using the challenge nonce.
+**Command:** `ECONOMIC_DEMO_LIVE_X402_CONFIRM=RUN_ECONOMIC_DEMO_LIVE_X402_READINESS ECONOMIC_DEMO_LIVE_X402_PAID_RETRY=1 npm run smoke:economic-demo:live-x402-readiness`
+**Result:** PASS for blocker identification; paid completion remains blocked by deployed config.
+**Evidence artifact:** `artifacts/economic-demo-live-x402-readiness/20260504T081222Z/summary.json` (git-ignored local artifact).
+
+### What worked
+
+The deployed `code-generation-agent` returned a canonical x402 challenge with network `solana-devnet`, payee wallet `8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To`, amount `0.05`, currency `USDC`, exact endpoint match, and nonce present. The readiness harness then made exactly one paid retry with `demo:<challengeNonce>`.
+
+### What failed or surprised us
+
+The paid retry returned HTTP 402 with `demo_payment_disabled`. This is a better blocker than the prior generic payment-provider gap: the deployed specialist intentionally does not accept demo receipts. Real receipt verification is not implemented in the runtime yet, so the next safe path is either enable demo payment only for the controlled demo deployment or implement a real devnet receipt verifier.
+
+### Drift check
+
+The probe made two bounded downstream calls total, used no signer material, attempted no signature, executed no devnet transfer from the harness, and made no Coolify changes.
+
+### Next phase adjustment
+
+Do not keep probing the live endpoint. The next implementation loop should add a fail-closed payment-mode readiness surface that tells the UI/operator exactly why paid completion is blocked (`demo_payment_disabled` vs real verifier unavailable), then choose one deliberate route: controlled demo receipts for the judge demo, or real devnet receipt verification.
+
+### Decision log additions
+
+- Current paid-completion blocker is `demo_payment_disabled` on the deployed specialist runtime.
+- A valid challenge is already emitted for USDC-on-devnet; the missing piece is accepted receipt verification, not endpoint discovery.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "demo:testing-specialist:smoke": "node ./scripts/run-testing-specialist-smoke.mjs",
     "demo:testing-specialist:capture": "node ./scripts/capture-testing-specialist-demo.mjs",
     "smoke:app-adapter": "node ./scripts/run-app-adapter-smoke.mjs",
-    "smoke:economic-demo:surfpool": "node ./scripts/run-economic-demo-surfpool-rehearsal.mjs"
+    "smoke:economic-demo:surfpool": "node ./scripts/run-economic-demo-surfpool-rehearsal.mjs",
+    "smoke:economic-demo:live-x402-readiness": "node ./scripts/run-economic-demo-live-x402-readiness.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/run-economic-demo-live-x402-readiness.mjs
+++ b/scripts/run-economic-demo-live-x402-readiness.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const timestamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+const outDir = join(rootDir, "artifacts", "economic-demo-live-x402-readiness", timestamp);
+mkdirSync(outDir, { recursive: true });
+
+const CONFIRM = "RUN_ECONOMIC_DEMO_LIVE_X402_READINESS";
+const endpoint = process.env.ECONOMIC_DEMO_LIVE_X402_ENDPOINT ?? "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions";
+const profileId = process.env.ECONOMIC_DEMO_LIVE_X402_PROFILE ?? "code-generation-agent";
+const confirm = process.env.ECONOMIC_DEMO_LIVE_X402_CONFIRM === CONFIRM;
+const allowPaidRetry = process.env.ECONOMIC_DEMO_LIVE_X402_PAID_RETRY === "1" || process.env.ECONOMIC_DEMO_LIVE_X402_PAID_RETRY === "true";
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function post(headers = {}) {
+  return fetch(endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: "Economic demo live x402 readiness probe: bounded one-edge payment readiness check." }],
+      metadata: {
+        mode: "economic_demo_live_x402_readiness",
+        profileId,
+        noCoolifyChanges: true,
+        noDevnetTransferFromHarness: true,
+      },
+    }),
+  });
+}
+
+async function responseSummary(response) {
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = { raw: text.slice(0, 500) };
+  }
+  return {
+    status: response.status,
+    ok: response.ok,
+    contentType: response.headers.get("content-type") ?? undefined,
+    x402Request: response.headers.get("x402-request") ?? undefined,
+    body,
+  };
+}
+
+assert(endpoint.startsWith("https://"), "live x402 readiness requires exact https endpoint");
+assert(confirm, `live x402 readiness requires ECONOMIC_DEMO_LIVE_X402_CONFIRM=${CONFIRM}`);
+
+const unpaidResponse = await post();
+const unpaid = await responseSummary(unpaidResponse);
+assert(unpaid.status === 402, `expected unpaid 402 challenge, got ${unpaid.status}`);
+assert(typeof unpaid.x402Request === "string" && unpaid.x402Request.length > 0, "expected x402-request header");
+
+let challenge;
+try {
+  challenge = JSON.parse(unpaid.x402Request);
+} catch (error) {
+  throw new Error(`invalid x402-request JSON: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+let paidRetry = null;
+if (allowPaidRetry) {
+  const demoPaymentHeader = `demo:${challenge.nonce}`;
+  const paidResponse = await post({ "x402-payment": demoPaymentHeader });
+  paidRetry = await responseSummary(paidResponse);
+}
+
+const paidCompletionReached = paidRetry?.ok === true;
+const blocker = paidRetry && !paidRetry.ok ? paidRetry.body?.error?.code ?? `http_${paidRetry.status}` : allowPaidRetry ? undefined : "paid_retry_not_requested";
+
+const report = {
+  schemaVersion: "reddi.economic-demo.live-x402-readiness.v1",
+  generatedAt: new Date().toISOString(),
+  endpoint,
+  profileId,
+  mode: "controlled_live_x402_readiness",
+  confirmationRequired: CONFIRM,
+  downstreamCallsExecuted: allowPaidRetry ? 2 : 1,
+  unpaidChallenge: {
+    status: unpaid.status,
+    contentType: unpaid.contentType,
+    challenge: {
+      version: challenge.version,
+      network: challenge.network,
+      payTo: challenge.payTo,
+      amount: challenge.amount,
+      currency: challenge.currency,
+      endpoint: challenge.endpoint,
+      noncePresent: typeof challenge.nonce === "string" && challenge.nonce.length > 0,
+    },
+    errorCode: unpaid.body?.error?.code,
+  },
+  paidRetry: paidRetry
+    ? {
+        status: paidRetry.status,
+        ok: paidRetry.ok,
+        contentType: paidRetry.contentType,
+        errorCode: paidRetry.body?.error?.code,
+        paymentSatisfied: paidRetry.ok,
+      }
+    : undefined,
+  conclusion: paidCompletionReached ? "paid_completion_reached" : "paid_completion_blocked",
+  blocker,
+  guardrails: {
+    exactEndpoint: true,
+    noSignerMaterialUsed: true,
+    noSignatureAttemptedByHarness: true,
+    noDevnetTransferFromHarness: true,
+    noCoolifyChanges: true,
+    boundedMaxTwoDownstreamCalls: true,
+  },
+};
+
+const summaryPath = join(outDir, "summary.json");
+writeFileSync(summaryPath, `${JSON.stringify(report, null, 2)}\n`);
+writeFileSync(
+  join(outDir, "SUMMARY.md"),
+  `# Economic Demo Live x402 Readiness\n\n- Endpoint: ${endpoint}\n- Profile: ${profileId}\n- Downstream calls: ${report.downstreamCallsExecuted}\n- Unpaid challenge: ${unpaid.status}\n- Paid retry: ${paidRetry ? paidRetry.status : "not requested"}\n- Conclusion: ${report.conclusion}\n- Blocker: ${blocker ?? "none"}\n- JSON: ${summaryPath}\n`,
+);
+
+console.log(JSON.stringify({ ok: true, summaryPath, conclusion: report.conclusion, blocker }, null, 2));


### PR DESCRIPTION
## Summary

Adds a bounded Phase 6 readiness probe for the live economic demo x402 edge.

`npm run smoke:economic-demo:live-x402-readiness`:
- requires explicit confirmation env
- sends one unpaid request to the exact allowlisted code-generation specialist endpoint
- records the canonical x402 challenge
- optionally sends one demo-paid retry using `demo:<challengeNonce>`
- records the precise paid-completion blocker
- writes a bounded local artifact under `artifacts/economic-demo-live-x402-readiness/<timestamp>/`

## Latest live finding

Command run:

```bash
ECONOMIC_DEMO_LIVE_X402_CONFIRM=RUN_ECONOMIC_DEMO_LIVE_X402_READINESS \
ECONOMIC_DEMO_LIVE_X402_PAID_RETRY=1 \
npm run smoke:economic-demo:live-x402-readiness
```

Result:
- endpoint: `https://reddi-code-generation.preview.reddi.tech/v1/chat/completions`
- unpaid challenge: HTTP 402 with x402-request
- challenge: `solana-devnet`, payee `8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To`, amount `0.05`, currency `USDC`, nonce present
- paid retry: HTTP 402
- blocker: `demo_payment_disabled`

This proves endpoint discovery and challenge generation are working; paid completion is blocked by receipt verification mode/config, not by discovery.

## Guardrails

- bounded max two downstream calls
- no signer material used
- no signature attempted by harness
- no devnet transfer from harness
- no Coolify changes

## Validation

- `npm run lint -- scripts/run-economic-demo-live-x402-readiness.mjs`
- `ECONOMIC_DEMO_LIVE_X402_CONFIRM=RUN_ECONOMIC_DEMO_LIVE_X402_READINESS ECONOMIC_DEMO_LIVE_X402_PAID_RETRY=1 npm run smoke:economic-demo:live-x402-readiness`
- `npm run build`