### PR TITLE
Show disclosure ledger status in economic demo

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,20 +1,20 @@
 # Reddi Agent Protocol Code — STATUS
 
 **Last updated:** 2026-05-05 AEST
-**State:** 🟢 PR #207 merged — Phase 1 disclosure-ledger evidence summary live on `main`; post-merge Anchor CI green.
+**State:** 🟢 Phase 2 `/economic-demo` disclosure-ledger UI implemented locally; ready for PR.
 
 ## RESUME FROM HERE
 
-1. Start Phase 2: `/economic-demo` should consume/display `disclosureLedgerSummary` rather than re-parsing raw edge ledgers.
-2. Validate with targeted helper/UI tests, targeted ESLint, and `npm run build`; complete Phase 2 retrospective before expanding scope.
+1. Open/merge Phase 2 branch `feature/economic-demo-disclosure-ledger-ui-20260505`: `/economic-demo` consumes and displays `disclosureLedgerSummary`.
+2. After Phase 2 lands, choose the next safe loop: wire latest generated evidence-pack summaries into UI data, or continue Phase 3 local manifest parity.
 3. External Coolify redeploy remains explicit-operator-only.
 
 ## Current Branch / Repo State
 
-- Local branch: `main`
-- Local working tree: clean after PR #207 merge.
-- Latest merge on main: `aefe7286 feat: summarize disclosure ledgers in evidence packs (#207)`.
-- PR #207: merged 2026-05-05 AEST; post-merge Anchor run `25346911473` passed.
+- Local branch: `feature/economic-demo-disclosure-ledger-ui-20260505`
+- Local working tree: Phase 2 UI changes in progress.
+- Latest merge on main: `93d146e6 docs: update status after phase 1 merge (#208)`.
+- PR #208: merged 2026-05-05 AEST; post-merge Anchor run `25347593058` passed.
 
 
 ## Current Follow-up PR — #203
@@ -87,6 +87,13 @@ Validation for Phase 1 PR #207:
 - PR checks passed: Vercel Preview Comments, Vercel deployment, Anchor runs `25346592595` / `25346594990`.
 - Post-merge `main` Anchor run `25346911473`, job `74317799175` — PASS, 7m46s.
 
+Validation for Phase 2 disclosure-ledger UI:
+
+- `npx jest --runTestsByPath lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts --runInBand` — PASS, 2/2.
+- Targeted ESLint for `app/economic-demo/page.tsx`, `lib/economic-demo/webpage-live-workflow-evidence.ts`, and the focused test — PASS.
+- `npm run build` — PASS.
+- `git diff --check` — PASS.
+
 ## Retrospective — Phase 6.5 Slice A
 
 ### What worked
@@ -116,6 +123,8 @@ Do not proceed as a waterfall into research/picture live workflows until the dis
 - 2026-05-05: BDD iterative plan for the agentic marketplace work must use explicit phase retrospectives before expanding scope: plan/BDD lock → artifact ledger summary → UI ledger display → manifest parity → hosted redeploy smoke → research → picture.
 
 - 2026-05-05: Evidence packs should expose a compact disclosure-ledger summary for judges/UI consumers instead of requiring raw edge JSON archaeology.
+
+- 2026-05-05: `/economic-demo` must render the normalized `disclosureLedgerSummary` and visibly mark historical pre-ledger artifacts as not evidence-complete.
 
 ## Blockers / Watch Items
 

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -12,7 +12,10 @@ import type { EconomicDemoBalanceReport } from "@/lib/economic-demo/balances";
 import type { DryRunEconomicPlan } from "@/lib/economic-demo/dry-run";
 import type { SurfpoolRehearsalReport } from "@/lib/economic-demo/surfpool-rehearsal";
 import type { EconomicDemoPaymentReadiness } from "@/lib/economic-demo/payment-readiness";
