### PR TITLE
feat: add picture storyboard artifact generator

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,19 +1,19 @@
 # Reddi Agent Protocol Code — STATUS
 
 **Last updated:** 2026-05-05 AEST
-**State:** 🟢 Phase 7 picture storyboard dry-run merged; Phase 6 live research and real image generation remain approval-gated.
+**State:** 🟢 Phase 7 picture storyboard dry-run merged; deterministic storyboard artifact generator in progress; Phase 6 live research and real image generation remain approval-gated.
 
 ## RESUME FROM HERE
 
-1. Phase 7 storyboard dry-run is complete through PR #219. Do not run real OpenAI/Fal image generation without explicit approval, provider choice, and budget cap.
+1. Deterministic picture storyboard artifact generator is the current safe local slice. Do not run real OpenAI/Fal image generation without explicit approval, provider choice, and budget cap.
 2. Do not run Phase 6 controlled live research without explicit approval for hosted/devnet calls and spend.
-3. Next safe local slice: either add a deterministic picture storyboard artifact generator, or fix the GitHub Actions Node.js 20 deprecation warning before it becomes urgent.
+3. After this slice, next safe local work is GitHub Actions Node.js 20 deprecation cleanup or a compact UI link to latest local evidence artifacts.
 
 ## Current Branch / Repo State
 
