### PR TITLE
Expose economic demo payment readiness blocker

### DIFF
--- a/app/api/economic-demo/payment-readiness/route.ts
+++ b/app/api/economic-demo/payment-readiness/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+import { getEconomicDemoPaymentReadiness } from "@/lib/economic-demo/payment-readiness";
+
+export function GET() {
+  return NextResponse.json({ ok: true, readiness: getEconomicDemoPaymentReadiness() });
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -11,6 +11,7 @@ import {
 import type { EconomicDemoBalanceReport } from "@/lib/economic-demo/balances";
 import type { DryRunEconomicPlan } from "@/lib/economic-demo/dry-run";
 import type { SurfpoolRehearsalReport } from "@/lib/economic-demo/surfpool-rehearsal";
+import type { EconomicDemoPaymentReadiness } from "@/lib/economic-demo/payment-readiness";
 
 function shortWallet(wallet: string) {
   return `${wallet.slice(0, 8)}…${wallet.slice(-6)}`;
@@ -31,6 +32,8 @@ export default function EconomicDemoPage() {
   const [balanceStatus, setBalanceStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const [surfpoolReport, setSurfpoolReport] = useState<SurfpoolRehearsalReport | null>(null);
   const [surfpoolStatus, setSurfpoolStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [paymentReadiness, setPaymentReadiness] = useState<EconomicDemoPaymentReadiness | null>(null);
+  const [paymentReadinessStatus, setPaymentReadinessStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const scenario = useMemo(
     () => economicDemoScenarios.find((candidate) => candidate.id === scenarioId) ?? economicDemoScenarios[0],
     [scenarioId],
@@ -51,6 +54,8 @@ export default function EconomicDemoPage() {
       setBalanceStatus("idle");
       setSurfpoolReport(null);
       setSurfpoolStatus("idle");
+      setPaymentReadiness(null);
+      setPaymentReadinessStatus("idle");
       setDryRunStatus("loaded");
     } catch {
       setDryRunStatus("error");
@@ -80,6 +85,19 @@ export default function EconomicDemoPage() {
       setSurfpoolStatus("loaded");
     } catch {
       setSurfpoolStatus("error");
+    }
+  }
+
+  async function loadPaymentReadiness() {
+    setPaymentReadinessStatus("loading");
+    try {
+      const res = await fetch("/api/economic-demo/payment-readiness");
+      const payload = (await res.json()) as { ok?: boolean; readiness?: EconomicDemoPaymentReadiness };
+      if (!res.ok || !payload.ok || !payload.readiness) throw new Error("payment_readiness_failed");
+      setPaymentReadiness(payload.readiness);
+      setPaymentReadinessStatus("loaded");
+    } catch {
+      setPaymentReadinessStatus("error");
     }
   }
 
@@ -146,6 +164,13 @@ export default function EconomicDemoPage() {
                 >
                   {surfpoolStatus === "loading" ? "Planning rehearsal…" : "Plan Surfpool rehearsal"}
                 </button>
+                <button
+                  onClick={loadPaymentReadiness}
+                  disabled={paymentReadinessStatus === "loading"}
+                  className="rounded-lg border border-yellow-400/30 bg-yellow-400/10 px-4 py-2 text-sm font-semibold text-yellow-100 transition hover:bg-yellow-400/15 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {paymentReadinessStatus === "loading" ? "Checking payment readiness…" : "Show payment readiness"}
+                </button>
                 <span className="text-xs text-gray-500">
                   Uses deployed 30-agent profile metadata · zero downstream calls
                 </span>
@@ -163,6 +188,11 @@ export default function EconomicDemoPage() {
               {surfpoolStatus === "error" && (
                 <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
                   Surfpool rehearsal plan failed. No local transfer was attempted.
+                </p>
+              )}
+              {paymentReadinessStatus === "error" && (
+                <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+                  Payment readiness failed. No live retry was attempted from the UI.
                 </p>
               )}
               <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
@@ -299,6 +329,38 @@ export default function EconomicDemoPage() {
             </div>
 
 
+
+
+              {paymentReadiness && (
+                <div className="mt-6 rounded-xl border border-yellow-400/30 bg-yellow-400/10 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-yellow-100">Live x402 payment readiness</p>
+                      <p className="mt-1 break-all font-mono text-sm text-white">{paymentReadiness.endpoint}</p>
+                    </div>
+                    <span className="rounded-full border border-yellow-400/40 bg-yellow-400/10 px-2 py-0.5 text-xs text-yellow-100">
+                      {paymentReadiness.status}: {paymentReadiness.blocker}
+                    </span>
+                  </div>
+                  <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">challenge</p>
+                      <p className="mt-1 text-sm text-[#14F195]">reachable · {paymentReadiness.liveChallenge.network}</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">price</p>
+                      <p className="mt-1 font-mono text-sm text-white">{paymentReadiness.liveChallenge.amount} {paymentReadiness.liveChallenge.currency}</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">paid retry</p>
+                      <p className="mt-1 font-mono text-sm text-yellow-100">HTTP {paymentReadiness.paidCompletion.lastAttemptStatus}</p>
+                    </div>
+                  </div>
+                  <p className="mt-4 text-sm leading-6 text-yellow-50/90">
+                    Paid completion is blocked because the deployed specialist rejects demo receipts. The UI will not auto-retry live payment; choose controlled demo receipts or real devnet receipt verification next.
+                  </p>
+                </div>
+              )}
 
               {activeSurfpoolReport && (
                 <div className="mt-6 rounded-xl border border-accent-purple/25 bg-accent-purple/10 p-4">

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -317,3 +317,33 @@ Do not keep probing the live endpoint. The next implementation loop should add a
 
 - Current paid-completion blocker is `demo_payment_disabled` on the deployed specialist runtime.
 - A valid challenge is already emitted for USDC-on-devnet; the missing piece is accepted receipt verification, not endpoint discovery.
+
+## Phase 6 implementation reflection — payment readiness UI/API
+
+**Date:** 2026-05-04 AEST
+**Scope shipped:** Added a fail-closed payment-readiness API and UI panel for the economic demo.
+**BDD scenarios touched:** Judge-facing evidence must show why paid completion is blocked instead of hiding it behind a generic failure.
+**Validation:** focused Jest 9/9 PASS; targeted lint PASS; `npm run build` PASS.
+**Result:** PASS.
+**Evidence artifacts:** `lib/economic-demo/payment-readiness.ts`, `app/api/economic-demo/payment-readiness/route.ts`, `lib/__tests__/economic-demo-payment-readiness.test.ts`, `/economic-demo` payment readiness panel.
+
+### What worked
+
+The UI now clearly separates three states: live x402 challenge is reachable, paid retry was attempted once, and paid completion is blocked because deployed runtime rejects demo receipts with `demo_payment_disabled`. This avoids the judge seeing a silent broken button or ambiguous payment failure.
+
+### What failed or surprised us
+
+The proof is evidence-backed but static until the operator intentionally reruns the readiness smoke. That is deliberate to avoid accidental live retries from the webpage.
+
+### Drift check
+
+No live request is triggered by loading the page. The panel only exposes the latest recorded readiness state and the next two implementation options.
+
+### Next phase adjustment
+
+Proceed by implementing one of two explicit paths: controlled demo receipt enablement for judge demo, or real devnet receipt verification. Recommendation for speed: controlled demo receipts on demo deployment only, with visible labeling and fail-closed production default.
+
+### Decision log additions
+
+- The economic demo UI must show payment-readiness blockers explicitly.
+- Live retry remains operator-script-only; the webpage must not trigger live x402 probes automatically.

--- a/lib/__tests__/economic-demo-payment-readiness.test.ts
+++ b/lib/__tests__/economic-demo-payment-readiness.test.ts
@@ -1,0 +1,29 @@
+import { getEconomicDemoPaymentReadiness } from "@/lib/economic-demo/payment-readiness";
+
+describe("economic demo payment readiness", () => {
+  it("records the current paid-completion blocker without triggering live retries", () => {
+    const readiness = getEconomicDemoPaymentReadiness();
+
+    expect(readiness.status).toBe("blocked");
+    expect(readiness.blocker).toBe("demo_payment_disabled");
+    expect(readiness.liveChallenge).toMatchObject({
+      reachable: true,
+      network: "solana-devnet",
+      payTo: "8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To",
+      amount: "0.05",
+      currency: "USDC",
+      nonceObserved: true,
+    });
+    expect(readiness.paidCompletion).toMatchObject({
+      reached: false,
+      lastAttemptStatus: 402,
+      lastAttemptErrorCode: "demo_payment_disabled",
+    });
+    expect(readiness.guardrails).toMatchObject({
+      noAutomaticLiveRetry: true,
+      noSignerMaterialInProbe: true,
+      noDevnetTransferFromProbe: true,
+      maxProbeCalls: 2,
+    });
+  });
+});

--- a/lib/economic-demo/payment-readiness.ts
+++ b/lib/economic-demo/payment-readiness.ts
@@ -1,0 +1,82 @@
+export type EconomicDemoPaymentReadiness = {
+  mode: "live_x402_payment_readiness";
+  profileId: "code-generation-agent";
+  endpoint: string;
+  status: "blocked" | "ready";
+  blocker?: "demo_payment_disabled" | "real_receipt_verifier_unavailable" | "unknown";
+  liveChallenge: {
+    reachable: boolean;
+    network: "solana-devnet";
+    payTo: string;
+    amount: string;
+    currency: string;
+    nonceObserved: boolean;
+  };
+  paidCompletion: {
+    reached: boolean;
+    lastAttemptStatus: 402;
+    lastAttemptErrorCode: "demo_payment_disabled";
+  };
+  guardrails: {
+    noAutomaticLiveRetry: true;
+    noSignerMaterialInProbe: true;
+    noDevnetTransferFromProbe: true;
+    maxProbeCalls: 2;
+  };
+  evidence: {
+    generatedAt: string;
+    localArtifactPath: string;
+    pr?: string;
+  };
+  nextOptions: Array<{
+    id: "controlled_demo_receipts" | "real_devnet_receipt_verifier";
+    label: string;
+    tradeoff: string;
+  }>;
+};
+
+export function getEconomicDemoPaymentReadiness(): EconomicDemoPaymentReadiness {
+  return {
+    mode: "live_x402_payment_readiness",
+    profileId: "code-generation-agent",
+    endpoint: "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions",
+    status: "blocked",
+    blocker: "demo_payment_disabled",
+    liveChallenge: {
+      reachable: true,
+      network: "solana-devnet",
+      payTo: "8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To",
+      amount: "0.05",
+      currency: "USDC",
+      nonceObserved: true,
+    },
+    paidCompletion: {
+      reached: false,
+      lastAttemptStatus: 402,
+      lastAttemptErrorCode: "demo_payment_disabled",
+    },
+    guardrails: {
+      noAutomaticLiveRetry: true,
+      noSignerMaterialInProbe: true,
+      noDevnetTransferFromProbe: true,
+      maxProbeCalls: 2,
+    },
+    evidence: {
+      generatedAt: "2026-05-04T08:12:23.130Z",
+      localArtifactPath: "artifacts/economic-demo-live-x402-readiness/20260504T081222Z/summary.json",
+      pr: "https://github.com/nissan/reddi-agent-protocol/pull/193",
+    },
+    nextOptions: [
+      {
+        id: "controlled_demo_receipts",
+        label: "Enable controlled demo receipts for the judge deployment",
+        tradeoff: "Fastest judge-facing path; must be visibly labeled as demo receipt verification, not production settlement.",
+      },
+      {
+        id: "real_devnet_receipt_verifier",
+        label: "Implement real devnet receipt verification",
+        tradeoff: "Stronger protocol proof; takes longer because the runtime must verify paid receipt semantics before OpenRouter execution.",
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

Adds a fail-closed payment-readiness API/UI layer for the economic demo so the judge-facing page shows the current paid-completion blocker instead of hiding it.

Adds:
- `lib/economic-demo/payment-readiness.ts`
- `app/api/economic-demo/payment-readiness`
- payment-readiness panel on `/economic-demo`
- tests for the recorded readiness/blocker state
- Phase 6 retrospective update

## Current readiness state shown

- live x402 challenge: reachable
- profile: `code-generation-agent`
- endpoint: `https://reddi-code-generation.preview.reddi.tech/v1/chat/completions`
- challenge: `solana-devnet`, payee `8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To`, amount `0.05`, currency `USDC`, nonce observed
- paid completion: blocked
- blocker: `demo_payment_disabled`

The UI does not trigger live x402 retries; it displays latest recorded evidence and the two explicit next options: controlled demo receipts or real devnet receipt verification.

## Validation

- focused Jest 9/9 PASS
- targeted lint PASS
- `npm run build` PASS