### PR TITLE
Expose manifest dependency parity

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,20 +1,20 @@
 # Reddi Agent Protocol Code — STATUS
 
 **Last updated:** 2026-05-05 AEST
-**State:** 🟢 Phase 2.5 latest evidence-pack summary UI wiring implemented locally; ready for PR.
+**State:** 🟢 Phase 3 local manifest parity implemented locally; ready for PR.
 
 ## RESUME FROM HERE
 
-1. Open/merge Phase 2.5 branch `feature/economic-demo-latest-evidence-pack-ui-20260505`: `/economic-demo` API/UI prefers the newest generated judge evidence-pack summary when present.
-2. Continue Phase 3 local manifest parity for `/.well-known/reddi-agent.json`: confirm tools/skills, marketplace-agent calls, external MCP servers, non-marketplace services, and disclosure policy.
+1. Open/merge Phase 3 branch `feature/local-manifest-parity-20260505`: `/.well-known/reddi-agent.json` now exposes tools/skills, marketplace-agent calls, external MCP servers, non-marketplace services, and disclosure policy.
+2. After Phase 3 merge, request explicit operator approval before any hosted Coolify redeploy/smoke.
 3. External Coolify redeploy remains explicit-operator-only.
 
 ## Current Branch / Repo State
 
-- Local branch: `feature/economic-demo-latest-evidence-pack-ui-20260505`
-- Local working tree: Phase 2.5 UI/API changes in progress.
-- Latest merge on main: `9a16e4ed docs: update status after phase 2 merge (#210)`.
-- PR #210: merged 2026-05-05 AEST; post-merge Anchor run `25348785645` passed.
+- Local branch: `feature/local-manifest-parity-20260505`
+- Local working tree: Phase 3 local manifest parity changes in progress.
+- Latest merge on main: `0a6999a1 feat: load latest evidence pack in economic demo (#211)`.
+- PR #211: merged 2026-05-05 AEST; post-merge Anchor run `25351170348` in progress at start of Phase 3.
 
 
 ## Current Follow-up PR — #203
@@ -110,6 +110,23 @@ Validation for Phase 2.5 latest evidence-pack UI wiring:
 - `git diff --check` — PASS.
 - Note: build retains existing workspace-root warning due multiple lockfiles; no build failure.
 
+
+Validation for Phase 2.5 PR #211:
+
+- PR: https://github.com/nissan/reddi-agent-protocol/pull/211
+- Merge commit: `0a6999a1e16b6a036e4dd31796533d5d3a092bc4`
+- PR checks passed: Vercel Preview Comments, Vercel deployment, Anchor runs `25350902818` / `25350904030`.
+- Post-merge `main` Anchor run `25351170348`, job `74330869241` — in progress when Phase 3 began.
+
+Validation for Phase 3 local manifest parity:
+
+- `npm test --prefix packages/openrouter-specialists` — PASS, 54/54.
+- `npm run manifest:parity --prefix packages/openrouter-specialists` — PASS, 30/30 profiles checked.
+- Targeted ESLint for OpenRouter specialist runtime/disclosure/test files — PASS.
+- `npm run test:bdd:index` — PASS.
+- `npm run build` — PASS (existing multiple-lockfile workspace-root warning; existing Turbopack NFT trace warning from server-side evidence-pack fs loader).
+- `git diff --check` — PASS.
+
 ## Retrospective — Phase 6.5 Slice A
 
 ### What worked
@@ -143,6 +160,7 @@ Do not proceed as a waterfall into research/picture live workflows until the dis
 - 2026-05-05: `/economic-demo` must render the normalized `disclosureLedgerSummary` and visibly mark historical pre-ledger artifacts as not evidence-complete.
 
 - 2026-05-05: `/economic-demo` should prefer the latest generated judge evidence-pack `disclosureLedgerSummary` when present, with fallback to the truthful historical pre-ledger summary.
+- 2026-05-05: `/.well-known/reddi-agent.json` must expose programmatic dependency disclosure parity with public marketplace cards/details before any purchase: tools, skills, marketplace-agent calls, external MCP servers, non-marketplace service calls, and downstream ledger disclosure policy.
 
 ## Blockers / Watch Items
 

