### PR TITLE
docs: plan Quasar hackathon cutover

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,19 +1,19 @@
 # Reddi Agent Protocol Code — STATUS
 
 **Last updated:** 2026-05-05 AEST
-**State:** 🟢 Demo/submission readiness BDD iterative loop complete through Phase 4 via Issue #228; final judge packet merged; Phase 6 live research and real image generation remain approval-gated.
+**State:** 🟡 Quasar hackathon cutover loop active via Issue #236; prior Issue #228 packet was Anchor-current-state readiness, but Nissan now requires hackathon demos to use Quasar-deployed Solana programs. Live research, real image generation, signing, deployment, wallet, and env mutations remain approval-gated.
 
 ## RESUME FROM HERE
 
 1. Phase 7 picture storyboard artifact generator is complete through PR #221. Do not run real OpenAI/Fal image generation without explicit approval, provider choice, and budget cap.
 2. GitHub Actions Node.js 20 deprecation cleanup is complete through PR #223; post-merge `main` Anchor CI has no Node.js 20 deprecation annotation.
-3. Demo/submission readiness follows Issue #228 and `docs/ECONOMIC-DEMO-BDD-SUBMISSION-ITERATIVE-PLAN-2026-05-05.md`: Phase 0 merged through PR #229; Phase 1 checker merged through PR #230; Phase 2 checklist merged through PR #231; Phase 3 retrospective merged through PR #233; Phase 4 final public-safe judge packet merged through PR #234 at `docs/ECONOMIC-DEMO-JUDGE-PACKET-2026-05-05.md`. Autonomous loop is complete unless Nissan requests Phase 5 polish or explicitly approves Phase 6 live research / real image generation.
+3. Quasar cutover follows Issue #236 and `docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md`: new target is hackathon demos using Quasar-deployed Solana programs. Next loop is Phase 1 Quasar deployment inventory/config contract. Do not deploy, sign, mutate wallets, mutate env/Coolify/Vercel, or run paid/live specialist work without explicit approval.
 
 ## Current Branch / Repo State
 
-- Local branch: `docs/status-after-final-judge-packet-20260505` (final status wrap after Phase 4).
+- Local branch: `docs/quasar-hackathon-cutover-plan-20260505` (Phase 0 Quasar cutover plan).
 - Local working tree: clean after PR #234 merge; local ignored evidence artifacts remain under `artifacts/manifest-parity-phase4/`, `artifacts/economic-demo-surfpool-rehearsal/20260505T021309Z/`, `artifacts/surfpool-smoke/20260505-121331/`, `artifacts/economic-demo-research-dry-run/20260505T025224Z/`, `artifacts/economic-demo-picture-storyboard/`, `artifacts/economic-demo-submission-prep/20260505T055411Z/`, and `artifacts/economic-demo-rehearsal/20260505T091725Z/`.
-- Latest merge on main: `47bd4f82 docs: add economic demo judge packet (#234)`.
+- Latest merge on main: `3ba5d720 docs: update status after final judge packet (#235)`.
 - PR #204: closed as superseded after Nissan accepted recommendation.
 - PR #214: merged 2026-05-05 AEST as `a290db7093458f45ca1b3dbc2a047b404c856a29`; post-merge Anchor run `25353582949`, job `74338163008` passed in 7m26s.
 - PR #215: merged 2026-05-05 AEST as `cd202ebd6360d29f0a896e852fe9f63c339fc4dc`; post-merge Anchor run `25353973718`, job `74339305929` passed in 7m23s.

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,7 +7,7 @@
 
 1. Phase 7 picture storyboard artifact generator is complete through PR #221. Do not run real OpenAI/Fal image generation without explicit approval, provider choice, and budget cap.
 2. GitHub Actions Node.js 20 deprecation cleanup is complete through PR #223; post-merge `main` Anchor CI has no Node.js 20 deprecation annotation.
