### PR TITLE
Show economic demo paid completion readiness

### DIFF
--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -332,14 +332,14 @@ export default function EconomicDemoPage() {
 
 
               {paymentReadiness && (
-                <div className="mt-6 rounded-xl border border-yellow-400/30 bg-yellow-400/10 p-4">
+                <div className={paymentReadiness.status === "ready" ? "mt-6 rounded-xl border border-[#14F195]/30 bg-[#14F195]/10 p-4" : "mt-6 rounded-xl border border-yellow-400/30 bg-yellow-400/10 p-4"}>
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
-                      <p className="text-xs uppercase tracking-wide text-yellow-100">Live x402 payment readiness</p>
+                      <p className={paymentReadiness.status === "ready" ? "text-xs uppercase tracking-wide text-[#14F195]" : "text-xs uppercase tracking-wide text-yellow-100"}>Live x402 payment readiness</p>
                       <p className="mt-1 break-all font-mono text-sm text-white">{paymentReadiness.endpoint}</p>
                     </div>
-                    <span className="rounded-full border border-yellow-400/40 bg-yellow-400/10 px-2 py-0.5 text-xs text-yellow-100">
-                      {paymentReadiness.status}: {paymentReadiness.blocker}
+                    <span className={paymentReadiness.status === "ready" ? "rounded-full border border-[#14F195]/40 bg-[#14F195]/10 px-2 py-0.5 text-xs text-[#14F195]" : "rounded-full border border-yellow-400/40 bg-yellow-400/10 px-2 py-0.5 text-xs text-yellow-100"}>
+                      {paymentReadiness.status}{paymentReadiness.blocker ? `: ${paymentReadiness.blocker}` : ""}
                     </span>
                   </div>
                   <div className="mt-4 grid gap-3 sm:grid-cols-3">
@@ -353,11 +353,13 @@ export default function EconomicDemoPage() {
                     </div>
                     <div className="rounded-lg border border-white/10 bg-black/20 p-3">
                       <p className="text-xs text-gray-500">paid retry</p>
-                      <p className="mt-1 font-mono text-sm text-yellow-100">HTTP {paymentReadiness.paidCompletion.lastAttemptStatus}</p>
+                      <p className={paymentReadiness.paidCompletion.reached ? "mt-1 font-mono text-sm text-[#14F195]" : "mt-1 font-mono text-sm text-yellow-100"}>HTTP {paymentReadiness.paidCompletion.lastAttemptStatus}</p>
                     </div>
                   </div>
-                  <p className="mt-4 text-sm leading-6 text-yellow-50/90">
-                    Paid completion is blocked because the deployed specialist rejects demo receipts. The UI will not auto-retry live payment; choose controlled demo receipts or real devnet receipt verification next.
+                  <p className={paymentReadiness.status === "ready" ? "mt-4 text-sm leading-6 text-[#14F195]/90" : "mt-4 text-sm leading-6 text-yellow-50/90"}>
+                    {paymentReadiness.status === "ready"
+                      ? "Controlled demo-paid completion reached HTTP 200 against the deployed code-generation specialist. The UI still will not auto-retry live payment; the next demo loop can promote this from one paid edge to a multi-edge workflow."
+                      : "Paid completion is blocked because the deployed specialist rejects demo receipts. The UI will not auto-retry live payment; choose controlled demo receipts or real devnet receipt verification next."}
                   </p>
                 </div>
               )}

--- a/lib/__tests__/economic-demo-payment-readiness.test.ts
+++ b/lib/__tests__/economic-demo-payment-readiness.test.ts
@@ -1,11 +1,11 @@
 import { getEconomicDemoPaymentReadiness } from "@/lib/economic-demo/payment-readiness";
 
 describe("economic demo payment readiness", () => {
-  it("records the current paid-completion blocker without triggering live retries", () => {
+  it("records the controlled paid-completion success without triggering live retries", () => {
     const readiness = getEconomicDemoPaymentReadiness();
 
-    expect(readiness.status).toBe("blocked");
-    expect(readiness.blocker).toBe("demo_payment_disabled");
+    expect(readiness.status).toBe("ready");
+    expect(readiness.blocker).toBeUndefined();
     expect(readiness.liveChallenge).toMatchObject({
       reachable: true,
       network: "solana-devnet",
@@ -15,9 +15,9 @@ describe("economic demo payment readiness", () => {
       nonceObserved: true,
     });
     expect(readiness.paidCompletion).toMatchObject({
-      reached: false,
-      lastAttemptStatus: 402,
-      lastAttemptErrorCode: "demo_payment_disabled",
+      reached: true,
+      lastAttemptStatus: 200,
+      paymentSatisfied: true,
     });
     expect(readiness.guardrails).toMatchObject({
       noAutomaticLiveRetry: true,
@@ -25,5 +25,6 @@ describe("economic demo payment readiness", () => {
       noDevnetTransferFromProbe: true,
       maxProbeCalls: 2,
     });
+    expect(readiness.evidence.localArtifactPath).toContain("20260504T085951Z");
   });
 });

--- a/lib/economic-demo/payment-readiness.ts
+++ b/lib/economic-demo/payment-readiness.ts
@@ -14,8 +14,9 @@ export type EconomicDemoPaymentReadiness = {
   };
   paidCompletion: {
     reached: boolean;
-    lastAttemptStatus: 402;
-    lastAttemptErrorCode: "demo_payment_disabled";
+    lastAttemptStatus: number;
+    lastAttemptErrorCode?: "demo_payment_disabled" | "http_502" | "unknown";
+    paymentSatisfied: boolean;
   };
   guardrails: {
     noAutomaticLiveRetry: true;
@@ -27,9 +28,10 @@ export type EconomicDemoPaymentReadiness = {
     generatedAt: string;
     localArtifactPath: string;
     pr?: string;
+    operationalChange?: string;
   };
   nextOptions: Array<{
-    id: "controlled_demo_receipts" | "real_devnet_receipt_verifier";
+    id: "multi_edge_webpage_workflow" | "real_devnet_receipt_verifier";
     label: string;
     tradeoff: string;
   }>;
@@ -40,8 +42,7 @@ export function getEconomicDemoPaymentReadiness(): EconomicDemoPaymentReadiness 
     mode: "live_x402_payment_readiness",
     profileId: "code-generation-agent",
     endpoint: "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions",
-    status: "blocked",
-    blocker: "demo_payment_disabled",
+    status: "ready",
     liveChallenge: {
       reachable: true,
       network: "solana-devnet",
@@ -51,9 +52,9 @@ export function getEconomicDemoPaymentReadiness(): EconomicDemoPaymentReadiness 
       nonceObserved: true,
     },
     paidCompletion: {
-      reached: false,
-      lastAttemptStatus: 402,
-      lastAttemptErrorCode: "demo_payment_disabled",
+      reached: true,
+      lastAttemptStatus: 200,
+      paymentSatisfied: true,
     },
     guardrails: {
       noAutomaticLiveRetry: true,
@@ -62,15 +63,16 @@ export function getEconomicDemoPaymentReadiness(): EconomicDemoPaymentReadiness 
       maxProbeCalls: 2,
     },
     evidence: {
-      generatedAt: "2026-05-04T08:12:23.130Z",
-      localArtifactPath: "artifacts/economic-demo-live-x402-readiness/20260504T081222Z/summary.json",
-      pr: "https://github.com/nissan/reddi-agent-protocol/pull/193",
+      generatedAt: "2026-05-04T09:00:02.570Z",
+      localArtifactPath: "artifacts/economic-demo-live-x402-readiness/20260504T085951Z/summary.json",
+      pr: "https://github.com/nissan/reddi-agent-protocol/pull/195",
+      operationalChange: "Controlled demo receipts enabled for the hosted code-generation specialist in Coolify; code-generation model slug corrected from unavailable anthropic/claude-3.5-sonnet to openai/gpt-4.1-mini.",
     },
     nextOptions: [
       {
-        id: "controlled_demo_receipts",
-        label: "Enable controlled demo receipts for the judge deployment",
-        tradeoff: "Fastest judge-facing path; must be visibly labeled as demo receipt verification, not production settlement.",
+        id: "multi_edge_webpage_workflow",
+        label: "Promote the webpage path from single paid edge to multi-edge economic workflow",
+        tradeoff: "Fastest judge-facing proof now that the first controlled paid completion reaches HTTP 200; still label receipts as controlled demo receipts until real settlement verification lands.",
       },
       {
         id: "real_devnet_receipt_verifier",


### PR DESCRIPTION
## Summary
- update `/api/economic-demo/payment-readiness` and `/economic-demo` to show the controlled demo-paid x402 completion is now ready/reached
- record evidence from the successful bounded readiness smoke: HTTP 402 challenge + demo-paid HTTP 200 completion
- keep UI fail-safe: no automatic live retry, no signer material, no devnet transfer from the probe

## Validation
- `npx jest --runTestsByPath lib/__tests__/economic-demo-payment-readiness.test.ts`
- `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/payment-readiness.ts lib/__tests__/economic-demo-payment-readiness.test.ts`
- `npm run build`
