### PR TITLE
Summarize disclosure ledgers in evidence packs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,18 +1,18 @@
 # Reddi Agent Protocol Code — STATUS
 
 **Last updated:** 2026-05-05 AEST
-**State:** 🟢 PR #205 merged; Phase 0 BDD iterative plan for manifest/disclosure-ledger loop in progress on docs branch.
+**State:** 🟢 Phase 1 disclosure-ledger evidence summary implemented locally; ready for PR.
 
 ## RESUME FROM HERE
 
-1. Finish Phase 0 docs branch `docs/bdd-agentic-marketplace-plan-20260505`: plan doc + BDD lock for public manifest/dependency disclosure and disclosure-ledger evidence display.
-2. Validate with `npm run test:bdd:index` and `git diff --check`, complete Phase 0 retrospective, then open PR.
-3. After Phase 0 lands, continue Phase 1: update live workflow smoke/evidence pack artifacts to display `reddi.downstream-disclosure-ledger.v1` entries. External Coolify redeploy remains explicit-operator-only.
+1. Open/merge Phase 1 branch `feature/disclosure-ledger-evidence-summary-20260505`: evidence packs now expose compact `reddi.economic-demo.disclosure-ledger-summary.v1` plus markdown ledger section.
+2. After Phase 1 lands, continue Phase 2: `/economic-demo` should consume/display `disclosureLedgerSummary` rather than re-parsing raw edge ledgers.
+3. External Coolify redeploy remains explicit-operator-only.
 
 ## Current Branch / Repo State
 
-- Local branch: `docs/bdd-agentic-marketplace-plan-20260505`
-- Local working tree: Phase 0 plan/BDD docs in progress.
+- Local branch: `feature/disclosure-ledger-evidence-summary-20260505`
+- Local working tree: Phase 1 evidence summary changes in progress.
 - Latest merge on main: `345f6af4 feat: expose agent manifests in marketplace (#205)`.
 - PR #205: merged 2026-05-05 AEST; post-merge Anchor run `25345416486` passed.
 
@@ -72,6 +72,14 @@ Validation for public manifest marketplace slice / PR #205:
 - PR #205 checks before merge — PASS: two Anchor runs + Vercel.
 - PR #205 post-merge `main` Anchor run `25345416486` — PASS, 7m11s.
 
+Validation for Phase 1 disclosure-ledger evidence summary:
+
+- Synthetic evidence-pack smoke via `ECONOMIC_DEMO_EVIDENCE_SOURCE=/tmp/reddi-ledger-source.json ECONOMIC_DEMO_EVIDENCE_OUT=artifacts/tmp-phase1-ledger-smoke node scripts/generate-economic-demo-evidence-pack.mjs` — PASS.
+- JSON assertions for `reddi.economic-demo.disclosure-ledger-summary.v1`, total ledger entries, and payload hash presence — PASS.
+- `node --check scripts/generate-economic-demo-evidence-pack.mjs` — PASS.
+- Targeted ESLint for `scripts/generate-economic-demo-evidence-pack.mjs` — PASS.
+- `git diff --check` — PASS.
+
 ## Retrospective — Phase 6.5 Slice A
 
 ### What worked
@@ -99,6 +107,8 @@ Do not proceed as a waterfall into research/picture live workflows until the dis
 - 2026-05-05: Public marketplace pages must expose agent manifest fields: tools, skills, marketplace-agent calls, external MCP servers, and non-marketplace agent/service calls, not just task capability tags.
 
 - 2026-05-05: BDD iterative plan for the agentic marketplace work must use explicit phase retrospectives before expanding scope: plan/BDD lock → artifact ledger summary → UI ledger display → manifest parity → hosted redeploy smoke → research → picture.
+
+- 2026-05-05: Evidence packs should expose a compact disclosure-ledger summary for judges/UI consumers instead of requiring raw edge JSON archaeology.
 
 ## Blockers / Watch Items
 

--- a/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
+++ b/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
@@ -268,6 +268,16 @@ Still pending:
 
 ## Running retrospective log
 