-3. Quasar cutover follows Issue #236 and `docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md`: new target is hackathon demos using Quasar-deployed Solana programs. Next loop is Phase 1 Quasar deployment inventory/config contract. Do not deploy, sign, mutate wallets, mutate env/Coolify/Vercel, or run paid/live specialist work without explicit approval.
+3. Quasar cutover follows Issue #236 and `docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md`: Phase 1 inventory is now scaffolded at `config/quasar/deployments.json` with `npm run check:quasar:deployments`. Candidate devnet Quasar program `VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW` is executable by read-only RPC check, but submissionReady remains false until demo runtime wiring + PER/judge-packet proof chain are cut over. Do not deploy, sign, mutate wallets, mutate env/Coolify/Vercel, or run paid/live specialist work without explicit approval.
 
 ## Current Branch / Repo State
 

--- a/config/quasar/deployments.json
+++ b/config/quasar/deployments.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "./deployments.schema.json",
+  "updatedAt": "2026-05-05",
+  "decisionIssue": 236,
+  "target": "hackathon-demo-quasar-cutover",
+  "submissionReady": false,
+  "submissionReadyReason": "Candidate Quasar devnet program has been discovered, but full demo runtime wiring and judge-packet proof chain are not yet cut over.",
+  "legacyAnchorReference": {
+    "cluster": "devnet",
+    "programId": "794nTFNyJknzDrR13ApSfVyNCRvcvnCN3BVDfic8dcZD",
+    "purpose": "Legacy/reference Anchor deployment only. Must not be used as hackathon demo target after Quasar cutover."
+  },
+  "quasarDeployments": {
+    "devnet": {
+      "cluster": "devnet",
+      "rpcHttp": "https://api.devnet.solana.com",
+      "programId": "VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW",
+      "status": "candidate-executable-verified",
+      "scope": [
+        "escrow-parity-candidate",
+        "registry-parity-docs-present",
+        "reputation-parity-docs-present",
+        "attestation-parity-docs-present"
+      ],
+      "knownGaps": [
+        "runtime demo wiring still assumes Anchor discriminators/layouts",
+        "PER/privacy-aware settlement is not yet proven end-to-end on Quasar",
+        "final judge packet still needs Quasar proof chain refresh"
+      ],
+      "evidence": [
+        {
+          "type": "read-only-rpc-account-check",
+          "checkedAt": "2026-05-05T20:25:00+10:00",
+          "command": "solana account VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW --url https://api.devnet.solana.com",
+          "result": "executable=true; owner=BPFLoaderUpgradeab1e11111111111111111111111; no signing or wallet mutation"
+        },
+        {
+          "type": "repo-artifact",
+          "path": "docs/verifiable-agent-protocol/colosseum-frontier-2026-04/QUASAR-REGISTRY-PARITY-REPORT.md"
+        },
+        {
+          "type": "repo-artifact",
+          "path": "docs/verifiable-agent-protocol/colosseum-frontier-2026-04/QUASAR-REPUTATION-PARITY-REPORT.md"
+        },
+        {
+          "type": "repo-artifact",
+          "path": "docs/verifiable-agent-protocol/colosseum-frontier-2026-04/QUASAR-ATTESTATION-PARITY-REPORT.md"
+        },
+        {
+          "type": "repo-artifact",
+          "path": "docs/verifiable-agent-protocol/colosseum-frontier-2026-04/QUASAR-PER-PARITY-REPORT.md"
+        }
+      ]
+    }
+  }
+}

