### PR TITLE
Document agentic marketplace BDD iteration plan

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,20 +1,20 @@
 # Reddi Agent Protocol Code — STATUS
 
 **Last updated:** 2026-05-05 AEST
-**State:** 🟢 PR #203 merged and post-merge Anchor CI green; working on public marketplace manifest disclosure slice.
+**State:** 🟢 PR #205 merged; Phase 0 BDD iterative plan for manifest/disclosure-ledger loop in progress on docs branch.
 
 ## RESUME FROM HERE
 
-1. Finish current branch `feature/public-agent-manifest-marketplace-20260505`: public `/agents` cards + `/agents/[wallet]` detail must show manifest tools/skills and downstream marketplace/MCP/non-marketplace agent dependencies.
-2. Open PR and wait for checks. Local validation already run: targeted Jest, targeted ESLint, `npm run build`.
-3. Next safe/local slice after this: update live workflow smoke/evidence pack UI/artifacts to display `reddi.downstream-disclosure-ledger.v1` entries. External Coolify redeploy remains explicit-operator-only.
+1. Finish Phase 0 docs branch `docs/bdd-agentic-marketplace-plan-20260505`: plan doc + BDD lock for public manifest/dependency disclosure and disclosure-ledger evidence display.
+2. Validate with `npm run test:bdd:index` and `git diff --check`, complete Phase 0 retrospective, then open PR.
+3. After Phase 0 lands, continue Phase 1: update live workflow smoke/evidence pack artifacts to display `reddi.downstream-disclosure-ledger.v1` entries. External Coolify redeploy remains explicit-operator-only.
 
 ## Current Branch / Repo State
 
-- Local branch: `feature/public-agent-manifest-marketplace-20260505`
-- Local working tree: current manifest marketplace slice in progress.
-- Latest merge on main: `ca20e898 test: require disclosure ledger in economic demo evidence (#203)`.
-- PR #203: merged 2026-05-05 AEST; post-merge Anchor run `25344663797` passed.
+- Local branch: `docs/bdd-agentic-marketplace-plan-20260505`
+- Local working tree: Phase 0 plan/BDD docs in progress.
+- Latest merge on main: `345f6af4 feat: expose agent manifests in marketplace (#205)`.
+- PR #205: merged 2026-05-05 AEST; post-merge Anchor run `25345416486` passed.
 
 
 ## Current Follow-up PR — #203
@@ -64,11 +64,13 @@ Post-merge `main` CI:
 
 - Run `25344663797` for merge commit `ca20e898` — PASS, 7m20s.
 
-Current local validation for public manifest marketplace slice:
+Validation for public manifest marketplace slice / PR #205:
 
 - `npx jest --runTestsByPath lib/__tests__/openrouter-registry-enrichment.test.ts lib/__tests__/capabilities-disclosure.test.ts --runInBand` — PASS, 6/6.
 - Targeted `npx eslint` over changed marketplace/registry/capability files — PASS.
 - `npm run build` — PASS.
+- PR #205 checks before merge — PASS: two Anchor runs + Vercel.
+- PR #205 post-merge `main` Anchor run `25345416486` — PASS, 7m11s.
 
 ## Retrospective — Phase 6.5 Slice A
 
@@ -96,8 +98,9 @@ Do not proceed as a waterfall into research/picture live workflows until the dis
 
 - 2026-05-05: Public marketplace pages must expose agent manifest fields: tools, skills, marketplace-agent calls, external MCP servers, and non-marketplace agent/service calls, not just task capability tags.
 
+- 2026-05-05: BDD iterative plan for the agentic marketplace work must use explicit phase retrospectives before expanding scope: plan/BDD lock → artifact ledger summary → UI ledger display → manifest parity → hosted redeploy smoke → research → picture.
+
 ## Blockers / Watch Items
 
-- Current public marketplace manifest slice needs PR opened and remote CI checked.
 - Hosted specialist manifests need redeploy/smoke before public endpoints expose `agenticWorkflowDisclosure`.
 - External Coolify redeploy is an infra mutation; avoid doing it silently unless the current instruction clearly authorizes it.