--- a/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
+++ b/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
@@ -185,6 +185,14 @@ Still pending:
 
 **Expected next refinement:** If local conformance passes, request/perform approved hosted redeploy + smoke.
 
+### Retrospective — Phase 3 local manifest parity
+
+- **What worked:** The runtime `/.well-known/reddi-agent.json` metadata now exposes the same dependency classes as the public marketplace: tools, skills, marketplace-agent calls, external MCP servers, non-marketplace services, and disclosure policy. A local conformance script checks all 30 OpenRouter specialist profiles.
+- **What failed or surprised us:** The package build emits source files under `dist/src/*` because `rootDir` is `.`, so the first conformance script import path targeted the wrong dist root. That was fixed and logged in `.learnings/2026-05-05-openrouter-specialists-dist-root.md`.
+- **Safety/spend review:** The slice is local metadata generation and tests only. It performs no hosted redeploy, no live specialist calls, no signing, no wallet mutation, and no paid API calls.
+- **Judge clarity:** Programmatic consumers can reject an agent before purchase based on dependency disclosure, while paid responses remain governed by `reddi.downstream-disclosure-ledger.v1`.
+- **Plan adjustment:** Do not claim hosted manifest parity until explicit redeploy and public smoke are approved. Next safe step is status/PR for Phase 3; Phase 4 remains operator-gated.
+
 ---
 
 ## Phase 4 — Hosted redeploy + public smoke, approval-gated

--- a/packages/openrouter-specialists/package.json
+++ b/packages/openrouter-specialists/package.json
@@ -22,6 +22,7 @@
     "wallet:register-devnet": "npm run build && node scripts/register-devnet-specialists.mjs",
     "check:devnet-balances": "node scripts/check-devnet-balances.mjs",
     "deployment:readiness": "npm run build && node scripts/deployment-readiness.mjs",
+    "manifest:parity": "npm run build && node scripts/check-local-manifest-parity.mjs",
     "delegation:noop-smoke": "npm run build && node scripts/live-noop-smoke.mjs",
     "delegation:private-smoke": "npm run build && node scripts/private-live-executor-smoke.mjs",
     "wallet:readiness": "npm run build && NODE_PATH=$PWD/node_modules node scripts/wallet-readiness.mjs",

