### PR TITLE
Add economic demo evidence pack generator

### DIFF
--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -431,3 +431,34 @@ Proceed to Phase 7B: generate a judge-facing evidence pack from the latest multi
 
 - UI evidence panels should consume sanitized summaries, not raw live artifact blobs.
 - Evidence-pack generation is now the next loop before research/picture expansion.
+
+## Phase 7B implementation reflection — judge-facing evidence pack generator
+
+**Date:** 2026-05-04 AEST
+**Scope shipped:** Added a local evidence-pack generator for the latest multi-edge webpage live x402 workflow artifact.
+**BDD scenarios touched:** Judge can inspect one bounded public evidence packet for request → specialist payload flow → x402 challenge/payment status → attestation summary → guardrails.
+**Validation:** `npm run evidence:economic-demo:webpage`; generated secret scan PASS; targeted script lint PASS with package.json ignored warning only; `npm run build` PASS.
+**Result:** PASS.
+**Evidence artifacts:** `artifacts/economic-demo-evidence-pack/20260504T103840Z/evidence-pack.json`, `artifacts/economic-demo-evidence-pack/20260504T103840Z/EVIDENCE.md`, `artifacts/economic-demo-evidence-pack/20260504T103840Z/SECRET-SCAN.json`.
+
+### What worked
+
+The pack turns raw smoke JSON into judge-readable proof: 4 specialist edges, 4 HTTP 402 x402 challenges, 4 controlled demo-paid HTTP 200 completions, payee wallets, USDC challenge amounts, output previews, and guardrails. The script also runs a local secret scan before declaring success.
+
+### What failed or surprised us
+
+The pack is intentionally generated under git-ignored `artifacts/`, so it is not committed by default. That is good for avoiding stale or oversized evidence blobs, but the UI still needs a stable way to reference or regenerate the latest pack for judges.
+
+### Drift check
+
+This improves judge clarity and evidence portability without adding live calls or spend. It still clearly states controlled demo receipts are not production USDC settlement verification.
+
+### Next phase adjustment
+
+Proceed to Phase 7C: ledger reconciliation. It should total the x402 challenge amounts, distinguish controlled-demo receipts from real settlement, and link the money-flow story back to Surfpool/local transfer proof.
+
+### Decision log additions
+
+- Evidence packs are generated artifacts, not committed source truth.
+- Secret scan is mandatory for every public evidence pack.
+- Next UI work should reconcile challenge amounts and receipt mode before expanding to research/picture workflows.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "smoke:app-adapter": "node ./scripts/run-app-adapter-smoke.mjs",
     "smoke:economic-demo:surfpool": "node ./scripts/run-economic-demo-surfpool-rehearsal.mjs",
     "smoke:economic-demo:live-x402-readiness": "node ./scripts/run-economic-demo-live-x402-readiness.mjs",
