### PR TITLE
feat: wire research dry-run disclosure plan

### DIFF
--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -479,11 +479,14 @@ export default function EconomicDemoPage() {
                 <div className="mt-6 rounded-xl border border-accent-purple/25 bg-accent-purple/10 p-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
-                      <p className="text-xs uppercase tracking-wide text-accent-purple">Phase 8A research workflow design</p>
+                      <p className="text-xs uppercase tracking-wide text-accent-purple">Phase 5 research workflow dry-run</p>
                       <p className="mt-1 text-sm leading-6 text-gray-200">{researchDesign.userRequest}</p>
+                      <p className="mt-2 text-xs leading-5 text-gray-400">
+                        Orchestrator: <span className="font-mono text-white">{researchDesign.orchestrator.profileId}</span> — {researchDesign.orchestrator.separationRationale}
+                      </p>
                     </div>
                     <span className="rounded-full border border-accent-purple/40 bg-accent-purple/10 px-2 py-0.5 text-xs text-accent-purple">
-                      design only · no live calls
+                      dry-run · downstream calls: {researchDesign.downstreamCallsExecuted}
                     </span>
                   </div>
                   <div className="mt-4 grid gap-3 md:grid-cols-2">
@@ -491,19 +494,35 @@ export default function EconomicDemoPage() {
                       <div key={edge.profileId} className="rounded-lg border border-white/10 bg-black/20 p-3">
                         <div className="flex flex-wrap items-center justify-between gap-2">
                           <p className="font-mono text-sm text-white">{edge.step}. {edge.profileId}</p>
-                          <p className="text-xs text-yellow-100">{edge.controlledDemoReceiptReadiness.replaceAll("_", " ")}</p>
+                          <p className="text-xs text-yellow-100">x402 {edge.disclosureLedgerExpectation.x402State}</p>
                         </div>
-                        <p className="mt-1 text-xs text-gray-400">{edge.capability} · {edge.priceUsdc} USDC</p>
+                        <p className="mt-1 text-xs text-gray-400">{edge.payloadClass.replaceAll("_", " ")} · {edge.capability} · {edge.priceUsdc} USDC</p>
                         <p className="mt-2 text-sm leading-6 text-gray-300">{edge.scopedPayload}</p>
                         <p className="mt-2 text-xs leading-5 text-[#14F195]">Evidence gate: {edge.evidenceRequirement}</p>
+                        <p className="mt-1 text-xs leading-5 text-yellow-100">Citation/caveat: {edge.citationOrEvidenceCaveat}</p>
+                        <p className="mt-1 text-xs leading-5 text-gray-400">Refund/dispute: {edge.refundOrDisputeBehavior}</p>
+                        <p className="mt-2 text-xs text-gray-500">
+                          Ledger: {edge.disclosureLedgerExpectation.requiredSchemaVersion} · {edge.disclosureLedgerExpectation.disclosureScope.replaceAll("_", " ")} · required fields {edge.disclosureLedgerExpectation.requiredFields.length}
+                        </p>
                       </div>
                     ))}
                   </div>
-                  <div className="mt-4 rounded-lg border border-white/10 bg-black/20 p-3">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Acceptance criteria</p>
-                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-6 text-gray-300">
-                      {researchDesign.acceptanceCriteria.map((criterion) => <li key={criterion}>{criterion}</li>)}
-                    </ul>
+                  <div className="mt-4 grid gap-3 md:grid-cols-2">
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs uppercase tracking-wide text-gray-400">Acceptance criteria</p>
+                      <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-6 text-gray-300">
+                        {researchDesign.acceptanceCriteria.map((criterion) => <li key={criterion}>{criterion}</li>)}
+                      </ul>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+                      <p className="text-xs uppercase tracking-wide text-gray-400">Live-call guardrails</p>
+                      <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-6 text-gray-300">
+                        <li>No live specialist calls: {String(researchDesign.guardrails.noLiveCalls)}</li>
+                        <li>No paid provider requests: {String(researchDesign.guardrails.noPaidProviderRequests)}</li>
+                        <li>No signing or wallet mutation: {String(researchDesign.guardrails.noSigningOperations && researchDesign.guardrails.noWalletMutation)}</li>
+                        <li>No devnet transfer: {String(researchDesign.guardrails.noDevnetTransfer)}</li>
+                      </ul>
+                    </div>
                   </div>
                 </div>
               )}

