### PR TITLE
test: require disclosure ledger in economic demo evidence

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,14 +1,12 @@
 # Reddi Agent Protocol Code — STATUS
 
 **Last updated:** 2026-05-05 AEST
-**State:** 🟢 PR #202 merged — agentic workflow disclosure contract on `main`; post-merge Anchor CI still in progress at last check.
+**State:** 🟢 PR #202 merged and post-merge Anchor CI green; PR #203 opened for disclosure-ledger evidence tooling.
 
 ## RESUME FROM HERE
 
-1. Check post-merge `main` run `25343819366` until complete:
-   - `cd /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code`
-   - `gh run view 25343819366 --json status,conclusion,jobs`
-2. If green, continue the next safe Phase 6.5 follow-up slice:
+1. Watch PR #203 checks and merge if green: https://github.com/nissan/reddi-agent-protocol/pull/203
+2. Continue the next Phase 6.5 follow-up slice:
    - Preferred safe/local slice: update the live workflow smoke/evidence pack to assert and display `reddi.downstream-disclosure-ledger.v1` entries.
    - External-infra slice, only with explicit operator intent: redeploy/smoke all 30 hosted Coolify specialists so public `/.well-known/reddi-agent.json` endpoints expose `agenticWorkflowDisclosure`.
 3. Keep the agile loop active: BDD expectation → scoped implementation → validation → evidence artifact → retrospective → plan refinement → STATUS update.
@@ -19,6 +17,24 @@
 - Local working tree: clean at last check after PR #202 merge.
 - Latest merge: `95ab928b feat: add agentic workflow disclosure contract (#202)`.
 - PR #202: merged 2026-05-05 AEST.
+
+
+## Current Follow-up PR — #203
+
+**Disclosure-ledger evidence tooling**
+
+PR #203 makes the retrospective requirement executable in future evidence:
+
+- Guarded webpage live x402 workflow smoke now requires `reddi.downstream-disclosure-ledger.v1` in every paid response.
+- Future live workflow artifacts include `disclosureContract` and per-edge ledger summaries.
+- Judge evidence pack generation rejects source artifacts missing all-edge disclosure-ledger evidence.
+- Historical 2026-05-04 artifacts are intentionally no longer sufficient as post-PR #202 judge evidence.
+
+Validation before PR:
+
+- `node --check` on both scripts — PASS
+- targeted ESLint for both scripts — PASS
+- `git diff --check` — PASS
 
 ## Latest Shipped Slice — PR #202
 
@@ -76,6 +92,6 @@ Do not proceed as a waterfall into research/picture live workflows until the dis
 
 ## Blockers / Watch Items
 
-- Post-merge Anchor CI run `25343819366` still in progress at last check.
+- PR #203 checks pending at last update.
 - Hosted specialist manifests need redeploy/smoke before public endpoints expose `agenticWorkflowDisclosure`.
 - External Coolify redeploy is an infra mutation; avoid doing it silently unless the current instruction clearly authorizes it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,81 @@