-- Local branch: `docs/status-after-picture-storyboard-20260505` (status-only follow-up after PR #219 merge).
-- Local working tree: status update after PR #219 merge. Local evidence artifacts are under `artifacts/manifest-parity-phase4/`, `artifacts/economic-demo-surfpool-rehearsal/20260505T021309Z/`, `artifacts/surfpool-smoke/20260505-121331/`, and `artifacts/economic-demo-research-dry-run/20260505T025224Z/`.
-- Latest merge on main: `2fdf9706 feat: add picture storyboard dry-run (#219)`.
+- Local branch: `feat/picture-storyboard-artifact-20260505`.
+- Local working tree: Phase 7 deterministic picture storyboard artifact generator in progress. Local evidence artifacts are under `artifacts/manifest-parity-phase4/`, `artifacts/economic-demo-surfpool-rehearsal/20260505T021309Z/`, `artifacts/surfpool-smoke/20260505-121331/`, and `artifacts/economic-demo-research-dry-run/20260505T025224Z/`.
+- Latest merge on main: `6d99b339 docs: update status after picture storyboard dry run (#220)`.
 - PR #204: closed as superseded after Nissan accepted recommendation.
 - PR #214: merged 2026-05-05 AEST as `a290db7093458f45ca1b3dbc2a047b404c856a29`; post-merge Anchor run `25353582949`, job `74338163008` passed in 7m26s.
 - PR #215: merged 2026-05-05 AEST as `cd202ebd6360d29f0a896e852fe9f63c339fc4dc`; post-merge Anchor run `25353973718`, job `74339305929` passed in 7m23s.
@@ -212,6 +212,14 @@ Validation for Phase 7 picture storyboard dry-run slice:
 - PR checks passed before merge: Vercel Preview Comments, Vercel deployment, `bdd-index-guard`, `source-conformance-matrix`, Anchor run `25355869246`, job `74344891406` — PASS, 6m2s.
 - Post-merge `main` Anchor run `25356047688`, job `74345428981` — PASS, 7m13s.
 
+Validation for Phase 7 picture storyboard artifact generator slice (local, not yet PR):
+
+- Added `scripts/generate-economic-demo-picture-storyboard.mjs` and `npm run evidence:economic-demo:picture-storyboard`.
+- Generated artifact `artifacts/economic-demo-picture-storyboard/20260505T034749Z/picture-storyboard.json` with schema `reddi.economic-demo.picture-storyboard-artifact.v1`.
+- Artifact summary: scenario `picture`, mode `storyboard_no_image_generation`, orchestrator `tool-using-agent`, 4 edges, 4 storyboard frames, blocked adapter x402 state `blocked_disabled_adapter`, `imageGenerationExecuted = 0`, `downstreamCallsExecuted = 0`.
+- Safety review counters: OpenAI image requests `0`, Fal.ai image requests `0`, paid provider requests `0`, signing operations `0`, wallet mutations `0`, devnet transfers `0`.
+- Secret grep over generated artifact produced only policy-text false positive `ENABLE_ECONOMIC_DEMO_IMAGE_GENERATION`; no credential material present.
+
 ## Retrospective — Phase 6.5 Slice A
 
 ### What worked
@@ -251,6 +259,7 @@ Do not proceed as a waterfall into research/picture live workflows until the dis
 - 2026-05-05: Research workflow orchestration should be owned by `agentic-workflow-system`; `scientific-research-agent` stays a synthesis specialist so paid-edge coordination and evidence synthesis remain separate.
 - 2026-05-05: Phase 6 controlled live research remains approval-gated; next safe progress is Phase 7 storyboard dry-run with image generation disabled.
 - 2026-05-05: Phase 7 storyboard dry-run is merged; real image generation needs a separate approval with provider and budget cap.
+- 2026-05-05: Picture storyboard artifact generation should remain local/ignored and assert the disabled adapter as evidence, not omit it.
 
 ## Blockers / Watch Items
 

--- a/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
+++ b/docs/AGENTIC-MARKETPLACE-BDD-ITERATIVE-PLAN-2026-05-05.md
@@ -1,7 +1,7 @@
 # Agentic Marketplace Manifest + Disclosure Ledger — BDD Iterative Plan
 
 _Date:_ 2026-05-05 AEST  
-_Status:_ Active after Phase 5 research dry-run artifact generator merge; Phase 7 storyboard dry-run local slice in progress
+_Status:_ Active after Phase 7 storyboard dry-run merge; picture storyboard artifact generator local slice in progress
 _Related:_ PR #202, PR #203, PR #205, PR #214, `ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md`, Bucket J BDD feature
 
 ## North star
@@ -44,7 +44,7 @@ Still pending:
 
 - Live economic workflow evidence still predates hosted manifest parity and should only be regenerated under an explicit live-run approval gate.
 - Research workflow design now has a disclosure-ledger-first dry-run graph and deterministic artifact generator before any live research calls.
-- Phase 6 live research is skipped for now because it needs explicit hosted/devnet spend approval; Phase 7 storyboard dry-run is the next safe local proof.
+- Phase 6 live research is skipped for now because it needs explicit hosted/devnet spend approval; Phase 7 storyboard dry-run is merged and now has a deterministic artifact generator slice underway.
 - Picture workflow expansion remains behind research planning and explicit image-generation approval.
 
 ## Phase 0 — Plan + BDD lock
@@ -347,6 +347,14 @@ Every planned edge must declare payload class, disclosure-ledger expectation, x4
 - **Safety/spend review:** Design/API/UI only. No OpenAI call, no Fal.ai call, no paid provider request, no signing, no wallet mutation, and no devnet transfer.
 - **Judge clarity:** Improved: storyboard mode can be shown as an honest visual proof plan, not mistaken for generated image evidence.
 - **Plan adjustment:** If the storyboard is sufficient for judging, stop before spend. If a real image is needed, request separate approval with provider, budget cap, and disclosure evidence requirements.
+
+### Retrospective — Phase 7 storyboard artifact generator
+
+- **What worked:** The picture storyboard can now be exported as a deterministic local artifact with schema `reddi.economic-demo.picture-storyboard-artifact.v1`, blocked adapter details, storyboard frames, disclosure-ledger expectations, and zero-execution safety counters.
+- **What failed or surprised us:** Artifact validation needs to treat the disabled adapter as a first-class edge, not as absence of an edge. The blocked state is the useful evidence because it proves adapter gating before spend.
+- **Safety/spend review:** Local artifact generation only. No OpenAI request, no Fal.ai request, no paid provider request, no signing, no wallet mutation, and no devnet transfer.
+- **Judge clarity:** Improved: reviewers can inspect one JSON artifact that says what would be generated, why it is not generated yet, and which disclosure fields must be preserved if the adapter is later approved.
+- **Plan adjustment:** Keep real image generation approval-gated. Next safe work is either CI Node.js 20 deprecation cleanup or a compact UI link to latest local evidence artifacts.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "smoke:economic-demo:live-x402-readiness": "node ./scripts/run-economic-demo-live-x402-readiness.mjs",
     "smoke:economic-demo:webpage-live-x402-workflow": "node ./scripts/run-economic-demo-webpage-live-x402-workflow.mjs",
     "evidence:economic-demo:webpage": "node ./scripts/generate-economic-demo-evidence-pack.mjs",
-    "evidence:economic-demo:research-dry-run": "node ./scripts/generate-economic-demo-research-dry-run.mjs"
+    "evidence:economic-demo:research-dry-run": "node ./scripts/generate-economic-demo-research-dry-run.mjs",
+    "evidence:economic-demo:picture-storyboard": "node ./scripts/generate-economic-demo-picture-storyboard.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/generate-economic-demo-picture-storyboard.mjs
+++ b/scripts/generate-economic-demo-picture-storyboard.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const Module = require("node:module");
+const ts = require("typescript");
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const originalResolveFilename = Module._resolveFilename;
+
+Module._resolveFilename = function resolveAlias(request, parent, isMain, options) {
+  if (request.startsWith("@/")) {
+    return originalResolveFilename.call(this, join(rootDir, request.slice(2)), parent, isMain, options);
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+require.extensions[".ts"] = function compileTypeScript(module, filename) {
+  const source = readFileSync(filename, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      resolveJsonModule: true,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: filename,
+  });
+  module._compile(outputText, filename);
+};
+
+const { buildPictureStoryboardDesign } = require("../lib/economic-demo/picture-storyboard-design.ts");
+
+function assertStoryboardOnly(design) {
+  const failures = [];
+  if (design.mode !== "storyboard_no_image_generation") failures.push(`mode=${design.mode}`);
+  if (design.downstreamCallsExecuted !== 0) failures.push(`downstreamCallsExecuted=${design.downstreamCallsExecuted}`);
+  if (design.imageGenerationExecuted !== 0) failures.push(`imageGenerationExecuted=${design.imageGenerationExecuted}`);
+  if (design.adapterReadiness.enabled !== false) failures.push("adapterReadiness.enabled=true");
+  if (!design.guardrails.noOpenAiImageGeneration) failures.push("noOpenAiImageGeneration=false");
+  if (!design.guardrails.noFalImageGeneration) failures.push("noFalImageGeneration=false");
+  if (!design.guardrails.noPaidProviderRequests) failures.push("noPaidProviderRequests=false");
+  if (!design.guardrails.noSigningOperations) failures.push("noSigningOperations=false");
+  if (!design.guardrails.noWalletMutation) failures.push("noWalletMutation=false");
+  if (!design.guardrails.noDevnetTransfer) failures.push("noDevnetTransfer=false");
+  if (!design.edges.some((edge) => edge.profileId === "image-generation-adapter" && edge.status === "blocked")) {
+    failures.push("blocked_image_adapter_missing");
+  }
+  if (design.edges.some((edge) => edge.disclosureLedgerExpectation.downstreamCallsExecuted !== 0)) failures.push("edge_downstream_calls_executed");
+  if (design.edges.some((edge) => edge.disclosureLedgerExpectation.requiredSchemaVersion !== "reddi.downstream-disclosure-ledger.v1")) {
+    failures.push("ledger_schema_mismatch");
+  }
+  if (design.storyboard.some((frame) => !frame.visualPrompt || !frame.negativePrompt || !frame.evidenceCaveat)) {
+    failures.push("storyboard_frame_missing_prompt_or_caveat");
+  }
+  if (failures.length > 0) throw new Error(`picture_storyboard_guardrail_failed:${failures.join(",")}`);
+}
+
+function main() {
+  const timestamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  const outDir = join(rootDir, "artifacts", "economic-demo-picture-storyboard", timestamp);
+  mkdirSync(outDir, { recursive: true });
+
+  const design = buildPictureStoryboardDesign();
+  assertStoryboardOnly(design);
+
+  const adapterEdge = design.edges.find((edge) => edge.profileId === "image-generation-adapter");
+  const artifact = {
+    schemaVersion: "reddi.economic-demo.picture-storyboard-artifact.v1",
+    generatedAt: new Date().toISOString(),
+    sourceSchemaVersion: design.schemaVersion,
+    disclosureContract: design.disclosureContract,
+    scenarioId: design.scenarioId,
+    mode: design.mode,
+    userRequest: design.userRequest,
+    downstreamCallsExecuted: design.downstreamCallsExecuted,
+    imageGenerationExecuted: design.imageGenerationExecuted,
+    orchestrator: design.orchestrator,
+    adapterReadiness: design.adapterReadiness,
+    blockedAdapter: adapterEdge
+      ? {
+          profileId: adapterEdge.profileId,
+          endpoint: adapterEdge.endpoint,
+          status: adapterEdge.status,
+          expectedOutput: adapterEdge.expectedOutput,
+          guardrail: adapterEdge.guardrail,
+          disclosureLedgerExpectation: adapterEdge.disclosureLedgerExpectation,
+        }
+      : null,
+    edgeCount: design.edges.length,
+    edges: design.edges.map((edge) => ({
+      step: edge.step,
+      profileId: edge.profileId,
+      capability: edge.capability,
+      endpoint: edge.endpoint,
+      walletAddress: edge.walletAddress,
+      priceUsdc: edge.priceUsdc,
+      status: edge.status,
+      payloadClass: edge.payloadClass,
+      scopedPayload: edge.scopedPayload,
+      expectedOutput: edge.expectedOutput,
+      guardrail: edge.guardrail,
+      disclosureLedgerExpectation: edge.disclosureLedgerExpectation,
+    })),
+    storyboard: design.storyboard,
+    acceptanceCriteria: design.acceptanceCriteria,
+    guardrails: design.guardrails,
+    nextStep: design.nextStep,
+    safetyReview: {
+      openAiImageRequests: 0,
+      falImageRequests: 0,
+      paidProviderRequests: 0,
+      signingOperations: 0,
+      walletMutations: 0,
+      devnetTransfers: 0,
+    },
+  };
+
+  const artifactPath = join(outDir, "picture-storyboard.json");
+  const summaryPath = join(outDir, "SUMMARY.md");
+  writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  writeFileSync(
+    summaryPath,
+    `# Economic Demo Picture Storyboard Dry-Run\n\n- Scenario: ${artifact.scenarioId}\n- Mode: ${artifact.mode}\n- Orchestrator: ${artifact.orchestrator.profileId}\n- Edges: ${artifact.edgeCount}\n- Storyboard frames: ${artifact.storyboard.length}\n- Image generation executed: ${artifact.imageGenerationExecuted}\n- Downstream calls executed: ${artifact.downstreamCallsExecuted}\n- Blocked adapter: ${artifact.blockedAdapter?.profileId ?? "missing"}\n- Blocked adapter x402 state: ${artifact.blockedAdapter?.disclosureLedgerExpectation.x402State ?? "missing"}\n- OpenAI image requests: ${artifact.safetyReview.openAiImageRequests}\n- Fal.ai image requests: ${artifact.safetyReview.falImageRequests}\n- Paid provider requests: ${artifact.safetyReview.paidProviderRequests}\n- Signing operations: ${artifact.safetyReview.signingOperations}\n- Wallet mutations: ${artifact.safetyReview.walletMutations}\n- Devnet transfers: ${artifact.safetyReview.devnetTransfers}\n- JSON: ${artifactPath}\n`,
+  );
+  console.log(JSON.stringify({ ok: true, artifactPath, summaryPath }, null, 2));
+}
+
+try {
+  main();
+} finally {
+  Module._resolveFilename = originalResolveFilename;
+}


### PR DESCRIPTION
## Summary\n- add deterministic local picture storyboard artifact generation\n- expose npm script evidence:economic-demo:picture-storyboard\n- artifact asserts blocked image adapter, storyboard frames, disclosure-ledger expectations, and zero spend/execution counters\n- update STATUS and iterative plan retrospective\n\n## Safety\n- local artifact generation only\n- imageGenerationExecuted = 0 and downstreamCallsExecuted = 0\n- no OpenAI/Fal request, paid provider request, signing, wallet mutation, or devnet transfer\n- generated artifacts remain ignored under artifacts/\n\n## Validation\n- npm run evidence:economic-demo:picture-storyboard\n- npx jest --runTestsByPath lib/__tests__/economic-demo-picture-storyboard-design.test.ts --runInBand\n- node --check scripts/generate-economic-demo-picture-storyboard.mjs\n- npx eslint scripts/generate-economic-demo-picture-storyboard.mjs lib/economic-demo/picture-storyboard-design.ts lib/__tests__/economic-demo-picture-storyboard-design.test.ts\n- npm run test:bdd:index\n- npm run build\n- git diff --check