### PR TITLE
feat: add agentic workflow disclosure contract

### DIFF
--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -308,6 +308,27 @@ export default function EconomicDemoPage() {
               </div>
             </div>
 
+            <div className="rounded-2xl border border-accent-purple/25 bg-accent-purple/10 p-6 shadow-card">
+              <p className="section-label">Agentic workflow disclosure</p>
+              <h3 className="mt-2 text-xl font-semibold text-white">Autonomous agents can become consumers</h3>
+              <p className="mt-3 text-sm leading-6 text-gray-300">
+                Specialists and attestors are wallet-bearing autonomous agents. If they may hire other marketplace agents while fulfilling their role, their manifest must disclose that before purchase and their response must return a downstream-disclosure ledger.
+              </p>
+              <div className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
+                <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">Manifest disclosure</p>
+                  <p className="mt-2 text-gray-300">may call agents · expected capabilities · budget policy · attestor expectations · payload-disclosure policy</p>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">Return disclosure</p>
+                  <p className="mt-2 text-gray-300">called agent · wallet/endpoint · payload summary/hash · x402 state · attestor links · moat-protection marker</p>
+                </div>
+              </div>
+              <p className="mt-4 text-xs leading-5 text-yellow-100">
+                Moat protection can obfuscate proprietary returned value-add details, but not called-agent identity, payload class, payment evidence, or attestation chain.
+              </p>
+            </div>
+
             <div className="rounded-2xl border border-white/10 bg-card/70 p-6 shadow-card">
               <p className="section-label">Guardrails</p>
               <ul className="mt-3 space-y-2 text-sm text-gray-300">

--- a/docs/ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md
+++ b/docs/ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md
@@ -14,7 +14,8 @@ A judge can open `/economic-demo`, choose an end-user request, and understand th
 3. every paid edge returns an x402 challenge and receipt/completion evidence;
 4. final output is verified by an attestor;
 5. balances/ledger show economic impact or an explicitly labeled controlled-demo receipt state;
-6. every phase has a retrospective before expanding scope.
+6. every phase has a retrospective before expanding scope;
+7. every autonomous specialist/attestor that may become a consumer agent discloses that capability in its manifest and returns a downstream-disclosure ledger when it delegates.
 
 ## Iteration contract
 
@@ -30,6 +31,7 @@ Phase expansion is not automatic. At the end of each phase we ask:
 - Did we accidentally add hidden spend, retries, or secret exposure?
 - Did judge-facing clarity improve?
 - What did the result change about the next phase?
+- Did the phase preserve agentic workflow transparency: manifest disclosure before execution, downstream payload/payment disclosure after execution, and clearly labeled obfuscation only where protecting a specialist's competitive moat?
 
 ## Current baseline
 
@@ -132,6 +134,34 @@ Completed before this roadmap:
 - UI smoke/build.
 
 **Retrospective prompt:** Is the money-flow story honest and still compelling?
+
+## Phase 7D — Agentic workflow manifest and downstream-disclosure contract
+
+**BDD expectation:** Consumer agents can discover, before purchase, whether a specialist or attestor may hire other marketplace agents; after completion, they receive transparent downstream delegation evidence.
+
+**Scope:**
+
+- Extend the Reddi agent manifest with `mayCallMarketplaceAgents`, expected downstream capabilities/categories, budget/allowlist policy, attestor expectations, and payload-disclosure policy.
+- Define a response-level downstream-disclosure ledger for live and controlled-demo delegation runs.
+- Show disclosure in `/economic-demo` beside the receipt chain.
+- Allow proprietary value-add obfuscation only for returned implementation details; never for called-agent identity, payload class/summary or hash, wallet/endpoint, payment evidence, or attestation links.
+
+**Acceptance criteria:**
+
+- Manifest makes downstream delegation optically obvious to consumer agents before execution.
+- Response ledger lists each downstream agent call, payload summary/hash, amount/challenge/receipt status, and any obfuscation reason.
+- Tests fail if a downstream call is executed without disclosure metadata.
+- Documentation distinguishes autonomous agentic workflow from a central orchestrator fan-out.
+
+**Validation:**
+
+- manifest/runtime unit tests;
+- BDD index check;
+- targeted lint/build.
+
+**Retrospective prompt:** Does this preserve full disclosure to the consumer agent while still allowing specialists to keep their proprietary synthesis/value-add opaque?
+
+**Expected next refinement:** Wire manifest fields into all 30 hosted agents, then require disclosure-ledger evidence in webpage/research/picture live smokes.
 
 ## Phase 8A — Research workflow dry-run/evidence design
 

--- a/docs/END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-DELIVERY-PLAN-2026-05-04.md
@@ -12,7 +12,10 @@ A judge can open one page, submit or select an end-user request, and watch Reddi
 1. request payload moves from user → orchestrator → specialists → attestors;
 2. x402 challenge/payment/receipt evidence moves with each paid edge;
 3. the final output is returned to the user;
-4. the page shows starting balance, ending balance, and net delta for every participating wallet.
+4. the page shows starting balance, ending balance, and net delta for every participating wallet;
+5. every autonomous specialist/attestor that may call other marketplace agents discloses that in its manifest, and every response returns a downstream-disclosure ledger showing which agents were called, what payload summaries were sent, receipt/payment evidence, and which returned details were intentionally obfuscated to protect the agent's competitive value-add.
+
+This is an agentic workflow proof, not just orchestration UI: specialists and attestors are autonomous wallet-bearing agents that may become consumer agents while fulfilling their role. The protocol must make that autonomy transparent to the original consumer agent before and after execution.
 
 This is the north star. Any implementation phase that does not improve proof of payload flow, money flow, attestation, final output, or wallet impact should be treated as drift.
 
@@ -26,6 +29,8 @@ This is the north star. Any implementation phase that does not improve proof of 
 - Live downstream specialist calls require exact endpoint allowlist, max call count, lamport cap, and bounded evidence artifact.
 - No automatic spend retries.
 - Each phase ends with reflection before expanding scope.
+- Agent manifests must disclose whether the agent may call downstream marketplace agents during execution, including expected call categories, budget policy, attestor expectations, and payload-disclosure policy.
+- Return payloads must include a downstream-disclosure ledger for any agent-to-agent calls: called agent/profile, wallet/endpoint, payload summary or hash, amount/receipt/challenge status, attestor links, and any obfuscation reason. Agents may obfuscate returned implementation details to preserve their moat, but may not hide that a downstream call happened or what class of payload was sent.
 
 ## Phase map
 
@@ -197,6 +202,32 @@ This is the north star. Any implementation phase that does not improve proof of 
 - reflection before any second live edge.
 
 **Reflection prompt:** Did the run produce real economic evidence, or just reach a protected endpoint?
+
+---
+
+### Phase 6.5 — Agentic workflow manifest and disclosure contract
+
+**Status:** inserted from interactive retrospective on 2026-05-05; must be completed before expanding beyond controlled webpage proof.
+
+**Goal:** make autonomous agent-to-agent execution explicit in marketplace discovery and response payloads.
+
+**Acceptance criteria:**
+
+- `/.well-known/reddi-agent.json` for every hosted specialist/attestor declares whether it may call downstream marketplace agents while fulfilling its role.
+- Manifest includes expected downstream call categories/capabilities, budget policy, attestor expectations, and payload-disclosure policy.
+- Consumer agents can inspect the manifest before purchase and decide whether downstream delegation is acceptable.
+- Any response that used downstream calls includes a downstream-disclosure ledger with called profile, endpoint/wallet, payload summary or payload hash, x402 challenge/receipt state, amount, attestor links, and obfuscation markers.
+- Competitive moat protection is allowed only for returned value-add details; payload class/summary, called-agent identity, payment evidence, and attestation chain remain transparent.
+- Tests cover manifest fields and disclosure-ledger shape.
+
+**Validation:**
+
+- runtime manifest tests;
+- response schema/unit tests for downstream-disclosure ledger;
+- BDD index check;
+- build.
+
+**Reflection prompt:** Would a consumer agent know, before paying, that this specialist may hire other agents, and after completion exactly what was delegated without forcing the specialist to reveal its proprietary method?
 
 ---
 

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -554,3 +554,34 @@ Before expanding beyond the controlled webpage proof, implement the agentic work
 - Downstream delegation must be disclosed in `/.well-known/reddi-agent.json` before purchase.
 - Return payloads must include downstream-disclosure ledger entries for called agents, payload summaries/hashes, payment/receipt state, and attestor links.
 - Competitive moat protection may obfuscate returned value-add details, but not called-agent identity, payload class, payment evidence, or attestation chain.
+
+## Phase 6.5 implementation reflection — manifest disclosure + downstream ledger slice A
+
+**Date:** 2026-05-05 AEST
+**Scope shipped:** Added runtime-level agentic workflow manifest disclosure, downstream-disclosure ledger schema/builders, live-delegation response ledger wiring, no-downstream ledger for ordinary completions/attestations, tests, and `/economic-demo` explanatory panel.
+**BDD scenarios touched:** Agent manifests disclose downstream marketplace delegation; downstream calls return transparent disclosure without exposing proprietary value-add.
+**Validation:** `npm test --prefix packages/openrouter-specialists`; targeted ESLint; `npm run build`.
+**Result:** PASS.
+
+### What worked
+
+The manifest now gives consumer agents a pre-purchase signal that a specialist/attestor may call other marketplace agents, including expected capabilities, budget guard requirements, attestor expectations, and payload-disclosure policy. Runtime live-delegation responses now include a downstream-disclosure ledger tied to the intent/audit/executor evidence, so a consumer can see the called profile, wallet/endpoint, payload summary, x402 state, and attestor link.
+
+### What failed or surprised us
+
+The first slice exposes the contract and runtime ledger shape, but hosted Coolify apps will need redeploy/smoke before the public `/.well-known/reddi-agent.json` endpoints show the new fields. Also, controlled multi-edge smoke artifacts still predate the ledger schema; future smokes should require disclosure-ledger evidence in the captured artifact.
+
+### Drift check
+
+This directly implements the retrospective outcome and keeps the loop agile: we paused workflow expansion to add autonomy/disclosure semantics before continuing research/picture live paths.
+
+### Next phase adjustment
+
+Next slice should either redeploy/smoke all 30 hosted manifests for public disclosure evidence or update the live workflow smoke/evidence pack to assert and display downstream-disclosure ledger entries for every delegated edge.
+
+### Decision log additions
+
+- `agenticWorkflowDisclosure` is part of the Reddi agent manifest contract.
+- `reddi.downstream-disclosure-ledger.v1` is the response contract for downstream delegation disclosure.
+- Ordinary completions and attestations return an explicit `no_downstream_calls` ledger.
+- Live-delegation responses must include disclosure ledger evidence alongside intent, audit, and executor evidence.

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -523,3 +523,34 @@ Before Phase 8B live controlled receipts, choose orchestrator separation and ena
 
 - Research acceptance requires citations or explicit evidence caveats; fluent prose alone fails.
 - Phase 8B must not start until controlled receipt readiness is deliberately enabled and exact endpoints are confirmed.
+
+## Interactive retrospective adjustment — agentic workflow disclosure contract
+
+**Date:** 2026-05-05 AEST
+**Trigger:** Nissan clarified that the demo must be framed as an agentic workflow: every specialist/attestor is autonomous, has its own wallet, and may act as a consumer agent by calling other marketplace agents when that is part of its execution plan.
+**Plan updates:** Added Phase 6.5 to the delivery plan and Phase 7D to the iterative roadmap; added BDD scenarios for manifest disclosure and downstream-disclosure ledgers.
+**Validation:** `npm run test:bdd:index`; `git diff --check`.
+**Result:** PASS.
+
+### What worked
+
+The retrospective changed the next implementation shape before we kept building: the value is not merely showing a central orchestrator paying specialists. The value is transparent autonomous delegation where any agent can hire other agents through Reddi/x402 while preserving buyer awareness, bounded spend, and receipt/attestation evidence.
+
+### What failed or surprised us
+
+The existing plan implied delegation evidence through receipt chains, but it did not make pre-purchase disclosure explicit enough. A consumer agent needs to know from the manifest whether a specialist/attestor may call downstream agents, and the final response needs a disclosure ledger even when returned implementation details are obfuscated for moat protection.
+
+### Drift check
+
+This improves payload flow, money flow, and trust transparency. It also keeps the build loop agile: the plan was refined before more research/picture workflow expansion, rather than discovering the disclosure gap after implementation.
+
+### Next phase adjustment
+
+Before expanding beyond the controlled webpage proof, implement the agentic workflow manifest/disclosure contract: manifest fields for downstream delegation policy, response-level downstream-disclosure ledger, tests that fail when downstream calls are not disclosed, and `/economic-demo` copy showing the distinction between transparent payload/payment disclosure and allowed proprietary result obfuscation.
+
+### Decision log additions
+
+- Specialists and attestors are wallet-bearing autonomous agents and may act as consumer agents when fulfilling their role.
+- Downstream delegation must be disclosed in `/.well-known/reddi-agent.json` before purchase.
+- Return payloads must include downstream-disclosure ledger entries for called agents, payload summaries/hashes, payment/receipt state, and attestor links.
+- Competitive moat protection may obfuscate returned value-add details, but not called-agent identity, payload class, payment evidence, or attestation chain.

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -4,6 +4,7 @@ Feature: End-user economic workflow demo
     Given the Reddi Agent Protocol marketplace is running on Solana devnet
     And live downstream specialist calls are disabled unless explicit spend gates are enabled
     And demo artifacts must not expose private keys, signer material, provider API keys, or payment secrets
+    And autonomous specialists and attestors may act as consumer agents only when their manifest discloses downstream marketplace delegation
 
   Scenario: Static fixture explains the economic workflow without spending
     Given the user opens /economic-demo
@@ -58,6 +59,21 @@ Feature: End-user economic workflow demo
     Then it captures an x402 receipt or fail-closed reason
     And it captures before and after balances for payer and payee
     And it does not retry automatically
+
+  Scenario: Agent manifests disclose downstream marketplace delegation
+    Given a marketplace specialist or attestor may call other agents while fulfilling its role
+    When a consumer agent reads /.well-known/reddi-agent.json
+    Then the manifest declares that downstream marketplace calls may occur
+    And it lists expected downstream capability categories, budget policy, attestor expectations, and payload-disclosure policy
+    And the consumer agent can reject the agent before purchase if the disclosure is unacceptable
+
+  Scenario: Downstream calls return transparent disclosure without exposing proprietary value-add
+    Given an autonomous specialist calls another marketplace agent during execution
+    When it returns its result to the consumer agent
+    Then the response includes a downstream-disclosure ledger
+    And the ledger identifies each called agent, endpoint or wallet, payload summary or hash, x402 amount and receipt or challenge state, and attestor links
+    And any obfuscated returned details include an explicit moat_protection reason
+    And called-agent identity, payload class, payment evidence, and attestation chain are not hidden
 
   Scenario: Multi-edge demo returns output and economic impact
     Given multi-edge demo mode is explicitly approved

--- a/packages/openrouter-specialists/src/agentic-workflow-disclosure.ts
+++ b/packages/openrouter-specialists/src/agentic-workflow-disclosure.ts
@@ -1,0 +1,150 @@
+import type { LiveDelegationExecutorEvidence } from "./delegation-executor.js";
+import type { LiveDelegationIntentPlan } from "./delegation-intent.js";
+import type { SpecialistProfile, SpecialistPrice } from "./types.js";
+
+export interface AgenticWorkflowManifestDisclosure {
+  schemaVersion: "reddi.agentic-workflow-disclosure.v1";
+  mayCallMarketplaceAgents: boolean;
+  disclosureRequiredBeforePurchase: true;
+  expectedDownstreamCapabilities: string[];
+  budgetPolicy: {
+    spendGuardRequired: boolean;
+    maxDownstreamCalls?: number;
+    maxDownstreamLamports?: number;
+    liveCallsEnabled: boolean;
+  };
+  attestorExpectations: {
+    preferredAttestors: string[];
+    attestationRequiredForDelegatedOutputs: boolean;
+  };
+  payloadDisclosurePolicy: {
+    mustDiscloseCalledAgentIdentity: true;
+    mustDisclosePayloadSummaryOrHash: true;
+    mustDisclosePaymentEvidence: true;
+    mustDiscloseAttestationLinks: true;
+    returnedValueAddMayBeObfuscatedForMoatProtection: true;
+    obfuscationReasonRequired: true;
+  };
+}
+
+export interface DownstreamDisclosureLedgerEntry {
+  schemaVersion: "reddi.downstream-disclosure-ledger-entry.v1";
+  calledProfileId: string;
+  endpoint?: string;
+  walletAddress?: string;
+  payloadSummary: string;
+  payloadHash?: string;
+  x402: {
+    amount?: string;
+    currency?: SpecialistPrice["currency"];
+    challengeOrReceiptState: "not_attempted" | "challenge_observed" | "controlled_demo_paid" | "real_settlement_verified" | "failed_closed";
+    evidenceRef?: string;
+  };
+  attestorLinks: string[];
+  obfuscation?: {
+    returnedDetailsObfuscated: boolean;
+    reason?: "moat_protection";
+  };
+}
+
+export interface DownstreamDisclosureLedger {
+  schemaVersion: "reddi.downstream-disclosure-ledger.v1";
+  disclosureScope: "no_downstream_calls" | "planned_downstream_calls" | "attempted_downstream_calls";
+  entries: DownstreamDisclosureLedgerEntry[];
+  transparencyGuarantees: string[];
+}
+
+export function buildAgenticWorkflowManifestDisclosure(profile: SpecialistProfile, config: { enableAgentToAgentCalls?: boolean; maxDownstreamCalls?: number; maxDownstreamLamports?: number }): AgenticWorkflowManifestDisclosure {
+  const mayCallMarketplaceAgents = profile.roles.includes("consumer");
+  return {
+    schemaVersion: "reddi.agentic-workflow-disclosure.v1",
+    mayCallMarketplaceAgents,
+    disclosureRequiredBeforePurchase: true,
+    expectedDownstreamCapabilities: mayCallMarketplaceAgents ? downstreamCapabilitiesFor(profile) : [],
+    budgetPolicy: {
+      spendGuardRequired: mayCallMarketplaceAgents,
+      maxDownstreamCalls: config.maxDownstreamCalls,
+      maxDownstreamLamports: config.maxDownstreamLamports,
+      liveCallsEnabled: config.enableAgentToAgentCalls === true,
+    },
+    attestorExpectations: {
+      preferredAttestors: profile.preferredAttestors,
+      attestationRequiredForDelegatedOutputs: mayCallMarketplaceAgents,
+    },
+    payloadDisclosurePolicy: {
+      mustDiscloseCalledAgentIdentity: true,
+      mustDisclosePayloadSummaryOrHash: true,
+      mustDisclosePaymentEvidence: true,
+      mustDiscloseAttestationLinks: true,
+      returnedValueAddMayBeObfuscatedForMoatProtection: true,
+      obfuscationReasonRequired: true,
+    },
+  };
+}
+
+export function buildNoDownstreamDisclosureLedger(): DownstreamDisclosureLedger {
+  return {
+    schemaVersion: "reddi.downstream-disclosure-ledger.v1",
+    disclosureScope: "no_downstream_calls",
+    entries: [],
+    transparencyGuarantees: transparencyGuarantees(),
+  };
+}
+
+export function buildDownstreamDisclosureLedger(input: { intentPlan: LiveDelegationIntentPlan; executorEvidence: LiveDelegationExecutorEvidence }): DownstreamDisclosureLedger {
+  const selected = input.intentPlan.selectedCandidate;
+  if (!selected) return buildNoDownstreamDisclosureLedger();
+  const attempted = input.executorEvidence.downstreamCallsExecuted > 0;
+  return {
+    schemaVersion: "reddi.downstream-disclosure-ledger.v1",
+    disclosureScope: attempted ? "attempted_downstream_calls" : "planned_downstream_calls",
+    entries: [
+      {
+        schemaVersion: "reddi.downstream-disclosure-ledger-entry.v1",
+        calledProfileId: selected.profileId,
+        endpoint: input.executorEvidence.target?.endpoint ?? selected.endpointPath,
+        walletAddress: input.executorEvidence.target?.walletAddress ?? selected.walletAddress,
+        payloadSummary: summarizePayload(input.intentPlan.task),
+        x402: {
+          amount: selected.price.amount,
+          currency: selected.price.currency,
+          challengeOrReceiptState: classifyEvidence(input.executorEvidence),
+          evidenceRef: input.executorEvidence.auditEnvelopeHash,
+        },
+        attestorLinks: input.intentPlan.requiredAttestor ? [input.intentPlan.requiredAttestor] : [],
+        obfuscation: {
+          returnedDetailsObfuscated: attempted,
+          reason: attempted ? "moat_protection" : undefined,
+        },
+      },
+    ],
+    transparencyGuarantees: transparencyGuarantees(),
+  };
+}
+
+function downstreamCapabilitiesFor(profile: SpecialistProfile): string[] {
+  return [...new Set([...profile.capabilities, "marketplace-discovery", "x402-payment", "delegated-attestation"])].sort();
+}
+
+function summarizePayload(task: string): string {
+  const normalized = task.replace(/\s+/g, " ").trim();
+  if (!normalized) return "Downstream task payload was empty or omitted.";
+  return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized;
+}
+
+function classifyEvidence(evidence: LiveDelegationExecutorEvidence): DownstreamDisclosureLedgerEntry["x402"]["challengeOrReceiptState"] {
+  if (evidence.downstreamCallsExecuted === 0) return evidence.executionStatus === "not_executed" ? "not_attempted" : "failed_closed";
+  if (evidence.downstreamResponse?.status === 200) return "controlled_demo_paid";
+  if (evidence.downstreamResponse?.status === 402) return "challenge_observed";
+  return "failed_closed";
+}
+
+function transparencyGuarantees(): string[] {
+  return [
+    "called-agent identity is disclosed",
+    "payload summary or hash is disclosed",
+    "payment/challenge/receipt state is disclosed",
+    "attestor links are disclosed",
+    "proprietary returned value-add may be obfuscated only with an explicit moat_protection reason",
+  ];
+}

--- a/packages/openrouter-specialists/src/index.ts
+++ b/packages/openrouter-specialists/src/index.ts
@@ -8,6 +8,7 @@ export * from "./delegation-budget.js";
 export * from "./delegation-intent.js";
 export * from "./delegation-audit.js";
 export * from "./delegation-executor.js";
+export * from "./agentic-workflow-disclosure.js";
 export * from "./runtime.js";
 export * from "./wallet-readiness.js";
 export * from "./wallet-rotation-plan.js";

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -8,6 +8,7 @@ import {
   type ReceiptVerificationResult,
   type X402Challenge,
 } from "@reddi/x402-solana";
+import { buildAgenticWorkflowManifestDisclosure, buildDownstreamDisclosureLedger, buildNoDownstreamDisclosureLedger } from "./agentic-workflow-disclosure.js";
 import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
 import { buildLiveDelegationAuditEnvelope } from "./delegation-audit.js";
 import { evaluateDelegationBudget } from "./delegation-budget.js";
@@ -115,6 +116,7 @@ export function marketplaceMetadata(profile: SpecialistProfile, config: RuntimeC
     safetyMode: profile.safetyMode,
     preferredAttestors: profile.preferredAttestors,
     model: profile.model,
+    agenticWorkflowDisclosure: buildAgenticWorkflowManifestDisclosure(profile, config),
   };
 }
 
