### PR TITLE
Fix code-generation specialist OpenRouter model

### DIFF
--- a/packages/openrouter-specialists/src/profiles/index.ts
+++ b/packages/openrouter-specialists/src/profiles/index.ts
@@ -119,7 +119,7 @@ export const specialistProfiles: SpecialistProfile[] = [
     price: { currency: "USDC", amount: "0.05", unit: "request" },
     safetyMode: "standard",
     preferredAttestors: ["verification-validation-agent"],
-    model: "anthropic/claude-3.5-sonnet",
+    model: "openai/gpt-4.1-mini",
     tags: ["engineering", "code", "tests"],
     systemPrompt:
       "You are the Reddi Code Generation Agent. Make minimal, testable code changes, explain tradeoffs, avoid secrets, and include validation evidence.",


### PR DESCRIPTION
## Summary
- switch the hosted code-generation specialist from unavailable OpenRouter slug `anthropic/claude-3.5-sonnet` to reachable `openai/gpt-4.1-mini`
- unblocks the controlled demo-paid x402 readiness path after Coolify demo receipts were enabled

## Validation
- `npm test --prefix packages/openrouter-specialists` — PASS 54/54
- `npm run build` — PASS

## Guardrails
- no signer/private-key material
- no devnet transfer from this PR
- no Coolify mutation in code change itself