--- a/lib/__tests__/economic-demo-research-workflow-design.test.ts
+++ b/lib/__tests__/economic-demo-research-workflow-design.test.ts
@@ -4,9 +4,12 @@ describe("economic demo research workflow design", () => {
   it("designs a no-live-call research workflow with evidence requirements before receipt enablement", () => {
     const design = buildResearchWorkflowDesign();
 
-    expect(design.phase).toBe("8A");
-    expect(design.mode).toBe("design_only_no_live_calls");
-    expect(design.orchestrator.profileId).toBe("scientific-research-agent");
+    expect(design.schemaVersion).toBe("reddi.economic-demo.research-workflow-design.v2");
+    expect(design.phase).toBe("5");
+    expect(design.mode).toBe("dry_run_no_live_calls");
+    expect(design.downstreamCallsExecuted).toBe(0);
+    expect(design.orchestrator.profileId).toBe("agentic-workflow-system");
+    expect(design.orchestrator.separationRationale).toContain("scientific-research-agent can remain a synthesis specialist");
     expect(design.edges.map((edge) => edge.profileId)).toEqual([
       "knowledge-retrieval-agent",
       "scientific-research-agent",
@@ -14,13 +17,31 @@ describe("economic demo research workflow design", () => {
       "explainable-agent",
       "verification-validation-agent",
     ]);
+    expect(design.edges.map((edge) => edge.payloadClass)).toEqual([
+      "source_map",
+      "research_synthesis",
+      "article_draft",
+      "explainability_review",
+      "verification_attestation",
+    ]);
     expect(design.edges.every((edge) => edge.controlledDemoReceiptReadiness === "not_enabled_yet")).toBe(true);
     expect(design.edges.every((edge) => edge.endpoint.endsWith("/v1/chat/completions"))).toBe(true);
     expect(design.edges.every((edge) => edge.evidenceRequirement.length > 20)).toBe(true);
+    expect(design.edges.every((edge) => edge.citationOrEvidenceCaveat.length > 20)).toBe(true);
+    expect(design.edges.every((edge) => edge.attestorCriteria.length >= 3)).toBe(true);
+    expect(design.edges.every((edge) => edge.refundOrDisputeBehavior.match(/refund|dispute|Release/i))).toBe(true);
+    expect(design.edges.every((edge) => edge.disclosureLedgerExpectation.x402State === "planned")).toBe(true);
+    expect(design.edges.every((edge) => edge.disclosureLedgerExpectation.downstreamCallsExecuted === 0)).toBe(true);
+    expect(design.edges.every((edge) => edge.disclosureLedgerExpectation.requiredSchemaVersion === "reddi.downstream-disclosure-ledger.v1")).toBe(true);
     expect(design.acceptanceCriteria.join(" ")).toContain("citations or explicit evidence caveats");
+    expect(design.acceptanceCriteria.join(" ")).toContain("planned downstream-disclosure ledger expectation");
     expect(design.guardrails).toMatchObject({
       noLiveCalls: true,
+      noPaidProviderRequests: true,
       noCoolifyMutation: true,
+      noSigningOperations: true,
+      noWalletMutation: true,
+      noDevnetTransfer: true,
       noReceiptEnablementYet: true,
       citationsOrEvidenceCaveatsRequired: true,
       attestorReleaseRefundDisputeRequired: true,

--- a/lib/economic-demo/dry-run.ts
+++ b/lib/economic-demo/dry-run.ts
@@ -28,7 +28,7 @@ export type DryRunEconomicPlan = {
 
 const ORCHESTRATORS: Record<EconomicDemoScenarioId, string> = {
   webpage: "agentic-workflow-system",
-  research: "scientific-research-agent",
+  research: "agentic-workflow-system",
   picture: "tool-using-agent",
 };
 

--- a/lib/economic-demo/research-workflow-design.ts
+++ b/lib/economic-demo/research-workflow-design.ts
@@ -1,5 +1,29 @@
 import { buildEconomicDemoDryRunPlan } from "@/lib/economic-demo/dry-run";
 
+export type ResearchWorkflowPayloadClass =
+  | "source_map"
+  | "research_synthesis"
+  | "article_draft"
+  | "explainability_review"
+  | "verification_attestation";
+
+export type ResearchWorkflowDisclosureLedgerExpectation = {
+  requiredSchemaVersion: "reddi.downstream-disclosure-ledger.v1";
+  x402State: "planned";
+  disclosureScope: "planned_downstream_calls";
+  downstreamCallsExecuted: 0;
+  requiredFields: Array<
+    | "calledAgentProfileId"
+    | "calledAgentWalletAddress"
+    | "calledAgentEndpoint"
+    | "payloadSummary"
+    | "payloadHash"
+    | "x402State"
+    | "attestorLinks"
+    | "obfuscationReason"
+  >;
+};
+
 export type ResearchWorkflowDesignEdge = {
   step: number;
   profileId: string;
@@ -7,29 +31,40 @@ export type ResearchWorkflowDesignEdge = {
   endpoint: string;
   walletAddress: string;
   priceUsdc: string;
+  payloadClass: ResearchWorkflowPayloadClass;
   scopedPayload: string;
   expectedOutput: string;
   evidenceRequirement: string;
+  citationOrEvidenceCaveat: string;
+  attestorCriteria: string[];
+  refundOrDisputeBehavior: string;
+  disclosureLedgerExpectation: ResearchWorkflowDisclosureLedgerExpectation;
   controlledDemoReceiptReadiness: "not_enabled_yet";
 };
 
 export type ResearchWorkflowDesign = {
-  schemaVersion: "reddi.economic-demo.research-workflow-design.v1";
+  schemaVersion: "reddi.economic-demo.research-workflow-design.v2";
   generatedAt: string;
-  phase: "8A";
+  phase: "5";
   scenarioId: "research";
-  mode: "design_only_no_live_calls";
+  mode: "dry_run_no_live_calls";
   userRequest: string;
+  downstreamCallsExecuted: 0;
   orchestrator: {
     profileId: string;
     endpoint: string;
     walletAddress: string;
+    separationRationale: string;
   };
   edges: ResearchWorkflowDesignEdge[];
   acceptanceCriteria: string[];
   guardrails: {
     noLiveCalls: true;
+    noPaidProviderRequests: true;
     noCoolifyMutation: true;
+    noSigningOperations: true;
+    noWalletMutation: true;
+    noDevnetTransfer: true;
     noReceiptEnablementYet: true;
     citationsOrEvidenceCaveatsRequired: true;
     attestorReleaseRefundDisputeRequired: true;
@@ -38,52 +73,137 @@ export type ResearchWorkflowDesign = {
   nextStep: string;
 };
 
-const scopedPayloadByProfile: Record<string, Pick<ResearchWorkflowDesignEdge, "scopedPayload" | "expectedOutput" | "evidenceRequirement">> = {
+type ResearchWorkflowScope = Pick<
+  ResearchWorkflowDesignEdge,
+  | "payloadClass"
+  | "scopedPayload"
+  | "expectedOutput"
+  | "evidenceRequirement"
+  | "citationOrEvidenceCaveat"
+  | "attestorCriteria"
+  | "refundOrDisputeBehavior"
+>;
+
+const requiredDisclosureFields: ResearchWorkflowDisclosureLedgerExpectation["requiredFields"] = [
+  "calledAgentProfileId",
+  "calledAgentWalletAddress",
+  "calledAgentEndpoint",
+  "payloadSummary",
+  "payloadHash",
+  "x402State",
+  "attestorLinks",
+  "obfuscationReason",
+];
+
+const scopedPayloadByProfile: Record<string, ResearchWorkflowScope> = {
   "knowledge-retrieval-agent": {
+    payloadClass: "source_map",
     scopedPayload:
       "Gather source/evidence candidates about decentralized agent marketplaces, x402 payment-gated APIs, agent attestations, and protocol limitations. Do not draft the article.",
     expectedOutput: "Source map with candidate claims, citations/evidence placeholders, and uncertainty notes.",
     evidenceRequirement: "Every major claim must have a source/caveat placeholder; unsupported claims must be labeled as hypotheses.",
+    citationOrEvidenceCaveat:
+      "If a source is inaccessible or weak, return a caveat instead of inventing citation detail.",
+    attestorCriteria: [
+      "Sources are attributable or explicitly marked as missing.",
+      "Claims are separated from hypotheses.",
+      "No provider output or secrets are included raw.",
+    ],
+    refundOrDisputeBehavior:
+      "Dispute if source map contains uncited factual claims or fabricated citation metadata.",
   },
   "scientific-research-agent": {
+    payloadClass: "research_synthesis",
     scopedPayload:
       "Synthesize retrieved evidence into a neutral thesis, outline, caveats, and claim hierarchy. Do not write marketing copy.",
     expectedOutput: "Research synthesis with thesis, outline, claim/evidence table, and limitations.",
     evidenceRequirement: "Claims must trace back to retrieval output or be marked as assumptions requiring verification.",
+    citationOrEvidenceCaveat:
+      "Every synthesized claim carries either a source-map reference or an explicit 'needs verification' caveat.",
+    attestorCriteria: [
+      "Synthesis preserves uncertainty from retrieval.",
+      "No unsupported claims are promoted to facts.",
+      "Claim hierarchy distinguishes protocol facts from positioning.",
+    ],
+    refundOrDisputeBehavior:
+      "Refund if synthesis drops material caveats or asserts unsupported protocol capabilities.",
   },
   "content-creation-agent": {
+    payloadClass: "article_draft",
     scopedPayload:
       "Turn the synthesis into a readable article draft while preserving citations/caveats and avoiding unsupported hype.",
     expectedOutput: "Article draft with headline, intro, sections, conclusion, and inline citation/caveat markers.",
     evidenceRequirement: "Draft must retain evidence markers and must not invent citations.",
+    citationOrEvidenceCaveat:
+      "Any fluent narrative claim without a citation marker must be labeled as interpretation or removed.",
+    attestorCriteria: [
+      "Draft preserves citation/caveat markers.",
+      "No fabricated citations or ungrounded numerical claims.",
+      "Moat/marketing language does not hide payment or dependency disclosure.",
+    ],
+    refundOrDisputeBehavior:
+      "Dispute if draft converts caveats into definitive claims or fabricates citations.",
   },
   "explainable-agent": {
+    payloadClass: "explainability_review",
     scopedPayload:
       "Review the draft for traceability, readability, reasoning gaps, and places where caveats should be clearer.",
     expectedOutput: "Explainability review with suggested edits and traceability notes.",
     evidenceRequirement: "Every flagged issue must reference a section or claim from the draft.",
+    citationOrEvidenceCaveat:
+      "Flag any section whose evidence chain is opaque, incomplete, or dependent on obfuscated value-add.",
+    attestorCriteria: [
+      "Traceability gaps are tied to concrete draft sections.",
+      "Obfuscation is limited to proprietary value-add, never called-agent identity or payment evidence.",
+      "Recommended edits improve judge readability.",
+    ],
+    refundOrDisputeBehavior:
+      "Dispute if explainability review cannot trace claims to source-map or synthesis inputs.",
   },
   "verification-validation-agent": {
+    payloadClass: "verification_attestation",
     scopedPayload:
       "Verify the article evidence chain and return release/refund/dispute guidance for the research workflow.",
     expectedOutput: "Attestation verdict with release/refund/dispute recommendation and reasons.",
     evidenceRequirement: "Verdict must explicitly assess citation/caveat adequacy and scoped-payload compliance.",
+    citationOrEvidenceCaveat:
+      "Release requires citation/caveat adequacy; refund/dispute must identify exact failing claims or edges.",
+    attestorCriteria: [
+      "Verdict names release, refund, or dispute.",
+      "Verdict checks every upstream payload class.",
+      "Verdict confirms downstream ledger expectations are satisfied before live receipt promotion.",
+    ],
+    refundOrDisputeBehavior:
+      "Release only if evidence chain is adequate; otherwise return refund/dispute with failing edge IDs.",
   },
 };
+
+function plannedDisclosureLedgerExpectation(): ResearchWorkflowDisclosureLedgerExpectation {
+  return {
+    requiredSchemaVersion: "reddi.downstream-disclosure-ledger.v1",
+    x402State: "planned",
+    disclosureScope: "planned_downstream_calls",
+    downstreamCallsExecuted: 0,
+    requiredFields: requiredDisclosureFields,
+  };
+}
 
 export function buildResearchWorkflowDesign(): ResearchWorkflowDesign {
   const plan = buildEconomicDemoDryRunPlan("research");
   return {
-    schemaVersion: "reddi.economic-demo.research-workflow-design.v1",
-    generatedAt: "2026-05-04T10:50:00.000Z",
-    phase: "8A",
+    schemaVersion: "reddi.economic-demo.research-workflow-design.v2",
+    generatedAt: "2026-05-05T02:40:00.000Z",
+    phase: "5",
     scenarioId: "research",
-    mode: "design_only_no_live_calls",
+    mode: "dry_run_no_live_calls",
     userRequest: "Write me a research article on decentralized agent marketplaces and x402-paid specialist workflows.",
+    downstreamCallsExecuted: 0,
     orchestrator: {
       profileId: plan.orchestrator.id,
       endpoint: plan.orchestrator.endpoint,
       walletAddress: plan.orchestrator.walletAddress,
+      separationRationale:
+        "agentic-workflow-system coordinates the research graph so scientific-research-agent can remain a synthesis specialist instead of self-orchestrating its own paid edge.",
     },
     edges: plan.edges.map((edge, index) => {
       const scoped = scopedPayloadByProfile[edge.toProfileId];
@@ -96,19 +216,24 @@ export function buildResearchWorkflowDesign(): ResearchWorkflowDesign {
         walletAddress: edge.walletAddress,
         priceUsdc: edge.price.amount,
         controlledDemoReceiptReadiness: "not_enabled_yet",
+        disclosureLedgerExpectation: plannedDisclosureLedgerExpectation(),
         ...scoped,
       };
     }),
     acceptanceCriteria: [
-      "Research workflow remains design-only in Phase 8A: no live specialist calls and no Coolify/env mutation.",
-      "Every specialist receives a scoped payload with clear boundaries and expected output.",
+      "Research workflow remains dry-run only in Phase 5: no live specialist calls, no paid provider requests, and no Coolify/env mutation.",
+      "Every planned edge declares payload class, citation/evidence caveats, attestor criteria, refund/dispute behavior, and a planned downstream-disclosure ledger expectation.",
+      "The orchestrator is separated from research synthesis unless a later retrospective justifies a self-loop.",
       "Final article path requires citations or explicit evidence caveats; fluent unsupported prose is not enough.",
-      "Verification agent must produce release/refund/dispute guidance based on the evidence chain.",
-      "Phase 8B may only begin after this design is reviewed and controlled receipt readiness is intentionally enabled for selected research path specialists.",
+      "Verification agent must produce release/refund/dispute guidance based on the evidence chain before any live receipt enablement.",
     ],
     guardrails: {
       noLiveCalls: true,
+      noPaidProviderRequests: true,
       noCoolifyMutation: true,
+      noSigningOperations: true,
+      noWalletMutation: true,
+      noDevnetTransfer: true,
       noReceiptEnablementYet: true,
       citationsOrEvidenceCaveatsRequired: true,
       attestorReleaseRefundDisputeRequired: true,
@@ -117,9 +242,10 @@ export function buildResearchWorkflowDesign(): ResearchWorkflowDesign {
       "Are citations/evidence meaningful, or is the article just fluent text?",
       "Are specialist boundaries clear enough to prevent duplicated or invented work?",
       "Does this add a genuinely new proof category beyond the webpage workflow?",
-      "Should Phase 8B proceed with controlled demo receipts, or should real receipt verification come first?",
+      "Does the planned disclosure ledger make payment/dependency transparency clear before live calls?",
+      "Should the next validation stay local Surfpool-only, or request separate approval for hosted/devnet controlled receipts?",
     ],
     nextStep:
-      "If this design passes review, prepare Phase 8B controlled research live x402 workflow smoke with exact endpoints, bounded calls, and evidence-caveat checks.",
+      "Implement a no-live-call research dry-run artifact generator that serializes this graph, then optionally rehearse local Surfpool transfer semantics before any hosted/devnet live workflow.",
   };
 }


### PR DESCRIPTION
## Summary\n- move research dry-run orchestration to agentic-workflow-system so scientific-research-agent remains a synthesis specialist\n- add Phase 5 v2 research dry-run graph fields for payload class, citation/evidence caveats, attestor criteria, refund/dispute behavior, and planned downstream disclosure ledger expectations\n- surface the richer dry-run guardrails and ledger expectations in /economic-demo\n\n## Safety\n- dry-run only: downstreamCallsExecuted remains 0\n- no hosted/devnet live calls, paid provider requests, signing, wallet mutation, or devnet transfer\n\n## Validation\n- npx jest --runTestsByPath lib/__tests__/economic-demo-research-workflow-design.test.ts lib/__tests__/economic-demo-dry-run.test.ts --runInBand\n- npx eslint lib/economic-demo/research-workflow-design.ts lib/economic-demo/dry-run.ts app/economic-demo/page.tsx lib/__tests__/economic-demo-research-workflow-design.test.ts\n- npm run test:bdd:index\n- npm run build\n- git diff --check