### PR TITLE
Document BDD roadmap and surface webpage evidence

### DIFF
--- a/app/api/economic-demo/webpage-live-workflow/route.ts
+++ b/app/api/economic-demo/webpage-live-workflow/route.ts
@@ -1,0 +1,5 @@
+import { getWebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
+
+export async function GET() {
+  return Response.json({ ok: true, evidence: getWebpageLiveWorkflowEvidence() });
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -12,6 +12,7 @@ import type { EconomicDemoBalanceReport } from "@/lib/economic-demo/balances";
 import type { DryRunEconomicPlan } from "@/lib/economic-demo/dry-run";
 import type { SurfpoolRehearsalReport } from "@/lib/economic-demo/surfpool-rehearsal";
 import type { EconomicDemoPaymentReadiness } from "@/lib/economic-demo/payment-readiness";
+import type { WebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
 
 function shortWallet(wallet: string) {
   return `${wallet.slice(0, 8)}…${wallet.slice(-6)}`;
@@ -34,6 +35,8 @@ export default function EconomicDemoPage() {
   const [surfpoolStatus, setSurfpoolStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const [paymentReadiness, setPaymentReadiness] = useState<EconomicDemoPaymentReadiness | null>(null);
   const [paymentReadinessStatus, setPaymentReadinessStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [webpageLiveEvidence, setWebpageLiveEvidence] = useState<WebpageLiveWorkflowEvidence | null>(null);
+  const [webpageLiveEvidenceStatus, setWebpageLiveEvidenceStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const scenario = useMemo(
     () => economicDemoScenarios.find((candidate) => candidate.id === scenarioId) ?? economicDemoScenarios[0],
     [scenarioId],
@@ -98,6 +101,19 @@ export default function EconomicDemoPage() {
       setPaymentReadinessStatus("loaded");
     } catch {
       setPaymentReadinessStatus("error");
+    }
+  }
+
+  async function loadWebpageLiveEvidence() {
+    setWebpageLiveEvidenceStatus("loading");
+    try {
+      const res = await fetch("/api/economic-demo/webpage-live-workflow");
+      const payload = (await res.json()) as { ok?: boolean; evidence?: WebpageLiveWorkflowEvidence };
+      if (!res.ok || !payload.ok || !payload.evidence) throw new Error("webpage_live_evidence_failed");
+      setWebpageLiveEvidence(payload.evidence);
+      setWebpageLiveEvidenceStatus("loaded");
+    } catch {
+      setWebpageLiveEvidenceStatus("error");
     }
   }
 
@@ -171,6 +187,13 @@ export default function EconomicDemoPage() {
                 >
                   {paymentReadinessStatus === "loading" ? "Checking payment readiness…" : "Show payment readiness"}
                 </button>
+                <button
+                  onClick={loadWebpageLiveEvidence}
+                  disabled={webpageLiveEvidenceStatus === "loading"}
+                  className="rounded-lg border border-[#14F195]/30 bg-[#14F195]/10 px-4 py-2 text-sm font-semibold text-[#14F195] transition hover:bg-[#14F195]/15 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {webpageLiveEvidenceStatus === "loading" ? "Loading live evidence…" : "Show multi-edge evidence"}
+                </button>
                 <span className="text-xs text-gray-500">
                   Uses deployed 30-agent profile metadata · zero downstream calls
                 </span>
@@ -193,6 +216,11 @@ export default function EconomicDemoPage() {
               {paymentReadinessStatus === "error" && (
                 <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
                   Payment readiness failed. No live retry was attempted from the UI.
+                </p>
+              )}
+              {webpageLiveEvidenceStatus === "error" && (
+                <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+                  Multi-edge evidence failed to load. No live specialist endpoint was called from the UI.
                 </p>
               )}
               <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
@@ -360,6 +388,51 @@ export default function EconomicDemoPage() {
                     {paymentReadiness.status === "ready"
                       ? "Controlled demo-paid completion reached HTTP 200 against the deployed code-generation specialist. The UI still will not auto-retry live payment; the next demo loop can promote this from one paid edge to a multi-edge workflow."
                       : "Paid completion is blocked because the deployed specialist rejects demo receipts. The UI will not auto-retry live payment; choose controlled demo receipts or real devnet receipt verification next."}
+                  </p>
+                </div>
+              )}
+
+              {webpageLiveEvidence && (
+                <div className="mt-6 rounded-xl border border-[#14F195]/30 bg-[#14F195]/10 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-[#14F195]">Multi-edge live x402 evidence</p>
+                      <p className="mt-1 text-sm leading-6 text-gray-200">{webpageLiveEvidence.userRequest}</p>
+                    </div>
+                    <span className="rounded-full border border-[#14F195]/40 bg-[#14F195]/10 px-2 py-0.5 text-xs text-[#14F195]">
+                      {webpageLiveEvidence.conclusion}
+                    </span>
+                  </div>
+                  <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">bounded calls</p>
+                      <p className="mt-1 font-mono text-lg text-white">{webpageLiveEvidence.downstreamCallsExecuted}</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">paid completions</p>
+                      <p className="mt-1 font-mono text-lg text-[#14F195]">{webpageLiveEvidence.edges.length}/4</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">receipt mode</p>
+                      <p className="mt-1 text-sm text-yellow-100">controlled demo receipts</p>
+                    </div>
+                  </div>
+                  <div className="mt-4 space-y-3">
+                    {webpageLiveEvidence.edges.map((edge) => (
+                      <div key={edge.profileId} className="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div>
+                            <p className="font-mono text-sm text-white">{edge.step}. {edge.profileId}</p>
+                            <p className="mt-1 text-xs text-gray-400">{edge.capability} · {edge.unpaidChallenge.amount} {edge.unpaidChallenge.currency} → {shortWallet(edge.unpaidChallenge.payTo)}</p>
+                          </div>
+                          <p className="text-xs text-[#14F195]">402 challenge → 200 paid</p>
+                        </div>
+                        <p className="mt-2 text-sm leading-6 text-gray-300">{edge.paidCompletion.outputPreview}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <p className="mt-4 text-sm leading-6 text-yellow-50/90">
+                    This panel reads a sanitized evidence summary only. Loading it does not call live specialist endpoints, sign receipts, or transfer devnet funds. Real devnet receipt verification remains a later phase.
                   </p>
                 </div>
               )}

--- a/docs/ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md
+++ b/docs/ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md
@@ -1,0 +1,243 @@
+# Economic Demo BDD Iterative Roadmap — Post Multi-Edge Proof
+
+_Date:_ 2026-05-04 AEST  
+_Status:_ Active after controlled multi-edge webpage workflow reached  
+_Source evidence:_ `artifacts/economic-demo-webpage-live-x402-workflow/20260504T093552Z/summary.json`  
+_Related:_ `END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md`, `END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md`, Bucket J BDD feature
+
+## North star
+
+A judge can open `/economic-demo`, choose an end-user request, and understand the full economic loop:
+
+1. user request enters a consumer/orchestrator;
+2. scoped payloads move to specialist agents;
+3. every paid edge returns an x402 challenge and receipt/completion evidence;
+4. final output is verified by an attestor;
+5. balances/ledger show economic impact or an explicitly labeled controlled-demo receipt state;
+6. every phase has a retrospective before expanding scope.
+
+## Iteration contract
+
+Every phase follows this loop:
+
+```text
+BDD expectation → scoped implementation → validation → evidence artifact → retrospective → plan refinement
+```
+
+Phase expansion is not automatic. At the end of each phase we ask:
+
+- Did this prove payload flow, money flow, attestation, final output, or wallet impact?
+- Did we accidentally add hidden spend, retries, or secret exposure?
+- Did judge-facing clarity improve?
+- What did the result change about the next phase?
+
+## Current baseline
+
+Completed before this roadmap:
+
+- Static fixture UI, dry-run planning, balance snapshots, Surfpool/local transfer rehearsal.
+- First live x402 challenge reached.
+- Controlled demo-paid single edge reached HTTP 200.
+- Controlled demo-paid multi-edge webpage workflow reached across:
+  - `planning-agent`,
+  - `content-creation-agent`,
+  - `code-generation-agent`,
+  - `verification-validation-agent`.
+- Latest live result: `multi_edge_paid_workflow_reached`, 8 bounded downstream calls, no blockers.
+
+## Phase 7A — Surface multi-edge live evidence in `/economic-demo`
+
+**BDD expectation:** A judge can see the latest multi-edge webpage live evidence without opening raw JSON.
+
+**Scope:**
+
+- Add a typed public summary for the latest controlled multi-edge webpage evidence.
+- Add an API route returning that summary.
+- Add a UI panel on `/economic-demo` showing:
+  - conclusion;
+  - 4 specialist edges;
+  - unpaid HTTP 402 challenge per edge;
+  - controlled demo-paid HTTP 200 completion per edge;
+  - total bounded downstream calls;
+  - guardrail labels.
+
+**Acceptance criteria:**
+
+- UI clearly labels this as controlled demo receipts, not production settlement verification.
+- No live endpoint is called by loading the page.
+- No artifact includes secrets or raw keys.
+- Tests verify conclusion, edge count, status codes, and guardrails.
+
+**Validation:**
+
+- focused Jest for evidence summary;
+- targeted lint for new API/UI/helper;
+- `npm run build`.
+
+**Retrospective prompt:** Does this panel make the economic proof obvious to a judge in under 30 seconds?
+
+**Expected next refinement:** If the panel is clear, generate a compact evidence pack. If not, improve labels/visual hierarchy before expanding.
+
+## Phase 7B — Judge-facing evidence pack
+
+**BDD expectation:** A judge can download or inspect a single bounded evidence packet for the webpage workflow.
+
+**Scope:**
+
+- Generate a sanitized evidence pack from the latest multi-edge smoke artifact.
+- Include summary JSON + human-readable markdown:
+  - user request;
+  - specialist sequence;
+  - receipt/challenge status;
+  - output previews;
+  - attestor recommendation;
+  - guardrails;
+  - known limitation: controlled demo receipts.
+
+**Acceptance criteria:**
+
+- Pack is public-data-only.
+- Pack includes no API keys, private keys, signer material, or unbounded raw model output.
+- The pack references the exact smoke command and artifact timestamp.
+
+**Validation:**
+
+- evidence pack script smoke;
+- secret grep over generated pack;
+- build if UI links the pack.
+
+**Retrospective prompt:** Is the evidence pack enough to explain why this is an economic agent network, not a normal multi-agent chat?
+
+## Phase 7C — Wallet/economic ledger reconciliation for controlled receipts
+
+**BDD expectation:** The demo explains the difference between controlled demo receipts and real devnet settlement.
+
+**Scope:**
+
+- Add a ledger reconciliation view:
+  - x402 challenge amount per edge;
+  - controlled-demo receipt status;
+  - no harness devnet transfer;
+  - link back to Surfpool/local transfer proof for real transfer semantics.
+
+**Acceptance criteria:**
+
+- No false claim of production USDC settlement.
+- Shows the exact payee wallet and USDC amount from each challenge.
+- Makes Surfpool vs controlled-demo vs future real verifier distinction explicit.
+
+**Validation:**
+
+- unit test for reconciliation totals;
+- UI smoke/build.
+
+**Retrospective prompt:** Is the money-flow story honest and still compelling?
+
+## Phase 8A — Research workflow dry-run/evidence design
+
+**BDD expectation:** Research article workflow has a planned specialist graph and evidence criteria before live calls.
+
+**Scope:**
+
+- Confirm retrieval → research → content → explainability → verification sequence.
+- Add/refine BDD scenarios for citation/evidence caveats.
+- Decide whether controlled demo receipts should be enabled for all research path specialists.
+
+**Acceptance criteria:**
+
+- Clear payload boundaries per specialist.
+- Evidence caveat format defined.
+- No live calls until plan/guardrails are updated.
+
+**Retrospective prompt:** Are citations/evidence meaningful enough, or would this become fluent-but-unverified text?
+
+## Phase 8B — Controlled multi-edge research workflow
+
+**BDD expectation:** Research workflow reaches paid completions and attestation with bounded controlled receipts.
+
+**Scope:**
+
+- Add guarded research live x402 workflow smoke.
+- Execute only after Coolify/env readiness is confirmed.
+- Save bounded artifact.
+
+**Acceptance criteria:**
+
+- All edges return 402 challenge then 200 controlled demo-paid completion.
+- Attestor gives release/refund/dispute guidance.
+- Output includes citations or explicit evidence caveats.
+
+**Retrospective prompt:** Does research add a new proof category beyond webpage, or just repeat the same pattern?
+
+## Phase 9A — Picture/storyboard path without external image spend
+
+**BDD expectation:** Picture case can be judge-explained without hidden image API cost.
+
+**Scope:**
+
+- Produce visual brief/storyboard through specialists.
+- Keep image generation disabled unless explicitly approved.
+- Vision/verification agents validate storyboard/prompt alignment.
+
+**Acceptance criteria:**
+
+- No OpenAI/Fal call unless enabled.
+- UI labels storyboard mode clearly.
+- Evidence still includes payload/payment/attestation flow.
+
+**Retrospective prompt:** Is storyboard mode acceptable for judging, or do we need actual image generation?
+
+## Phase 9B — Actual image adapter run, approval-gated
+
+**BDD expectation:** Actual image generation stays inside the economic protocol story.
+
+**Scope:**
+
+- Enable `ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION=true` only with explicit approval and configured provider.
+- Generate image through `/api/economic-demo/image` only.
+- Validate via `vision-language-agent` and attestor.
+
+**Acceptance criteria:**
+
+- Provider/model recorded.
+- Cost/external-call boundary documented.
+- Generated artifact safely persisted.
+
+**Retrospective prompt:** Did image generation improve the protocol demo enough to justify the external spend?
+
+## Phase 10 — Real devnet receipt verifier design/implementation
+
+**BDD expectation:** Move from controlled demo receipts to real receipt verification without breaking demo UX.
+
+**Scope:**
+
+- Specify canonical receipt fields and verification semantics.
+- Implement verifier behind fail-closed feature flag.
+- Add negative tests: wrong nonce, wrong payee, wrong amount, duplicate receipt.
+
+**Acceptance criteria:**
+
+- Controlled demo receipts remain visibly separate.
+- Real verifier proves payment semantics before OpenRouter execution.
+- Replay protection tested.
+
+**Retrospective prompt:** Did real verifier reduce demo ambiguity enough to warrant replacing controlled receipts for judge run?
+
+## Phase 11 — Submission polish and final judge rehearsal
+
+**BDD expectation:** The submission can be rehearsed from cold open.
+
+**Scope:**
+
+- Final `/economic-demo` walkthrough.
+- Evidence pack links.
+- Known limitations copy.
+- Screenshots/video capture if needed.
+
+**Acceptance criteria:**
+
+- Cold-open judge flow under 2 minutes.
+- No broken buttons or stale blocker states.
+- Latest artifacts and statuses are synchronized.
+
+**Retrospective prompt:** Would a judge understand Reddi Agent Protocol as a paid, attestable agent economy?

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -347,3 +347,87 @@ Proceed by implementing one of two explicit paths: controlled demo receipt enabl
 
 - The economic demo UI must show payment-readiness blockers explicitly.
 - Live retry remains operator-script-only; the webpage must not trigger live x402 probes automatically.
+
+## Phase 6/7 transition reflection — controlled paid completion and multi-edge webpage proof
+
+**Date:** 2026-05-04 AEST
+**Scope shipped:** Enabled controlled demo receipt mode for the webpage path, fixed the unavailable OpenRouter model slug for `code-generation-agent`, and reached controlled demo-paid completions across planning, content, code, and verification specialists.
+**BDD scenarios touched:** Webpage demo composes specialists and attestation with bounded paid edges.
+**Validation:** PR #195, #196, and #197 checks green; `npm run smoke:economic-demo:live-x402-readiness`; `npm run smoke:economic-demo:webpage-live-x402-workflow`.
+**Result:** PASS.
+**Evidence artifacts:** `artifacts/economic-demo-live-x402-readiness/20260504T085951Z/summary.json`; `artifacts/economic-demo-webpage-live-x402-workflow/20260504T093552Z/summary.json`.
+
+### What worked
+
+The economic workflow is now real enough to prove the core judge thesis: one user request can become multiple x402-gated specialist calls, each with an unpaid challenge and a controlled demo-paid completion. Passing prior outputs into the verification edge made the attestor response meaningfully inspect the workflow instead of asking for missing context.
+
+### What failed or surprised us
+
+The first paid retry after enabling demo receipts hit HTTP 502 because OpenRouter rejected the stale `anthropic/claude-3.5-sonnet` slug. Fixing the slug to `openai/gpt-4.1-mini` unblocked the path. This means model availability is now part of payment-readiness, not just a model-quality concern.
+
+### Drift check
+
+This improves payload flow, payment/challenge flow, final output, and attestation. It does **not** prove production USDC settlement; receipts are controlled demo receipts and must remain labeled as such.
+
+### Next phase adjustment
+
+Before expanding to research or picture workflows, surface the latest multi-edge evidence directly in `/economic-demo` and then generate a judge-facing evidence pack. The UI must not trigger live retries.
+
+### Decision log additions
+
+- Controlled demo receipts are acceptable for judge demo proof only when clearly labeled.
+- Model endpoint availability belongs in readiness gates.
+- Multi-edge evidence should be UI-visible before adding more live workflow categories.
+
+## Phase 7A implementation plan — surface multi-edge live evidence
+
+**Status:** in progress.
+**Roadmap:** `docs/ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md`
+
+### Scope slice
+
+Add a sanitized evidence summary helper, API route, and `/economic-demo` panel for the latest controlled multi-edge webpage run.
+
+### BDD check
+
+A judge can click one button and see: 4 specialist edges, 4 unpaid HTTP 402 challenges, 4 controlled demo-paid HTTP 200 completions, total bounded calls, guardrails, and the controlled-demo limitation.
+
+### Validation target
+
+- focused Jest for evidence summary;
+- targeted lint;
+- `npm run build`.
+
+### Retrospective gate
+
+After validation, decide whether the next loop should be evidence-pack generation or more UI clarity work.
+
+### Phase 7A implementation reflection — multi-edge evidence UI/API
+
+**Date:** 2026-05-04 AEST
+**Scope shipped:** Added typed sanitized evidence summary, `/api/economic-demo/webpage-live-workflow`, and `/economic-demo` panel for the latest controlled multi-edge webpage run.
+**BDD scenarios touched:** Webpage multi-edge workflow with visible x402 challenge/payment evidence and attestation summary.
+**Validation:** `npx jest --runTestsByPath lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts lib/__tests__/economic-demo-payment-readiness.test.ts`; targeted lint; `npm run build`.
+**Result:** PASS.
+**Evidence artifacts:** `lib/economic-demo/webpage-live-workflow-evidence.ts`, `app/api/economic-demo/webpage-live-workflow/route.ts`, `/economic-demo` multi-edge evidence panel.
+
+#### What worked
+
+The judge-facing page can now show the latest multi-edge proof without sending live requests. It summarizes the four specialist edges, their HTTP 402 x402 challenges, HTTP 200 controlled demo-paid completions, outputs, and guardrails in one place.
+
+#### What failed or surprised us
+
+The evidence is intentionally a sanitized static summary, not a raw artifact loader. That keeps the UI safe and stable, but the next evidence-pack phase should make the source artifact and derived summary relationship more formal.
+
+#### Drift check
+
+This improves judge clarity and keeps live-spend safety intact: loading the panel performs no specialist calls, no signing, and no devnet transfers. It still does not prove production settlement verification.
+
+#### Next phase adjustment
+
+Proceed to Phase 7B: generate a judge-facing evidence pack from the latest multi-edge smoke artifact, with a human-readable markdown summary and secret scan. Include the controlled-demo receipt limitation prominently.
+
+#### Decision log additions
+
+- UI evidence panels should consume sanitized summaries, not raw live artifact blobs.
+- Evidence-pack generation is now the next loop before research/picture expansion.

--- a/lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts
+++ b/lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts
@@ -1,0 +1,29 @@
+import { getWebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
+
+describe("economic demo webpage live workflow evidence", () => {
+  it("summarizes the multi-edge controlled paid workflow without live UI calls", () => {
+    const evidence = getWebpageLiveWorkflowEvidence();
+
+    expect(evidence.conclusion).toBe("multi_edge_paid_workflow_reached");
+    expect(evidence.downstreamCallsExecuted).toBe(8);
+    expect(evidence.edges.map((edge) => edge.profileId)).toEqual([
+      "planning-agent",
+      "content-creation-agent",
+      "code-generation-agent",
+      "verification-validation-agent",
+    ]);
+    expect(evidence.edges.every((edge) => edge.unpaidChallenge.status === 402)).toBe(true);
+    expect(evidence.edges.every((edge) => edge.paidCompletion.status === 200)).toBe(true);
+    expect(evidence.edges.every((edge) => edge.paidCompletion.paymentSatisfied)).toBe(true);
+    expect(evidence.guardrails).toMatchObject({
+      exactEndpoints: true,
+      noSignerMaterialUsed: true,
+      noSignatureAttemptedByHarness: true,
+      noDevnetTransferFromHarness: true,
+      controlledDemoReceiptsOnly: true,
+      boundedMaxDownstreamCalls: 8,
+      noLiveCallsFromUi: true,
+    });
+    expect(evidence.limitations.join(" ")).toContain("controlled demo receipts");
+  });
+});

--- a/lib/economic-demo/webpage-live-workflow-evidence.ts
+++ b/lib/economic-demo/webpage-live-workflow-evidence.ts
@@ -1,0 +1,160 @@
+export type WebpageLiveWorkflowEvidenceEdge = {
+  step: number;
+  profileId: string;
+  capability: string;
+  endpoint: string;
+  unpaidChallenge: {
+    status: 402;
+    network: "solana-devnet";
+    payTo: string;
+    amount: string;
+    currency: "USDC";
+    noncePresent: true;
+  };
+  paidCompletion: {
+    status: 200;
+    paymentSatisfied: true;
+    model: string;
+    outputPreview: string;
+  };
+};
+
+export type WebpageLiveWorkflowEvidence = {
+  schemaVersion: "reddi.economic-demo.webpage.live-x402-workflow.summary.v1";
+  generatedAt: string;
+  sourceArtifactPath: string;
+  mode: "controlled_demo_receipt_multi_edge_webpage_workflow";
+  scenarioId: "webpage";
+  userRequest: string;
+  conclusion: "multi_edge_paid_workflow_reached";
+  downstreamCallsExecuted: 8;
+  edges: WebpageLiveWorkflowEvidenceEdge[];
+  blockers: [];
+  guardrails: {
+    exactEndpoints: true;
+    noSignerMaterialUsed: true;
+    noSignatureAttemptedByHarness: true;
+    noDevnetTransferFromHarness: true;
+    controlledDemoReceiptsOnly: true;
+    boundedMaxDownstreamCalls: 8;
+    noLiveCallsFromUi: true;
+  };
+  limitations: string[];
+  nextStep: string;
+};
+
+export function getWebpageLiveWorkflowEvidence(): WebpageLiveWorkflowEvidence {
+  return {
+    schemaVersion: "reddi.economic-demo.webpage.live-x402-workflow.summary.v1",
+    generatedAt: "2026-05-04T09:35:08.940Z",
+    sourceArtifactPath: "artifacts/economic-demo-webpage-live-x402-workflow/20260504T093552Z/summary.json",
+    mode: "controlled_demo_receipt_multi_edge_webpage_workflow",
+    scenarioId: "webpage",
+    userRequest:
+      "Design me a webpage for a trustless AI agent marketplace where users pay specialist agents via x402 and receive attested outputs.",
+    conclusion: "multi_edge_paid_workflow_reached",
+    downstreamCallsExecuted: 8,
+    edges: [
+      {
+        step: 1,
+        profileId: "planning-agent",
+        capability: "task-decomposition",
+        endpoint: "https://reddi-planning-agent.preview.reddi.tech/v1/chat/completions",
+        unpaidChallenge: {
+          status: 402,
+          network: "solana-devnet",
+          payTo: "2wYpzbExNi2vHSdK48jBusfEx3WNVjzPFEVNcbCA5cAs",
+          amount: "0.03",
+          currency: "USDC",
+          noncePresent: true,
+        },
+        paidCompletion: {
+          status: 200,
+          paymentSatisfied: true,
+          model: "openai/gpt-4.1-mini-2025-04-14",
+          outputPreview:
+            "Produced a concise landing-page plan with hero/header, marketplace explanation, sections, calls to action, and acceptance criteria.",
+        },
+      },
+      {
+        step: 2,
+        profileId: "content-creation-agent",
+        capability: "marketing-copy",
+        endpoint: "https://reddi-content-creation.preview.reddi.tech/v1/chat/completions",
+        unpaidChallenge: {
+          status: 402,
+          network: "solana-devnet",
+          payTo: "4RfVeJp8si1KunYbvf41i5cDjr2SEjNEHEknUMXSEvEE",
+          amount: "0.025",
+          currency: "USDC",
+          noncePresent: true,
+        },
+        paidCompletion: {
+          status: 200,
+          paymentSatisfied: true,
+          model: "openai/gpt-4.1-mini-2025-04-14",
+          outputPreview:
+            "Drafted headline, subheadline, and benefit bullets explaining trustless specialist hiring, x402 payments, and attested outputs.",
+        },
+      },
+      {
+        step: 3,
+        profileId: "code-generation-agent",
+        capability: "webpage-code",
+        endpoint: "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions",
+        unpaidChallenge: {
+          status: 402,
+          network: "solana-devnet",
+          payTo: "8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To",
+          amount: "0.05",
+          currency: "USDC",
+          noncePresent: true,
+        },
+        paidCompletion: {
+          status: 200,
+          paymentSatisfied: true,
+          model: "openai/gpt-4.1-mini-2025-04-14",
+          outputPreview:
+            "Returned a React/Tailwind landing-page component for the trustless AI agent marketplace plus validation notes.",
+        },
+      },
+      {
+        step: 4,
+        profileId: "verification-validation-agent",
+        capability: "attestation",
+        endpoint: "https://reddi-verification-agent.preview.reddi.tech/v1/chat/completions",
+        unpaidChallenge: {
+          status: 402,
+          network: "solana-devnet",
+          payTo: "2EmtCTzhoSSorg2rRSnTbngGJqkqNufgtFUZRGU4iFWq",
+          amount: "0.025",
+          currency: "USDC",
+          noncePresent: true,
+        },
+        paidCompletion: {
+          status: 200,
+          paymentSatisfied: true,
+          model: "openai/gpt-4.1-mini-2025-04-14",
+          outputPreview:
+            "Assessed the evidence chain across planning, copy, code, and release criteria and returned release/refund/dispute guidance.",
+        },
+      },
+    ],
+    blockers: [],
+    guardrails: {
+      exactEndpoints: true,
+      noSignerMaterialUsed: true,
+      noSignatureAttemptedByHarness: true,
+      noDevnetTransferFromHarness: true,
+      controlledDemoReceiptsOnly: true,
+      boundedMaxDownstreamCalls: 8,
+      noLiveCallsFromUi: true,
+    },
+    limitations: [
+      "Receipts are controlled demo receipts, not production USDC settlement verification.",
+      "The UI reads this sanitized summary only; it does not call live specialist endpoints.",
+      "Real devnet receipt verification remains a later phase.",
+    ],
+    nextStep: "Generate a judge-facing evidence pack and reconcile controlled receipt amounts with the ledger view.",
+  };
+}


### PR DESCRIPTION
## Summary
- document the post-multi-edge BDD iterative roadmap with phase-by-phase retrospective gates
- append the Phase 6/7 transition retrospective and Phase 7A retrospective to the iteration log
- add a sanitized multi-edge webpage evidence summary/API and `/economic-demo` panel
- keep the UI safe: loading evidence does not call live specialist endpoints, sign receipts, or transfer funds

## BDD loop
Phase 7A expectation: a judge can see the latest multi-edge webpage proof in `/economic-demo` without opening raw JSON.

## Validation
- `npx jest --runTestsByPath lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts lib/__tests__/economic-demo-payment-readiness.test.ts`
- `npm run lint -- app/economic-demo/page.tsx app/api/economic-demo/webpage-live-workflow/route.ts lib/economic-demo/webpage-live-workflow-evidence.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts`
- `npm run build`

## Next loop after merge
Phase 7B: judge-facing evidence pack generator from the latest multi-edge smoke artifact, with human-readable markdown and secret scan.