+# Reddi Agent Protocol Code — STATUS
+
+**Last updated:** 2026-05-05 AEST
+**State:** 🟢 PR #202 merged — agentic workflow disclosure contract on `main`; post-merge Anchor CI still in progress at last check.
+
+## RESUME FROM HERE
+
+1. Check post-merge `main` run `25343819366` until complete:
+   - `cd /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code`
+   - `gh run view 25343819366 --json status,conclusion,jobs`
+2. If green, continue the next safe Phase 6.5 follow-up slice:
+   - Preferred safe/local slice: update the live workflow smoke/evidence pack to assert and display `reddi.downstream-disclosure-ledger.v1` entries.
+   - External-infra slice, only with explicit operator intent: redeploy/smoke all 30 hosted Coolify specialists so public `/.well-known/reddi-agent.json` endpoints expose `agenticWorkflowDisclosure`.
+3. Keep the agile loop active: BDD expectation → scoped implementation → validation → evidence artifact → retrospective → plan refinement → STATUS update.
+
+## Current Branch / Repo State
+
+- Local branch: `main`
+- Local working tree: clean at last check after PR #202 merge.
+- Latest merge: `95ab928b feat: add agentic workflow disclosure contract (#202)`.
+- PR #202: merged 2026-05-05 AEST.
+
+## Latest Shipped Slice — PR #202
+
+**Agentic workflow disclosure contract**
+
+Nissan clarified the product truth: this is an agentic workflow network. Specialists and attestors are autonomous wallet-bearing agents that may act as consumer agents and hire other marketplace agents while fulfilling their role.
+
+PR #202 implemented the corresponding protocol/runtime contract:
+
+- `agenticWorkflowDisclosure` exposed in `/.well-known/reddi-agent.json`.
+- `reddi.downstream-disclosure-ledger.v1` response contract added.
+- Runtime responses include explicit no-call/planned-call/attempted-call ledgers.
+- Live-delegation responses wire disclosure ledger alongside intent, audit, and executor evidence.
+- `/economic-demo` explains manifest disclosure, return disclosure, and moat-protection boundaries.
+- BDD + delivery plan + iterative roadmap + iteration log updated.
+
+## Validation Evidence
+
+Local/PR validation for #202:
+
+- `npm run test:bdd:index` — PASS
+- `npm test --prefix packages/openrouter-specialists` — PASS, 54/54
+- Targeted ESLint over economic demo + OpenRouter specialist runtime/disclosure/tests — PASS
+- `npm run build` — PASS
+- Oli QA — APPROVE: no hidden spend/signing path, live delegation remains fail-closed, no secrets, package tests passing.
+- PR checks before merge — green.
+
+Post-merge `main` CI:
+
+- Run `25343819366` started after merge; still in progress at last check.
+
+## Retrospective — Phase 6.5 Slice A
+
+### What worked
+
+The retrospective outcome was converted into executable protocol shape before further workflow expansion. The system now distinguishes a central fan-out demo from an autonomous agent economy: a consumer agent can inspect whether a specialist/attestor may delegate downstream before purchase, and receive a disclosure ledger afterward.
+
+### What failed or surprised us
+
+Oli noticed this repo-local `STATUS.md` did not exist, even though project-level status existed under `projects/colosseum-frontier/STATUS.md` and an older sibling project status existed under `projects/reddi-agent-protocol/STATUS.md`. That was a continuity gap. This file now exists as the repo-local resume point.
+
+The hosted 30 Coolify apps still need redeploy before public manifests expose the new runtime disclosure fields. Existing live workflow evidence also predates the ledger schema, so future evidence packs should assert disclosure-ledger presence.
+
+### Plan adjustment
+
+Do not proceed as a waterfall into research/picture live workflows until the disclosure contract is represented in evidence. Next safest step is a local/code slice that makes smoke/evidence tooling require `reddi.downstream-disclosure-ledger.v1`. Then perform hosted redeploy/smoke when external infra mutation is explicitly intended.
+
+## Key Decisions — append only
+
+- 2026-05-05: Repo-local `STATUS.md` created because Oli could not find one during PR #202 QA; this file is now the first resume point for repo-code work.
+- 2026-05-05: Agentic workflow disclosure is a protocol/runtime requirement, not just UI copy.
+- 2026-05-05: Marketplace manifests must disclose downstream delegation capability/policy before purchase.
+- 2026-05-05: Return payloads must include downstream disclosure for called agent identity, wallet/endpoint, payload summary/hash, x402 state, and attestor links.
+- 2026-05-05: Moat protection may obfuscate proprietary returned value-add details, but not called-agent identity, payload class, payment evidence, or attestation chain.
+
+## Blockers / Watch Items
+
+- Post-merge Anchor CI run `25343819366` still in progress at last check.
+- Hosted specialist manifests need redeploy/smoke before public endpoints expose `agenticWorkflowDisclosure`.
+- External Coolify redeploy is an infra mutation; avoid doing it silently unless the current instruction clearly authorizes it.

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -585,3 +585,32 @@ Next slice should either redeploy/smoke all 30 hosted manifests for public discl
 - `reddi.downstream-disclosure-ledger.v1` is the response contract for downstream delegation disclosure.
 - Ordinary completions and attestations return an explicit `no_downstream_calls` ledger.
 - Live-delegation responses must include disclosure ledger evidence alongside intent, audit, and executor evidence.
+
+## Phase 6.5 implementation reflection — disclosure-ledger evidence tooling slice B
+
+**Date:** 2026-05-05 AEST
+**Scope shipped:** Updated the guarded webpage live x402 workflow smoke so future reruns require `reddi.downstream-disclosure-ledger.v1` in each paid response, summarize the ledgers in the artifact, and mark `disclosureLedgerRequired` in guardrails. Updated the judge evidence pack generator to reject source artifacts that lack all-edge disclosure-ledger evidence.
+**BDD scenarios touched:** Downstream calls return transparent disclosure without exposing proprietary value-add; multi-edge demo returns output and economic impact.
+**Validation:** `node --check` for both scripts; targeted ESLint; `git diff --check`.
+**Result:** PASS for local/static validation. Live smoke intentionally not rerun because hosted specialists must be redeployed before their public runtime exposes the new disclosure fields.
+
+### What worked
+
+The plan adjustment is now enforced in tooling: future live workflow artifacts cannot silently pass while missing downstream-disclosure ledgers. This preserves the value of the interactive retrospective by making the new disclosure requirement an executable gate.
+
+### What failed or surprised us
+
+The historical 2026-05-04 live evidence artifact predates PR #202, so the updated evidence pack generator will reject it. That is correct; the next valid pack must be generated from a post-redeploy smoke where hosted specialists return disclosure ledgers.
+
+### Drift check
+
+This prevents drift back into a central-orchestrator demo. The next live evidence must prove autonomous-agent transparency, not only x402 challenge/payment success.
+
+### Next phase adjustment
+
+After post-merge CI is green, choose the external-infra slice: redeploy/smoke the 30 hosted specialists, then rerun `npm run smoke:economic-demo:webpage-live-x402-workflow` with the existing explicit confirmation env so the new artifact includes disclosure-ledger evidence.
+
+### Decision log additions
+
+- Evidence packs must reject multi-edge source artifacts that lack all-edge downstream disclosure ledgers.
+- Historical controlled-demo artifacts remain useful context but are no longer sufficient for judge evidence after PR #202.

