### PR TITLE
feat: add hackathon ecosystem proof map

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -537,3 +537,11 @@ RESUME FROM HERE: commit/push the PR evidence polish, then monitor PR #244 check
 - **Actions:** Patched `scripts/generate-economic-demo-submission-prep.mjs` to always `rmSync(latestLink, { recursive: true, force: true })` before creating the latest symlink. Regenerated the prep artifact; `latest` now points to `20260506T211913Z` and resolves correctly.
 - **Validation:** `node --check scripts/generate-economic-demo-submission-prep.mjs` PASS; `npm run generate:economic-demo:submission-prep` PASS; `test -f artifacts/economic-demo-submission-prep/latest/SUBMISSION-PREP.md` PASS; `git diff --check` PASS; `npm run test:bdd:index` PASS.
 - **Review/retrospective:** The final packet was right to use a latest pointer, but the pointer itself was fragile. Plan adjustment: open a tiny PR for the symlink fix, then re-run the final packet pointer check from main after merge.
+
+## Autonomous Loop 13 — bounty showcase coverage pass
+- **Time:** 2026-05-07 AEST
+- **Loop:** Review all hackathon bounty/ecosystem projects for deployed demo/website showcase coverage.
+- **Finding:** Quasar/x402/OpenRouter/Surfpool/Jupiter-boundary evidence were visible enough; Torque existed but was under-showcased; ElizaOS/SendAI existed as adapter packages but lacked a recording beat; MagicBlock is intentionally honest-boundary only unless a separate live PER/TEE validation is approved.
+- **Actions:** Added homepage “Hackathon ecosystem proof map” cards for Quasar, x402, OpenRouter, Jupiter, Surfpool, Torque, MagicBlock, and ElizaOS/SendAI; added `docs/HACKATHON-BOUNTY-SHOWCASE-AUDIT-2026-05-07.md`; updated final proof map and recording runbook to include Torque and ElizaOS/SendAI as supporting beats without overclaiming MagicBlock/Jupiter.
+- **Validation:** `npm run test:bdd:index` PASS; `npx eslint app/page.tsx` PASS; `git diff --check` PASS; `NEXT_PUBLIC_DEMO_PROGRAM_TARGET=quasar npm run build` PASS with existing workspace-root/NFT trace warnings only.
+- **Review/retrospective:** The deployed website needed a judge-visible sponsor map, not just buried docs/tests. Plan adjustment: keep MagicBlock safe unless Nissan approves live PER/TEE validation; otherwise the new map maximizes showcase coverage without false claims.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,57 @@ import type { SpecialistListing } from "@/lib/registry/bridge"
 
 const FALLBACK = { agents: 42, transactions: 128, volume: 18.4 }
 
+const ECOSYSTEM_PROOFS = [
+  {
+    name: "Quasar",
+    status: "Live devnet proof",
+    desc: "Final on-chain path uses Quasar-compiled Registry, Escrow, Reputation, and Attestation programs.",
+    href: "/economic-demo",
+  },
+  {
+    name: "x402",
+    status: "Visible payment boundary",
+    desc: "Planner, onboarding, tester guides, and economic demo show 402 challenges, receipts, and fail-closed paid calls.",
+    href: "/planner",
+  },
+  {
+    name: "OpenRouter specialists",
+    status: "Marketplace surface",
+    desc: "30 specialist profiles power the human-triggered workflow story without hidden paid calls on page load.",
+    href: "/agents",
+  },
+  {
+    name: "Jupiter",
+    status: "Boundary proof",
+    desc: "SOL→USDC quote/build/sign is evidenced; public devnet execution is not claimed. Surfpool provides the successful no-real-funds visual.",
+    href: "/economic-demo",
+  },
+  {
+    name: "Surfpool",
+    status: "Local rehearsal",
+    desc: "Local validator rehearsal proves payment ordering, budget reconciliation, and Quasar confidence before devnet.",
+    href: "/economic-demo",
+  },
+  {
+    name: "Torque",
+    status: "Retention layer",
+    desc: "Leaderboard and custom-event plumbing show how completed jobs can become retention and reward signals.",
+    href: "/leaderboard",
+  },
+  {
+    name: "MagicBlock",
+    status: "Honest boundary",
+    desc: "PER/TEE is presented as approval-gated supporting evidence; the final Quasar path does not claim live PER execution.",
+    href: "/economic-demo",
+  },
+  {
+    name: "ElizaOS + SendAI",
+    status: "Adapter evidence",
+    desc: "Framework packages expose x402 agent-commerce adapters for distribution beyond the web demo.",
+    href: "/testers",
+  },
+]
+
 type HeartbeatData = {
   ok: boolean
   total?: number
@@ -151,6 +202,37 @@ export default function Home() {
           ]}
         />
       </div>
