### PR TITLE
Design research economic workflow phase

### DIFF
--- a/app/api/economic-demo/research-workflow-design/route.ts
+++ b/app/api/economic-demo/research-workflow-design/route.ts
@@ -1,0 +1,5 @@
+import { buildResearchWorkflowDesign } from "@/lib/economic-demo/research-workflow-design";
+
+export async function GET() {
+  return Response.json({ ok: true, design: buildResearchWorkflowDesign() });
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -14,6 +14,7 @@ import type { SurfpoolRehearsalReport } from "@/lib/economic-demo/surfpool-rehea
 import type { EconomicDemoPaymentReadiness } from "@/lib/economic-demo/payment-readiness";
 import type { WebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
 import type { EconomicDemoLedgerReconciliation } from "@/lib/economic-demo/ledger-reconciliation";
+import type { ResearchWorkflowDesign } from "@/lib/economic-demo/research-workflow-design";
 
 function shortWallet(wallet: string) {
   return `${wallet.slice(0, 8)}…${wallet.slice(-6)}`;
@@ -40,6 +41,8 @@ export default function EconomicDemoPage() {
   const [webpageLiveEvidenceStatus, setWebpageLiveEvidenceStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const [ledgerReconciliation, setLedgerReconciliation] = useState<EconomicDemoLedgerReconciliation | null>(null);
   const [ledgerReconciliationStatus, setLedgerReconciliationStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [researchDesign, setResearchDesign] = useState<ResearchWorkflowDesign | null>(null);
+  const [researchDesignStatus, setResearchDesignStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const scenario = useMemo(
     () => economicDemoScenarios.find((candidate) => candidate.id === scenarioId) ?? economicDemoScenarios[0],
     [scenarioId],
@@ -133,6 +136,19 @@ export default function EconomicDemoPage() {
     }
   }
 
+  async function loadResearchDesign() {
+    setResearchDesignStatus("loading");
+    try {
+      const res = await fetch("/api/economic-demo/research-workflow-design");
+      const payload = (await res.json()) as { ok?: boolean; design?: ResearchWorkflowDesign };
+      if (!res.ok || !payload.ok || !payload.design) throw new Error("research_design_failed");
+      setResearchDesign(payload.design);
+      setResearchDesignStatus("loaded");
+    } catch {
+      setResearchDesignStatus("error");
+    }
+  }
+
   return (
     <main className="min-h-screen bg-page">
       <section className="relative overflow-hidden border-b border-white/5">
@@ -217,6 +233,13 @@ export default function EconomicDemoPage() {
                 >
                   {ledgerReconciliationStatus === "loading" ? "Reconciling ledger…" : "Reconcile ledger"}
                 </button>
+                <button
+                  onClick={loadResearchDesign}
+                  disabled={researchDesignStatus === "loading"}
+                  className="rounded-lg border border-accent-purple/30 bg-accent-purple/10 px-4 py-2 text-sm font-semibold text-accent-purple transition hover:bg-accent-purple/15 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {researchDesignStatus === "loading" ? "Designing research path…" : "Design research workflow"}
+                </button>
                 <span className="text-xs text-gray-500">
                   Uses deployed 30-agent profile metadata · zero downstream calls
                 </span>
@@ -249,6 +272,11 @@ export default function EconomicDemoPage() {
               {ledgerReconciliationStatus === "error" && (
                 <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
                   Ledger reconciliation failed. No live call or transfer was attempted.
+                </p>
+              )}
+              {researchDesignStatus === "error" && (
+                <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+                  Research workflow design failed. No live call or Coolify mutation was attempted.
                 </p>
               )}
               <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
@@ -417,6 +445,39 @@ export default function EconomicDemoPage() {
                       ? "Controlled demo-paid completion reached HTTP 200 against the deployed code-generation specialist. The UI still will not auto-retry live payment; the next demo loop can promote this from one paid edge to a multi-edge workflow."
                       : "Paid completion is blocked because the deployed specialist rejects demo receipts. The UI will not auto-retry live payment; choose controlled demo receipts or real devnet receipt verification next."}
                   </p>
+                </div>
+              )}
+
+              {researchDesign && (
+                <div className="mt-6 rounded-xl border border-accent-purple/25 bg-accent-purple/10 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-accent-purple">Phase 8A research workflow design</p>
+                      <p className="mt-1 text-sm leading-6 text-gray-200">{researchDesign.userRequest}</p>
+                    </div>
+                    <span className="rounded-full border border-accent-purple/40 bg-accent-purple/10 px-2 py-0.5 text-xs text-accent-purple">
+                      design only · no live calls
+                    </span>
+                  </div>
+                  <div className="mt-4 grid gap-3 md:grid-cols-2">
+                    {researchDesign.edges.map((edge) => (
+                      <div key={edge.profileId} className="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="font-mono text-sm text-white">{edge.step}. {edge.profileId}</p>
+                          <p className="text-xs text-yellow-100">{edge.controlledDemoReceiptReadiness.replaceAll("_", " ")}</p>
+                        </div>
+                        <p className="mt-1 text-xs text-gray-400">{edge.capability} · {edge.priceUsdc} USDC</p>
+                        <p className="mt-2 text-sm leading-6 text-gray-300">{edge.scopedPayload}</p>
+                        <p className="mt-2 text-xs leading-5 text-[#14F195]">Evidence gate: {edge.evidenceRequirement}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-4 rounded-lg border border-white/10 bg-black/20 p-3">
+                    <p className="text-xs uppercase tracking-wide text-gray-400">Acceptance criteria</p>
+                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-6 text-gray-300">
+                      {researchDesign.acceptanceCriteria.map((criterion) => <li key={criterion}>{criterion}</li>)}
+                    </ul>
+                  </div>
                 </div>
               )}
 

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -493,3 +493,33 @@ Now that webpage proof is judge-readable and financially reconciled, choose betw
 - Never equate Surfpool SOL transfer semantics with live USDC challenge settlement; show them as separate proof layers.
 - Controlled demo receipt count and real settlement verified count must both be visible.
 - Phase 8A should reuse the reconciliation pattern for research if we expand breadth.
+
+## Phase 8A implementation reflection — research workflow design
+
+**Date:** 2026-05-04 AEST
+**Scope shipped:** Added no-live-call research workflow design helper, API route, UI panel, and unit test.
+**BDD scenarios touched:** Research article workflow design with scoped specialist payloads, citation/evidence caveat requirements, and attestation release/refund/dispute criteria before any live receipt enablement.
+**Validation:** `npx jest --runTestsByPath lib/__tests__/economic-demo-research-workflow-design.test.ts lib/__tests__/economic-demo-dry-run.test.ts`; targeted lint; `npm run build`.
+**Result:** PASS.
+**Evidence artifacts:** `lib/economic-demo/research-workflow-design.ts`, `app/api/economic-demo/research-workflow-design/route.ts`, `lib/__tests__/economic-demo-research-workflow-design.test.ts`, `/economic-demo` Phase 8A panel.
+
+### What worked
+
+The research workflow is now designed as a distinct proof category rather than a clone of the webpage path: retrieval maps evidence, scientific research synthesizes claims, content drafts with caveat retention, explainability reviews traceability, and verification returns release/refund/dispute guidance.
+
+### What failed or surprised us
+
+The existing dry-run plan uses `scientific-research-agent` as both orchestrator and a downstream specialist. That may be acceptable for self-synthesis, but Phase 8B should decide whether to keep that loop or move orchestration to `agentic-workflow-system` for clearer separation.
+
+### Drift check
+
+No live calls, no Coolify mutation, and no receipt enablement. This phase improves payload boundaries and evidence standards before spend.
+
+### Next phase adjustment
+
+Before Phase 8B live controlled receipts, choose orchestrator separation and enable controlled demo receipts only for selected research path specialists after review. If judge feedback prioritizes settlement, pause research and do real receipt verifier design first.
+
+### Decision log additions
+
+- Research acceptance requires citations or explicit evidence caveats; fluent prose alone fails.
+- Phase 8B must not start until controlled receipt readiness is deliberately enabled and exact endpoints are confirmed.

--- a/lib/__tests__/economic-demo-research-workflow-design.test.ts
+++ b/lib/__tests__/economic-demo-research-workflow-design.test.ts
@@ -1,0 +1,29 @@
+import { buildResearchWorkflowDesign } from "@/lib/economic-demo/research-workflow-design";
+
+describe("economic demo research workflow design", () => {
+  it("designs a no-live-call research workflow with evidence requirements before receipt enablement", () => {
+    const design = buildResearchWorkflowDesign();
+
+    expect(design.phase).toBe("8A");
+    expect(design.mode).toBe("design_only_no_live_calls");
+    expect(design.orchestrator.profileId).toBe("scientific-research-agent");
+    expect(design.edges.map((edge) => edge.profileId)).toEqual([
+      "knowledge-retrieval-agent",
+      "scientific-research-agent",
+      "content-creation-agent",
+      "explainable-agent",
+      "verification-validation-agent",
+    ]);
+    expect(design.edges.every((edge) => edge.controlledDemoReceiptReadiness === "not_enabled_yet")).toBe(true);
+    expect(design.edges.every((edge) => edge.endpoint.endsWith("/v1/chat/completions"))).toBe(true);
+    expect(design.edges.every((edge) => edge.evidenceRequirement.length > 20)).toBe(true);
+    expect(design.acceptanceCriteria.join(" ")).toContain("citations or explicit evidence caveats");
+    expect(design.guardrails).toMatchObject({
+      noLiveCalls: true,
+      noCoolifyMutation: true,
+      noReceiptEnablementYet: true,
+      citationsOrEvidenceCaveatsRequired: true,
+      attestorReleaseRefundDisputeRequired: true,
+    });
+  });
+});

--- a/lib/economic-demo/research-workflow-design.ts
+++ b/lib/economic-demo/research-workflow-design.ts
@@ -1,0 +1,125 @@
+import { buildEconomicDemoDryRunPlan } from "@/lib/economic-demo/dry-run";
+
+export type ResearchWorkflowDesignEdge = {
+  step: number;
+  profileId: string;
+  capability: string;
+  endpoint: string;
+  walletAddress: string;
+  priceUsdc: string;
+  scopedPayload: string;
+  expectedOutput: string;
+  evidenceRequirement: string;
+  controlledDemoReceiptReadiness: "not_enabled_yet";
+};
+
+export type ResearchWorkflowDesign = {
+  schemaVersion: "reddi.economic-demo.research-workflow-design.v1";
+  generatedAt: string;
+  phase: "8A";
+  scenarioId: "research";
+  mode: "design_only_no_live_calls";
+  userRequest: string;
+  orchestrator: {
+    profileId: string;
+    endpoint: string;
+    walletAddress: string;
+  };
+  edges: ResearchWorkflowDesignEdge[];
+  acceptanceCriteria: string[];
+  guardrails: {
+    noLiveCalls: true;
+    noCoolifyMutation: true;
+    noReceiptEnablementYet: true;
+    citationsOrEvidenceCaveatsRequired: true;
+    attestorReleaseRefundDisputeRequired: true;
+  };
+  retrospectiveQuestions: string[];
+  nextStep: string;
+};
+
+const scopedPayloadByProfile: Record<string, Pick<ResearchWorkflowDesignEdge, "scopedPayload" | "expectedOutput" | "evidenceRequirement">> = {
+  "knowledge-retrieval-agent": {
+    scopedPayload:
+      "Gather source/evidence candidates about decentralized agent marketplaces, x402 payment-gated APIs, agent attestations, and protocol limitations. Do not draft the article.",
+    expectedOutput: "Source map with candidate claims, citations/evidence placeholders, and uncertainty notes.",
+    evidenceRequirement: "Every major claim must have a source/caveat placeholder; unsupported claims must be labeled as hypotheses.",
+  },
+  "scientific-research-agent": {
+    scopedPayload:
+      "Synthesize retrieved evidence into a neutral thesis, outline, caveats, and claim hierarchy. Do not write marketing copy.",
+    expectedOutput: "Research synthesis with thesis, outline, claim/evidence table, and limitations.",
+    evidenceRequirement: "Claims must trace back to retrieval output or be marked as assumptions requiring verification.",
+  },
+  "content-creation-agent": {
+    scopedPayload:
+      "Turn the synthesis into a readable article draft while preserving citations/caveats and avoiding unsupported hype.",
+    expectedOutput: "Article draft with headline, intro, sections, conclusion, and inline citation/caveat markers.",
+    evidenceRequirement: "Draft must retain evidence markers and must not invent citations.",
+  },
+  "explainable-agent": {
+    scopedPayload:
+      "Review the draft for traceability, readability, reasoning gaps, and places where caveats should be clearer.",
+    expectedOutput: "Explainability review with suggested edits and traceability notes.",
+    evidenceRequirement: "Every flagged issue must reference a section or claim from the draft.",
+  },
+  "verification-validation-agent": {
+    scopedPayload:
+      "Verify the article evidence chain and return release/refund/dispute guidance for the research workflow.",
+    expectedOutput: "Attestation verdict with release/refund/dispute recommendation and reasons.",
+    evidenceRequirement: "Verdict must explicitly assess citation/caveat adequacy and scoped-payload compliance.",
+  },
+};
+
+export function buildResearchWorkflowDesign(): ResearchWorkflowDesign {
+  const plan = buildEconomicDemoDryRunPlan("research");
+  return {
+    schemaVersion: "reddi.economic-demo.research-workflow-design.v1",
+    generatedAt: "2026-05-04T10:50:00.000Z",
+    phase: "8A",
+    scenarioId: "research",
+    mode: "design_only_no_live_calls",
+    userRequest: "Write me a research article on decentralized agent marketplaces and x402-paid specialist workflows.",
+    orchestrator: {
+      profileId: plan.orchestrator.id,
+      endpoint: plan.orchestrator.endpoint,
+      walletAddress: plan.orchestrator.walletAddress,
+    },
+    edges: plan.edges.map((edge, index) => {
+      const scoped = scopedPayloadByProfile[edge.toProfileId];
+      if (!scoped) throw new Error(`missing_research_scope:${edge.toProfileId}`);
+      return {
+        step: index + 1,
+        profileId: edge.toProfileId,
+        capability: edge.capability,
+        endpoint: edge.endpoint,
+        walletAddress: edge.walletAddress,
+        priceUsdc: edge.price.amount,
+        controlledDemoReceiptReadiness: "not_enabled_yet",
+        ...scoped,
+      };
+    }),
+    acceptanceCriteria: [
+      "Research workflow remains design-only in Phase 8A: no live specialist calls and no Coolify/env mutation.",
+      "Every specialist receives a scoped payload with clear boundaries and expected output.",
+      "Final article path requires citations or explicit evidence caveats; fluent unsupported prose is not enough.",
+      "Verification agent must produce release/refund/dispute guidance based on the evidence chain.",
+      "Phase 8B may only begin after this design is reviewed and controlled receipt readiness is intentionally enabled for selected research path specialists.",
+    ],
+    guardrails: {
+      noLiveCalls: true,
+      noCoolifyMutation: true,
+      noReceiptEnablementYet: true,
+      citationsOrEvidenceCaveatsRequired: true,
+      attestorReleaseRefundDisputeRequired: true,
+    },
+    retrospectiveQuestions: [
+      "Are citations/evidence meaningful, or is the article just fluent text?",
+      "Are specialist boundaries clear enough to prevent duplicated or invented work?",
+      "Does this add a genuinely new proof category beyond the webpage workflow?",
+      "Should Phase 8B proceed with controlled demo receipts, or should real receipt verification come first?",
+    ],
+    nextStep:
+      "If this design passes review, prepare Phase 8B controlled research live x402 workflow smoke with exact endpoints, bounded calls, and evidence-caveat checks.",
+  };
+}


### PR DESCRIPTION
## Summary
- start Phase 8A research workflow design with no live calls or Coolify mutation
- add typed research workflow design helper/API/UI panel
- define scoped payloads, expected outputs, evidence requirements, and receipt-readiness state for retrieval → research → drafting → explainability → verification
- append Phase 8A retrospective and refine Phase 8B decision points

## Validation
- `npx jest --runTestsByPath lib/__tests__/economic-demo-research-workflow-design.test.ts lib/__tests__/economic-demo-dry-run.test.ts`
- `npm run lint -- app/economic-demo/page.tsx app/api/economic-demo/research-workflow-design/route.ts lib/economic-demo/research-workflow-design.ts lib/__tests__/economic-demo-research-workflow-design.test.ts`
- `npm run build`

## Guardrails
- design only: no live specialist calls
- no Coolify/env mutation
- controlled receipt readiness remains `not_enabled_yet`
- citations or explicit evidence caveats required
- attestor release/refund/dispute guidance required

## Next loop
Choose Phase 8B controlled research live workflow after review, or pause for real devnet receipt verifier design if settlement semantics are higher priority.
