### PR TITLE
chore: guard Quasar demo readiness

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -7,7 +7,7 @@
 
 1. Phase 7 picture storyboard artifact generator is complete through PR #221. Do not run real OpenAI/Fal image generation without explicit approval, provider choice, and budget cap.
 2. GitHub Actions Node.js 20 deprecation cleanup is complete through PR #223; post-merge `main` Anchor CI has no Node.js 20 deprecation annotation.
-3. Quasar cutover follows Issue #236 and `docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md`: Phase 1 inventory is now scaffolded at `config/quasar/deployments.json` with `npm run check:quasar:deployments`. Candidate devnet Quasar program `VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW` is executable by read-only RPC check, but submissionReady remains false until demo runtime wiring + PER/judge-packet proof chain are cut over. Do not deploy, sign, mutate wallets, mutate env/Coolify/Vercel, or run paid/live specialist work without explicit approval.
+3. Quasar cutover follows Issue #236 and `docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md`: Phase 1 inventory is now scaffolded at `config/quasar/deployments.json` with `npm run check:quasar:deployments`. Candidate devnet Quasar program `VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW` is executable by read-only RPC check. Phase 2 guard is `npm run check:quasar:demo-readiness`; submissionReady remains false until demo runtime wiring + PER/judge-packet proof chain are cut over. Next: Phase 3 runtime/config wiring. Do not deploy, sign, mutate wallets, mutate env/Coolify/Vercel, or run paid/live specialist work without explicit approval.
 
 ## Current Branch / Repo State
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,9 +11,10 @@
 
 ## Current Branch / Repo State
 