--- a/scripts/generate-economic-demo-evidence-pack.mjs
+++ b/scripts/generate-economic-demo-evidence-pack.mjs
@@ -69,6 +69,8 @@ assert(Array.isArray(source.edges) && source.edges.length === 4, "expected four 
 assert(source.edges.every((edge) => edge.unpaidChallenge?.status === 402), "every edge must include unpaid 402 challenge proof");
 assert(source.edges.every((edge) => edge.paidCompletion?.status === 200 && edge.paidCompletion?.paymentSatisfied === true), "every edge must include controlled paid 200 proof");
 assert(source.guardrails?.controlledDemoReceiptsOnly === true, "source must be controlled-demo-receipt evidence");
+assert(source.disclosureContract?.allEdgesHaveDisclosureLedger === true, "source must include downstream disclosure ledger evidence for every edge");
+assert(source.guardrails?.disclosureLedgerRequired === true, "source guardrails must require downstream disclosure ledgers");
 
 mkdirSync(outDir, { recursive: true });
 
@@ -82,6 +84,7 @@ const pack = {
   edgeCount: source.edges.length,
   downstreamCallsExecuted: source.downstreamCallsExecuted,
   receiptMode: "controlled_demo_receipts",
+  disclosureContract: source.disclosureContract,
   limitation: "Controlled demo receipts prove x402 challenge/receipt-gated specialist execution for the judge demo, not production USDC settlement verification.",
   edges: source.edges.map((edge) => ({
     step: edge.step,
@@ -95,6 +98,7 @@ const pack = {
       model: edge.paidCompletion.model,
       outputPreview: preview(edge.paidCompletion.outputPreview),
     },
+    downstreamDisclosureLedger: edge.downstreamDisclosureLedger,
   })),
   guardrails: source.guardrails,
   nextRecommendedPhase: "Phase 7C ledger reconciliation, then research workflow planning.",
@@ -120,6 +124,7 @@ writeFileSync(
     `- Specialist edges: **${pack.edgeCount}**`,
     `- Bounded downstream calls: **${pack.downstreamCallsExecuted}** (4 unpaid challenges + 4 controlled demo-paid completions)`,
     "- Receipt mode: **controlled demo receipts**",
+    `- Disclosure ledger contract: **${pack.disclosureContract.requiredLedgerSchemaVersion}** on all edges = **${pack.disclosureContract.allEdgesHaveDisclosureLedger}**`,
     "",
     "## User request",
     "",
@@ -131,6 +136,7 @@ writeFileSync(
     "- Each specialist endpoint enforced x402 first by returning HTTP 402 and a challenge.",
     "- Each controlled demo receipt unlocked an HTTP 200 specialist completion.",
     "- The final verification edge received prior workflow outputs and returned an assessment/release recommendation.",
+    "- Every edge returned a downstream-disclosure ledger, making downstream agent identity, payload/payment state, and attestor linkage transparent to the consumer agent.",
     "- The harness used exact hosted HTTPS endpoints and bounded call counts.",
     "",
     "## Important limitation",

--- a/scripts/run-economic-demo-webpage-live-x402-workflow.mjs
+++ b/scripts/run-economic-demo-webpage-live-x402-workflow.mjs
@@ -97,6 +97,31 @@ async function summarizeResponse(response) {
       choiceContentPreview: redactText(content),
       rawPreview: content ? undefined : redactText(body?.raw ?? JSON.stringify(body).slice(0, 900)),
     },
+    downstreamDisclosureLedger: body?.reddi?.downstreamDisclosureLedger,
+  };
+}
+
+function validateDownstreamDisclosureLedger(edge, paid) {
+  const ledger = paid.downstreamDisclosureLedger;
+  assert(ledger?.schemaVersion === "reddi.downstream-disclosure-ledger.v1", `${edge.profileId}: expected reddi.downstream-disclosure-ledger.v1 in paid response`);
+  assert(["no_downstream_calls", "planned_downstream_calls", "attempted_downstream_calls"].includes(ledger.disclosureScope), `${edge.profileId}: invalid disclosure scope`);
+  assert(Array.isArray(ledger.entries), `${edge.profileId}: disclosure ledger entries must be an array`);
+  assert(Array.isArray(ledger.transparencyGuarantees) && ledger.transparencyGuarantees.length > 0, `${edge.profileId}: expected transparency guarantees`);
+  return {
+    schemaVersion: ledger.schemaVersion,
+    disclosureScope: ledger.disclosureScope,
+    entryCount: ledger.entries.length,
+    entries: ledger.entries.map((entry) => ({
+      calledProfileId: entry.calledProfileId,
+      endpoint: entry.endpoint,
+      walletAddress: entry.walletAddress,
+      payloadSummary: redactText(entry.payloadSummary, 240),
+      payloadHashPresent: typeof entry.payloadHash === "string" && entry.payloadHash.length > 0,
+      x402: entry.x402,
+      attestorLinks: Array.isArray(entry.attestorLinks) ? entry.attestorLinks : [],
+      obfuscation: entry.obfuscation,
+    })),
+    transparencyGuarantees: ledger.transparencyGuarantees,
   };
 }
 
@@ -122,6 +147,7 @@ for (const edge of edges) {
   const unpaid = await summarizeResponse(await post(edge, prompt));
   const challenge = parseChallenge(edge, unpaid);
   const paid = await summarizeResponse(await post(edge, prompt, { "x402-payment": `demo:${challenge.nonce}` }));
+  const downstreamDisclosureLedger = validateDownstreamDisclosureLedger(edge, paid);
   outputs[edge.profileId] = paid.bodySummary.choiceContentPreview ?? paid.bodySummary.rawPreview ?? "";
   results.push({
     ...edge,
@@ -149,10 +175,12 @@ for (const edge of edges) {
       model: paid.bodySummary.model,
       outputPreview: paid.bodySummary.choiceContentPreview ?? paid.bodySummary.rawPreview,
     },
+    downstreamDisclosureLedger,
   });
 }
 
 const allPaidCompletionsReached = results.every((edge) => edge.paidCompletion.ok === true);
+const allDisclosureLedgersPresent = results.every((edge) => edge.downstreamDisclosureLedger?.schemaVersion === "reddi.downstream-disclosure-ledger.v1");
 const blockers = results
   .filter((edge) => !edge.paidCompletion.ok)
   .map((edge) => ({ profileId: edge.profileId, status: edge.paidCompletion.status, errorCode: edge.paidCompletion.errorCode }));
@@ -167,7 +195,13 @@ const report = {
   orchestratorProfileId: "agentic-workflow-system",
   downstreamCallsExecuted: results.length * 2,
   edges: results,
-  conclusion: allPaidCompletionsReached ? "multi_edge_paid_workflow_reached" : "multi_edge_paid_workflow_blocked",
+  disclosureContract: {
+    schemaVersion: "reddi.economic-demo.disclosure-contract-check.v1",
+    allEdgesHaveDisclosureLedger: allDisclosureLedgersPresent,
+    requiredLedgerSchemaVersion: "reddi.downstream-disclosure-ledger.v1",
+    manifestDisclosureRequired: true,
+  },
+  conclusion: allPaidCompletionsReached && allDisclosureLedgersPresent ? "multi_edge_paid_workflow_reached" : "multi_edge_paid_workflow_blocked",
   blockers,
   guardrails: {
     exactEndpoints: true,
@@ -175,6 +209,7 @@ const report = {
     noSignatureAttemptedByHarness: true,
     noDevnetTransferFromHarness: true,
     controlledDemoReceiptsOnly: true,
+    disclosureLedgerRequired: true,
     boundedMaxDownstreamCalls: edges.length * 2,
   },
 };


### PR DESCRIPTION
## Summary
- add repo-local `STATUS.md` so this code project has a first-class resume point
- update the guarded webpage live x402 workflow smoke to require `reddi.downstream-disclosure-ledger.v1` in every paid response
- include disclosure contract status/ledger summaries in future live workflow artifacts
- make judge evidence pack generation reject source artifacts that lack all-edge downstream disclosure-ledger evidence
- append the Phase 6.5 retrospective showing why historical pre-PR #202 artifacts are no longer sufficient for judge evidence

## Validation
- `node --check scripts/run-economic-demo-webpage-live-x402-workflow.mjs`
- `node --check scripts/generate-economic-demo-evidence-pack.mjs`
- `npm run lint -- scripts/run-economic-demo-webpage-live-x402-workflow.mjs scripts/generate-economic-demo-evidence-pack.mjs`
- `git diff --check`

## Notes
- Live smoke intentionally not rerun in this PR because hosted specialists need redeploy before public runtimes return the new disclosure fields.
- Post-merge `main` Anchor run for PR #202 completed successfully.