--- a/docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md
+++ b/docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md
@@ -1,0 +1,146 @@
+# Quasar Hackathon Cutover Plan
+
+_Date:_ 2026-05-05 AEST
+_Issue:_ #236
+_Status:_ Phase 0 plan/spec. No signing, deployment, wallet mutation, env mutation, or live paid/provider calls performed.
+
+## Decision reversal
+
+Prior Quasar docs treated Quasar as fork-isolated/post-hackathon optimisation. Nissan has now changed the product goal:
+
+> Hackathon submission and all demos must use Quasar-deployed Solana programs.
+
+This document supersedes the older "Anchor now, Quasar later" submission posture for demo/submission readiness. Anchor may remain as a legacy/reference implementation until parity is complete, but it must not be presented as the hackathon demo proof after cutover.
+
+## Current state audit
+
+- Canonical CI is still Anchor-named and Anchor-executing: `.github/workflows/anchor-test.yml` installs Anchor CLI 1.0.0 and runs `anchor build --ignore-keys`.
+- Canonical on-chain program code is still Anchor-based: `programs/escrow/Cargo.toml` depends on `anchor-lang = 1.0.0`.
+- Frontend program config still assumes Anchor instruction/account discriminators and layouts in `lib/program.ts`.
+- Quasar parity reports exist for escrow, registry, reputation, and attestation; PER parity is partial/conditional.
+- A stale `feature/wire-quasar-programs` branch exists, but it is not directly mergeable because it diverges heavily, deletes many current files, and includes vendored `node_modules`. Use it only as a research artifact.
+
+## Cutover principle
+
+All hackathon demo surfaces must answer three questions clearly:
+
+1. **Which Quasar program ID is this using?**
+2. **Which deployment/evidence artifact proves that program is deployed and demo-relevant?**
+3. **Which demo routes/scripts/readiness checks would fail if the app silently fell back to Anchor?**
+
+If any answer is missing, that phase is not submission-ready.
+
+## Guardrails
+
+Allowed without further approval:
+
+- Local docs/spec/BDD changes.
+- Local static/source checks.
+- Local config scaffolding that does not mutate secrets or deployment environments.
+- Reading public GitHub/docs and existing repo artifacts.
+
+Requires explicit approval before action:
+
+- Any signing operation.
+- Any wallet mutation.
+- Any devnet deployment or transfer.
+- Any Coolify/Vercel/env/secret mutation.
+- Any paid provider call.
+- Any live specialist/research execution beyond current approved local-only checks.
+
+## BDD iterative phases
+
+### Phase 0 — Decision lock and migration plan
+
+**Expectation:** The repo records Quasar-deployed programs as the hackathon demo target and stops treating Anchor CI as sufficient submission proof.
+
+**Implementation:** This plan, BDD scenario, STATUS update, and Issue #236.
+
+**Acceptance:**
+
+- Plan states the new Quasar target and supersedes prior Anchor-first submission posture.
+- BDD scenario requires Quasar-deployed program alignment for hackathon demos.
+- STATUS points future work at Quasar cutover.
+
+**Validation:**
+
+- `npm run test:bdd:index`
+- `git diff --check`
+
+**Retrospective:** Required before Phase 1.
+
+### Phase 1 — Quasar deployment inventory and config contract
+
+**Expectation:** The repo has one canonical place for Quasar deployment metadata.
+
+**Implementation target:** Add a Quasar deployment inventory/config contract that records program IDs, cluster, source artifact/report, and validation status. It must distinguish Quasar deployment IDs from legacy Anchor IDs.
+
+**Acceptance:**
+
+- A local check can load the inventory and verify required fields exist.
+- Missing Quasar program IDs fails locally.
+- Anchor program IDs are allowed only under explicit `legacyAnchorReference`, not as demo target IDs.
+
+**Retrospective:** Decide whether known Quasar IDs are sufficient or deployment approval is needed.
+
+### Phase 2 — Demo/readiness guardrail
+
+**Expectation:** Demo submission checks fail if hackathon demo surfaces target Anchor-only evidence.
+
+**Implementation target:** Extend local submission/demo readiness scripts to require Quasar deployment inventory and Quasar target mode for `/economic-demo`, demo agent scripts, and judge packet references.
+
+**Acceptance:**
+
+- `npm run check:economic-demo:submission-prep` or a new Quasar-specific script fails without Quasar metadata.
+- Judge packet/readiness docs reference Quasar deployment evidence, not Anchor-only CI.
+
+**Retrospective:** Confirm whether UI copy needs immediate changes before wiring runtime.
+
+### Phase 3 — Runtime/demo wiring
+
+**Expectation:** Demo code resolves Quasar program IDs from the new config when in hackathon/demo mode.
+
+**Implementation target:** Update `lib/program.ts`, network profiles, demo routes/scripts, and visible UI copy to use Quasar deployment metadata for hackathon demos while leaving Anchor as a clearly-labelled legacy/reference path if still needed.
+
+**Acceptance:**
+
+- Local tests prove Quasar IDs are used in hackathon/demo mode.
+- Tests prove legacy Anchor IDs are not silently used.
+- UI surfaces state Quasar deployment status honestly.
+
+**Retrospective:** Decide whether Anchor CI should be removed, renamed, or kept as legacy reference.
+
+### Phase 4 — CI cutover
+
+**Expectation:** PR/main checks reflect the Quasar submission path.
+
+**Implementation target:** Add QuasarSVM/build/readiness CI or rename legacy Anchor CI so it cannot be mistaken for final submission proof.
+
+**Acceptance:**
+
+- Quasar checks run in CI or a documented blocker explains why local-only Quasar checks are temporarily required.
+- Anchor check, if retained, is named legacy/reference.
+- Judge packet proof chain cites Quasar checks/evidence.
+
+**Retrospective:** Decide whether submission is ready or deployment/signing approval is required.
+
+### Phase 5 — Final Quasar judge packet and rehearsal
+
+**Expectation:** The final submission packet and operator rehearsal use Quasar-deployed programs.
+
+**Implementation target:** Refresh judge packet, operator checklist, local rehearsal, and STATUS around Quasar proof.
+
+**Acceptance:**
+
+- Final packet answers the three cutover questions.
+- Rehearsal demonstrates demo flow against Quasar-targeted metadata/evidence.
+- Approval-gated items remain explicit.
+
+## Phase 0 retrospective
+
+_Status:_ Complete locally; ready for PR.
+
+- **What worked:** The audit found a clear mismatch: our latest submission-readiness loop was rigorous, but it validated the current Anchor-based repo state rather than the newly stated Quasar demo goal.
+- **What failed or surprised us:** A stale `feature/wire-quasar-programs` branch exists, but it is too divergent and polluted to merge directly. We need a clean forward-port, not a branch resurrection.
+- **Safety review:** Phase 0 was docs/issue/source inspection only. No signing, deployment, wallet mutation, env mutation, paid calls, or live specialist execution.
+- **Plan adjustment:** Phase 1 must inventory actual Quasar deployment IDs/evidence before runtime wiring. If no valid deployed Quasar IDs exist, the next honest blocker is explicit approval to deploy/sign.