--- a/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
+++ b/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
@@ -1,0 +1,279 @@
+# Agentic Marketplace Manifest + Disclosure Ledger — BDD Iterative Plan
+
+_Date:_ 2026-05-05 AEST  
+_Status:_ Active after PR #205 merged public marketplace manifest disclosure  
+_Related:_ PR #202, PR #203, PR #205, `ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md`, Bucket J BDD feature
+
+## North star
+
+A judge or consumer agent can inspect Reddi before purchase, execute a bounded workflow, and verify afterward that the agent economy behaved transparently:
+
+1. public marketplace cards reveal that specialists/attestors have manifests, not just capability tags;
+2. specialist detail pages expose public manifest fields: roles, tools, skills, preferred attestors, marketplace-agent calls, external MCP servers, and non-marketplace agent/service calls;
+3. `/.well-known/reddi-agent.json` exposes the same disclosure contract for programmatic consumers;
+4. every paid response returns `reddi.downstream-disclosure-ledger.v1` for downstream calls;
+5. evidence packs and `/economic-demo` explain payload flow, money flow, attestation, and disclosure without claiming hidden production settlement;
+6. every phase ends with a retrospective before scope expands.
+
+## Iteration contract
+
+Every phase follows the same loop:
+
+```text
+BDD expectation → scoped implementation → validation → evidence artifact → retrospective → plan refinement
+```
+
+Phase expansion is not automatic. At the end of each phase, record:
+
+- **What worked:** What did the phase prove?
+- **What failed or surprised us:** Missing data, confusing UI, flaky CI, incorrect assumptions.
+- **Safety/spend review:** Did anything create hidden spend, wallet mutation, secret exposure, or unbounded retries?
+- **Judge clarity:** Can a judge understand the proof in under 30 seconds?
+- **Plan adjustment:** What changes before the next loop?
+
+## Current baseline
+
+Shipped:
+
+- PR #202: agentic workflow disclosure contract in runtime and manifests.
+- PR #203: evidence tooling rejects future live artifacts without downstream-disclosure ledger evidence.
+- PR #205: public `/agents` and `/agents/[wallet]` marketplace pages expose manifest tools, skills, downstream marketplace-agent dependencies, external MCP servers, and non-marketplace agent/service dependencies.
+
+Still pending:
+
+- Hosted Coolify specialist redeploy/smoke before public `/.well-known/reddi-agent.json` endpoints can be claimed current.
+- `/economic-demo` UI and evidence packs still need first-class display of `reddi.downstream-disclosure-ledger.v1` entries.
+- Research and picture workflows should not expand until webpage evidence is understandable and disclosure-complete.
+
+## Phase 0 — Plan + BDD lock
+
+**BDD expectation:** The repo contains a staged, retrospective-driven plan and BDD scenarios that prevent us from forgetting manifest/dependency disclosure.
+
+**Scope:**
+
+- Add this plan document.
+- Add/confirm BDD scenarios covering public marketplace manifest disclosure and downstream ledger evidence display.
+- Update `STATUS.md` with resume point and current phase.
+
+**Acceptance criteria:**
+
+- Plan names phase order and retrospective gates.
+- BDD feature mentions marketplace tools/skills/MCP/non-marketplace dependency disclosure.
+- No runtime behavior changes in this phase.
+
+**Validation:**
+
+- `npm run test:bdd:index`
+- `git diff --check`
+
+**Retrospective prompt:** Did the plan make the next executable slice obvious enough that a fresh session can resume without asking where we were?
+
+**Expected next refinement:** If yes, enter Phase 1. If not, tighten the plan before touching code.
+
+---
+
+## Phase 1 — Disclosure ledger evidence summary in artifacts
+
+**BDD expectation:** A live workflow artifact cannot pass evidence packaging unless every paid edge includes `reddi.downstream-disclosure-ledger.v1` summary data.
+
+**Scope:**
+
+- Normalize artifact summary shape for downstream-disclosure ledger entries.
+- Include each edge's ledger schema, called profile/wallet/endpoint, payload summary or hash, x402 challenge/receipt state, attestor links, and obfuscation reason.
+- Keep existing guard that rejects historical artifacts without ledger evidence.
+
+**Acceptance criteria:**
+
+- Generated evidence summary has a compact `downstreamDisclosureLedger` block.
+- Missing ledger entries fail closed with actionable error.
+- Historical pre-PR #202 artifacts remain invalid for new evidence packs.
+
+**Validation:**
+
+- script smoke for webpage evidence pack generation;
+- targeted `node --check` / ESLint for scripts;
+- focused Jest if helper added.
+
+**Retrospective prompt:** Does the artifact prove the agentic workflow disclosure contract without requiring raw JSON archaeology?
+
+**Expected next refinement:** If the artifact is clear, surface it in UI. If not, revise the summary schema first.
+
+---
+
+## Phase 2 — `/economic-demo` ledger disclosure UI
+
+**BDD expectation:** A judge opening `/economic-demo` can see downstream disclosure ledger entries next to the multi-edge workflow proof.
+
+**Scope:**
+
+- Add a panel to the latest live evidence section showing `reddi.downstream-disclosure-ledger.v1` entries.
+- Show marketplace agent identity, wallet/endpoint, payload class/summary/hash, amount/receipt/challenge state, attestor links, and obfuscation reasons.
+- Label controlled-demo receipts distinctly from production settlement.
+
+**Acceptance criteria:**
+
+- Page load does not call live endpoints.
+- UI distinguishes planned, attempted, paid, failed, and no-call ledger states.
+- No secrets/raw provider output are rendered.
+- Empty/missing ledger state is visibly treated as not evidence-complete.
+
+**Validation:**
+
+- targeted Jest/helper tests;
+- targeted ESLint;
+- `npm run build`.
+
+**Retrospective prompt:** Can a judge understand exactly which downstream agents were called and what was paid/disclosed in under 30 seconds?
+
+**Expected next refinement:** If clear, move to programmatic manifest parity. If not, adjust visual hierarchy and labels.
+
+---
+
+## Phase 3 — Programmatic manifest parity for hosted agents
+
+**BDD expectation:** Programmatic consumers reading `/.well-known/reddi-agent.json` see the same tools/skills/dependency disclosure as the public marketplace.
+
+**Scope:**
+
+- Confirm runtime manifest fields match marketplace registry enrichment.
+- Add conformance smoke for local runtime manifest disclosure.
+- Prepare hosted redeploy checklist without mutating external infra automatically.
+
+**Acceptance criteria:**
+
+- Local runtime manifests expose tools/skills, marketplace-agent calls, external MCP servers, non-marketplace services, and disclosure policy.
+- Conformance output lists any profile missing disclosure.
+- External redeploy remains separately approved.
+
+**Validation:**
+
+- package tests for OpenRouter specialists;
+- manifest conformance script;
+- targeted lint/build if app code changes.
+
+**Retrospective prompt:** Is there any mismatch between what humans see in `/agents` and what consumer agents discover programmatically?
+
+**Expected next refinement:** If local conformance passes, request/perform approved hosted redeploy + smoke.
+
+---
+
+## Phase 4 — Hosted redeploy + public smoke, approval-gated
+
+**BDD expectation:** Public hosted specialist endpoints expose current manifest disclosure fields.
+
+**Scope:**
+
+- Only after explicit operator approval, redeploy hosted Coolify specialists.
+- Smoke `/.well-known/reddi-agent.json` for all hosted specialists.
+- Save sanitized evidence artifact with endpoint, profile id, wallet, manifest disclosure presence, and timestamp.
+
+**Acceptance criteria:**
+
+- Every hosted endpoint returns current manifest disclosure or is listed with a blocker.
+- No secrets or Coolify credentials in artifacts.
+- Failed endpoints have clear remediation.
+
+**Validation:**
+
+- hosted manifest smoke script;
+- secret grep over artifact;
+- STATUS update.
+
+**Retrospective prompt:** Did external infra match local expectations, and did any deployment gap change the next phase?
+
+**Expected next refinement:** If public manifests are current, continue research workflow design. If not, fix infra/runtime drift first.
+
+---
+
+## Phase 5 — Research workflow BDD + dry-run design
+
+**BDD expectation:** The research article workflow has planned specialist graph, citation/evidence caveats, and disclosure-ledger expectations before live calls.
+
+**Scope:**
+
+- Extend BDD for research path evidence quality.
+- Define retrieval/research/content/explainability/verification edges.
+- Confirm every planned edge has manifest disclosure and ledger output expectations.
+
+**Acceptance criteria:**
+
+- No live research calls in this phase.
+- Payload boundaries and evidence caveats are explicit.
+- Attestor criteria are defined.
+
+**Validation:**
+
+- BDD index check;
+- doc inspection;
+- optional dry-run route test.
+
+**Retrospective prompt:** Does research add a new proof category, or does it just repeat webpage with weaker evidence?
+
+**Expected next refinement:** If useful, run controlled multi-edge research. If not, improve evidence criteria first.
+
+---
+
+## Phase 6 — Controlled research live workflow
+
+**BDD expectation:** Research article workflow reaches bounded paid completions and returns disclosure-complete evidence.
+
+**Scope:**
+
+- Add guarded research live x402 workflow smoke.
+- Execute only after endpoint readiness and spend gates are explicit.
+- Save bounded artifact and evidence pack.
+
+**Acceptance criteria:**
+
+- All edges capture 402 challenge and controlled 200 completion or fail-closed reason.
+- Output includes citations or explicit evidence caveats.
+- Disclosure ledger is complete for every attempted downstream call.
+
+**Validation:**
+
+- live smoke artifact;
+- evidence pack generation;
+- secret grep;
+- retrospective.
+
+**Retrospective prompt:** Did this prove a richer agent economy than webpage, with honest evidence quality?
+
+---
+
+## Phase 7 — Picture/storyboard path, no hidden image spend
+
+**BDD expectation:** Picture path is explainable without accidental image-generation spend.
+
+**Scope:**
+
+- Produce visual brief/storyboard through marketplace specialists.
+- Keep real image generation disabled unless explicitly approved.
+- Validate prompt/storyboard alignment through vision/verification specialists where possible.
+
+**Acceptance criteria:**
+
+- No OpenAI/Fal call unless explicitly enabled.
+- Storyboard mode is clearly labeled.
+- Disclosure ledger still includes payload/payment/attestation flow.
+
+**Validation:**
+
+- disabled-generation smoke;
+- build;
+- optional approval-gated image run later.
+
+**Retrospective prompt:** Is storyboard mode sufficient for judging, or do we need approval-gated real image generation?
+
+---
+
+## Running retrospective log
+
+### Phase 0 retrospective
+
+_Status:_ Complete locally; ready for PR.
+
+- **What worked:** The phase produced a single resumeable plan with explicit phase order, validation gates, and retrospective prompts. BDD now locks public marketplace manifest dependency disclosure and disclosure-ledger evidence expectations.
+- **What failed or surprised us:** PR #205 already shipped the public UI slice before this plan existed, so Phase 0 had to document the already-completed marketplace baseline rather than starting from a blank plan.
+- **Safety/spend review:** Docs/BDD-only change; no runtime calls, wallet mutations, external infra mutation, or provider spend.
+- **Judge clarity:** The next proof gap is now concrete: artifacts and `/economic-demo` must display `reddi.downstream-disclosure-ledger.v1`, not merely require it behind the scenes.
+- **Plan adjustment:** Phase 1 should focus on evidence artifact summary shape before more UI work; external Coolify redeploy remains approval-gated.

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -60,11 +60,20 @@ Feature: End-user economic workflow demo
     And it captures before and after balances for payer and payee
     And it does not retry automatically
 
