### PR TITLE
feat: add picture storyboard dry-run

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,19 +1,19 @@
 # Reddi Agent Protocol Code — STATUS
 
 **Last updated:** 2026-05-05 AEST
-**State:** 🟢 Phase 5 research dry-run disclosure implementation merged; artifact generator slice in progress; hosted manifest parity remains 30/30.
+**State:** 🟢 Phase 5 research dry-run artifact generator merged; Phase 6 live research remains approval-gated; Phase 7 storyboard dry-run is next safe local slice.
 
 ## RESUME FROM HERE
 
-1. Continue Phase 5 by shipping the research dry-run artifact generator slice, then run the Phase 5 retrospective before deciding whether Phase 6 controlled live research is worth approval.
-2. Local Surfpool validator live tests are approved for safety validation because they use only offline/local SOL and do not risk real or devnet tokens.
-3. Do not execute hosted/devnet live downstream specialist calls, paid provider paths, signing with real/devnet wallets, or devnet transfers unless explicitly approved for that specific live run.
+1. Phase 5 is complete through the deterministic research dry-run artifact generator. Do not run Phase 6 controlled live research without explicit approval for hosted/devnet calls and spend.
+2. Continue with Phase 7 storyboard dry-run locally: prove the picture path without OpenAI/Fal image generation, signing, wallet mutation, or devnet transfer.
+3. Local Surfpool validator live tests remain approved for safety validation because they use only offline/local SOL and do not risk real or devnet tokens.
 
 ## Current Branch / Repo State
 
-- Local branch: `main`.
-- Local working tree: research dry-run artifact generator slice in progress; local evidence artifacts are under `artifacts/manifest-parity-phase4/`, `artifacts/economic-demo-surfpool-rehearsal/20260505T021309Z/`, `artifacts/surfpool-smoke/20260505-121331/`, and `artifacts/economic-demo-research-dry-run/20260505T025224Z/`.
-- Latest merge on main: `ecdcdbd1 feat: wire research dry-run disclosure plan (#217)`.
+- Local branch: `feat/picture-storyboard-dry-run-20260505`.
+- Local working tree: Phase 7 picture storyboard dry-run slice in progress. Local evidence artifacts are under `artifacts/manifest-parity-phase4/`, `artifacts/economic-demo-surfpool-rehearsal/20260505T021309Z/`, `artifacts/surfpool-smoke/20260505-121331/`, and `artifacts/economic-demo-research-dry-run/20260505T025224Z/`.
+- Latest merge on main: `5da85ccd feat: add research dry-run artifact generator (#218)`.
 - PR #204: closed as superseded after Nissan accepted recommendation.
 - PR #214: merged 2026-05-05 AEST as `a290db7093458f45ca1b3dbc2a047b404c856a29`; post-merge Anchor run `25353582949`, job `74338163008` passed in 7m26s.
 - PR #215: merged 2026-05-05 AEST as `cd202ebd6360d29f0a896e852fe9f63c339fc4dc`; post-merge Anchor run `25353973718`, job `74339305929` passed in 7m23s.
@@ -184,7 +184,7 @@ Validation for Phase 5 research dry-run disclosure implementation:
 - PR checks passed before merge: Vercel Preview Comments, Vercel deployment, Anchor run `25354771446`, job `74341647480` — PASS, 7m15s.
 - Post-merge `main` Anchor run `25354979566`, job `74342253225` — PASS, 7m30s.
 
-Validation for Phase 5 research dry-run artifact generator slice (local, not yet PR):
+Validation for Phase 5 research dry-run artifact generator slice:
 
 - `npm run evidence:economic-demo:research-dry-run` — PASS; artifact `artifacts/economic-demo-research-dry-run/20260505T025224Z/research-dry-run.json`.
 - Artifact summary: scenario `research`, mode `dry_run_no_live_calls`, orchestrator `agentic-workflow-system`, 5 planned edges, downstream calls executed `0`, x402 state `planned` for every edge, live calls/provider requests/signing/wallet mutation/devnet transfers all `0`.