@@ -267,6 +269,7 @@ export async function handleDelegationPlanning(input: {
     const executorEvidence = input.config.enableLiveDelegationExecutor
       ? await (input.liveDelegationExecutor ?? new NoopLiveDelegationExecutor()).execute({ intentPlan, auditEnvelope })
       : buildDisabledLiveDelegationExecutorEvidence({ intentPlan, auditEnvelope });
+    const downstreamDisclosureLedger = buildDownstreamDisclosureLedger({ intentPlan, executorEvidence });
 
     return {
       status: 501,
@@ -286,6 +289,7 @@ export async function handleDelegationPlanning(input: {
           intentPlan,
           auditEnvelope,
           executorEvidence,
+          downstreamDisclosureLedger,
         },
       },
     };
@@ -315,6 +319,7 @@ export async function handleDelegationPlanning(input: {
         liveCallsEnabled: false,
         downstreamCallsExecuted: 0,
         requiredAttestor: plan.requiredAttestor,
+        downstreamDisclosureLedger: buildNoDownstreamDisclosureLedger(),
       },
     },
   };
@@ -349,6 +354,7 @@ export async function handleAttestationEvaluation(input: {
     mockOpenRouter: input.config.mockOpenRouter,
     mode: "attestation",
     schemaVersion: promptEnvelope.schemaVersion,
+    downstreamDisclosureLedger: buildNoDownstreamDisclosureLedger(),
   };
   const upstream = await input.client.createChatCompletion({
     model: profile.model,
@@ -397,6 +403,7 @@ export async function handleChatCompletions(input: {
     paymentSatisfied: input.config.requirePayment,
     safetyMode: profile.safetyMode,
     mockOpenRouter: input.config.mockOpenRouter,
+    downstreamDisclosureLedger: buildNoDownstreamDisclosureLedger(),
   };
   const upstream = await input.client.createChatCompletion({
     model: profile.model,

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -153,7 +153,11 @@ test("paid completion invokes OpenRouter mock with explicit demo flag, profile g
     paymentSatisfied: true,
     safetyMode: "standard",
     mockOpenRouter: true,
+    downstreamDisclosureLedger: (response.body.reddi as { downstreamDisclosureLedger: unknown }).downstreamDisclosureLedger,
   });
+  const noDownstreamLedger = (response.body.reddi as { downstreamDisclosureLedger: { disclosureScope: string; entries: unknown[] } }).downstreamDisclosureLedger;
+  assert.equal(noDownstreamLedger.disclosureScope, "no_downstream_calls");
+  assert.deepEqual(noDownstreamLedger.entries, []);
   assert.match((response.body.reddi as { requestId: string }).requestId, /^[0-9a-f-]{36}$/);
 });
 
@@ -238,6 +242,26 @@ test("well-known metadata includes Reddi marketplace fields", async () => {
   }
   assert.equal(metadata.profileId, "planning-agent");
   assert.equal(metadata.endpoint, "https://planning.example.test/v1/chat/completions");
+  const disclosure = metadata.agenticWorkflowDisclosure as {
+    schemaVersion: string;
+    mayCallMarketplaceAgents: boolean;
+    disclosureRequiredBeforePurchase: boolean;
+    expectedDownstreamCapabilities: string[];
+    budgetPolicy: { spendGuardRequired: boolean; liveCallsEnabled: boolean };
+    payloadDisclosurePolicy: { mustDiscloseCalledAgentIdentity: boolean; mustDisclosePayloadSummaryOrHash: boolean; mustDisclosePaymentEvidence: boolean; mustDiscloseAttestationLinks: boolean; returnedValueAddMayBeObfuscatedForMoatProtection: boolean; obfuscationReasonRequired: boolean };
+  };
+  assert.equal(disclosure.schemaVersion, "reddi.agentic-workflow-disclosure.v1");
+  assert.equal(disclosure.mayCallMarketplaceAgents, true);
+  assert.equal(disclosure.disclosureRequiredBeforePurchase, true);
+  assert.ok(disclosure.expectedDownstreamCapabilities.includes("marketplace-discovery"));
+  assert.equal(disclosure.budgetPolicy.spendGuardRequired, true);
+  assert.equal(disclosure.budgetPolicy.liveCallsEnabled, false);
+  assert.equal(disclosure.payloadDisclosurePolicy.mustDiscloseCalledAgentIdentity, true);
+  assert.equal(disclosure.payloadDisclosurePolicy.mustDisclosePayloadSummaryOrHash, true);
+  assert.equal(disclosure.payloadDisclosurePolicy.mustDisclosePaymentEvidence, true);
+  assert.equal(disclosure.payloadDisclosurePolicy.mustDiscloseAttestationLinks, true);
+  assert.equal(disclosure.payloadDisclosurePolicy.returnedValueAddMayBeObfuscatedForMoatProtection, true);
+  assert.equal(disclosure.payloadDisclosurePolicy.obfuscationReasonRequired, true);
 });
 
 test("attestor route returns structured release verdict for sample specialist output and receipt chain", async () => {
@@ -543,6 +567,18 @@ test("live delegation mode fails closed before any downstream paid call executor
   assert.equal(executorEvidence.guardrails.noExternalPersistence, true);
   assert.equal(executorEvidence.guardrails.noDevnetTransferExecuted, true);
   assert.equal(executorEvidence.guardrails.noDownstreamX402Executed, true);
+  const disclosureLedger = (response.body.reddi as { downstreamDisclosureLedger: { schemaVersion: string; disclosureScope: string; entries: Array<{ calledProfileId: string; payloadSummary: string; x402: { amount: string; currency: string; challengeOrReceiptState: string; evidenceRef: string }; attestorLinks: string[]; obfuscation?: { returnedDetailsObfuscated: boolean; reason?: string } }>; transparencyGuarantees: string[] } }).downstreamDisclosureLedger;
+  assert.equal(disclosureLedger.schemaVersion, "reddi.downstream-disclosure-ledger.v1");
+  assert.equal(disclosureLedger.disclosureScope, "planned_downstream_calls");
+  assert.equal(disclosureLedger.entries[0]?.calledProfileId, "code-generation-agent");
+  assert.match(disclosureLedger.entries[0]?.payloadSummary ?? "", /Hire a code agent/);
+  assert.equal(disclosureLedger.entries[0]?.x402.amount, "0.05");
+  assert.equal(disclosureLedger.entries[0]?.x402.currency, "USDC");
+  assert.equal(disclosureLedger.entries[0]?.x402.challengeOrReceiptState, "not_attempted");
+  assert.equal(disclosureLedger.entries[0]?.x402.evidenceRef, auditEnvelope.envelopeHash);
+  assert.ok(disclosureLedger.entries[0]?.attestorLinks.includes("verification-validation-agent"));
+  assert.equal(disclosureLedger.entries[0]?.obfuscation?.returnedDetailsObfuscated, false);
+  assert.ok(disclosureLedger.transparencyGuarantees.some((item) => item.includes("called-agent identity")));
 
   const liveWithoutBudgetPolicy = await handleChatCompletions({
     headers: new Headers({ "x402-payment": "demo:delegation-live-fail-closed-2" }),
@@ -654,6 +690,10 @@ test("live delegation executor gate controls invocation and remains fail-closed"
   assert.equal(enabledEvidence.reason, "executor_not_implemented");
   assert.equal(enabledEvidence.executionStatus, "not_executed");
   assert.equal(enabledEvidence.downstreamCallsExecuted, 0);
+  const enabledDisclosureLedger = (enabledNoop.body.reddi as { downstreamDisclosureLedger: { disclosureScope: string; entries: Array<{ calledProfileId: string; x402: { challengeOrReceiptState: string } }> } }).downstreamDisclosureLedger;
+  assert.equal(enabledDisclosureLedger.disclosureScope, "planned_downstream_calls");
+  assert.equal(enabledDisclosureLedger.entries[0]?.calledProfileId, "code-generation-agent");
+  assert.equal(enabledDisclosureLedger.entries[0]?.x402.challengeOrReceiptState, "not_attempted");
 
   const denied = await handleDelegationPlanning({
     headers: new Headers({ "x402-payment": "demo:delegation-executor-gate-denied" }),
@@ -719,8 +759,10 @@ test("HTTP core routes expose health, models, tags, metadata, attestation, and c
     client,
   );
   assert.equal(attestation.status, 200);
-  const attestationBody = (await attestation.json()) as { object: string; verdictSource: string; verdict: { recommendedAction: string } };
+  const attestationBody = (await attestation.json()) as { object: string; verdictSource: string; verdict: { recommendedAction: string }; reddi: { downstreamDisclosureLedger: { disclosureScope: string; entries: unknown[] } } };
   assert.equal(attestationBody.object, "reddi.attestation.verdict");
   assert.equal(attestationBody.verdictSource, "deterministic_local_evaluator");
   assert.equal(attestationBody.verdict.recommendedAction, "release");
+  assert.equal(attestationBody.reddi.downstreamDisclosureLedger.disclosureScope, "no_downstream_calls");
+  assert.deepEqual(attestationBody.reddi.downstreamDisclosureLedger.entries, []);
 });


### PR DESCRIPTION
## Summary
- capture the interactive retrospective adjustment that the economic demo is an autonomous agentic workflow, not central orchestration
- require manifests to disclose downstream marketplace delegation capability/policy before purchase
- add runtime `agenticWorkflowDisclosure` manifest fields and `reddi.downstream-disclosure-ledger.v1` response contract
- wire live-delegation responses to include called agent, wallet/endpoint, payload summary, x402 state, attestor links, and moat-protection markers
- surface the disclosure model in `/economic-demo` and keep BDD/iteration docs updated

## Validation
- `npm run test:bdd:index`
- `npm test --prefix packages/openrouter-specialists`
- `npm run lint -- app/economic-demo/page.tsx packages/openrouter-specialists/src/agentic-workflow-disclosure.ts packages/openrouter-specialists/src/runtime.ts packages/openrouter-specialists/tests/runtime.test.ts`
- `npm run build`