+  Scenario: Public marketplace pages show agent manifest tools, skills, and dependencies
+    Given a marketplace specialist or attestor may call other agents or external MCP services while fulfilling its role
+    When a user opens /agents or /agents/:wallet
+    Then the public marketplace shows manifest tools and skills for the agent
+    And the detail page lists marketplace agents it may call
+    And the detail page lists external MCP servers it may use
+    And the detail page lists non-marketplace agents or services it may leverage
+    And the disclosure is visible before the user invokes the agent
+
   Scenario: Agent manifests disclose downstream marketplace delegation
     Given a marketplace specialist or attestor may call other agents while fulfilling its role
     When a consumer agent reads /.well-known/reddi-agent.json
     Then the manifest declares that downstream marketplace calls may occur
-    And it lists expected downstream capability categories, budget policy, attestor expectations, and payload-disclosure policy
+    And it lists expected downstream capability categories, tools, skills, external MCP servers, non-marketplace agent calls, budget policy, attestor expectations, and payload-disclosure policy
     And the consumer agent can reject the agent before purchase if the disclosure is unacceptable
 
   Scenario: Downstream calls return transparent disclosure without exposing proprietary value-add
@@ -75,10 +84,11 @@ Feature: End-user economic workflow demo
     And any obfuscated returned details include an explicit moat_protection reason
     And called-agent identity, payload class, payment evidence, and attestation chain are not hidden
 
-  Scenario: Multi-edge demo returns output and economic impact
+  Scenario: Multi-edge demo returns output, disclosure ledger, and economic impact
     Given multi-edge demo mode is explicitly approved
     When the webpage or research article workflow completes
     Then the final output is shown to the user
     And attestor guidance is shown
+    And each downstream call has a reddi.downstream-disclosure-ledger.v1 entry
     And each participating wallet has a start balance, end balance, and delta
     And a bounded evidence artifact is produced


### PR DESCRIPTION
## Summary
- add staged BDD iterative plan for marketplace manifest + downstream disclosure ledger work
- add retrospective gates for each phase before scope expansion
- update Bucket J BDD scenarios for public manifest tools/skills/MCP/non-marketplace dependencies and disclosure-ledger evidence
- update repo STATUS resume point

## Validation
- `npm run test:bdd:index`
- `git diff --check`