### PR TITLE
Load latest evidence pack in economic demo

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,20 +1,20 @@
 # Reddi Agent Protocol Code — STATUS
 
 **Last updated:** 2026-05-05 AEST
-**State:** 🟢 PR #209 merged — Phase 2 `/economic-demo` disclosure-ledger UI live on `main`; post-merge Anchor CI green.
+**State:** 🟢 Phase 2.5 latest evidence-pack summary UI wiring implemented locally; ready for PR.
 
 ## RESUME FROM HERE
 
-1. Choose next safe loop: wire latest generated evidence-pack summaries into UI data, or continue Phase 3 local manifest parity for `/.well-known/reddi-agent.json`.
-2. If choosing Phase 3, confirm local runtime manifests expose tools/skills, marketplace-agent calls, external MCP servers, non-marketplace services, and disclosure policy.
+1. Open/merge Phase 2.5 branch `feature/economic-demo-latest-evidence-pack-ui-20260505`: `/economic-demo` API/UI prefers the newest generated judge evidence-pack summary when present.
+2. Continue Phase 3 local manifest parity for `/.well-known/reddi-agent.json`: confirm tools/skills, marketplace-agent calls, external MCP servers, non-marketplace services, and disclosure policy.
 3. External Coolify redeploy remains explicit-operator-only.
 
 ## Current Branch / Repo State
 
-- Local branch: `main`
-- Local working tree: clean after PR #209 merge.
-- Latest merge on main: `b12a3c87 feat: show disclosure ledger status in economic demo (#209)`.
-- PR #209: merged 2026-05-05 AEST; post-merge Anchor run `25348267647` passed.
+- Local branch: `feature/economic-demo-latest-evidence-pack-ui-20260505`
+- Local working tree: Phase 2.5 UI/API changes in progress.
+- Latest merge on main: `9a16e4ed docs: update status after phase 2 merge (#210)`.
+- PR #210: merged 2026-05-05 AEST; post-merge Anchor run `25348785645` passed.
 
 
 ## Current Follow-up PR — #203
@@ -101,6 +101,15 @@ Validation for Phase 2 PR #209:
 - PR checks passed: Vercel Preview Comments, Vercel deployment, Anchor runs `25347986266` / `25347987599`.
 - Post-merge `main` Anchor run `25348267647`, job `74322061553` — PASS, 6m15s.
 
+Validation for Phase 2.5 latest evidence-pack UI wiring:
+
+- `npx jest --runTestsByPath lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts --runInBand` — PASS, 3/3.
+- Targeted ESLint for economic-demo page/API/evidence helper/server/test — PASS.
+- `npm run build` — PASS.
+- `npm run test:bdd:index` — PASS.
+- `git diff --check` — PASS.
+- Note: build retains existing workspace-root warning due multiple lockfiles; no build failure.
+
 ## Retrospective — Phase 6.5 Slice A
 
 ### What worked
@@ -132,6 +141,8 @@ Do not proceed as a waterfall into research/picture live workflows until the dis
 - 2026-05-05: Evidence packs should expose a compact disclosure-ledger summary for judges/UI consumers instead of requiring raw edge JSON archaeology.
 
 - 2026-05-05: `/economic-demo` must render the normalized `disclosureLedgerSummary` and visibly mark historical pre-ledger artifacts as not evidence-complete.
+
+- 2026-05-05: `/economic-demo` should prefer the latest generated judge evidence-pack `disclosureLedgerSummary` when present, with fallback to the truthful historical pre-ledger summary.
 
 ## Blockers / Watch Items
 