--- a/docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md
+++ b/docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md
@@ -73,7 +73,7 @@ Requires explicit approval before action:
 
 **Expectation:** The repo has one canonical place for Quasar deployment metadata.
 
-**Implementation target:** Add a Quasar deployment inventory/config contract that records program IDs, cluster, source artifact/report, and validation status. It must distinguish Quasar deployment IDs from legacy Anchor IDs.
+**Implementation:** `config/quasar/deployments.json` plus `npm run check:quasar:deployments`.
 
 **Acceptance:**
 
@@ -81,7 +81,13 @@ Requires explicit approval before action:
 - Missing Quasar program IDs fails locally.
 - Anchor program IDs are allowed only under explicit `legacyAnchorReference`, not as demo target IDs.
 
-**Retrospective:** Decide whether known Quasar IDs are sufficient or deployment approval is needed.
+**Validation:**
+
+- `npm run check:quasar:deployments`
+- `npm run test:bdd:index`
+- `git diff --check`
+
+**Retrospective:** Complete locally. Known Quasar candidate ID exists and is executable on devnet by read-only RPC check, but this is not enough for submission readiness because runtime wiring and PER/judge-packet proof chain are still incomplete. No deployment/signing approval has been used.
 
 ### Phase 2 — Demo/readiness guardrail
 

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -144,3 +144,11 @@ Feature: End-user economic workflow demo
     And it cites the public PR and CI proof chain by identifier
     And it separates approval-gated future proof categories from current evidence
     And it does not publish raw ignored artifacts, secrets, provider outputs, private logs, or unsupported production settlement claims