+### Phase 1 retrospective
+
+_Status:_ Complete locally; ready for PR.
+
+- **What worked:** Evidence pack generation now creates a compact `reddi.economic-demo.disclosure-ledger-summary.v1` block and repeats the ledger in human-readable markdown, so reviewers do not need to inspect raw edge JSON to understand downstream disclosure.
+- **What failed or surprised us:** The existing markdown renderer assumed raw source-edge shape; once the pack switched to normalized edge summaries, the smoke caught a shape mismatch before commit.
+- **Safety/spend review:** Used a synthetic local source artifact only. No live endpoints, wallet mutation, external infra mutation, provider calls, or hidden retries. Secret scan still runs over generated pack output.
+- **Judge clarity:** Improved: the evidence pack now states total disclosure entries and includes a dedicated compact downstream disclosure ledger section.
+- **Plan adjustment:** Phase 2 should consume `disclosureLedgerSummary` from evidence packs/UI helpers rather than re-parsing raw source edge ledgers.
+
 ### Phase 0 retrospective
 
 _Status:_ Complete locally; ready for PR.

--- a/scripts/generate-economic-demo-evidence-pack.mjs
+++ b/scripts/generate-economic-demo-evidence-pack.mjs
@@ -24,14 +24,69 @@ function preview(text, max = 520) {
   return text.replace(/```/g, "~~~").replace(/\s+$/g, "").slice(0, max);
 }
 
+function summarizeDisclosureLedger(edge) {
+  const ledger = edge.downstreamDisclosureLedger;
+  assert(ledger?.schemaVersion === "reddi.downstream-disclosure-ledger.v1", `${edge.profileId}: missing downstream disclosure ledger`);
+  assert(Array.isArray(ledger.entries), `${edge.profileId}: disclosure ledger entries must be an array`);
+  return {
+    schemaVersion: ledger.schemaVersion,
+    disclosureScope: ledger.disclosureScope,
+    entryCount: ledger.entries.length,
+    transparencyGuarantees: Array.isArray(ledger.transparencyGuarantees) ? ledger.transparencyGuarantees : [],
+    entries: ledger.entries.map((entry) => ({
+      calledProfileId: entry.calledProfileId ?? "none",
+      walletAddress: entry.walletAddress ?? null,
+      endpoint: entry.endpoint ?? null,
+      payloadSummary: preview(entry.payloadSummary, 240),
+      payloadHashPresent: Boolean(entry.payloadHashPresent || (typeof entry.payloadHash === "string" && entry.payloadHash.length > 0)),
+      x402: {
+        state: entry.x402?.state ?? entry.x402?.status ?? "not_applicable",
+        amount: entry.x402?.amount ?? null,
+        currency: entry.x402?.currency ?? null,
+        receiptPresent: Boolean(entry.x402?.receiptPresent || entry.x402?.receipt),
+        challengePresent: Boolean(entry.x402?.challengePresent || entry.x402?.challenge),
+      },
+      attestorLinks: Array.isArray(entry.attestorLinks) ? entry.attestorLinks : [],
+      obfuscation: entry.obfuscation ?? null,
+    })),
+  };
+}
+
+function disclosureMarkdown(edge) {
+  const ledger = edge.downstreamDisclosureLedgerSummary;
+  const lines = [
+    `- Disclosure ledger: \`${ledger.schemaVersion}\` · scope=${ledger.disclosureScope} · entries=${ledger.entryCount}`,
+  ];
+
+  if (ledger.entries.length === 0) {
+    lines.push("  - No downstream calls were disclosed for this edge.");
+  } else {
+    for (const entry of ledger.entries) {
+      lines.push(`  - Called: \`${entry.calledProfileId}\``);
+      lines.push(`    - Wallet: \`${entry.walletAddress ?? "not_disclosed"}\``);
+      lines.push(`    - Endpoint: \`${entry.endpoint ?? "not_disclosed"}\``);
+      lines.push(`    - Payload: ${entry.payloadSummary || (entry.payloadHashPresent ? "hash present" : "not disclosed")}`);
+      lines.push(`    - x402: ${entry.x402.state}${entry.x402.amount ? ` · ${entry.x402.amount} ${entry.x402.currency ?? ""}` : ""} · challenge=${entry.x402.challengePresent} · receipt=${entry.x402.receiptPresent}`);
+      if (entry.attestorLinks.length > 0) lines.push(`    - Attestors: ${entry.attestorLinks.map((link) => `\`${link}\``).join(", ")}`);
+      if (entry.obfuscation) lines.push(`    - Obfuscation: ${typeof entry.obfuscation === "string" ? entry.obfuscation : JSON.stringify(entry.obfuscation)}`);
+    }
+  }
+
+  if (ledger.transparencyGuarantees.length > 0) {
+    lines.push(`  - Guarantees: ${ledger.transparencyGuarantees.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}
+
 function edgeMarkdown(edge) {
   return [
     `### ${edge.step}. ${edge.profileId}`,
     "",
     `- Capability: \`${edge.capability}\``,
     `- Endpoint: \`${edge.endpoint}\``,
-    `- x402 challenge: HTTP ${edge.unpaidChallenge.status} · ${edge.unpaidChallenge.challenge.amount} ${edge.unpaidChallenge.challenge.currency} · ${edge.unpaidChallenge.challenge.network}`,
-    `- Payee wallet: \`${edge.unpaidChallenge.challenge.payTo}\``,
+    `- x402 challenge: HTTP 402 · ${edge.challenge.amount} ${edge.challenge.currency} · ${edge.challenge.network}`,
+    `- Payee wallet: \`${edge.challenge.payTo}\``,
     `- Controlled demo-paid completion: HTTP ${edge.paidCompletion.status} · paymentSatisfied=${edge.paidCompletion.paymentSatisfied}`,
     `- Model: \`${edge.paidCompletion.model ?? "unknown"}\``,
     "",
@@ -41,6 +96,8 @@ function edgeMarkdown(edge) {
       .split("\n")
       .map((line) => `> ${line}`)
       .join("\n"),
+    "",
+    disclosureMarkdown(edge),
     "",
   ].join("\n");
 }
@@ -74,6 +131,37 @@ assert(source.guardrails?.disclosureLedgerRequired === true, "source guardrails 
 
 mkdirSync(outDir, { recursive: true });
 
+const edgeSummaries = source.edges.map((edge) => ({
+  step: edge.step,
+  profileId: edge.profileId,
+  capability: edge.capability,
+  endpoint: edge.endpoint,
+  challenge: edge.unpaidChallenge.challenge,
+  paidCompletion: {
+    status: edge.paidCompletion.status,
+    paymentSatisfied: edge.paidCompletion.paymentSatisfied,
+    model: edge.paidCompletion.model,
+    outputPreview: preview(edge.paidCompletion.outputPreview),
+  },
+  downstreamDisclosureLedgerSummary: summarizeDisclosureLedger(edge),
+}));
+
+const disclosureLedgerSummary = {
+  schemaVersion: "reddi.economic-demo.disclosure-ledger-summary.v1",
+  requiredLedgerSchemaVersion: source.disclosureContract.requiredLedgerSchemaVersion,
+  allEdgesHaveDisclosureLedger: source.disclosureContract.allEdgesHaveDisclosureLedger,
+  edgeCount: edgeSummaries.length,
+  totalLedgerEntries: edgeSummaries.reduce((sum, edge) => sum + edge.downstreamDisclosureLedgerSummary.entryCount, 0),
+  scopes: [...new Set(edgeSummaries.map((edge) => edge.downstreamDisclosureLedgerSummary.disclosureScope))].sort(),
+  edges: edgeSummaries.map((edge) => ({
+    step: edge.step,
+    profileId: edge.profileId,
+    disclosureScope: edge.downstreamDisclosureLedgerSummary.disclosureScope,
+    entryCount: edge.downstreamDisclosureLedgerSummary.entryCount,
+    entries: edge.downstreamDisclosureLedgerSummary.entries,
+  })),
+};
+
 const pack = {
   schemaVersion: "reddi.economic-demo.judge-evidence-pack.v1",
   generatedAt: new Date().toISOString(),
@@ -85,21 +173,9 @@ const pack = {
   downstreamCallsExecuted: source.downstreamCallsExecuted,
   receiptMode: "controlled_demo_receipts",
   disclosureContract: source.disclosureContract,
+  disclosureLedgerSummary,
   limitation: "Controlled demo receipts prove x402 challenge/receipt-gated specialist execution for the judge demo, not production USDC settlement verification.",
-  edges: source.edges.map((edge) => ({
-    step: edge.step,
-    profileId: edge.profileId,
-    capability: edge.capability,
-    endpoint: edge.endpoint,
-    challenge: edge.unpaidChallenge.challenge,
-    paidCompletion: {
-      status: edge.paidCompletion.status,
-      paymentSatisfied: edge.paidCompletion.paymentSatisfied,
-      model: edge.paidCompletion.model,
-      outputPreview: preview(edge.paidCompletion.outputPreview),
-    },
-    downstreamDisclosureLedger: edge.downstreamDisclosureLedger,
-  })),
+  edges: edgeSummaries,
   guardrails: source.guardrails,
   nextRecommendedPhase: "Phase 7C ledger reconciliation, then research workflow planning.",
 };
@@ -125,6 +201,7 @@ writeFileSync(
     `- Bounded downstream calls: **${pack.downstreamCallsExecuted}** (4 unpaid challenges + 4 controlled demo-paid completions)`,
     "- Receipt mode: **controlled demo receipts**",
     `- Disclosure ledger contract: **${pack.disclosureContract.requiredLedgerSchemaVersion}** on all edges = **${pack.disclosureContract.allEdgesHaveDisclosureLedger}**`,
+    `- Disclosure ledger entries summarized: **${pack.disclosureLedgerSummary.totalLedgerEntries}** across ${pack.disclosureLedgerSummary.edgeCount} edges`,
     "",
     "## User request",
     "",
@@ -145,7 +222,23 @@ writeFileSync(
     "",
     "## Specialist edges",
     "",
-    ...source.edges.map(edgeMarkdown),
+    ...pack.edges.map(edgeMarkdown),
+    "## Compact downstream disclosure ledger",
+    "",
+    ...pack.disclosureLedgerSummary.edges.flatMap((edge) => [
+      `### ${edge.step}. ${edge.profileId}`,
+      "",
+      `- Scope: ${edge.disclosureScope}`,
+      `- Entries: ${edge.entryCount}`,
+      ...edge.entries.flatMap((entry) => [
+        `  - Called: \`${entry.calledProfileId}\``,
+        `    - Wallet: \`${entry.walletAddress ?? "not_disclosed"}\``,
+        `    - Endpoint: \`${entry.endpoint ?? "not_disclosed"}\``,
+        `    - Payload: ${entry.payloadSummary || (entry.payloadHashPresent ? "hash present" : "not disclosed")}`,
+        `    - x402: ${entry.x402.state}${entry.x402.amount ? ` · ${entry.x402.amount} ${entry.x402.currency ?? ""}` : ""} · challenge=${entry.x402.challengePresent} · receipt=${entry.x402.receiptPresent}`,
+      ]),
+      "",
+    ]),
     "## Guardrails",
     "",
     ...Object.entries(source.guardrails).map(([key, value]) => `- ${key}: ${value}`),


### PR DESCRIPTION
## Summary
- add compact `reddi.economic-demo.disclosure-ledger-summary.v1` to judge evidence packs
- render downstream disclosure ledger details in `EVIDENCE.md` so reviewers do not need raw JSON archaeology
- complete Phase 1 retrospective and update STATUS resume point

## Validation
- synthetic evidence-pack smoke with `ECONOMIC_DEMO_EVIDENCE_SOURCE=/tmp/reddi-ledger-source.json ECONOMIC_DEMO_EVIDENCE_OUT=artifacts/tmp-phase1-ledger-smoke node scripts/generate-economic-demo-evidence-pack.mjs`
- JSON assertions for ledger summary schema, total entries, payload hash presence
- `node --check scripts/generate-economic-demo-evidence-pack.mjs`
- `npx eslint scripts/generate-economic-demo-evidence-pack.mjs`
- `npm run test:bdd:index`
- `git diff --check`