--- a/packages/openrouter-specialists/scripts/check-local-manifest-parity.mjs
+++ b/packages/openrouter-specialists/scripts/check-local-manifest-parity.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { marketplaceMetadata } from "../dist/src/runtime.js";
+import { specialistProfiles } from "../dist/src/profiles/index.js";
+
+const config = {
+  profileId: "planning-agent",
+  endpointBaseUrl: "http://localhost:8787",
+  openRouterBaseUrl: "https://openrouter.ai/api/v1",
+  mockOpenRouter: true,
+  requirePayment: true,
+  enableAgentToAgentCalls: false,
+  maxDownstreamCalls: 0,
+  maxDownstreamLamports: 0,
+};
+
+const requiredArrayFields = [
+  "tools",
+  "skills",
+  "marketplaceAgentCalls",
+  "externalMcpServers",
+  "nonMarketplaceAgentCalls",
+];
+
+const failures = [];
+const summaries = [];
+
+for (const profile of specialistProfiles) {
+  const metadata = marketplaceMetadata(profile, {
+    ...config,
+    profileId: profile.id,
+  });
+  const dependencyDisclosure = metadata.dependencyDisclosure;
+  if (!dependencyDisclosure || typeof dependencyDisclosure !== "object") {
+    failures.push(`${profile.id}: missing dependencyDisclosure`);
+    continue;
+  }
+  if (dependencyDisclosure.schemaVersion !== "reddi.agent-dependency-manifest.v1") {
+    failures.push(`${profile.id}: invalid dependencyDisclosure schemaVersion`);
+  }
+  for (const field of requiredArrayFields) {
+    if (!Array.isArray(metadata[field])) failures.push(`${profile.id}: top-level ${field} is not an array`);
+    if (!Array.isArray(dependencyDisclosure[field])) failures.push(`${profile.id}: dependencyDisclosure.${field} is not an array`);
+    if (JSON.stringify(metadata[field] ?? null) !== JSON.stringify(dependencyDisclosure[field] ?? null)) {
+      failures.push(`${profile.id}: top-level ${field} does not match dependencyDisclosure.${field}`);
+    }
+  }
+  if (typeof metadata.disclosurePolicy !== "string" || !metadata.disclosurePolicy.includes("downstream-disclosure-ledger")) {
+    failures.push(`${profile.id}: missing downstream disclosure policy`);
+  }
+  if (metadata.disclosurePolicy !== dependencyDisclosure.disclosurePolicy) {
+    failures.push(`${profile.id}: top-level disclosurePolicy does not match dependencyDisclosure.disclosurePolicy`);
+  }
+  if (!metadata.agenticWorkflowDisclosure || metadata.agenticWorkflowDisclosure.schemaVersion !== "reddi.agentic-workflow-disclosure.v1") {
+    failures.push(`${profile.id}: missing agentic workflow disclosure`);
+  }
+  if (profile.roles.includes("consumer")) {
+    if (!metadata.tools.includes("marketplace_discovery")) failures.push(`${profile.id}: consumer missing marketplace_discovery tool`);
+    if (!metadata.tools.includes("x402_specialist_call")) failures.push(`${profile.id}: consumer missing x402_specialist_call tool`);
+  }
+  summaries.push({
+    profileId: profile.id,
+    tools: metadata.tools.length,
+    skills: metadata.skills.length,
+    marketplaceAgentCalls: metadata.marketplaceAgentCalls.length,
+    externalMcpServers: metadata.externalMcpServers.length,
+    nonMarketplaceAgentCalls: metadata.nonMarketplaceAgentCalls.length,
+  });
+}
+
+if (failures.length > 0) {
+  console.error(JSON.stringify({ ok: false, failures }, null, 2));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ ok: true, checkedProfiles: summaries.length, summaries }, null, 2));

--- a/packages/openrouter-specialists/src/agentic-workflow-disclosure.ts
+++ b/packages/openrouter-specialists/src/agentic-workflow-disclosure.ts
@@ -2,6 +2,16 @@ import type { LiveDelegationExecutorEvidence } from "./delegation-executor.js";
 import type { LiveDelegationIntentPlan } from "./delegation-intent.js";
 import type { SpecialistProfile, SpecialistPrice } from "./types.js";
 
+export interface AgentDependencyManifestDisclosure {
+  schemaVersion: "reddi.agent-dependency-manifest.v1";
+  tools: string[];
+  skills: string[];
+  marketplaceAgentCalls: string[];
+  externalMcpServers: string[];
+  nonMarketplaceAgentCalls: string[];
+  disclosurePolicy: string;
+}
+
 export interface AgenticWorkflowManifestDisclosure {
   schemaVersion: "reddi.agentic-workflow-disclosure.v1";
   mayCallMarketplaceAgents: boolean;
@@ -82,6 +92,20 @@ export function buildAgenticWorkflowManifestDisclosure(profile: SpecialistProfil
   };
 }
 