+
+  Scenario: Hackathon demos target Quasar deployed programs
+    Given Nissan has selected Quasar as the hackathon Solana program target
+    When demo or submission readiness is evaluated
+    Then the demo evidence must identify the Quasar program IDs used by the demo
+    And the readiness gate must reject silent fallback to legacy Anchor program IDs
+    And Anchor CI alone must not be presented as final hackathon submission proof
+    And any missing Quasar deployment, signing, wallet, devnet, or environment action must be surfaced as an approval-gated blocker

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "evidence:economic-demo:webpage": "node ./scripts/generate-economic-demo-evidence-pack.mjs",
     "evidence:economic-demo:research-dry-run": "node ./scripts/generate-economic-demo-research-dry-run.mjs",
     "evidence:economic-demo:picture-storyboard": "node ./scripts/generate-economic-demo-picture-storyboard.mjs",
-    "check:economic-demo:submission-prep": "node ./scripts/check-economic-demo-submission-prep.mjs"
+    "check:economic-demo:submission-prep": "node ./scripts/check-economic-demo-submission-prep.mjs",
+    "check:quasar:deployments": "node ./scripts/check-quasar-deployment-inventory.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/check-quasar-deployment-inventory.mjs
+++ b/scripts/check-quasar-deployment-inventory.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const inventoryPath = path.join(repoRoot, "config/quasar/deployments.json");
+const inventory = JSON.parse(fs.readFileSync(inventoryPath, "utf8"));
+
+const fail = (message) => {
+  console.error(`[quasar-inventory] FAIL: ${message}`);
+  process.exitCode = 1;
+};
+
+const isSolanaAddressLike = (value) =>
+  typeof value === "string" && /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value);
+
+if (inventory.target !== "hackathon-demo-quasar-cutover") {
+  fail("target must be hackathon-demo-quasar-cutover");
+}
+
+const legacy = inventory.legacyAnchorReference;
+if (!legacy || !isSolanaAddressLike(legacy.programId)) {
+  fail("legacyAnchorReference.programId must be present for explicit non-demo comparison");
+}
+
+const devnet = inventory.quasarDeployments?.devnet;
+if (!devnet) {
+  fail("quasarDeployments.devnet is required");
+} else {
+  if (devnet.cluster !== "devnet") fail("devnet.cluster must be devnet");
+  if (!isSolanaAddressLike(devnet.programId)) fail("devnet.programId must be a valid-looking Solana address");
+  if (devnet.programId === legacy?.programId) fail("Quasar devnet programId must not equal legacy Anchor programId");
+  if (!Array.isArray(devnet.evidence) || devnet.evidence.length === 0) fail("devnet.evidence must include at least one proof artifact");
+  if (!Array.isArray(devnet.knownGaps)) fail("devnet.knownGaps must be explicit, even when empty");
+}
+
+if (inventory.submissionReady === true && devnet?.knownGaps?.length) {
+  fail("submissionReady cannot be true while knownGaps are present");
+}
+
+if (!process.exitCode) {
+  console.log(`[quasar-inventory] OK: devnet Quasar candidate ${devnet.programId}; submissionReady=${inventory.submissionReady}`);
+}


### PR DESCRIPTION
## Summary\n- reverse the prior Anchor-first submission posture for the new Quasar hackathon goal\n- add Issue #236 cutover plan with BDD phases, guardrails, and Phase 0/1 retrospectives\n- add BDD scenario requiring hackathon demos to target Quasar-deployed programs\n- add Quasar deployment inventory + local check script\n- refresh STATUS toward Phase 2 demo/readiness guardrails\n\n## Validation\n- npm run check:quasar:deployments\n- npm run test:bdd:index\n- git diff --check\n\n## Guardrails\n- docs/config/check/status only\n- read-only devnet account check only; no signing, deployment, wallet mutation, env/Coolify/Vercel mutation, paid calls, or live specialist execution