-import type { WebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
+import {
+  getDisclosureLedgerEvidenceStatus,
+  type WebpageLiveWorkflowEvidence,
+} from "@/lib/economic-demo/webpage-live-workflow-evidence";
 import type { EconomicDemoLedgerReconciliation } from "@/lib/economic-demo/ledger-reconciliation";
 import type { ResearchWorkflowDesign } from "@/lib/economic-demo/research-workflow-design";
 
@@ -51,6 +54,9 @@ export default function EconomicDemoPage() {
   const activeDryRunPlan = dryRunPlan?.scenarioId === scenario.id ? dryRunPlan : null;
   const activeBalanceReport = balanceReport?.scenarioId === scenario.id ? balanceReport : null;
   const activeSurfpoolReport = surfpoolReport?.scenarioId === scenario.id ? surfpoolReport : null;
+  const webpageDisclosureStatus = webpageLiveEvidence
+    ? getDisclosureLedgerEvidenceStatus(webpageLiveEvidence.disclosureLedgerSummary)
+    : null;
 
   async function loadDryRunPlan() {
     setDryRunStatus("loading");
@@ -555,7 +561,7 @@ export default function EconomicDemoPage() {
                 </div>
               )}
 
-              {webpageLiveEvidence && (
+              {webpageLiveEvidence && webpageDisclosureStatus && (
                 <div className="mt-6 rounded-xl border border-[#14F195]/30 bg-[#14F195]/10 p-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
@@ -578,6 +584,45 @@ export default function EconomicDemoPage() {
                     <div className="rounded-lg border border-white/10 bg-black/20 p-3">
                       <p className="text-xs text-gray-500">receipt mode</p>
                       <p className="mt-1 text-sm text-yellow-100">controlled demo receipts</p>
+                    </div>
+                  </div>
+                  <div className={webpageDisclosureStatus.isComplete ? "mt-4 rounded-lg border border-[#14F195]/30 bg-black/20 p-3" : "mt-4 rounded-lg border border-yellow-400/40 bg-yellow-400/10 p-3"}>
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className={webpageDisclosureStatus.isComplete ? "text-xs uppercase tracking-wide text-[#14F195]" : "text-xs uppercase tracking-wide text-yellow-100"}>
+                          Downstream disclosure ledger
+                        </p>
+                        <p className="mt-1 text-sm leading-6 text-gray-200">{webpageDisclosureStatus.detail}</p>
+                      </div>
+                      <span className={webpageDisclosureStatus.isComplete ? "rounded-full border border-[#14F195]/30 px-2 py-0.5 text-xs text-[#14F195]" : "rounded-full border border-yellow-400/40 px-2 py-0.5 text-xs text-yellow-100"}>
+                        {webpageDisclosureStatus.label}
+                      </span>
+                    </div>
+                    <div className="mt-3 grid gap-3 md:grid-cols-2">
+                      {webpageLiveEvidence.disclosureLedgerSummary.edges.map((edge) => (
+                        <div key={edge.profileId} className="rounded-lg border border-white/10 bg-black/20 p-3">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <p className="font-mono text-sm text-white">{edge.step}. {edge.profileId}</p>
+                            <span className="rounded-full border border-white/10 px-2 py-0.5 text-xs text-gray-300">{edge.disclosureScope}</span>
+                          </div>
+                          <p className="mt-1 text-xs text-gray-400">ledger entries: {edge.entryCount}</p>
+                          {edge.entries.length === 0 ? (
+                            <p className="mt-2 text-xs leading-5 text-yellow-100/90">No downstream disclosure entries available for this edge in the current evidence summary.</p>
+                          ) : (
+                            <div className="mt-2 space-y-2">
+                              {edge.entries.map((entry) => (
+                                <div key={`${edge.profileId}-${entry.calledProfileId}-${entry.endpoint ?? "none"}`} className="rounded border border-white/10 bg-black/30 p-2 text-xs text-gray-300">
+                                  <p className="font-mono text-white">called: {entry.calledProfileId}</p>
+                                  <p className="mt-1">wallet: {entry.walletAddress ? shortWallet(entry.walletAddress) : "not disclosed"}</p>
+                                  <p className="mt-1">endpoint: {entry.endpoint ?? "not disclosed"}</p>
+                                  <p className="mt-1">payload: {entry.payloadSummary || (entry.payloadHashPresent ? "hash present" : "not disclosed")}</p>
+                                  <p className="mt-1 text-yellow-100">x402: {entry.x402.state} · challenge={String(entry.x402.challengePresent)} · receipt={String(entry.x402.receiptPresent)}</p>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      ))}
                     </div>
                   </div>
                   <div className="mt-4 space-y-3">

--- a/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
+++ b/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
@@ -268,6 +268,16 @@ Still pending:
 
 ## Running retrospective log
 
+### Phase 2 retrospective
+
+_Status:_ Complete locally; ready for PR.
+
+- **What worked:** `/economic-demo` now consumes the normalized `disclosureLedgerSummary` shape and renders a dedicated downstream disclosure-ledger panel next to the multi-edge proof. The UI does not inspect raw source artifact edge JSON.
+- **What failed or surprised us:** The currently committed 2026-05-04 live webpage artifact predates `reddi.downstream-disclosure-ledger.v1`, so the truthful UI state is **not evidence-complete** rather than a green ledger. This is useful judge-facing honesty, not a failure.
+- **Safety/spend review:** UI/API summary only. No live endpoint calls from page load, no wallet mutation, no signing, no external infra mutation, no paid model calls.
+- **Judge clarity:** Improved: the panel names the missing ledger contract and lists each edge with `missing_pre_ledger_artifact`, so a judge can distinguish historical x402 proof from complete downstream-disclosure proof.
+- **Plan adjustment:** Next phase should either (a) wire latest generated evidence-pack summaries into the UI when available, or (b) move to local manifest parity. Do not claim hosted endpoints are ledger-complete until Coolify redeploy/smoke is explicitly approved and new artifacts are generated.
+
 ### Phase 1 retrospective
 
 _Status:_ Complete locally; ready for PR.

--- a/lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts
+++ b/lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts
@@ -1,4 +1,7 @@
-import { getWebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
+import {
+  getDisclosureLedgerEvidenceStatus,
+  getWebpageLiveWorkflowEvidence,
+} from "@/lib/economic-demo/webpage-live-workflow-evidence";
 
 describe("economic demo webpage live workflow evidence", () => {
   it("summarizes the multi-edge controlled paid workflow without live UI calls", () => {
@@ -25,5 +28,31 @@ describe("economic demo webpage live workflow evidence", () => {
       noLiveCallsFromUi: true,
     });
     expect(evidence.limitations.join(" ")).toContain("controlled demo receipts");
+  });
+
+  it("surfaces disclosure ledger completion state for the UI without raw edge parsing", () => {
+    const evidence = getWebpageLiveWorkflowEvidence();
+    const status = getDisclosureLedgerEvidenceStatus(evidence.disclosureLedgerSummary);
+
+    expect(evidence.disclosureLedgerSummary).toMatchObject({
+      schemaVersion: "reddi.economic-demo.disclosure-ledger-summary.v1",
+      requiredLedgerSchemaVersion: "reddi.downstream-disclosure-ledger.v1",
+      allEdgesHaveDisclosureLedger: false,
+      evidenceComplete: false,
+      edgeCount: 4,
+      totalLedgerEntries: 0,
+      scopes: ["missing_pre_ledger_artifact"],
+    });
+    expect(evidence.disclosureLedgerSummary.edges.map((edge) => edge.profileId)).toEqual([
+      "planning-agent",
+      "content-creation-agent",
+      "code-generation-agent",
+      "verification-validation-agent",
+    ]);
+    expect(status).toMatchObject({
+      label: "disclosure ledger not evidence-complete",
+      isComplete: false,
+    });
+    expect(status.detail).toContain("predates reddi.downstream-disclosure-ledger.v1");
   });
 });

--- a/lib/economic-demo/webpage-live-workflow-evidence.ts
+++ b/lib/economic-demo/webpage-live-workflow-evidence.ts
@@ -19,6 +19,41 @@ export type WebpageLiveWorkflowEvidenceEdge = {
   };
 };
 
+export type WebpageLiveWorkflowDisclosureLedgerEntry = {
+  calledProfileId: string;
+  walletAddress: string | null;
+  endpoint: string | null;
+  payloadSummary: string;
+  payloadHashPresent: boolean;
+  x402: {
+    state: string;
+    amount: string | null;
+    currency: "USDC" | null;
+    receiptPresent: boolean;
+    challengePresent: boolean;
+  };
+  attestorLinks: string[];
+  obfuscation: string | Record<string, unknown> | null;
+};
+
+export type WebpageLiveWorkflowDisclosureLedgerSummary = {
+  schemaVersion: "reddi.economic-demo.disclosure-ledger-summary.v1";
+  requiredLedgerSchemaVersion: "reddi.downstream-disclosure-ledger.v1";
+  allEdgesHaveDisclosureLedger: boolean;
+  evidenceComplete: boolean;
+  incompleteReason: string | null;
+  edgeCount: number;
+  totalLedgerEntries: number;
+  scopes: string[];
+  edges: Array<{
+    step: number;
+    profileId: string;
+    disclosureScope: string;
+    entryCount: number;
+    entries: WebpageLiveWorkflowDisclosureLedgerEntry[];
+  }>;
+};
+
 export type WebpageLiveWorkflowEvidence = {
   schemaVersion: "reddi.economic-demo.webpage.live-x402-workflow.summary.v1";
   generatedAt: string;
@@ -28,6 +63,7 @@ export type WebpageLiveWorkflowEvidence = {
   userRequest: string;
   conclusion: "multi_edge_paid_workflow_reached";
   downstreamCallsExecuted: 8;
+  disclosureLedgerSummary: WebpageLiveWorkflowDisclosureLedgerSummary;
   edges: WebpageLiveWorkflowEvidenceEdge[];
   blockers: [];
   guardrails: {
@@ -43,7 +79,41 @@ export type WebpageLiveWorkflowEvidence = {
   nextStep: string;
 };
 
+export function getDisclosureLedgerEvidenceStatus(summary: WebpageLiveWorkflowDisclosureLedgerSummary) {
+  return {
+    label: summary.evidenceComplete ? "disclosure ledger complete" : "disclosure ledger not evidence-complete",
+    isComplete: summary.evidenceComplete,
+    detail: summary.evidenceComplete
+      ? `${summary.totalLedgerEntries} downstream ledger entries across ${summary.edgeCount} edges.`
+      : (summary.incompleteReason ?? "Missing downstream disclosure ledger evidence."),
+  };
+}
+
 export function getWebpageLiveWorkflowEvidence(): WebpageLiveWorkflowEvidence {
+  const disclosureLedgerSummary: WebpageLiveWorkflowDisclosureLedgerSummary = {
+    schemaVersion: "reddi.economic-demo.disclosure-ledger-summary.v1",
+    requiredLedgerSchemaVersion: "reddi.downstream-disclosure-ledger.v1",
+    allEdgesHaveDisclosureLedger: false,
+    evidenceComplete: false,
+    incompleteReason:
+      "The committed 2026-05-04 live webpage artifact predates reddi.downstream-disclosure-ledger.v1; future evidence packs must include this ledger before the proof is considered complete.",
+    edgeCount: 4,
+    totalLedgerEntries: 0,
+    scopes: ["missing_pre_ledger_artifact"],
+    edges: [
+      "planning-agent",
+      "content-creation-agent",
+      "code-generation-agent",
+      "verification-validation-agent",
+    ].map((profileId, index) => ({
+      step: index + 1,
+      profileId,
+      disclosureScope: "missing_pre_ledger_artifact",
+      entryCount: 0,
+      entries: [],
+    })),
+  };
+
   return {
     schemaVersion: "reddi.economic-demo.webpage.live-x402-workflow.summary.v1",
     generatedAt: "2026-05-04T09:35:08.940Z",
@@ -54,6 +124,7 @@ export function getWebpageLiveWorkflowEvidence(): WebpageLiveWorkflowEvidence {
       "Design me a webpage for a trustless AI agent marketplace where users pay specialist agents via x402 and receive attested outputs.",
     conclusion: "multi_edge_paid_workflow_reached",
     downstreamCallsExecuted: 8,
+    disclosureLedgerSummary,
     edges: [
       {
         step: 1,


### PR DESCRIPTION
## Summary
- add normalized `disclosureLedgerSummary` state to webpage live workflow evidence
- render a downstream disclosure-ledger panel in `/economic-demo` beside the multi-edge x402 proof
- truthfully mark the historical 2026-05-04 artifact as not evidence-complete because it predates `reddi.downstream-disclosure-ledger.v1`
- record Phase 2 retrospective and update STATUS

## Validation
- `npx jest --runTestsByPath lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts --runInBand`
- `npx eslint app/economic-demo/page.tsx lib/economic-demo/webpage-live-workflow-evidence.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts`
- `npm run build`
- `npm run test:bdd:index`
- `git diff --check`