-- Local branch: `docs/quasar-hackathon-cutover-plan-20260505` (Phase 0 Quasar cutover plan).
-- Local working tree: clean after PR #234 merge; local ignored evidence artifacts remain under `artifacts/manifest-parity-phase4/`, `artifacts/economic-demo-surfpool-rehearsal/20260505T021309Z/`, `artifacts/surfpool-smoke/20260505-121331/`, `artifacts/economic-demo-research-dry-run/20260505T025224Z/`, `artifacts/economic-demo-picture-storyboard/`, `artifacts/economic-demo-submission-prep/20260505T055411Z/`, and `artifacts/economic-demo-rehearsal/20260505T091725Z/`.
-- Latest merge on main: `3ba5d720 docs: update status after final judge packet (#235)`.
+- Local branch: `chore/quasar-demo-readiness-guard-20260505` (PR #238, Phase 2 Quasar demo-readiness guard).
+- Local working tree: clean; local ignored evidence artifacts remain under `artifacts/manifest-parity-phase4/`, `artifacts/economic-demo-surfpool-rehearsal/20260505T021309Z/`, `artifacts/surfpool-smoke/20260505-121331/`, `artifacts/economic-demo-research-dry-run/20260505T025224Z/`, `artifacts/economic-demo-picture-storyboard/`, `artifacts/economic-demo-submission-prep/20260505T055411Z/`, and `artifacts/economic-demo-rehearsal/20260505T091725Z/`.
+- Latest merge on main: `3b04fd14 docs: plan Quasar hackathon cutover (#237)`.
+- Current PR: #238 `chore: guard Quasar demo readiness` — open, mergeable, all checks green (Anchor, BDD index, source conformance, Vercel).
 - PR #204: closed as superseded after Nissan accepted recommendation.
 - PR #214: merged 2026-05-05 AEST as `a290db7093458f45ca1b3dbc2a047b404c856a29`; post-merge Anchor run `25353582949`, job `74338163008` passed in 7m26s.
 - PR #215: merged 2026-05-05 AEST as `cd202ebd6360d29f0a896e852fe9f63c339fc4dc`; post-merge Anchor run `25353973718`, job `74339305929` passed in 7m23s.

--- a/docs/ECONOMIC-DEMO-JUDGE-PACKET-2026-05-05.md
+++ b/docs/ECONOMIC-DEMO-JUDGE-PACKET-2026-05-05.md
@@ -1,8 +1,9 @@
 # Economic Demo Judge Packet
 
 _Date:_ 2026-05-05 AEST
-_Status:_ Public-safe final packet for BDD submission-readiness Phase 4
+_Status:_ Public-safe Anchor-era packet; superseded for hackathon readiness by Quasar cutover Issue #236 until refreshed
 _Demo route:_ `/economic-demo`
+_Quasar cutover target:_ Quasar-deployed Solana programs; candidate devnet program `VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW` from `config/quasar/deployments.json`
 _Operator checklist:_ `docs/ECONOMIC-DEMO-OPERATOR-CHECKLIST-2026-05-05.md`
 _Local-only rehearsal report:_ `artifacts/economic-demo-rehearsal/20260505T091725Z/REHEARSAL-REPORT.md` (ignored; not part of public packet)
 
@@ -15,6 +16,10 @@ Reddi Agent Protocol demonstrates an agentic workflow economy where a user reque
 - Demo page: `/economic-demo`
 - Local evidence anchor: `/economic-demo#local-evidence-artifacts`
 - Operator checklist: `docs/ECONOMIC-DEMO-OPERATOR-CHECKLIST-2026-05-05.md`
+
+## Quasar cutover status
+
+Nissan has selected Quasar-deployed Solana programs as the hackathon demo target. This packet remains useful as an Anchor-era economic-demo evidence packet, but it is **not final hackathon submission proof** until the Quasar proof chain is refreshed. The candidate Quasar devnet program is `VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW`; the legacy Anchor reference is recorded only for comparison in `config/quasar/deployments.json`. Current approval-gated blocker set: no signing, deployment, wallet mutation, devnet transfer, Coolify/env mutation, or paid/live provider calls without Nissan approval. Runtime wiring, PER/privacy-aware settlement proof, and final judge-packet proof chain remain known gaps.
 
 ## What is proven by the current packet
 
@@ -56,6 +61,8 @@ Reddi Agent Protocol demonstrates an agentic workflow economy where a user reque
 
 ## Public proof chain
 
+The historical rows below prove the Anchor-era/local economic-demo readiness loop. They must not be presented as Quasar final submission proof; Anchor CI alone is insufficient for the new hackathon target.
+
 | PR | Purpose | Merge commit | CI/evidence |
 | --- | --- | --- | --- |
 | #225 | Compact `/economic-demo` local evidence UI links | `f36d4bb55b7f10bbc5177b3fda189c67f17d7cd3` | PR checks passed; post-merge Anchor run `25359075289` passed |
@@ -75,6 +82,9 @@ git diff --check
 ```
 
 ## Recommended submission wording
+
+**Do not use this wording as final hackathon copy until Quasar runtime wiring and proof chain are refreshed.**
+
 
 > Reddi Agent Protocol demonstrates an agentic workflow marketplace where agents can disclose their dependencies before purchase and report downstream calls after execution using `reddi.downstream-disclosure-ledger.v1`. The current demo is deliberately evidence-bounded: it shows controlled/local economic workflow proof, public manifest disclosure, local evidence pointers, and storyboard-only image planning without hidden live calls, provider spend, signing, wallet mutation, or production settlement claims.
 

--- a/docs/ECONOMIC-DEMO-OPERATOR-CHECKLIST-2026-05-05.md
+++ b/docs/ECONOMIC-DEMO-OPERATOR-CHECKLIST-2026-05-05.md
@@ -11,6 +11,11 @@ Use this checklist to record or narrate the economic demo without relying on cha
 
 This checklist is public-safe repo documentation. It references local ignored evidence paths only as operator pointers; it does not publish raw artifact contents or private logs.
 
+
+## Quasar cutover operator note
+
+Hackathon demos now target Quasar-deployed Solana programs, not the legacy Anchor deployment. Candidate devnet Quasar program: `VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW` (`config/quasar/deployments.json`). Treat any missing Quasar runtime wiring, PER/privacy-aware settlement proof, judge-packet refresh, signing, deployment, wallet mutation, devnet transfer, Coolify/env mutation, or paid/live provider call as an approval-gated blocker. Anchor CI can be cited only as historical/legacy implementation evidence, never as final Quasar submission proof.
+
 ## Before recording
 
 1. Confirm the repo is on the intended branch or `main`.

--- a/docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md
+++ b/docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md
@@ -93,14 +93,22 @@ Requires explicit approval before action:
 
 **Expectation:** Demo submission checks fail if hackathon demo surfaces target Anchor-only evidence.
 
-**Implementation target:** Extend local submission/demo readiness scripts to require Quasar deployment inventory and Quasar target mode for `/economic-demo`, demo agent scripts, and judge packet references.
+**Implementation:** `npm run check:quasar:demo-readiness` plus Quasar cutover notes in the judge packet and operator checklist.
 
 **Acceptance:**
 
-- `npm run check:economic-demo:submission-prep` or a new Quasar-specific script fails without Quasar metadata.
+- `npm run check:quasar:demo-readiness` fails without Quasar metadata.
 - Judge packet/readiness docs reference Quasar deployment evidence, not Anchor-only CI.
+- `submissionReady=false` is allowed only when known gaps and approval-gated blockers are explicit.
 
-**Retrospective:** Confirm whether UI copy needs immediate changes before wiring runtime.
+**Validation:**
+
+- `npm run check:quasar:deployments`
+- `npm run check:quasar:demo-readiness`
+- `npm run test:bdd:index`
+- `git diff --check`
+
+**Retrospective:** Complete locally. The guard now prevents us from accidentally treating the Anchor-era judge packet as final Quasar proof. UI/runtime copy needs Phase 3 wiring next because `lib/program.ts` still assumes Anchor-compatible instruction/account layouts.
 
 ### Phase 3 — Runtime/demo wiring
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "evidence:economic-demo:research-dry-run": "node ./scripts/generate-economic-demo-research-dry-run.mjs",
     "evidence:economic-demo:picture-storyboard": "node ./scripts/generate-economic-demo-picture-storyboard.mjs",
     "check:economic-demo:submission-prep": "node ./scripts/check-economic-demo-submission-prep.mjs",
-    "check:quasar:deployments": "node ./scripts/check-quasar-deployment-inventory.mjs"
+    "check:quasar:deployments": "node ./scripts/check-quasar-deployment-inventory.mjs",
+    "check:quasar:demo-readiness": "node ./scripts/check-quasar-demo-readiness.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/check-quasar-demo-readiness.mjs
+++ b/scripts/check-quasar-demo-readiness.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const inventoryPath = path.join(repoRoot, "config/quasar/deployments.json");
+const docsToCheck = [
+  "docs/ECONOMIC-DEMO-JUDGE-PACKET-2026-05-05.md",
+  "docs/ECONOMIC-DEMO-OPERATOR-CHECKLIST-2026-05-05.md",
+  "docs/QUASAR-HACKATHON-CUTOVER-PLAN-2026-05-05.md",
+];
+
+const fail = (message, detail) => {
+  console.error(`[quasar-demo-readiness] FAIL: ${message}`);
+  if (detail) console.error(detail);
+  process.exit(1);
+};
+
+const inventory = JSON.parse(fs.readFileSync(inventoryPath, "utf8"));
+const quasar = inventory.quasarDeployments?.devnet;
+const legacy = inventory.legacyAnchorReference;
+
+if (!quasar?.programId) fail("missing devnet Quasar programId in config/quasar/deployments.json");
+if (!legacy?.programId) fail("missing legacy Anchor reference programId in config/quasar/deployments.json");
+if (quasar.programId === legacy.programId) fail("Quasar programId must not equal legacy Anchor programId");
+if (!Array.isArray(quasar.evidence) || quasar.evidence.length === 0) fail("Quasar deployment inventory must include evidence");
+
+const missingDocs = docsToCheck.filter((file) => !fs.existsSync(path.join(repoRoot, file)));
+if (missingDocs.length) fail("required Quasar/demo docs are missing", missingDocs.map((f) => `- ${f}`).join("\n"));
+
+const combined = docsToCheck.map((file) => fs.readFileSync(path.join(repoRoot, file), "utf8")).join("\n---DOC---\n");
+const requiredPhrases = [
+  "Quasar-deployed Solana programs",
+  quasar.programId,
+  "legacy Anchor",
+  "approval-gated blocker",
+];
+const missingPhrases = requiredPhrases.filter((phrase) => !combined.includes(phrase));
+if (missingPhrases.length) fail("docs do not surface required Quasar cutover language", missingPhrases.map((p) => `- ${p}`).join("\n"));
+
+const disallowedFinalProofPatterns = [
+  /Anchor CI alone (?:is|as) (?:sufficient|final)/i,
+  /Anchor run `?\d+`?.{0,80}(?:final|submission proof)/i,
+];
+for (const pattern of disallowedFinalProofPatterns) {
+  if (pattern.test(combined)) fail("docs appear to present Anchor CI as final submission proof", String(pattern));
+}
+
+const knownGaps = quasar.knownGaps ?? [];
+if (inventory.submissionReady === true && knownGaps.length > 0) {
+  fail("inventory cannot be submissionReady=true while knownGaps remain", knownGaps.map((g) => `- ${g}`).join("\n"));
+}
+
+if (inventory.submissionReady !== true) {
+  const reason = inventory.submissionReadyReason || "missing submissionReadyReason";
+  if (!reason || reason === "missing submissionReadyReason") fail("submissionReady=false must include submissionReadyReason");
+  if (!knownGaps.length) fail("submissionReady=false must include explicit knownGaps on the Quasar deployment");
+  console.log(`[quasar-demo-readiness] BLOCKED: ${reason}`);
+  console.log(`[quasar-demo-readiness] known gaps: ${knownGaps.length}`);
+}
+
+console.log(`[quasar-demo-readiness] OK: Quasar devnet target ${quasar.programId}; legacy Anchor reference ${legacy.programId}`);


### PR DESCRIPTION
## Summary\n- add a Quasar demo-readiness guard for Issue #236 Phase 2\n- mark the current economic-demo judge packet/checklist as Anchor-era evidence, not final Quasar submission proof\n- require Quasar program ID/evidence, known gaps, and approval-gated blockers to be explicit\n- update STATUS and cutover plan toward Phase 3 runtime/config wiring\n\n## Validation\n- npm run check:quasar:deployments\n- npm run check:quasar:demo-readiness\n- npm run test:bdd:index\n- git diff --check\n\n## Guardrails\nNo signing, deployment, wallet mutation, devnet transfer, Coolify/Vercel/env mutation, paid calls, or live provider/specialist execution.