### PR TITLE
feat: add economic demo submission prep checker

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -7,7 +7,7 @@
 
 1. Phase 7 picture storyboard artifact generator is complete through PR #221. Do not run real OpenAI/Fal image generation without explicit approval, provider choice, and budget cap.
 2. GitHub Actions Node.js 20 deprecation cleanup is complete through PR #223; post-merge `main` Anchor CI has no Node.js 20 deprecation annotation.
-3. Compact `/economic-demo` local-evidence artifact links are complete through PR #225. Demo/submission readiness now follows Issue #228 and `docs/ECONOMIC-DEMO-BDD-SUBMISSION-ITERATIVE-PLAN-2026-05-05.md`: complete Phase 0 docs/BDD validation, write the Phase 0 retrospective, then refine Phase 1 before implementation. Do not run Phase 6 controlled live research or real image generation without explicit approval gates.
+3. Demo/submission readiness follows Issue #228 and `docs/ECONOMIC-DEMO-BDD-SUBMISSION-ITERATIVE-PLAN-2026-05-05.md`: Phase 0 is merged through PR #229; Phase 1 local submission-prep checker is in progress. Next loop is Phase 2 operator checklist/UI after Phase 1 PR/CI/retro. Do not run Phase 6 controlled live research or real image generation without explicit approval gates.
 
 ## Current Branch / Repo State
 

--- a/docs/ECONOMIC-DEMO-BDD-SUBMISSION-ITERATIVE-PLAN-2026-05-05.md
+++ b/docs/ECONOMIC-DEMO-BDD-SUBMISSION-ITERATIVE-PLAN-2026-05-05.md
@@ -181,3 +181,13 @@ _Status:_ Complete locally; ready for PR.
 - **Safety/spend review:** Docs/BDD/status only. No live research, OpenAI/Fal image generation, paid provider calls, signing, wallet mutation, devnet transfer, or Coolify/env mutation.
 - **Judge clarity:** Improved. The plan separates local proof, controlled demo evidence, storyboard-only proof, and approval-gated future work so the submission story stays honest.
 - **Plan adjustment:** Phase 1 should stay local and add/check the submission prep artifact index before any UI/runtime polish. If the index is confusing or leaks too much local detail, revise the pack schema before moving to Phase 2.
+
+### Phase 1 retrospective
+
+_Status:_ Complete locally; ready for PR.
+
+- **What worked:** Added `check:economic-demo:submission-prep` so the ignored local prep pack can be validated without publishing its contents. The checker confirms required sections/guardrails and verifies referenced local evidence paths exist.
+- **What failed or surprised us:** The existing `latest` symlink was broken because it pointed to `artifacts/economic-demo-submission-prep/...` from inside the same directory. The checker now falls back to the newest timestamped prep directory when `latest` is absent or broken. `git diff --check` also caught a trailing blank line in the BDD feature before commit.
+- **Safety/spend review:** Local filesystem validation only. No hosted specialist calls, provider requests, signing, wallet mutation, devnet transfer, Coolify/env mutation, or paid spend.
+- **Judge clarity:** Improved for operators: the prep pack now has a repeatable validation command before recording/submission, reducing reliance on chat memory.
+- **Plan adjustment:** Phase 2 should surface a committed operator checklist or UI panel using sanitized claims, not raw ignored artifact contents. Keep the checker as a local preflight before any rehearsal.

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -121,3 +121,10 @@ Feature: End-user economic workflow demo
     And the retrospective must record what worked, what failed or surprised us, safety and spend review, judge clarity, and plan adjustment
     And the next phase cannot expand scope until the retrospective updates the plan
     And local ignored evidence paths may be referenced but raw private artifact contents are not published
+
+  Scenario: Submission prep artifact index is locally checkable without live calls
+    Given a local economic demo submission prep pack exists under artifacts/economic-demo-submission-prep/latest
+    When the submission prep checker validates the pack
+    Then it confirms the demo entrypoint, green evidence chain, local evidence paths, recording outline, and hard no-go list are present
+    And every referenced local evidence artifact path exists
+    And no hosted specialist call, provider request, signing operation, wallet mutation, devnet transfer, or Coolify mutation occurs

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "smoke:economic-demo:webpage-live-x402-workflow": "node ./scripts/run-economic-demo-webpage-live-x402-workflow.mjs",
     "evidence:economic-demo:webpage": "node ./scripts/generate-economic-demo-evidence-pack.mjs",
     "evidence:economic-demo:research-dry-run": "node ./scripts/generate-economic-demo-research-dry-run.mjs",