+
+      <section className="mx-auto max-w-6xl px-4 pt-10 sm:px-6 lg:px-8">
+        <div className="rounded-xl border border-indigo-300/20 bg-card/30 p-6 glow-border">
+          <div className="mb-5 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="section-label">Hackathon ecosystem proof map</p>
+              <h2 className="font-display text-2xl font-bold text-white">Every sponsor surface, honestly labelled</h2>
+            </div>
+            <Link href="/economic-demo" className="text-sm text-indigo-300 hover:text-indigo-200">
+              Open final demo →
+            </Link>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+            {ECOSYSTEM_PROOFS.map((proof) => (
+              <Link
+                key={proof.name}
+                href={proof.href}
+                className="rounded-lg border border-white/10 bg-white/[0.03] p-4 transition hover:border-indigo-300/40 hover:bg-white/[0.06]"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <h3 className="text-sm font-semibold text-white">{proof.name}</h3>
+                  <span className="rounded-full border border-white/10 bg-black/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-gray-300">
+                    {proof.status}
+                  </span>
+                </div>
+                <p className="mt-3 text-xs leading-5 text-gray-400">{proof.desc}</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
 
       <section className="mx-auto max-w-6xl px-4 pt-10 sm:px-6 lg:px-8">
         <div className="rounded-xl border border-emerald-300/20 bg-emerald-400/10 p-6 glow-border">

--- a/docs/COLOSSEUM-FINAL-QUASAR-PROOF-MAP-2026-05-06.md
+++ b/docs/COLOSSEUM-FINAL-QUASAR-PROOF-MAP-2026-05-06.md
@@ -17,7 +17,9 @@ Legacy Anchor artifacts and devnet registrations may remain as historical/refere
 | OpenRouter / 30 specialists | Marketplace of specialist agents for human-triggered workflows | `/economic-demo` uses deployed 30-agent profile metadata and specific use-case triggers | No hidden downstream paid calls on page load |
 | Jupiter | Cross-token settlement/boundary lane | Jupiter quote + wallet-specific transaction + devnet signature attempt are evidenced; local Surfpool/mock-Jupiter invoke lane passed at `artifacts/surfpool-jupiter-invoke/20260507-023023/SUMMARY.md`; research note `docs/JUPITER-DEVNET-SWAP-RESEARCH-2026-05-07.md` shows public Jupiter APIs route against mainnet liquidity/account material | Do not claim successful Jupiter devnet execution. Claim only: local successful swap-shaped invoke proof, plus devnet quote/build/sign boundary, unless explicit approved tiny mainnet-beta swap is run |
 | MagicBlock | Ecosystem product boundary | Demo explicitly fail-closes/not-claims PER/TEE for final Quasar path unless separately validated | No PER/TEE claim in final Quasar demo today |
-| Web app | Human-triggered demo surface | `NEXT_PUBLIC_DEMO_PROGRAM_TARGET=quasar npm run build` PASS; `/economic-demo` separates Quasar proof from supporting economic evidence | Inspect before recording for visual Anchor ambiguity |
+| Torque | Retention/leaderboard support layer | `/leaderboard`, `/api/torque/event`, `lib/torque/*`, and Bucket G tests show event/leaderboard plumbing | Supporting layer; not core Quasar on-chain proof |
+| ElizaOS / SendAI | Framework adapter distribution | `packages/eliza-plugin-x402`, `packages/sendai-x402`, and planner tool manifest show x402 adapter surfaces | Adapter evidence; not final on-chain proof |
+| Web app | Human-triggered demo surface | `NEXT_PUBLIC_DEMO_PROGRAM_TARGET=quasar npm run build` PASS; homepage ecosystem proof map + `/economic-demo` separate Quasar proof from supporting economic evidence | Inspect before recording for visual Anchor ambiguity |
 
 ## Latest devnet evidence
 

--- a/docs/FINAL-RECORDING-REHEARSAL-RUNBOOK-2026-05-06.md
+++ b/docs/FINAL-RECORDING-REHEARSAL-RUNBOOK-2026-05-06.md
@@ -54,15 +54,17 @@ npm run test:surfpool:quasar-critical
 1. Open `/economic-demo` with `NEXT_PUBLIC_DEMO_PROGRAM_TARGET=quasar`.
 2. Show the Solana program target card: “Quasar hackathon target active”.
 3. Show the four Quasar program IDs and `submission readiness: ready`.
-4. Trigger the human-action economic demo panels:
+4. Show the homepage ecosystem proof map briefly: Quasar, x402, OpenRouter, Jupiter, Surfpool, Torque, MagicBlock, and ElizaOS/SendAI are all visible with status labels.
+5. Trigger the human-action economic demo panels:
    - dry-run workflow plan
    - balance snapshot
    - Surfpool rehearsal plan/evidence
    - x402 readiness / disclosure evidence
    - 30-agent OpenRouter metadata/use-case triggers
-5. Switch to terminal proof and run/show the Quasar A→B→C devnet demo output.
-6. Highlight latest proof map: `docs/COLOSSEUM-FINAL-QUASAR-PROOF-MAP-2026-05-06.md`.
-7. Close with honest boundaries:
+6. Optional supporting beat: open `/leaderboard` for Torque retention/leaderboard evidence and `/testers` for ElizaOS/SendAI-style x402 adapter distribution evidence.
+7. Switch to terminal proof and run/show the Quasar A→B→C devnet demo output.
+8. Highlight latest proof map: `docs/COLOSSEUM-FINAL-QUASAR-PROOF-MAP-2026-05-06.md` and `docs/HACKATHON-BOUNTY-SHOWCASE-AUDIT-2026-05-07.md`.
+9. Close with honest boundaries:
    - Quasar-native devnet proof is live.
    - Surfpool localnet confidence passed.
    - x402/OpenRouter/Jupiter evidence is visible with exact boundaries.

--- a/docs/HACKATHON-BOUNTY-SHOWCASE-AUDIT-2026-05-07.md
+++ b/docs/HACKATHON-BOUNTY-SHOWCASE-AUDIT-2026-05-07.md
@@ -1,0 +1,27 @@
+# Hackathon Bounty Showcase Audit — 2026-05-07
+
+## Verdict
+
+Most bounty/ecosystem surfaces are incorporated into the website/demo enough to showcase, but they are not all equally strong. Quasar, x402, OpenRouter, Surfpool, and Jupiter-boundary evidence are strong. Torque exists but needed a clearer website/showcase beat. MagicBlock is intentionally honest-boundary only unless live PER/TEE validation is separately approved. ElizaOS/SendAI exist as framework adapter evidence, not core on-chain proof.
+
+## Showcase matrix
+
+| Surface | Website/demo presence | Qualification posture | Recording framing |
+| --- | --- | --- | --- |
+| Quasar | `/economic-demo`, `/register`, `/onboarding`, demo-agent script, CI/readiness docs | Strongest: live devnet final path across Registry/Escrow/Reputation/Attestation | “Final demo-critical on-chain path is Quasar-native.” |
+| x402 | `/economic-demo`, `/planner`, `/onboarding`, `/testers`, `packages/x402-solana` | Strong: visible fail-closed payment challenge/receipt story | “Agent calls are payment-gated with x402-style challenge/receipt boundaries.” |
+| OpenRouter specialists | `/economic-demo`, `/agents`, `packages/openrouter-specialists` | Strong: marketplace/profile layer visible without hidden paid calls | “30 specialist profiles support human-triggered workflow routing.” |
+| Jupiter | `/economic-demo`, run-report/submission-prep artifacts, Surfpool/mock-Jupiter invoke lane | Medium/strong if framed honestly: quote/build/sign + local no-real-funds invoke proof | “Public Jupiter devnet execution is not claimed; successful live Jupiter would require approved mainnet.” |
+| Surfpool | `/economic-demo`, local rehearsal scripts/artifacts | Strong supporting proof | “Local validator confidence gate before devnet; caught bugs before live proof.” |
+| Torque | `/leaderboard`, `/api/torque/event`, `lib/torque/*`, Bucket G tests | Medium: implemented, now made more visible via homepage ecosystem map | “Retention/leaderboard and custom event plumbing for completed agent jobs.” |
+| MagicBlock | `packages/per-client`, docs/proof boundaries, demo-agent fail-closed behavior | Weak for prize unless live PER/TEE validation is approved/run | “PER/TEE is not claimed in final Quasar path; approval-gated supporting lane.” |
+| ElizaOS | `packages/eliza-plugin-x402`, planner tool manifest | Medium/weak: adapter evidence, not central demo path | “Framework adapter for x402-protected agent commerce.” |
+| SendAI | `packages/sendai-x402` | Medium/weak: adapter evidence, not central demo path | “Framework adapter for distribution beyond the web app.” |
+
+## Action taken in Loop 13
+
+Added a homepage “Hackathon ecosystem proof map” so the deployed website can route judges to each sponsor/evidence surface without overclaiming. The panel includes Quasar, x402, OpenRouter, Jupiter, Surfpool, Torque, MagicBlock, and ElizaOS/SendAI with status labels and links.
+
+## Remaining decision
+
+If MagicBlock has a must-win bounty, decide whether to approve a separate live PER/TEE validation lane. Without that, keep MagicBlock as an honest supporting/boundary surface, not a final claim.


### PR DESCRIPTION
## Summary\n- Add homepage Hackathon ecosystem proof map covering Quasar, x402, OpenRouter, Jupiter, Surfpool, Torque, MagicBlock, and ElizaOS/SendAI\n- Add docs/HACKATHON-BOUNTY-SHOWCASE-AUDIT-2026-05-07.md with sponsor/bounty showcase matrix\n- Update final proof map and recording runbook to include Torque + framework-adapter beats without overclaiming MagicBlock/Jupiter\n\n## Validation\n- `npm run test:bdd:index` PASS\n- `npx eslint app/page.tsx` PASS\n- `git diff --check` PASS\n- `NEXT_PUBLIC_DEMO_PROGRAM_TARGET=quasar npm run build` PASS with existing workspace-root/NFT trace warnings only\n\n## Retrospective\nThe website already had most integrations, but Torque and framework adapters were too buried for judges. This makes every bounty surface visible while keeping MagicBlock as an honest approval-gated boundary unless live PER/TEE validation is explicitly run.