### PR TITLE
ci: use Node 24 GitHub Actions releases

### DIFF
--- a/.github/workflows/anchor-test.yml
+++ b/.github/workflows/anchor-test.yml
@@ -1,8 +1,5 @@
 name: Anchor Tests
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 on:
   push:
     branches: [main, feature/**]
@@ -16,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain (matches rust-toolchain.toml)
         uses: dtolnay/rust-toolchain@stable
@@ -25,7 +22,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/anchor-test.yml
+++ b/.github/workflows/anchor-test.yml
@@ -1,5 +1,8 @@
 name: Anchor Tests
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   push:
     branches: [main, feature/**]

--- a/.github/workflows/bdd-bucket-sweep-confidence.yml
+++ b/.github/workflows/bdd-bucket-sweep-confidence.yml
@@ -1,5 +1,8 @@
 name: BDD Bucket Sweep Confidence
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/bdd-bucket-sweep-confidence.yml
+++ b/.github/workflows/bdd-bucket-sweep-confidence.yml
@@ -1,8 +1,5 @@
 name: BDD Bucket Sweep Confidence
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 on:
   workflow_dispatch:
   schedule:
@@ -14,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/bdd-index-guard.yml
+++ b/.github/workflows/bdd-index-guard.yml
@@ -1,5 +1,8 @@
 name: BDD Feature Index Guard
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/bdd-index-guard.yml
+++ b/.github/workflows/bdd-index-guard.yml
@@ -1,8 +1,5 @@
 name: BDD Feature Index Guard
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 on:
   pull_request:
     paths:
@@ -18,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/integration-lane-nightly.yml
+++ b/.github/workflows/integration-lane-nightly.yml
@@ -1,5 +1,8 @@
 name: Integration Lane (Nightly Artifacts)
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   schedule:
     - cron: "0 20 * * *" # 06:00 AEST (approx, UTC-based)

--- a/.github/workflows/integration-lane-nightly.yml
+++ b/.github/workflows/integration-lane-nightly.yml
@@ -1,8 +1,5 @@
 name: Integration Lane (Nightly Artifacts)
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 on:
   schedule:
     - cron: "0 20 * * *" # 06:00 AEST (approx, UTC-based)
@@ -14,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/source-conformance-matrix.yml
+++ b/.github/workflows/source-conformance-matrix.yml
@@ -1,5 +1,8 @@
 name: Source Conformance Matrix
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/source-conformance-matrix.yml
+++ b/.github/workflows/source-conformance-matrix.yml
@@ -1,8 +1,5 @@
 name: Source Conformance Matrix
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 on:
   pull_request:
     paths:
@@ -23,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/surfpool-acceptance-manual.yml
+++ b/.github/workflows/surfpool-acceptance-manual.yml
@@ -1,5 +1,8 @@
 name: Surfpool Acceptance (manual)
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/surfpool-acceptance-manual.yml
+++ b/.github/workflows/surfpool-acceptance-manual.yml
@@ -1,8 +1,5 @@
 name: Surfpool Acceptance (manual)
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 on:
   workflow_dispatch:
     inputs:
@@ -23,7 +20,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary\n- upgrade actions/checkout from v4 to v5 across workflows\n- upgrade actions/cache from v4 to v5 in Anchor CI\n- removes the temporary Node 24 force-env workaround so GitHub no longer emits the forced-runtime warning\n\n## Validation\n- ruby YAML parser over .github/workflows/*.yml\n- git diff --check\n- PR checks