--- a/app/api/economic-demo/webpage-live-workflow/route.ts
+++ b/app/api/economic-demo/webpage-live-workflow/route.ts
@@ -1,4 +1,4 @@
-import { getWebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
+import { getWebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence-server";
 
 export async function GET() {
   return Response.json({ ok: true, evidence: getWebpageLiveWorkflowEvidence() });

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -572,7 +572,7 @@ export default function EconomicDemoPage() {
                       {webpageLiveEvidence.conclusion}
                     </span>
                   </div>
-                  <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                  <div className="mt-4 grid gap-3 sm:grid-cols-4">
                     <div className="rounded-lg border border-white/10 bg-black/20 p-3">
                       <p className="text-xs text-gray-500">bounded calls</p>
                       <p className="mt-1 font-mono text-lg text-white">{webpageLiveEvidence.downstreamCallsExecuted}</p>
@@ -585,7 +585,26 @@ export default function EconomicDemoPage() {
                       <p className="text-xs text-gray-500">receipt mode</p>
                       <p className="mt-1 text-sm text-yellow-100">controlled demo receipts</p>
                     </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs text-gray-500">evidence pack</p>
+                      <p className="mt-1 text-sm text-gray-200">{webpageLiveEvidence.latestEvidencePack ? "latest generated" : "fallback summary"}</p>
+                    </div>
                   </div>
+                  {webpageLiveEvidence.latestEvidencePack && (
+                    <div className="mt-3 rounded-lg border border-white/10 bg-black/20 p-3 text-xs leading-5 text-gray-300">
+                      <p>
+                        Evidence pack: <span className="font-mono text-white">{webpageLiveEvidence.latestEvidencePack.artifactPath}</span>
+                      </p>
+                      <p className="mt-1">
+                        Generated: <span className="font-mono text-gray-100">{webpageLiveEvidence.latestEvidencePack.generatedAt}</span>
+                      </p>
+                      {webpageLiveEvidence.latestEvidencePack.sourceArtifactPath && (
+                        <p className="mt-1">
+                          Source: <span className="font-mono text-gray-100">{webpageLiveEvidence.latestEvidencePack.sourceArtifactPath}</span>
+                        </p>
+                      )}
+                    </div>
+                  )}
                   <div className={webpageDisclosureStatus.isComplete ? "mt-4 rounded-lg border border-[#14F195]/30 bg-black/20 p-3" : "mt-4 rounded-lg border border-yellow-400/40 bg-yellow-400/10 p-3"}>
                     <div className="flex flex-wrap items-start justify-between gap-3">
                       <div>

--- a/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
+++ b/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
@@ -129,6 +129,36 @@ Still pending:
 
 ---
 
+## Phase 2.5 — Latest generated evidence-pack summaries in `/economic-demo`
+
+**BDD expectation:** When a generated judge evidence pack exists, `/economic-demo` uses that pack's compact summary instead of stale hardcoded ledger data.
+
+**Scope:**
+
+- Load the newest local `artifacts/economic-demo-evidence-pack/*/evidence-pack.json` from the server-side evidence API.
+- Prefer its `disclosureLedgerSummary` and evidence-pack metadata in the UI.
+- Fall back to the truthful historical pre-ledger summary when no generated pack is present.
+
+**Acceptance criteria:**
+
+- Page load still does not call live specialist endpoints, sign receipts, or mutate wallets.
+- The UI labels whether it is showing the latest generated evidence pack or fallback summary.
+- Tests prove a generated pack with complete ledger data drives the UI-facing API summary.
+
+**Validation:**
+
+- focused Jest for generated evidence-pack summary selection;
+- targeted ESLint;
+- `npm run build`;
+- `npm run test:bdd:index`;
+- `git diff --check`.
+
+**Retrospective prompt:** Does the UI now follow the newest generated artifact without hiding historical incompleteness?
+
+**Expected next refinement:** Continue Phase 3 local manifest parity; hosted redeploy remains approval-gated.
+
+---
+
 ## Phase 3 — Programmatic manifest parity for hosted agents
 
 **BDD expectation:** Programmatic consumers reading `/.well-known/reddi-agent.json` see the same tools/skills/dependency disclosure as the public marketplace.
@@ -267,6 +297,15 @@ Still pending:
 ---
 
 ## Running retrospective log
+
+### Phase 2.5 retrospective
+
+_Status:_ Complete locally; ready for PR.
+
+- **What worked:** The webpage evidence API now checks the newest generated judge evidence pack and prefers its compact `disclosureLedgerSummary` for `/economic-demo`. The client visibly labels whether it is reading a latest generated pack or the fallback summary.
+- **What failed or surprised us:** Existing committed historical artifacts still predate the downstream ledger contract, so fallback remains intentionally yellow/not evidence-complete until a new approved live/synthetic evidence pack is generated.
+- **Safety/spend review:** Server-side local file read only. No specialist endpoint calls, no signing, no wallet mutation, no external redeploy, no paid model calls.
+- **Plan adjustment:** Proceed to Phase 3 local manifest parity next. Do not run hosted Coolify redeploy/smoke without explicit operator approval.
 
 ### Phase 2 retrospective
 

--- a/lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts
+++ b/lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts
@@ -1,7 +1,12 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import {
   getDisclosureLedgerEvidenceStatus,
   getWebpageLiveWorkflowEvidence,
 } from "@/lib/economic-demo/webpage-live-workflow-evidence";
+import { getWebpageLiveWorkflowEvidence as getServerWebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence-server";
 
 describe("economic demo webpage live workflow evidence", () => {
   it("summarizes the multi-edge controlled paid workflow without live UI calls", () => {
@@ -54,5 +59,75 @@ describe("economic demo webpage live workflow evidence", () => {
       isComplete: false,
     });
     expect(status.detail).toContain("predates reddi.downstream-disclosure-ledger.v1");
+  });
+
+  it("uses the latest generated evidence-pack disclosure summary when available", () => {
+    const root = mkdtempSync(join(tmpdir(), "reddi-evidence-pack-ui-"));
+    const packDir = join(root, "artifacts", "economic-demo-evidence-pack", "20260505T000001Z");
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(
+      join(packDir, "evidence-pack.json"),
+      `${JSON.stringify(
+        {
+          schemaVersion: "reddi.economic-demo.judge-evidence-pack.v1",
+          generatedAt: "2026-05-05T00:00:01.000Z",
+          sourceArtifactPath: "artifacts/economic-demo-webpage-live-x402-workflow/synthetic/summary.json",
+          disclosureLedgerSummary: {
+            schemaVersion: "reddi.economic-demo.disclosure-ledger-summary.v1",
+            requiredLedgerSchemaVersion: "reddi.downstream-disclosure-ledger.v1",
+            allEdgesHaveDisclosureLedger: true,
+            evidenceComplete: true,
+            incompleteReason: null,
+            edgeCount: 1,
+            totalLedgerEntries: 1,
+            scopes: ["called_marketplace_agent"],
+            edges: [
+              {
+                step: 1,
+                profileId: "planning-agent",
+                disclosureScope: "called_marketplace_agent",
+                entryCount: 1,
+                entries: [
+                  {
+                    calledProfileId: "research-agent",
+                    walletAddress: "11111111111111111111111111111111",
+                    endpoint: "https://research.example/v1/chat/completions",
+                    payloadSummary: "research brief",
+                    payloadHashPresent: true,
+                    x402: {
+                      state: "paid",
+                      amount: "0.01",
+                      currency: "USDC",
+                      receiptPresent: true,
+                      challengePresent: true,
+                    },
+                    attestorLinks: [],
+                    obfuscation: null,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const evidence = getServerWebpageLiveWorkflowEvidence(join(root, "artifacts", "economic-demo-evidence-pack"));
+
+    expect(evidence.latestEvidencePack).toMatchObject({
+      artifactPath: join(root, "artifacts", "economic-demo-evidence-pack", "20260505T000001Z", "evidence-pack.json"),
+      generatedAt: "2026-05-05T00:00:01.000Z",
+    });
+    expect(evidence.disclosureLedgerSummary).toMatchObject({
+      evidenceComplete: true,
+      totalLedgerEntries: 1,
+      scopes: ["called_marketplace_agent"],
+    });
+    expect(getDisclosureLedgerEvidenceStatus(evidence.disclosureLedgerSummary)).toMatchObject({
+      label: "disclosure ledger complete",
+      isComplete: true,
+    });
   });
 });

--- a/lib/economic-demo/webpage-live-workflow-evidence-server.ts
+++ b/lib/economic-demo/webpage-live-workflow-evidence-server.ts
@@ -1,0 +1,70 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  getFallbackDisclosureLedgerSummary,
+  getStaticWebpageLiveWorkflowEvidence,
+  type WebpageLiveWorkflowDisclosureLedgerSummary,
+  type WebpageLiveWorkflowEvidence,
+} from "@/lib/economic-demo/webpage-live-workflow-evidence";
+
+type EvidencePackJson = {
+  schemaVersion?: string;
+  generatedAt?: string;
+  sourceArtifactPath?: string;
+  disclosureLedgerSummary?: WebpageLiveWorkflowDisclosureLedgerSummary;
+};
+
+export type LatestEvidencePackSummary = {
+  schemaVersion: string;
+  generatedAt: string;
+  artifactPath: string;
+  sourceArtifactPath: string | null;
+  disclosureLedgerSummary: WebpageLiveWorkflowDisclosureLedgerSummary;
+};
+
+function defaultEvidencePackRoot() {
+  return join(process.cwd(), "artifacts", "economic-demo-evidence-pack");
+}
+
+function latestEvidencePackPath(evidencePackRoot = defaultEvidencePackRoot()) {
+  if (!existsSync(evidencePackRoot)) return null;
+
+  const candidates = readdirSync(evidencePackRoot)
+    .map((entry) => join(evidencePackRoot, entry, "evidence-pack.json"))
+    .filter((path) => existsSync(path))
+    .map((path) => ({ path, mtimeMs: statSync(path).mtimeMs }))
+    .sort((a, b) => b.mtimeMs - a.mtimeMs || b.path.localeCompare(a.path));
+
+  return candidates[0]?.path ?? null;
+}
+
+export function getLatestEvidencePackSummary(evidencePackRoot = defaultEvidencePackRoot()): LatestEvidencePackSummary | null {
+  const path = latestEvidencePackPath(evidencePackRoot);
+  if (!path) return null;
+
+  const pack = JSON.parse(readFileSync(path, "utf8")) as EvidencePackJson;
+  if (pack.schemaVersion !== "reddi.economic-demo.judge-evidence-pack.v1") return null;
+
+  return {
+    schemaVersion: pack.schemaVersion,
+    generatedAt: pack.generatedAt ?? "unknown",
+    artifactPath: path.replace(`${process.cwd()}/`, ""),
+    sourceArtifactPath: pack.sourceArtifactPath ?? null,
+    disclosureLedgerSummary: pack.disclosureLedgerSummary ?? getFallbackDisclosureLedgerSummary(),
+  };
+}
+
+export function getWebpageLiveWorkflowEvidence(evidencePackRoot = defaultEvidencePackRoot()): WebpageLiveWorkflowEvidence {
+  const base = getStaticWebpageLiveWorkflowEvidence();
+  const evidencePack = getLatestEvidencePackSummary(evidencePackRoot);
+
+  if (!evidencePack) return base;
+
+  return {
+    ...base,
+    sourceArtifactPath: evidencePack.sourceArtifactPath ?? base.sourceArtifactPath,
+    disclosureLedgerSummary: evidencePack.disclosureLedgerSummary,
+    latestEvidencePack: evidencePack,
+  };
+}

--- a/lib/economic-demo/webpage-live-workflow-evidence.ts
+++ b/lib/economic-demo/webpage-live-workflow-evidence.ts
@@ -58,6 +58,13 @@ export type WebpageLiveWorkflowEvidence = {
   schemaVersion: "reddi.economic-demo.webpage.live-x402-workflow.summary.v1";
   generatedAt: string;
   sourceArtifactPath: string;
+  latestEvidencePack?: {
+    schemaVersion: string;
+    generatedAt: string;
+    artifactPath: string;
+    sourceArtifactPath: string | null;
+    disclosureLedgerSummary: WebpageLiveWorkflowDisclosureLedgerSummary;
+  };
   mode: "controlled_demo_receipt_multi_edge_webpage_workflow";
   scenarioId: "webpage";
   userRequest: string;
@@ -89,8 +96,8 @@ export function getDisclosureLedgerEvidenceStatus(summary: WebpageLiveWorkflowDi
   };
 }
 
-export function getWebpageLiveWorkflowEvidence(): WebpageLiveWorkflowEvidence {
-  const disclosureLedgerSummary: WebpageLiveWorkflowDisclosureLedgerSummary = {
+export function getFallbackDisclosureLedgerSummary(): WebpageLiveWorkflowDisclosureLedgerSummary {
+  return {
     schemaVersion: "reddi.economic-demo.disclosure-ledger-summary.v1",
     requiredLedgerSchemaVersion: "reddi.downstream-disclosure-ledger.v1",
     allEdgesHaveDisclosureLedger: false,
@@ -113,7 +120,9 @@ export function getWebpageLiveWorkflowEvidence(): WebpageLiveWorkflowEvidence {
       entries: [],
     })),
   };
+}
 
+export function getStaticWebpageLiveWorkflowEvidence(): WebpageLiveWorkflowEvidence {
   return {
     schemaVersion: "reddi.economic-demo.webpage.live-x402-workflow.summary.v1",
     generatedAt: "2026-05-04T09:35:08.940Z",
@@ -124,7 +133,7 @@ export function getWebpageLiveWorkflowEvidence(): WebpageLiveWorkflowEvidence {
       "Design me a webpage for a trustless AI agent marketplace where users pay specialist agents via x402 and receive attested outputs.",
     conclusion: "multi_edge_paid_workflow_reached",
     downstreamCallsExecuted: 8,
-    disclosureLedgerSummary,
+    disclosureLedgerSummary: getFallbackDisclosureLedgerSummary(),
     edges: [
       {
         step: 1,
@@ -228,4 +237,8 @@ export function getWebpageLiveWorkflowEvidence(): WebpageLiveWorkflowEvidence {
     ],
     nextStep: "Generate a judge-facing evidence pack and reconcile controlled receipt amounts with the ledger view.",
   };
+}
+
+export function getWebpageLiveWorkflowEvidence(): WebpageLiveWorkflowEvidence {
+  return getStaticWebpageLiveWorkflowEvidence();
 }


### PR DESCRIPTION
## Summary
- make the webpage live workflow API prefer the newest local generated judge evidence pack when present
- use its compact `disclosureLedgerSummary` for `/economic-demo` instead of stale hardcoded ledger data
- show evidence-pack metadata in the UI while preserving the fallback historical pre-ledger state
- add Phase 2.5 plan/retrospective/status updates

## Validation
- `npx jest --runTestsByPath lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts --runInBand`
- `npx eslint app/economic-demo/page.tsx app/api/economic-demo/webpage-live-workflow/route.ts lib/economic-demo/webpage-live-workflow-evidence.ts lib/economic-demo/webpage-live-workflow-evidence-server.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts`
- `npm run build`
- `npm run test:bdd:index`
- `git diff --check`

Note: build still emits the existing workspace-root warning due multiple lockfiles; build exits 0.