### PR TITLE
Add economic demo ledger reconciliation

### DIFF
--- a/app/api/economic-demo/ledger-reconciliation/route.ts
+++ b/app/api/economic-demo/ledger-reconciliation/route.ts
@@ -1,0 +1,5 @@
+import { buildEconomicDemoLedgerReconciliation } from "@/lib/economic-demo/ledger-reconciliation";
+
+export async function GET() {
+  return Response.json({ ok: true, reconciliation: buildEconomicDemoLedgerReconciliation() });
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -13,6 +13,7 @@ import type { DryRunEconomicPlan } from "@/lib/economic-demo/dry-run";
 import type { SurfpoolRehearsalReport } from "@/lib/economic-demo/surfpool-rehearsal";
 import type { EconomicDemoPaymentReadiness } from "@/lib/economic-demo/payment-readiness";
 import type { WebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
+import type { EconomicDemoLedgerReconciliation } from "@/lib/economic-demo/ledger-reconciliation";
 
 function shortWallet(wallet: string) {
   return `${wallet.slice(0, 8)}…${wallet.slice(-6)}`;
@@ -37,6 +38,8 @@ export default function EconomicDemoPage() {
   const [paymentReadinessStatus, setPaymentReadinessStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const [webpageLiveEvidence, setWebpageLiveEvidence] = useState<WebpageLiveWorkflowEvidence | null>(null);
   const [webpageLiveEvidenceStatus, setWebpageLiveEvidenceStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [ledgerReconciliation, setLedgerReconciliation] = useState<EconomicDemoLedgerReconciliation | null>(null);
+  const [ledgerReconciliationStatus, setLedgerReconciliationStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const scenario = useMemo(
     () => economicDemoScenarios.find((candidate) => candidate.id === scenarioId) ?? economicDemoScenarios[0],
     [scenarioId],
@@ -117,6 +120,19 @@ export default function EconomicDemoPage() {
     }
   }
 
+  async function loadLedgerReconciliation() {
+    setLedgerReconciliationStatus("loading");
+    try {
+      const res = await fetch("/api/economic-demo/ledger-reconciliation");
+      const payload = (await res.json()) as { ok?: boolean; reconciliation?: EconomicDemoLedgerReconciliation };
+      if (!res.ok || !payload.ok || !payload.reconciliation) throw new Error("ledger_reconciliation_failed");
+      setLedgerReconciliation(payload.reconciliation);
+      setLedgerReconciliationStatus("loaded");
+    } catch {
+      setLedgerReconciliationStatus("error");
+    }
+  }
+
   return (
     <main className="min-h-screen bg-page">
       <section className="relative overflow-hidden border-b border-white/5">
@@ -194,6 +210,13 @@ export default function EconomicDemoPage() {
                 >
                   {webpageLiveEvidenceStatus === "loading" ? "Loading live evidence…" : "Show multi-edge evidence"}
                 </button>
+                <button
+                  onClick={loadLedgerReconciliation}
+                  disabled={ledgerReconciliationStatus === "loading"}
+                  className="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-gray-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {ledgerReconciliationStatus === "loading" ? "Reconciling ledger…" : "Reconcile ledger"}
+                </button>
                 <span className="text-xs text-gray-500">
                   Uses deployed 30-agent profile metadata · zero downstream calls
                 </span>
@@ -221,6 +244,11 @@ export default function EconomicDemoPage() {
               {webpageLiveEvidenceStatus === "error" && (
                 <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
                   Multi-edge evidence failed to load. No live specialist endpoint was called from the UI.
+                </p>
+              )}
+              {ledgerReconciliationStatus === "error" && (
+                <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+                  Ledger reconciliation failed. No live call or transfer was attempted.
                 </p>
               )}
               <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
@@ -389,6 +417,59 @@ export default function EconomicDemoPage() {
                       ? "Controlled demo-paid completion reached HTTP 200 against the deployed code-generation specialist. The UI still will not auto-retry live payment; the next demo loop can promote this from one paid edge to a multi-edge workflow."
                       : "Paid completion is blocked because the deployed specialist rejects demo receipts. The UI will not auto-retry live payment; choose controlled demo receipts or real devnet receipt verification next."}
                   </p>
+                </div>
+              )}
+
+              {ledgerReconciliation && (
+                <div className="mt-6 rounded-xl border border-white/10 bg-white/5 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-gray-300">Ledger reconciliation</p>
+                      <p className="mt-1 text-sm leading-6 text-gray-200">
+                        Controlled receipt totals are reconciled against x402 challenge amounts and Surfpool/local transfer semantics.
+                      </p>
+                    </div>
+                    <span className="rounded-full border border-yellow-400/40 bg-yellow-400/10 px-2 py-0.5 text-xs text-yellow-100">
+                      no production settlement claim
+                    </span>
+                  </div>
+                  <div className="mt-4 grid gap-3 sm:grid-cols-4">
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">x402 total</p>
+                      <p className="mt-1 font-mono text-lg text-white">{ledgerReconciliation.totals.challengeAmountUsdc} USDC</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">demo completions</p>
+                      <p className="mt-1 font-mono text-lg text-[#14F195]">{ledgerReconciliation.totals.controlledPaidCompletions}/4</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">real settlements</p>
+                      <p className="mt-1 font-mono text-lg text-yellow-100">{ledgerReconciliation.totals.realSettlementsVerified}</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">Surfpool local proof</p>
+                      <p className="mt-1 font-mono text-lg text-white">{ledgerReconciliation.totals.surfpoolLocalTransferSol} SOL</p>
+                    </div>
+                  </div>
+                  <div className="mt-4 grid gap-3 md:grid-cols-2">
+                    {ledgerReconciliation.edges.map((edge) => (
+                      <div key={edge.profileId} className="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <p className="font-mono text-sm text-white">{edge.profileId}</p>
+                        <p className="mt-1 text-xs text-gray-400">{edge.challengeAmountUsdc} USDC challenge → {shortWallet(edge.payeeWallet)}</p>
+                        <p className="mt-2 text-xs text-[#14F195]">controlled receipt: {edge.controlledReceiptStatus}</p>
+                        <p className="mt-1 text-xs text-yellow-100">real settlement: {edge.realSettlementStatus}</p>
+                        <p className="mt-1 text-xs text-gray-400">Surfpool local transfer: {formatLamports(edge.surfpoolLocalTransferLamports)}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-4 grid gap-2 md:grid-cols-2">
+                    {ledgerReconciliation.proofLayers.map((layer) => (
+                      <div key={layer.id} className="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <p className="text-xs uppercase tracking-wide text-gray-400">{layer.id}: {layer.status}</p>
+                        <p className="mt-1 text-sm leading-6 text-gray-300">{layer.summary}</p>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               )}
 

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -462,3 +462,34 @@ Proceed to Phase 7C: ledger reconciliation. It should total the x402 challenge a
 - Evidence packs are generated artifacts, not committed source truth.
 - Secret scan is mandatory for every public evidence pack.
 - Next UI work should reconcile challenge amounts and receipt mode before expanding to research/picture workflows.
+
+## Phase 7C implementation reflection — ledger reconciliation
+
+**Date:** 2026-05-04 AEST
+**Scope shipped:** Added ledger reconciliation helper, API route, unit test, and `/economic-demo` panel that bridges controlled x402 receipts to Surfpool/local transfer semantics.
+**BDD scenarios touched:** Judge can distinguish x402 challenge/payment evidence, controlled demo receipt completion, local transfer-semantics proof, and not-yet-implemented real devnet receipt verification.
+**Validation:** `npx jest --runTestsByPath lib/__tests__/economic-demo-ledger-reconciliation.test.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts`; targeted lint; `npm run build`.
+**Result:** PASS.
+**Evidence artifacts:** `lib/economic-demo/ledger-reconciliation.ts`, `app/api/economic-demo/ledger-reconciliation/route.ts`, `lib/__tests__/economic-demo-ledger-reconciliation.test.ts`, `/economic-demo` ledger reconciliation panel.
+
+### What worked
+
+The UI now states the money-flow story honestly: x402 challenges total `0.13 USDC`, controlled demo receipts satisfied 4/4 completions, real settlements verified remain 0, and Surfpool/local proof covers 3,500,000 lamports of transfer semantics. This makes the difference between challenge/payment gating and production settlement explicit instead of hand-wavy.
+
+### What failed or surprised us
+
+The live x402 challenge amounts are denominated as USDC while Surfpool local rehearsal uses SOL lamports for transfer semantics. The reconciliation has to show them as separate proof layers rather than pretending they are the same unit.
+
+### Drift check
+
+This improves money-flow honesty and judge clarity without live calls, signing, or devnet transfer from the UI. It still does not implement real devnet receipt verification.
+
+### Next phase adjustment
+
+Now that webpage proof is judge-readable and financially reconciled, choose between: (A) research workflow expansion using the same controlled-demo pattern, or (B) real devnet receipt verifier design. Recommendation: do Phase 8A research workflow design next for breadth, unless judging feedback demands production settlement semantics first.
+
+### Decision log additions
+
+- Never equate Surfpool SOL transfer semantics with live USDC challenge settlement; show them as separate proof layers.
+- Controlled demo receipt count and real settlement verified count must both be visible.
+- Phase 8A should reuse the reconciliation pattern for research if we expand breadth.

--- a/lib/__tests__/economic-demo-ledger-reconciliation.test.ts
+++ b/lib/__tests__/economic-demo-ledger-reconciliation.test.ts
@@ -1,0 +1,30 @@
+import { buildEconomicDemoLedgerReconciliation } from "@/lib/economic-demo/ledger-reconciliation";
+
+describe("economic demo ledger reconciliation", () => {
+  it("reconciles controlled x402 challenge amounts against local transfer semantics without claiming real settlement", () => {
+    const reconciliation = buildEconomicDemoLedgerReconciliation();
+
+    expect(reconciliation.scenarioId).toBe("webpage");
+    expect(reconciliation.edgeCount).toBe(4);
+    expect(reconciliation.edges.map((edge) => edge.profileId)).toEqual([
+      "planning-agent",
+      "content-creation-agent",
+      "code-generation-agent",
+      "verification-validation-agent",
+    ]);
+    expect(reconciliation.totals.challengeAmountUsdc).toBe("0.13");
+    expect(reconciliation.totals.challengeAmountMicrousd).toBe(130000);
+    expect(reconciliation.totals.controlledPaidCompletions).toBe(4);
+    expect(reconciliation.totals.realSettlementsVerified).toBe(0);
+    expect(reconciliation.totals.surfpoolLocalTransferLamports).toBe(3500000);
+    expect(reconciliation.edges.every((edge) => edge.controlledReceiptStatus === "satisfied_demo_only")).toBe(true);
+    expect(reconciliation.edges.every((edge) => edge.realSettlementStatus === "not_verified")).toBe(true);
+    expect(reconciliation.guardrails).toMatchObject({
+      noLiveCallsFromUi: true,
+      noDevnetTransferFromUi: true,
+      controlledDemoReceiptsClearlyLabeled: true,
+      noProductionSettlementClaim: true,
+    });
+    expect(reconciliation.proofLayers.find((layer) => layer.id === "real_devnet_receipt_verifier")?.status).toBe("not_implemented");
+  });
+});

--- a/lib/economic-demo/ledger-reconciliation.ts
+++ b/lib/economic-demo/ledger-reconciliation.ts
@@ -1,0 +1,131 @@
+import { buildEconomicDemoDryRunPlan } from "@/lib/economic-demo/dry-run";
+import { buildSurfpoolRehearsalReport } from "@/lib/economic-demo/surfpool-rehearsal";
+import { getWebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
+
+export type EconomicDemoLedgerReconciliationEdge = {
+  profileId: string;
+  payeeWallet: string;
+  challengeAmountUsdc: string;
+  challengeAmountMicrousd: number;
+  controlledReceiptStatus: "satisfied_demo_only";
+  realSettlementStatus: "not_verified";
+  surfpoolLocalTransferLamports: number;
+  surfpoolTransferStatus: "planned_local_transfer_semantics";
+};
+
+export type EconomicDemoLedgerReconciliation = {
+  schemaVersion: "reddi.economic-demo.ledger-reconciliation.v1";
+  generatedAt: string;
+  scenarioId: "webpage";
+  mode: "controlled_demo_receipt_reconciliation";
+  sourceEvidenceArtifactPath: string;
+  edgeCount: 4;
+  totals: {
+    challengeAmountUsdc: string;
+    challengeAmountMicrousd: number;
+    controlledPaidCompletions: 4;
+    realSettlementsVerified: 0;
+    surfpoolLocalTransferLamports: number;
+    surfpoolLocalTransferSol: string;
+  };
+  edges: EconomicDemoLedgerReconciliationEdge[];
+  proofLayers: Array<{
+    id: "x402_challenge" | "controlled_demo_receipt" | "surfpool_local_transfer" | "real_devnet_receipt_verifier";
+    status: "complete" | "planned" | "not_implemented";
+    summary: string;
+  }>;
+  guardrails: {
+    noLiveCallsFromUi: true;
+    noDevnetTransferFromUi: true;
+    controlledDemoReceiptsClearlyLabeled: true;
+    noProductionSettlementClaim: true;
+  };
+  nextStep: string;
+};
+
+function amountToMicrousd(amount: string): number {
+  const [whole = "0", fraction = ""] = amount.split(".");
+  const normalizedFraction = `${fraction}000000`.slice(0, 6);
+  return Number.parseInt(whole, 10) * 1_000_000 + Number.parseInt(normalizedFraction, 10);
+}
+
+function microusdToAmount(microusd: number): string {
+  const whole = Math.floor(microusd / 1_000_000);
+  const fraction = String(microusd % 1_000_000).padStart(6, "0").replace(/0+$/, "");
+  return fraction ? `${whole}.${fraction}` : `${whole}`;
+}
+
+function lamportsToSol(lamports: number): string {
+  return (lamports / 1_000_000_000).toFixed(6).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+export function buildEconomicDemoLedgerReconciliation(): EconomicDemoLedgerReconciliation {
+  const evidence = getWebpageLiveWorkflowEvidence();
+  const surfpool = buildSurfpoolRehearsalReport(buildEconomicDemoDryRunPlan("webpage"));
+  const surfpoolTransferByProfile = new Map(surfpool.transfers.map((transfer) => [transfer.toProfileId, transfer]));
+
+  const edges = evidence.edges.map((edge): EconomicDemoLedgerReconciliationEdge => {
+    const transfer = surfpoolTransferByProfile.get(edge.profileId);
+    if (!transfer) throw new Error(`missing_surfpool_transfer:${edge.profileId}`);
+    return {
+      profileId: edge.profileId,
+      payeeWallet: edge.unpaidChallenge.payTo,
+      challengeAmountUsdc: edge.unpaidChallenge.amount,
+      challengeAmountMicrousd: amountToMicrousd(edge.unpaidChallenge.amount),
+      controlledReceiptStatus: "satisfied_demo_only",
+      realSettlementStatus: "not_verified",
+      surfpoolLocalTransferLamports: transfer.amountLamports,
+      surfpoolTransferStatus: "planned_local_transfer_semantics",
+    };
+  });
+
+  const challengeAmountMicrousd = edges.reduce((sum, edge) => sum + edge.challengeAmountMicrousd, 0);
+  const surfpoolLocalTransferLamports = edges.reduce((sum, edge) => sum + edge.surfpoolLocalTransferLamports, 0);
+
+  return {
+    schemaVersion: "reddi.economic-demo.ledger-reconciliation.v1",
+    generatedAt: "2026-05-04T10:38:40.306Z",
+    scenarioId: "webpage",
+    mode: "controlled_demo_receipt_reconciliation",
+    sourceEvidenceArtifactPath: evidence.sourceArtifactPath,
+    edgeCount: 4,
+    totals: {
+      challengeAmountUsdc: microusdToAmount(challengeAmountMicrousd),
+      challengeAmountMicrousd,
+      controlledPaidCompletions: 4,
+      realSettlementsVerified: 0,
+      surfpoolLocalTransferLamports,
+      surfpoolLocalTransferSol: lamportsToSol(surfpoolLocalTransferLamports),
+    },
+    edges,
+    proofLayers: [
+      {
+        id: "x402_challenge",
+        status: "complete",
+        summary: "Each hosted specialist returned an HTTP 402 x402 challenge with payee wallet, amount, currency, network, endpoint, and nonce.",
+      },
+      {
+        id: "controlled_demo_receipt",
+        status: "complete",
+        summary: "Each specialist accepted a bounded controlled demo receipt and returned HTTP 200 completion evidence.",
+      },
+      {
+        id: "surfpool_local_transfer",
+        status: "complete",
+        summary: "Surfpool/local rehearsal proves transfer semantics with deterministic local wallets and blocked-transfer zero-delta proof.",
+      },
+      {
+        id: "real_devnet_receipt_verifier",
+        status: "not_implemented",
+        summary: "Production-style devnet USDC receipt verification is a later phase; this reconciliation makes no real-settlement claim.",
+      },
+    ],
+    guardrails: {
+      noLiveCallsFromUi: true,
+      noDevnetTransferFromUi: true,
+      controlledDemoReceiptsClearlyLabeled: true,
+      noProductionSettlementClaim: true,
+    },
+    nextStep: "Use this reconciliation as the bridge into real devnet receipt verifier design, or proceed to research workflow with the same controlled-demo labeling.",
+  };
+}


### PR DESCRIPTION
## Summary
- add Phase 7C ledger reconciliation for the webpage economic demo
- reconcile live x402 challenge totals (`0.13 USDC`) against controlled demo receipt completions and Surfpool/local transfer semantics
- add `/api/economic-demo/ledger-reconciliation` and `/economic-demo` panel
- append Phase 7C retrospective and refine next loop recommendation

## Validation
- `npx jest --runTestsByPath lib/__tests__/economic-demo-ledger-reconciliation.test.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts`
- `npm run lint -- app/economic-demo/page.tsx app/api/economic-demo/ledger-reconciliation/route.ts lib/economic-demo/ledger-reconciliation.ts lib/__tests__/economic-demo-ledger-reconciliation.test.ts`
- `npm run build`

## Guardrails
- UI performs no live specialist calls
- UI performs no signing or devnet transfers
- controlled demo receipts are visible as demo-only
- real settlements verified remains explicitly `0`
- Surfpool SOL transfer semantics are separate from live USDC challenge amounts

## Next loop recommendation
Phase 8A research workflow design for breadth, unless we decide production settlement semantics should come first via real devnet receipt verifier design.