-    "smoke:economic-demo:webpage-live-x402-workflow": "node ./scripts/run-economic-demo-webpage-live-x402-workflow.mjs"
+    "smoke:economic-demo:webpage-live-x402-workflow": "node ./scripts/run-economic-demo-webpage-live-x402-workflow.mjs",
+    "evidence:economic-demo:webpage": "node ./scripts/generate-economic-demo-evidence-pack.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/generate-economic-demo-evidence-pack.mjs
+++ b/scripts/generate-economic-demo-evidence-pack.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const defaultSource = join(rootDir, "artifacts", "economic-demo-webpage-live-x402-workflow", "20260504T093552Z", "summary.json");
+const sourcePath = process.env.ECONOMIC_DEMO_EVIDENCE_SOURCE ?? defaultSource;
+const timestamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+const outDir = process.env.ECONOMIC_DEMO_EVIDENCE_OUT
+  ? join(rootDir, process.env.ECONOMIC_DEMO_EVIDENCE_OUT)
+  : join(rootDir, "artifacts", "economic-demo-evidence-pack", timestamp);
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function preview(text, max = 520) {
+  if (typeof text !== "string") return "";
+  return text.replace(/```/g, "~~~").replace(/\s+$/g, "").slice(0, max);
+}
+
+function edgeMarkdown(edge) {
+  return [
+    `### ${edge.step}. ${edge.profileId}`,
+    "",
+    `- Capability: \`${edge.capability}\``,
+    `- Endpoint: \`${edge.endpoint}\``,
+    `- x402 challenge: HTTP ${edge.unpaidChallenge.status} · ${edge.unpaidChallenge.challenge.amount} ${edge.unpaidChallenge.challenge.currency} · ${edge.unpaidChallenge.challenge.network}`,
+    `- Payee wallet: \`${edge.unpaidChallenge.challenge.payTo}\``,
+    `- Controlled demo-paid completion: HTTP ${edge.paidCompletion.status} · paymentSatisfied=${edge.paidCompletion.paymentSatisfied}`,
+    `- Model: \`${edge.paidCompletion.model ?? "unknown"}\``,
+    "",
+    "> Output preview:",
+    ">",
+    preview(edge.paidCompletion.outputPreview)
+      .split("\n")
+      .map((line) => `> ${line}`)
+      .join("\n"),
+    "",
+  ].join("\n");
+}
+
+function scanForSecrets(files) {
+  const patterns = [
+    { id: "openai-or-openrouter-key", regex: /\bsk-[A-Za-z0-9_-]{20,}\b/ },
+    { id: "solana-keypair-array", regex: /\[[\s\n]*(?:\d{1,3}\s*,\s*){20,}\d{1,3}[\s\n]*\]/ },
+    { id: "private-key-label", regex: /(private[_ -]?key|secret[_ -]?key|signer material)/i },
+    { id: "onepassword-ref", regex: /op:\/\//i },
+  ];
+  const findings = [];
+  for (const file of files) {
+    const text = readFileSync(file, "utf8");
+    for (const pattern of patterns) {
+      if (pattern.regex.test(text)) findings.push({ file: relative(rootDir, file), pattern: pattern.id });
+    }
+  }
+  return findings;
+}
+
+const source = readJson(sourcePath);
+assert(source.schemaVersion === "reddi.economic-demo.webpage.live-x402-workflow.v1", "unsupported source artifact schema");
+assert(source.conclusion === "multi_edge_paid_workflow_reached", "source artifact did not reach multi-edge workflow");
+assert(Array.isArray(source.edges) && source.edges.length === 4, "expected four webpage workflow edges");
+assert(source.edges.every((edge) => edge.unpaidChallenge?.status === 402), "every edge must include unpaid 402 challenge proof");
+assert(source.edges.every((edge) => edge.paidCompletion?.status === 200 && edge.paidCompletion?.paymentSatisfied === true), "every edge must include controlled paid 200 proof");
+assert(source.guardrails?.controlledDemoReceiptsOnly === true, "source must be controlled-demo-receipt evidence");
+
+mkdirSync(outDir, { recursive: true });
+
+const pack = {
+  schemaVersion: "reddi.economic-demo.judge-evidence-pack.v1",
+  generatedAt: new Date().toISOString(),
+  sourceArtifactPath: relative(rootDir, sourcePath),
+  scenarioId: source.scenarioId,
+  userRequest: source.userRequest,
+  conclusion: source.conclusion,
+  edgeCount: source.edges.length,
+  downstreamCallsExecuted: source.downstreamCallsExecuted,
+  receiptMode: "controlled_demo_receipts",
+  limitation: "Controlled demo receipts prove x402 challenge/receipt-gated specialist execution for the judge demo, not production USDC settlement verification.",
+  edges: source.edges.map((edge) => ({
+    step: edge.step,
+    profileId: edge.profileId,
+    capability: edge.capability,
+    endpoint: edge.endpoint,
+    challenge: edge.unpaidChallenge.challenge,
+    paidCompletion: {
+      status: edge.paidCompletion.status,
+      paymentSatisfied: edge.paidCompletion.paymentSatisfied,
+      model: edge.paidCompletion.model,
+      outputPreview: preview(edge.paidCompletion.outputPreview),
+    },
+  })),
+  guardrails: source.guardrails,
+  nextRecommendedPhase: "Phase 7C ledger reconciliation, then research workflow planning.",
+};
+
+const jsonPath = join(outDir, "evidence-pack.json");
+const mdPath = join(outDir, "EVIDENCE.md");
+const scanPath = join(outDir, "SECRET-SCAN.json");
+
+writeFileSync(jsonPath, `${JSON.stringify(pack, null, 2)}\n`);
+writeFileSync(
+  mdPath,
+  [
+    "# Reddi Agent Protocol — Multi-Edge Economic Workflow Evidence Pack",
+    "",
+    `Generated: ${pack.generatedAt}`,
+    `Source artifact: \`${pack.sourceArtifactPath}\``,
+    "",
+    "## Verdict",
+    "",
+    `- Conclusion: **${pack.conclusion}**`,
+    `- Scenario: **${pack.scenarioId}**`,
+    `- Specialist edges: **${pack.edgeCount}**`,
+    `- Bounded downstream calls: **${pack.downstreamCallsExecuted}** (4 unpaid challenges + 4 controlled demo-paid completions)`,
+    "- Receipt mode: **controlled demo receipts**",
+    "",
+    "## User request",
+    "",
+    `> ${pack.userRequest}`,
+    "",
+    "## What this proves",
+    "",
+    "- A single end-user request was decomposed into specialist work.",
+    "- Each specialist endpoint enforced x402 first by returning HTTP 402 and a challenge.",
+    "- Each controlled demo receipt unlocked an HTTP 200 specialist completion.",
+    "- The final verification edge received prior workflow outputs and returned an assessment/release recommendation.",
+    "- The harness used exact hosted HTTPS endpoints and bounded call counts.",
+    "",
+    "## Important limitation",
+    "",
+    pack.limitation,
+    "",
+    "## Specialist edges",
+    "",
+    ...source.edges.map(edgeMarkdown),
+    "## Guardrails",
+    "",
+    ...Object.entries(source.guardrails).map(([key, value]) => `- ${key}: ${value}`),
+    "",
+    "## Next phase",
+    "",
+    pack.nextRecommendedPhase,
+    "",
+  ].join("\n"),
+);
+
+const findings = scanForSecrets([jsonPath, mdPath]);
+writeFileSync(scanPath, `${JSON.stringify({ ok: findings.length === 0, findings }, null, 2)}\n`);
+assert(findings.length === 0, `secret scan failed: ${JSON.stringify(findings)}`);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      outDir,
+      jsonPath,
+      mdPath,
+      scanPath,
+      conclusion: pack.conclusion,
+      edgeCount: pack.edgeCount,
+      downstreamCallsExecuted: pack.downstreamCallsExecuted,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## Summary
- add `npm run evidence:economic-demo:webpage`
- generate a judge-facing evidence pack from the latest multi-edge webpage live x402 artifact
- emit `evidence-pack.json`, `EVIDENCE.md`, and `SECRET-SCAN.json` under git-ignored `artifacts/economic-demo-evidence-pack/<timestamp>/`
- append Phase 7B retrospective and refine next loop to Phase 7C ledger reconciliation

## Latest generated pack
- `artifacts/economic-demo-evidence-pack/20260504T103840Z/evidence-pack.json`
- `artifacts/economic-demo-evidence-pack/20260504T103840Z/EVIDENCE.md`
- `artifacts/economic-demo-evidence-pack/20260504T103840Z/SECRET-SCAN.json`

## Validation
- `npm run evidence:economic-demo:webpage` — PASS, secret scan PASS
- `npm run lint -- scripts/generate-economic-demo-evidence-pack.mjs package.json` — PASS with package.json ignored warning only
- `npm run build` — PASS

## Next loop
Phase 7C: ledger reconciliation for controlled receipts vs real settlement, linked back to Surfpool/local transfer proof.