+export function buildAgentDependencyManifestDisclosure(profile: SpecialistProfile): AgentDependencyManifestDisclosure {
+  const capabilities = profile.capabilities.map((capability) => capability.toLowerCase());
+  return {
+    schemaVersion: "reddi.agent-dependency-manifest.v1",
+    tools: toolsFor(profile, capabilities),
+    skills: skillsFor(profile, capabilities),
+    marketplaceAgentCalls: marketplaceAgentCallsFor(profile),
+    externalMcpServers: externalMcpServersFor(capabilities),
+    nonMarketplaceAgentCalls: nonMarketplaceAgentCallsFor(profile, capabilities),
+    disclosurePolicy:
+      "Public manifest discloses tool, skill, MCP, marketplace-agent, and non-marketplace-agent dependencies before purchase. Paid responses must return reddi.downstream-disclosure-ledger.v1 for attempted downstream calls.",
+  };
+}
+
 export function buildNoDownstreamDisclosureLedger(): DownstreamDisclosureLedger {
   return {
     schemaVersion: "reddi.downstream-disclosure-ledger.v1",
@@ -124,6 +148,48 @@ export function buildDownstreamDisclosureLedger(input: { intentPlan: LiveDelegat
 
 function downstreamCapabilitiesFor(profile: SpecialistProfile): string[] {
   return [...new Set([...profile.capabilities, "marketplace-discovery", "x402-payment", "delegated-attestation"])].sort();
+}
+
+function toolsFor(profile: SpecialistProfile, capabilities: string[]): string[] {
+  const tools = new Set<string>(["chat_completion"]);
+  if (profile.roles.includes("consumer")) tools.add("marketplace_discovery");
+  if (profile.roles.includes("consumer")) tools.add("x402_specialist_call");
+  if (profile.roles.includes("attestor")) tools.add("receipt_review");
+  if (profile.roles.includes("attestor")) tools.add("evidence_checks");
+  if (capabilities.some((capability) => /document|evidence|classification|summarization/.test(capability))) tools.add("document_parser");
+  if (capabilities.some((capability) => /code|debug|test/.test(capability))) tools.add("code_review_workspace");
+  return [...tools];
+}
+
+function skillsFor(profile: SpecialistProfile, capabilities: string[]): string[] {
+  return [...new Set([...profile.tags, ...capabilities])];
+}
+
+function marketplaceAgentCallsFor(profile: SpecialistProfile): string[] {
+  return [...new Set(profile.preferredAttestors)];
+}
+
+function externalMcpServersFor(capabilities: string[]): string[] {
+  const servers = new Set<string>();
+  if (capabilities.some((capability) => /document|evidence|classification|summarization/.test(capability))) {
+    servers.add("reddi.document-context-mcp");
+  }
+  if (capabilities.some((capability) => /code|debug|test/.test(capability))) {
+    servers.add("reddi.code-workspace-mcp");
+  }
+  return [...servers];
+}
+
+function nonMarketplaceAgentCallsFor(profile: SpecialistProfile, capabilities: string[]): string[] {
+  const calls = new Set<string>();
+  if (profile.model) calls.add(`openrouter:${profile.model}`);
+  if (capabilities.some((capability) => /document|evidence|classification|summarization/.test(capability))) {
+    calls.add("non-marketplace:document-parser");
+  }
+  if (capabilities.some((capability) => /code|debug|test/.test(capability))) {
+    calls.add("non-marketplace:static-analysis-worker");
+  }
+  return [...calls];
 }
 
 function summarizePayload(task: string): string {

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -8,7 +8,7 @@ import {
   type ReceiptVerificationResult,
   type X402Challenge,
 } from "@reddi/x402-solana";
-import { buildAgenticWorkflowManifestDisclosure, buildDownstreamDisclosureLedger, buildNoDownstreamDisclosureLedger } from "./agentic-workflow-disclosure.js";
+import { buildAgentDependencyManifestDisclosure, buildAgenticWorkflowManifestDisclosure, buildDownstreamDisclosureLedger, buildNoDownstreamDisclosureLedger } from "./agentic-workflow-disclosure.js";
 import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
 import { buildLiveDelegationAuditEnvelope } from "./delegation-audit.js";
 import { evaluateDelegationBudget } from "./delegation-budget.js";
@@ -102,6 +102,7 @@ export async function verifyPayment(input: {
 }
 
 export function marketplaceMetadata(profile: SpecialistProfile, config: RuntimeConfig): Record<string, unknown> {
+  const dependencyDisclosure = buildAgentDependencyManifestDisclosure(profile);
   return {
     protocol: "reddi-agent-protocol",
     version: "0.1.0",
@@ -116,6 +117,13 @@ export function marketplaceMetadata(profile: SpecialistProfile, config: RuntimeC
     safetyMode: profile.safetyMode,
     preferredAttestors: profile.preferredAttestors,
     model: profile.model,
+    dependencyDisclosure,
+    tools: dependencyDisclosure.tools,
+    skills: dependencyDisclosure.skills,
+    marketplaceAgentCalls: dependencyDisclosure.marketplaceAgentCalls,
+    externalMcpServers: dependencyDisclosure.externalMcpServers,
+    nonMarketplaceAgentCalls: dependencyDisclosure.nonMarketplaceAgentCalls,
+    disclosurePolicy: dependencyDisclosure.disclosurePolicy,
     agenticWorkflowDisclosure: buildAgenticWorkflowManifestDisclosure(profile, config),
   };
 }

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -237,11 +237,34 @@ test("well-known metadata includes Reddi marketplace fields", async () => {
   assert.ok(profile);
   const metadata = marketplaceMetadata(profile, config) as Record<string, unknown>;
 
-  for (const field of ["profileId", "displayName", "walletAddress", "endpoint", "capabilities", "roles", "price", "safetyMode", "preferredAttestors"]) {
+  for (const field of ["profileId", "displayName", "walletAddress", "endpoint", "capabilities", "roles", "price", "safetyMode", "preferredAttestors", "dependencyDisclosure", "tools", "skills", "marketplaceAgentCalls", "externalMcpServers", "nonMarketplaceAgentCalls", "disclosurePolicy"]) {
     assert.ok(metadata[field], `missing ${field}`);
   }
   assert.equal(metadata.profileId, "planning-agent");
   assert.equal(metadata.endpoint, "https://planning.example.test/v1/chat/completions");
+  const dependencyDisclosure = metadata.dependencyDisclosure as {
+    schemaVersion: string;
+    tools: string[];
+    skills: string[];
+    marketplaceAgentCalls: string[];
+    externalMcpServers: string[];
+    nonMarketplaceAgentCalls: string[];
+    disclosurePolicy: string;
+  };
+  assert.equal(dependencyDisclosure.schemaVersion, "reddi.agent-dependency-manifest.v1");
+  assert.ok(dependencyDisclosure.tools.includes("chat_completion"));
+  assert.ok(dependencyDisclosure.tools.includes("marketplace_discovery"));
+  assert.ok(dependencyDisclosure.tools.includes("x402_specialist_call"));
+  assert.ok(dependencyDisclosure.skills.includes("planning"));
+  assert.ok(dependencyDisclosure.marketplaceAgentCalls.includes("verification-validation-agent"));
+  assert.ok(dependencyDisclosure.nonMarketplaceAgentCalls.includes("openrouter:openai/gpt-4.1-mini"));
+  assert.match(dependencyDisclosure.disclosurePolicy, /downstream-disclosure-ledger/);
+  assert.deepEqual(metadata.tools, dependencyDisclosure.tools);
+  assert.deepEqual(metadata.skills, dependencyDisclosure.skills);
+  assert.deepEqual(metadata.marketplaceAgentCalls, dependencyDisclosure.marketplaceAgentCalls);
+  assert.deepEqual(metadata.externalMcpServers, dependencyDisclosure.externalMcpServers);
+  assert.deepEqual(metadata.nonMarketplaceAgentCalls, dependencyDisclosure.nonMarketplaceAgentCalls);
+  assert.equal(metadata.disclosurePolicy, dependencyDisclosure.disclosurePolicy);
   const disclosure = metadata.agenticWorkflowDisclosure as {
     schemaVersion: string;
     mayCallMarketplaceAgents: boolean;


### PR DESCRIPTION
## Summary
- add programmatic dependency disclosure to `/.well-known/reddi-agent.json` runtime metadata
- expose tools, skills, marketplace-agent calls, external MCP servers, non-marketplace service calls, and disclosure policy before purchase
- add a local manifest parity conformance script for all OpenRouter specialist profiles
- record Phase 3 retrospective/status updates

## Validation
- `npm test --prefix packages/openrouter-specialists`
- `npm run manifest:parity --prefix packages/openrouter-specialists`
- `npx eslint packages/openrouter-specialists/src/agentic-workflow-disclosure.ts packages/openrouter-specialists/src/runtime.ts packages/openrouter-specialists/tests/runtime.test.ts`
- `npm run test:bdd:index`
- `npm run build`
- `git diff --check`

Notes: build exits 0 with existing multiple-lockfile workspace-root warning and the existing Turbopack NFT trace warning from the server-side evidence-pack fs loader. No hosted redeploy/smoke is included.