@@ -192,6 +192,21 @@ Validation for Phase 5 research dry-run artifact generator slice (local, not yet
 - `node --check scripts/generate-economic-demo-research-dry-run.mjs` — PASS.
 - Targeted ESLint + `npm run test:bdd:index` + `npm run build` + `git diff --check` — PASS.
 - Secret grep over generated dry-run artifact produced only policy-text false positives (`secrets`, `Coolify` guardrail wording); no credential material present.
+- PR: https://github.com/nissan/reddi-agent-protocol/pull/218
+- Merge commit: `5da85ccdd78661b3ea29a3c69ce2bcf9885f7de0`
+- PR checks passed before merge: Vercel Preview Comments, Vercel deployment, `bdd-index-guard`, `source-conformance-matrix`, Anchor run `25355281318`, job `74343109526` — PASS, 7m30s.
+- Post-merge `main` Anchor run `25355508196`, job `74343778434` — PASS, 7m35s.
+
+Validation for Phase 7 picture storyboard dry-run slice (local, not yet PR):
+
+- Added `reddi.economic-demo.picture-storyboard-design.v1` design/API/UI path for storyboard-only picture proof.
+- The image-generation adapter is explicitly represented as `blocked` with `x402State = blocked_disabled_adapter` and `reddi.downstream-disclosure-ledger.v1` expectations.
+- Storyboard frames include positive prompts, negative prompts, and evidence caveats; `imageGenerationExecuted = 0`, `downstreamCallsExecuted = 0`.
+- Targeted Jest for picture storyboard + dry-run — PASS, 7/7.
+- Targeted ESLint for picture storyboard design/test/API/page — PASS.
+- `npm run test:bdd:index` — PASS.
+- `npm run build` — PASS; existing workspace-root/NFT trace warnings only.
+- `git diff --check` — PASS.
 
 ## Retrospective — Phase 6.5 Slice A
 
@@ -230,9 +245,11 @@ Do not proceed as a waterfall into research/picture live workflows until the dis
 - 2026-05-05: Hosted Phase 4 redeploy/smoke is approved and complete; public hosted OpenRouter specialist manifests now expose dependency disclosure parity across 30/30 endpoints.
 - 2026-05-05: Surfpool local-validator live tests are approved as a safe validation lane because they use only offline/local SOL and do not risk real or devnet tokens.
 - 2026-05-05: Research workflow orchestration should be owned by `agentic-workflow-system`; `scientific-research-agent` stays a synthesis specialist so paid-edge coordination and evidence synthesis remain separate.
+- 2026-05-05: Phase 6 controlled live research remains approval-gated; next safe progress is Phase 7 storyboard dry-run with image generation disabled.
 
 ## Blockers / Watch Items
 
 - Live hosted/devnet economic workflow evidence still predates Phase 4 hosted manifest parity; regenerate only under an explicit hosted/devnet live-run approval gate.
-- Continue Phase 5 research implementation as dry-run/local-only first: no paid specialist spend, hosted downstream calls, real/devnet signing, wallet mutation, or devnet transfer from harness without specific approval.
+- Phase 6 controlled live research is blocked pending explicit approval for hosted/devnet live downstream specialist calls and spend.
+- Phase 7 picture/storyboard work must remain dry-run/local-only first: no OpenAI/Fal image generation, paid provider spend, hosted downstream calls, real/devnet signing, wallet mutation, or devnet transfer without specific approval.
 - Existing demo-agent CLI copy still labels some local Surfpool transactions as `devnet`/Explorer links even when RPC is local; keep evidence/status wording explicit that the executed lane used local Surfpool RPC.

--- a/app/api/economic-demo/picture-storyboard-design/route.ts
+++ b/app/api/economic-demo/picture-storyboard-design/route.ts
@@ -1,0 +1,5 @@
+import { buildPictureStoryboardDesign } from "@/lib/economic-demo/picture-storyboard-design";
+
+export async function GET() {
+  return Response.json({ ok: true, design: buildPictureStoryboardDesign() });
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/economic-demo/webpage-live-workflow-evidence";
 import type { EconomicDemoLedgerReconciliation } from "@/lib/economic-demo/ledger-reconciliation";
 import type { ResearchWorkflowDesign } from "@/lib/economic-demo/research-workflow-design";
+import type { PictureStoryboardDesign } from "@/lib/economic-demo/picture-storyboard-design";
 
 function shortWallet(wallet: string) {
   return `${wallet.slice(0, 8)}…${wallet.slice(-6)}`;
@@ -46,6 +47,8 @@ export default function EconomicDemoPage() {
   const [ledgerReconciliationStatus, setLedgerReconciliationStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const [researchDesign, setResearchDesign] = useState<ResearchWorkflowDesign | null>(null);
   const [researchDesignStatus, setResearchDesignStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [pictureStoryboardDesign, setPictureStoryboardDesign] = useState<PictureStoryboardDesign | null>(null);
+  const [pictureStoryboardStatus, setPictureStoryboardStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const scenario = useMemo(
     () => economicDemoScenarios.find((candidate) => candidate.id === scenarioId) ?? economicDemoScenarios[0],
     [scenarioId],
@@ -155,6 +158,19 @@ export default function EconomicDemoPage() {
     }
   }
 
+  async function loadPictureStoryboardDesign() {
+    setPictureStoryboardStatus("loading");
+    try {
+      const res = await fetch("/api/economic-demo/picture-storyboard-design");
+      const payload = (await res.json()) as { ok?: boolean; design?: PictureStoryboardDesign };
+      if (!res.ok || !payload.ok || !payload.design) throw new Error("picture_storyboard_failed");
+      setPictureStoryboardDesign(payload.design);
+      setPictureStoryboardStatus("loaded");
+    } catch {
+      setPictureStoryboardStatus("error");
+    }
+  }
+
   return (
     <main className="min-h-screen bg-page">
       <section className="relative overflow-hidden border-b border-white/5">
@@ -246,6 +262,13 @@ export default function EconomicDemoPage() {
                 >
                   {researchDesignStatus === "loading" ? "Designing research path…" : "Design research workflow"}
                 </button>
+                <button
+                  onClick={loadPictureStoryboardDesign}
+                  disabled={pictureStoryboardStatus === "loading"}
+                  className="rounded-lg border border-yellow-400/30 bg-yellow-400/10 px-4 py-2 text-sm font-semibold text-yellow-100 transition hover:bg-yellow-400/15 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {pictureStoryboardStatus === "loading" ? "Building storyboard…" : "Design picture storyboard"}
+                </button>
                 <span className="text-xs text-gray-500">
                   Uses deployed 30-agent profile metadata · zero downstream calls
                 </span>
@@ -283,6 +306,11 @@ export default function EconomicDemoPage() {
               {researchDesignStatus === "error" && (
                 <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
                   Research workflow design failed. No live call or Coolify mutation was attempted.
+                </p>
+              )}
+              {pictureStoryboardStatus === "error" && (
+                <p className="mt-3 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-sm text-yellow-100">
+                  Picture storyboard design failed. No image-generation provider, signing, or transfer was attempted.
                 </p>
               )}
               <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
@@ -523,6 +551,59 @@ export default function EconomicDemoPage() {
                         <li>No devnet transfer: {String(researchDesign.guardrails.noDevnetTransfer)}</li>
                       </ul>
                     </div>
+                  </div>
+                </div>
+              )}
+
+              {pictureStoryboardDesign && (
+                <div className="mt-6 rounded-xl border border-yellow-400/25 bg-yellow-400/10 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-yellow-100">Phase 7 picture storyboard dry-run</p>
+                      <p className="mt-1 text-sm leading-6 text-gray-200">{pictureStoryboardDesign.userRequest}</p>
+                      <p className="mt-2 text-xs leading-5 text-gray-400">
+                        Orchestrator: <span className="font-mono text-white">{pictureStoryboardDesign.orchestrator.profileId}</span> — {pictureStoryboardDesign.orchestrator.separationRationale}
+                      </p>
+                    </div>
+                    <span className="rounded-full border border-yellow-400/40 bg-yellow-400/10 px-2 py-0.5 text-xs text-yellow-100">
+                      storyboard · images generated: {pictureStoryboardDesign.imageGenerationExecuted}
+                    </span>
+                  </div>
+                  <div className="mt-4 grid gap-3 md:grid-cols-2">
+                    {pictureStoryboardDesign.storyboard.map((frame) => (
+                      <div key={frame.frame} className="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <p className="font-mono text-sm text-white">Frame {frame.frame}: {frame.title}</p>
+                        <p className="mt-2 text-sm leading-6 text-gray-300">{frame.visualPrompt}</p>
+                        <p className="mt-2 text-xs leading-5 text-red-100">Negative prompt: {frame.negativePrompt}</p>
+                        <p className="mt-1 text-xs leading-5 text-yellow-100">Evidence caveat: {frame.evidenceCaveat}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-4 space-y-2">
+                    {pictureStoryboardDesign.edges.map((edge) => (
+                      <div key={`${edge.step}-${edge.profileId}`} className="rounded-lg border border-white/10 bg-black/20 p-3">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="font-mono text-sm text-white">{edge.step}. {edge.profileId}</p>
+                          <span className={edge.status === "blocked" ? "rounded-full border border-red-400/40 bg-red-400/10 px-2 py-0.5 text-xs text-red-200" : "rounded-full border border-white/15 bg-white/5 px-2 py-0.5 text-xs text-gray-300"}>{edge.status}</span>
+                        </div>
+                        <p className="mt-1 text-xs text-gray-400">{edge.payloadClass.replaceAll("_", " ")} · {edge.capability} · {edge.priceUsdc} USDC</p>
+                        <p className="mt-2 text-sm leading-6 text-gray-300">{edge.scopedPayload}</p>
+                        <p className="mt-2 text-xs leading-5 text-[#14F195]">Expected output: {edge.expectedOutput}</p>
+                        <p className="mt-1 text-xs leading-5 text-yellow-100">Guardrail: {edge.guardrail}</p>
+                        <p className="mt-2 text-xs text-gray-500">
+                          Ledger: {edge.disclosureLedgerExpectation.requiredSchemaVersion} · {edge.disclosureLedgerExpectation.x402State} · calls {edge.disclosureLedgerExpectation.downstreamCallsExecuted}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-4 rounded-lg border border-white/10 bg-black/20 p-3">
+                    <p className="text-xs uppercase tracking-wide text-gray-400">Provider guardrails</p>
+                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-6 text-gray-300">
+                      <li>OpenAI image generation: {String(!pictureStoryboardDesign.guardrails.noOpenAiImageGeneration)}</li>
+                      <li>Fal.ai image generation: {String(!pictureStoryboardDesign.guardrails.noFalImageGeneration)}</li>
+                      <li>Paid provider requests: {String(!pictureStoryboardDesign.guardrails.noPaidProviderRequests)}</li>
+                      <li>Signing/wallet mutation/devnet transfer: {String(!(pictureStoryboardDesign.guardrails.noSigningOperations && pictureStoryboardDesign.guardrails.noWalletMutation && pictureStoryboardDesign.guardrails.noDevnetTransfer))}</li>
+                    </ul>
                   </div>
                 </div>
               )}

--- a/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
+++ b/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
@@ -1,7 +1,7 @@
 # Agentic Marketplace Manifest + Disclosure Ledger — BDD Iterative Plan
 
 _Date:_ 2026-05-05 AEST  
-_Status:_ Active after Phase 5 research dry-run disclosure implementation; artifact generator slice in progress
+_Status:_ Active after Phase 5 research dry-run artifact generator merge; Phase 7 storyboard dry-run local slice in progress
 _Related:_ PR #202, PR #203, PR #205, PR #214, `ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md`, Bucket J BDD feature
 
 ## North star
@@ -43,7 +43,8 @@ Shipped:
 Still pending:
 
 - Live economic workflow evidence still predates hosted manifest parity and should only be regenerated under an explicit live-run approval gate.
-- Research workflow design now has a disclosure-ledger-first dry-run graph; artifact generation is being added before any live research calls.
+- Research workflow design now has a disclosure-ledger-first dry-run graph and deterministic artifact generator before any live research calls.
+- Phase 6 live research is skipped for now because it needs explicit hosted/devnet spend approval; Phase 7 storyboard dry-run is the next safe local proof.
 - Picture workflow expansion remains behind research planning and explicit image-generation approval.
 
 ## Phase 0 — Plan + BDD lock
@@ -330,6 +331,22 @@ Every planned edge must declare payload class, disclosure-ledger expectation, x4
 - optional approval-gated image run later.
 
 **Retrospective prompt:** Is storyboard mode sufficient for judging, or do we need approval-gated real image generation?
+
+### Retrospective — Phase 5 research dry-run artifact generator
+
+- **What worked:** The research dry-run graph is now serializable as a deterministic local artifact with mode `dry_run_no_live_calls`, planned x402 state on every edge, and zero live/provider/signing/wallet/devnet activity.
+- **What failed or surprised us:** The artifact generator needed runtime TypeScript transpilation because the repo does not emit a standalone build artifact for these library helpers. The script keeps alias resolution local and asserts dry-run guardrails before writing output.
+- **Safety/spend review:** Local artifact generation only. No hosted specialist calls, no paid provider requests, no Coolify mutation, no signing, no wallet mutation, and no devnet transfer.
+- **Judge clarity:** Improved: reviewers can inspect one JSON artifact that names the orchestrator, five planned research edges, disclosure-ledger expectations, and safety review counters.
+- **Plan adjustment:** Do not proceed to Phase 6 live research without explicit approval. Continue to Phase 7 storyboard dry-run so the picture path proves adapter gating without hidden image spend.
+
+### Retrospective — Phase 7 storyboard dry-run design
+
+- **What worked:** The picture path now models `tool-using-agent` as an adapter-gating orchestrator, marks `image-generation-adapter` as blocked, and produces storyboard frames with positive prompts, negative prompts, and evidence caveats.
+- **What failed or surprised us:** The existing picture dry-run graph included `tool-using-agent` as an edge target as well as orchestrator. The dedicated storyboard design makes that self-planning step explicit and keeps the provider adapter blocked.
+- **Safety/spend review:** Design/API/UI only. No OpenAI call, no Fal.ai call, no paid provider request, no signing, no wallet mutation, and no devnet transfer.
+- **Judge clarity:** Improved: storyboard mode can be shown as an honest visual proof plan, not mistaken for generated image evidence.
+- **Plan adjustment:** If the storyboard is sufficient for judging, stop before spend. If a real image is needed, request separate approval with provider, budget cap, and disclosure evidence requirements.
 
 ---
 

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -32,6 +32,16 @@ Feature: End-user economic workflow demo
     And the generated image is available to the workflow
     And vision validation and verification attestation can be attached afterward
 
+  Scenario: Picture workflow dry-run produces a storyboard without hidden image spend
+    Given picture workflow planning is in storyboard dry-run mode
+    And ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION is not true
+    When the picture storyboard graph is proposed
+    Then it includes visual brief, blocked image adapter, storyboard validation, and release attestation edges
+    And the blocked image adapter edge has downstream-disclosure ledger expectation reddi.downstream-disclosure-ledger.v1
+    And the storyboard frames include positive prompts, negative prompts, and evidence caveats
+    And imageGenerationExecuted is 0
+    And no OpenAI request, Fal.ai request, paid provider request, signing operation, wallet mutation, or devnet transfer occurs
+
   Scenario: Dry-run orchestration builds a real planned economic graph
     Given dry-run marketplace delegation is enabled
     When the user submits an end-user scenario

--- a/lib/__tests__/economic-demo-picture-storyboard-design.test.ts
+++ b/lib/__tests__/economic-demo-picture-storyboard-design.test.ts
@@ -1,0 +1,77 @@
+import { buildPictureStoryboardDesign } from "@/lib/economic-demo/picture-storyboard-design";
+
+describe("picture storyboard dry-run design", () => {
+  const previousEnableFlag = process.env.ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION;
+  const previousOpenAiKey = process.env.OPENAI_API_KEY;
+  const previousFalKey = process.env.FAL_KEY;
+  const previousFalApiKey = process.env.FAL_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.FAL_KEY;
+    delete process.env.FAL_API_KEY;
+  });
+
+  afterAll(() => {
+    if (previousEnableFlag === undefined) delete process.env.ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION;
+    else process.env.ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION = previousEnableFlag;
+    if (previousOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousOpenAiKey;
+    if (previousFalKey === undefined) delete process.env.FAL_KEY;
+    else process.env.FAL_KEY = previousFalKey;
+    if (previousFalApiKey === undefined) delete process.env.FAL_API_KEY;
+    else process.env.FAL_API_KEY = previousFalApiKey;
+  });
+
+  it("keeps image generation disabled while producing a storyboard graph", () => {
+    const design = buildPictureStoryboardDesign();
+
+    expect(design.schemaVersion).toBe("reddi.economic-demo.picture-storyboard-design.v1");
+    expect(design.disclosureContract).toBe("reddi.downstream-disclosure-ledger.v1");
+    expect(design.mode).toBe("storyboard_no_image_generation");
+    expect(design.downstreamCallsExecuted).toBe(0);
+    expect(design.imageGenerationExecuted).toBe(0);
+    expect(design.adapterReadiness.enabled).toBe(false);
+    expect(design.orchestrator.profileId).toBe("tool-using-agent");
+    expect(design.storyboard).toHaveLength(4);
+    expect(design.storyboard.every((frame) => !frame.evidenceCaveat.toLowerCase().includes("generated image evidence"))).toBe(true);
+  });
+
+  it("represents the image adapter as blocked with disclosure-ledger expectations", () => {
+    const design = buildPictureStoryboardDesign();
+    const adapterEdge = design.edges.find((edge) => edge.profileId === "image-generation-adapter");
+
+    expect(adapterEdge).toBeDefined();
+    expect(adapterEdge?.status).toBe("blocked");
+    expect(adapterEdge?.payloadClass).toBe("image_generation_request");
+    expect(adapterEdge?.disclosureLedgerExpectation).toMatchObject({
+      requiredSchemaVersion: "reddi.downstream-disclosure-ledger.v1",
+      x402State: "blocked_disabled_adapter",
+      downstreamCallsExecuted: 0,
+      disclosureScope: "disabled_image_adapter",
+    });
+    expect(adapterEdge?.disclosureLedgerExpectation.requiredFields).toEqual(expect.arrayContaining(["payloadHash", "x402State", "attestorLinks"]));
+  });
+
+  it("plans vision and verification as storyboard-only validation", () => {
+    const design = buildPictureStoryboardDesign();
+
+    expect(design.edges.map((edge) => edge.profileId)).toEqual([
+      "tool-using-agent",
+      "image-generation-adapter",
+      "vision-language-agent",
+      "verification-validation-agent",
+    ]);
+    expect(design.edges.find((edge) => edge.profileId === "vision-language-agent")?.payloadClass).toBe("storyboard_validation");
+    expect(design.edges.find((edge) => edge.profileId === "verification-validation-agent")?.payloadClass).toBe("release_attestation");
+    expect(design.guardrails).toMatchObject({
+      noOpenAiImageGeneration: true,
+      noFalImageGeneration: true,
+      noPaidProviderRequests: true,
+      noSigningOperations: true,
+      noWalletMutation: true,
+      noDevnetTransfer: true,
+    });
+  });
+});

--- a/lib/economic-demo/picture-storyboard-design.ts
+++ b/lib/economic-demo/picture-storyboard-design.ts
@@ -1,0 +1,214 @@
+import { buildEconomicDemoDryRunPlan } from "@/lib/economic-demo/dry-run";
+import { imageAdapterReadiness } from "@/lib/economic-demo/image-adapter";
+
+export type PictureStoryboardEdgeStatus = "planned" | "blocked";
+
+export type PictureStoryboardLedgerExpectation = {
+  requiredSchemaVersion: "reddi.downstream-disclosure-ledger.v1";
+  x402State: "planned" | "blocked_disabled_adapter";
+  downstreamCallsExecuted: 0;
+  disclosureScope: "storyboard_payload_only" | "disabled_image_adapter" | "validation_attestation";
+  requiredFields: string[];
+};
+
+export type PictureStoryboardFrame = {
+  frame: number;
+  title: string;
+  visualPrompt: string;
+  negativePrompt: string;
+  evidenceCaveat: string;
+};
+
+export type PictureStoryboardEdge = {
+  step: number;
+  profileId: string;
+  capability: string;
+  endpoint: string;
+  walletAddress: string;
+  priceUsdc: string;
+  status: PictureStoryboardEdgeStatus;
+  payloadClass: "visual_brief" | "image_generation_request" | "storyboard_validation" | "release_attestation";
+  scopedPayload: string;
+  expectedOutput: string;
+  guardrail: string;
+  disclosureLedgerExpectation: PictureStoryboardLedgerExpectation;
+};
+
+export type PictureStoryboardDesign = {
+  schemaVersion: "reddi.economic-demo.picture-storyboard-design.v1";
+  disclosureContract: "reddi.downstream-disclosure-ledger.v1";
+  scenarioId: "picture";
+  mode: "storyboard_no_image_generation";
+  userRequest: string;
+  downstreamCallsExecuted: 0;
+  imageGenerationExecuted: 0;
+  adapterReadiness: ReturnType<typeof imageAdapterReadiness>;
+  orchestrator: {
+    profileId: "tool-using-agent";
+    separationRationale: string;
+  };
+  edges: PictureStoryboardEdge[];
+  storyboard: PictureStoryboardFrame[];
+  acceptanceCriteria: string[];
+  guardrails: {
+    noOpenAiImageGeneration: boolean;
+    noFalImageGeneration: boolean;
+    noPaidProviderRequests: boolean;
+    noSigningOperations: boolean;
+    noWalletMutation: boolean;
+    noDevnetTransfer: boolean;
+  };
+  nextStep: string;
+};
+
+const LEDGER_FIELDS = [
+  "calledAgentId",
+  "walletAddress",
+  "endpoint",
+  "payloadClass",
+  "payloadSummary",
+  "payloadHash",
+  "x402State",
+  "attestorLinks",
+  "moatProtection",
+];
+
+const STORYBOARD: PictureStoryboardFrame[] = [
+  {
+    frame: 1,
+    title: "Market order arrives",
+    visualPrompt:
+      "Wide cinematic view of autonomous robot agents entering a neon Malatang night-market kitchen, task cards and tiny wallet glyphs hovering beside them.",
+    negativePrompt: "No brand logos, no real people likenesses, no unsafe kitchen chaos, no misleading claim that this image was generated live.",
+    evidenceCaveat: "Storyboard text only; no image model output exists in this dry-run.",
+  },
+  {
+    frame: 2,
+    title: "Specialists split the recipe",
+    visualPrompt:
+      "Three friendly agent chefs divide broth, noodles, vegetables, and spice-level tasks on a glowing workflow board with x402 receipt placeholders.",
+    negativePrompt: "No gore, no copyrighted characters, no photorealistic celebrity likenesses.",
+    evidenceCaveat: "Payload is a visual brief, not a generated asset.",
+  },
+  {
+    frame: 3,
+    title: "Attestor tastes the evidence",
+    visualPrompt:
+      "A verification agent with a clipboard checks prompt adherence, ingredient consistency, and disclosure-ledger entries before release.",
+    negativePrompt: "No claim of real payment settlement; no hidden provider watermark removal.",
+    evidenceCaveat: "Validation is planned against storyboard criteria until image generation is explicitly approved.",
+  },
+  {
+    frame: 4,
+    title: "Disclosure-complete handoff",
+    visualPrompt:
+      "Final hero composition: autonomous agents serving Malatang with transparent ledger ribbons showing called agents, payload classes, and planned x402 states.",
+    negativePrompt: "No opaque downstream calls, no undisclosed adapter invocation, no real provider output implied.",
+    evidenceCaveat: "Final output remains an image brief/storyboard; live OpenAI/Fal generation is disabled.",
+  },
+];
+
+function plannedLedger(scope: PictureStoryboardLedgerExpectation["disclosureScope"]): PictureStoryboardLedgerExpectation {
+  return {
+    requiredSchemaVersion: "reddi.downstream-disclosure-ledger.v1",
+    x402State: scope === "disabled_image_adapter" ? "blocked_disabled_adapter" : "planned",
+    downstreamCallsExecuted: 0,
+    disclosureScope: scope,
+    requiredFields: LEDGER_FIELDS,
+  };
+}
+
+export function buildPictureStoryboardDesign(): PictureStoryboardDesign {
+  const plan = buildEconomicDemoDryRunPlan("picture");
+  const adapterReadiness = imageAdapterReadiness();
+
+  const edges: PictureStoryboardEdge[] = [
+    {
+      step: 1,
+      profileId: "tool-using-agent",
+      capability: "visual-workflow-planning",
+      endpoint: plan.orchestrator.endpoint,
+      walletAddress: plan.orchestrator.walletAddress,
+      priceUsdc: plan.orchestrator.price.amount,
+      status: "planned",
+      payloadClass: "visual_brief",
+      scopedPayload:
+        "Convert the user prompt into a four-frame storyboard, explicit negative prompts, safety constraints, and evidence caveats before any image adapter can run.",
+      expectedOutput: "Storyboard brief with no provider output and no image receipt.",
+      guardrail: "The orchestrator may prepare adapter inputs but must not call OpenAI/Fal in storyboard mode.",
+      disclosureLedgerExpectation: plannedLedger("storyboard_payload_only"),
+    },
+    {
+      step: 2,
+      profileId: "image-generation-adapter",
+      capability: "image-generation",
+      endpoint: "/api/economic-demo/image",
+      walletAddress: "PendingAdapter11111111111111111111111111",
+      priceUsdc: "0.00",
+      status: "blocked",
+      payloadClass: "image_generation_request",
+      scopedPayload:
+        "The exact adapter request remains disabled unless ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION=true and an explicit live image-generation approval is recorded.",
+      expectedOutput: "Blocked adapter result: image_generation_disabled.",
+      guardrail: "No OpenAI or Fal.ai request is permitted in Phase 7 storyboard dry-run.",
+      disclosureLedgerExpectation: plannedLedger("disabled_image_adapter"),
+    },
+    ...plan.edges
+      .filter((edge) => edge.toProfileId === "vision-language-agent" || edge.toProfileId === "verification-validation-agent")
+      .map((edge, index): PictureStoryboardEdge => ({
+        step: index + 3,
+        profileId: edge.toProfileId,
+        capability: edge.capability,
+        endpoint: edge.endpoint,
+        walletAddress: edge.walletAddress,
+        priceUsdc: edge.price.amount,
+        status: "planned",
+        payloadClass: edge.toProfileId === "vision-language-agent" ? "storyboard_validation" : "release_attestation",
+        scopedPayload:
+          edge.toProfileId === "vision-language-agent"
+            ? "Validate the storyboard brief against the original prompt, negative prompts, and image-generation-disabled caveat."
+            : "Issue release/refund/dispute guidance based on storyboard completeness and disabled-adapter disclosure.",
+        expectedOutput:
+          edge.toProfileId === "vision-language-agent"
+            ? "Prompt-alignment review for storyboard mode, not generated-image analysis."
+            : "Attestation guidance that release is safe only as a storyboard artifact.",
+        guardrail: "Validate storyboard text only; do not request or infer generated image bytes.",
+        disclosureLedgerExpectation: plannedLedger("validation_attestation"),
+      })),
+  ];
+
+  return {
+    schemaVersion: "reddi.economic-demo.picture-storyboard-design.v1",
+    disclosureContract: "reddi.downstream-disclosure-ledger.v1",
+    scenarioId: "picture",
+    mode: "storyboard_no_image_generation",
+    userRequest: "Give me a picture that shows autonomous agents cooking Malatang.",
+    downstreamCallsExecuted: 0,
+    imageGenerationExecuted: 0,
+    adapterReadiness,
+    orchestrator: {
+      profileId: "tool-using-agent",
+      separationRationale:
+        "tool-using-agent owns adapter gating and storyboard preparation; the image-generation adapter stays blocked until a separately approved live image run.",
+    },
+    edges,
+    storyboard: STORYBOARD,
+    acceptanceCriteria: [
+      "No OpenAI or Fal.ai image generation request is executed.",
+      "The adapter edge is represented as blocked with an explicit disabled-adapter ledger expectation.",
+      "Storyboard frames include positive prompts, negative prompts, and evidence caveats.",
+      "Vision and verification specialists are planned for storyboard validation only.",
+      "The design is honest that the final output is an image brief, not generated image evidence.",
+    ],
+    guardrails: {
+      noOpenAiImageGeneration: true,
+      noFalImageGeneration: true,
+      noPaidProviderRequests: true,
+      noSigningOperations: true,
+      noWalletMutation: true,
+      noDevnetTransfer: true,
+    },
+    nextStep:
+      "Review the storyboard artifact locally, then request explicit approval only if a real OpenAI/Fal image-generation run is worth the spend and disclosure risk.",
+  };
+}


### PR DESCRIPTION
## Summary\n- add a Phase 7 picture storyboard dry-run design/API/UI path\n- model the image-generation adapter as blocked with downstream-disclosure ledger expectations\n- add storyboard frames with positive prompts, negative prompts, evidence caveats, and validation/attestation planning\n- update BDD/status/iterative plan retrospectives\n\n## Safety\n- storyboard only: imageGenerationExecuted = 0 and downstreamCallsExecuted = 0\n- no OpenAI/Fal generation, paid provider request, signing, wallet mutation, or devnet transfer\n- Phase 6 live research remains approval-gated\n\n## Validation\n- npx jest --runTestsByPath lib/__tests__/economic-demo-picture-storyboard-design.test.ts lib/__tests__/economic-demo-dry-run.test.ts --runInBand\n- npx eslint lib/economic-demo/picture-storyboard-design.ts lib/__tests__/economic-demo-picture-storyboard-design.test.ts app/api/economic-demo/picture-storyboard-design/route.ts app/economic-demo/page.tsx\n- npm run test:bdd:index\n- npm run build\n- git diff --check