-    "evidence:economic-demo:picture-storyboard": "node ./scripts/generate-economic-demo-picture-storyboard.mjs"
+    "evidence:economic-demo:picture-storyboard": "node ./scripts/generate-economic-demo-picture-storyboard.mjs",
+    "check:economic-demo:submission-prep": "node ./scripts/check-economic-demo-submission-prep.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/check-economic-demo-submission-prep.mjs
+++ b/scripts/check-economic-demo-submission-prep.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const defaultPrepParent = resolve(repoRoot, "artifacts/economic-demo-submission-prep");
+const defaultPrepRoot = resolve(defaultPrepParent, "latest");
+
+function newestPrepDir() {
+  if (!existsSync(defaultPrepParent)) return defaultPrepRoot;
+  const candidates = readdirSync(defaultPrepParent, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /^\d{8}T\d{6}Z$/.test(entry.name))
+    .map((entry) => resolve(defaultPrepParent, entry.name))
+    .sort();
+  return candidates.at(-1) ?? defaultPrepRoot;
+}
+
+let prepRoot = resolve(process.env.ECONOMIC_DEMO_SUBMISSION_PREP_ROOT ?? defaultPrepRoot);
+if (!process.env.ECONOMIC_DEMO_SUBMISSION_PREP_ROOT && !existsSync(prepRoot)) {
+  prepRoot = await newestPrepDir();
+}
+const prepFile = resolve(prepRoot, "SUBMISSION-PREP.md");
+
+const requiredPhrases = [
+  "Scope: safe local/demo prep only",
+  "## Demo entrypoint",
+  "## Current green evidence",
+  "## Local evidence paths to mention/demo",
+  "## Five-beat recording outline",
+  "## Hard no-go list unless Nissan explicitly approves",
+  "No Phase 6 controlled live research",
+  "No OpenAI/Fal image generation",
+  "No paid provider requests",
+  "No signing operations",
+  "No wallet mutation",
+  "No devnet transfer",
+  "No Coolify/env mutation",
+];
+
+function relativeToRepo(path) {
+  return path.startsWith(repoRoot) ? path.slice(repoRoot.length + 1) : path;
+}
+
+function fail(message, detail) {
+  console.error(`[submission-prep-check] FAIL: ${message}`);
+  if (detail) console.error(detail);
+  process.exit(1);
+}
+
+if (!existsSync(prepRoot)) {
+  fail("submission prep root is missing", relativeToRepo(prepRoot));
+}
+
+if (!lstatSync(prepRoot).isDirectory()) {
+  fail("submission prep root is not a directory", relativeToRepo(prepRoot));
+}
+
+if (!existsSync(prepFile)) {
+  fail("SUBMISSION-PREP.md is missing", relativeToRepo(prepFile));
+}
+
+const markdown = readFileSync(prepFile, "utf8");
+const missingPhrases = requiredPhrases.filter((phrase) => !markdown.includes(phrase));
+if (missingPhrases.length > 0) {
+  fail("prep pack is missing required sections/guardrails", missingPhrases.map((p) => `- ${p}`).join("\n"));
+}
+
+const pathMatches = [...markdown.matchAll(/`(artifacts\/[^`]+)`/g)].map((match) => match[1]);
+const evidencePaths = [...new Set(pathMatches.filter((p) => !p.includes("economic-demo-submission-prep/latest")))];
+if (evidencePaths.length === 0) {
+  fail("prep pack does not reference any local evidence artifact paths");
+}
+
+const missingPaths = evidencePaths.filter((artifactPath) => !existsSync(resolve(repoRoot, artifactPath)));
+if (missingPaths.length > 0) {
+  fail("prep pack references missing local evidence paths", missingPaths.map((p) => `- ${p}`).join("\n"));
+}
+
+console.log(`[submission-prep-check] OK: ${relativeToRepo(prepFile)}`);
+console.log(`[submission-prep-check] evidence paths: ${evidencePaths.length}`);


### PR DESCRIPTION
## Summary
- add a local submission prep checker for ignored economic-demo prep packs
- add package script `check:economic-demo:submission-prep`
- extend Bucket J BDD for local submission-prep index validation
- write Phase 1 retrospective and refresh STATUS resume point

## Validation
- `npm run check:economic-demo:submission-prep`
- `node --check scripts/check-economic-demo-submission-prep.mjs`
- `npm run test:bdd:index`
- `git diff --check`

## Guardrails
- local filesystem validation only
- no hosted specialist calls, provider requests, signing, wallet mutation, devnet transfer, Coolify/env mutation, or paid spend
