### PR TITLE
fix: harden devnet MCP payment guards

### DIFF
--- a/packages/rap-mcp-bridge/scripts/smoke-devnet-mcp.mjs
+++ b/packages/rap-mcp-bridge/scripts/smoke-devnet-mcp.mjs
@@ -21,7 +21,7 @@ const transport = new StdioClientTransport({
     ...process.env,
     REDDI_RAP_MCP_MODE: 'devnet',
     REDDI_MCP_STORE_DIR: storeDir,
-    RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS: process.env.RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS ?? '100050',
+    RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS: process.env.RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS ?? '3300000',
   },
   stderr: 'pipe',
 });
@@ -59,7 +59,7 @@ try {
 
   const prepareResult = await client.callTool({
     name: 'reddi.prepare_devnet_payment',
-    arguments: { quoteId: quote.quoteId, maxTotalDebitLamports: 100050 },
+    arguments: { quoteId: quote.quoteId, maxTotalDebitLamports: 3300000 },
   });
   const readiness = parseToolJson(prepareResult, 'prepare_devnet_payment');
   if (!readiness.spendCapRespected) throw new Error('readiness cap not respected');
@@ -69,7 +69,7 @@ try {
     arguments: {
       quoteId: quote.quoteId,
       idempotencyKey: `devnet-mcp-exec-${quote.quoteId}`,
-      maxTotalDebitLamports: 100050,
+      maxTotalDebitLamports: 3300000,
       approvalPhrase: 'EXECUTE_DEVNET_RAP_PAYMENT',
     },
   });

--- a/packages/rap-mcp-bridge/src/config.ts
+++ b/packages/rap-mcp-bridge/src/config.ts
@@ -6,7 +6,7 @@ export type BridgeConfig = {
   storeDir: string;
   devnetProofApproved: boolean;
   devnetFunderKeypairPath?: string;
-  devnetRpcUrl?: string;
+  devnetRpcUrl: string;
   devnetMaxTotalDebitLamports?: number;
 };
 
@@ -37,6 +37,37 @@ export function assertLocalRapBaseUrl(rawUrl: string): string {
   return parsed.toString().replace(/\/$/, "");
 }
 
+
+export function assertDevnetRpcUrl(rawUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error("invalid_devnet_rpc_url");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("unsupported_devnet_rpc_url_protocol");
+  }
+  if (parsed.hostname.includes("mainnet")) {
+    throw new Error("mainnet_rpc_url_forbidden");
+  }
+  if (parsed.hostname !== "api.devnet.solana.com" && parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1" && parsed.hostname !== "::1") {
+    throw new Error(`unsupported_devnet_rpc_url_host:${parsed.hostname}`);
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function parsePositiveSafeInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error("invalid_positive_integer_env");
+  }
+  return parsed;
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): BridgeConfig {
   const policyMode = env.REDDI_RAP_MCP_MODE ?? env.REDDI_MCP_POLICY_MODE ?? "dry_run";
   if (policyMode !== "dry_run" && policyMode !== "devnet") {
@@ -53,7 +84,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): BridgeConfig {
     storeDir: env.REDDI_MCP_STORE_DIR ?? `${home}/.reddi/rap-mcp-bridge`,
     devnetProofApproved: env.RAP_MCP_DEVNET_PROOF_APPROVED === "1",
     devnetFunderKeypairPath: sanitizeSmallText(env.RAP_MCP_DEVNET_FUNDER_KEYPAIR, 512),
-    devnetRpcUrl: env.RAP_MCP_DEVNET_RPC_URL,
-    devnetMaxTotalDebitLamports: env.RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS ? Number(env.RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS) : undefined,
+    devnetRpcUrl: assertDevnetRpcUrl(env.RAP_MCP_DEVNET_RPC_URL ?? "https://api.devnet.solana.com"),
+    devnetMaxTotalDebitLamports: parsePositiveSafeInteger(env.RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS, 3_200_000),
   };
 }

--- a/packages/rap-mcp-bridge/src/policy.ts
+++ b/packages/rap-mcp-bridge/src/policy.ts
@@ -7,7 +7,8 @@ export type BridgePolicyState = {
   toolNames: readonly string[];
 };
 
-export function currentPolicy(mode: "dry_run" | "devnet" = "dry_run"): BridgePolicyState {
+export function currentPolicy(mode: "dry_run" | "devnet" = "dry_run", gatesReady = mode === "dry_run"): BridgePolicyState {
+  const effectiveMode = mode === "devnet" && gatesReady ? "devnet" : "dry_run";
   const dryRunTools = [
     "reddi.discover_specialists",
     "reddi.request_quote",
@@ -15,12 +16,12 @@ export function currentPolicy(mode: "dry_run" | "devnet" = "dry_run"): BridgePol
     "reddi.export_disclosure_ledger",
   ] as const;
   return {
-    mode,
-    allowPayment: mode === "devnet",
+    mode: effectiveMode,
+    allowPayment: effectiveMode === "devnet",
     allowInvoke: false,
     allowPrivatePayloads: false,
     allowMainnet: false,
-    toolNames: mode === "devnet" ? [
+    toolNames: effectiveMode === "devnet" ? [
       ...dryRunTools,
       "reddi.prepare_devnet_payment",
       "reddi.execute_devnet_payment",

--- a/packages/rap-mcp-bridge/src/server.ts
+++ b/packages/rap-mcp-bridge/src/server.ts
@@ -26,7 +26,8 @@ function jsonContent(value: unknown) {
 
 export function createServer(env: NodeJS.ProcessEnv = process.env) {
   const config = loadConfig(env);
-  const policy = currentPolicy(config.policyMode);
+  const devnetToolsEnabled = config.policyMode === "devnet" && config.devnetProofApproved && Boolean(config.devnetFunderKeypairPath);
+  const policy = currentPolicy(config.policyMode, devnetToolsEnabled);
   const client = new RapClient(config);
   const store = new BridgeStore(config.storeDir);
   const server = new McpServer({ name: "reddi-rap-mcp-bridge", version: "0.1.0" });
@@ -51,7 +52,7 @@ export function createServer(env: NodeJS.ProcessEnv = process.env) {
     inputSchema: exportDisclosureLedgerInputSchema,
   }, async (args) => jsonContent(exportDisclosureLedger(args, store)));
 
-  if (config.policyMode === "devnet") {
+  if (devnetToolsEnabled) {
     server.registerTool("reddi.prepare_devnet_payment", {
       description: "Prepare a bounded Solana devnet payment for a bridge quote. Non-mutating readiness check; no mainnet and no specialist invocation.",
       inputSchema: prepareDevnetPaymentInputSchema,
@@ -70,7 +71,7 @@ export function createServer(env: NodeJS.ProcessEnv = process.env) {
 
   server.registerResource("reddi-policy-current", "reddi://policy/current", {
     title: "Current RAP MCP Bridge policy",
-    description: "Dry-run policy state for the RAP MCP Bridge.",
+    description: "Current policy state for the RAP MCP Bridge.",
     mimeType: "application/json",
   }, async (uri) => ({
     contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify({ config: { rapBaseUrl: config.rapBaseUrl, hostFramework: config.hostFramework, agentName: config.agentName, policyMode: config.policyMode, devnetProofApproved: config.devnetProofApproved, devnetFunderConfigured: Boolean(config.devnetFunderKeypairPath) }, policy }, null, 2) }],

--- a/packages/rap-mcp-bridge/src/store.ts
+++ b/packages/rap-mcp-bridge/src/store.ts
@@ -6,17 +6,18 @@ type StoreData = {
   quotes: ReddiQuote[];
   idempotency: Record<string, { quoteId: string; requestHash: string }>;
   devnetReceipts: DevnetReceipt[];
-  devnetIdempotency: Record<string, { quoteId: string; requestHash: string }>;
+  devnetIdempotency: Record<string, { receiptId: string; quoteId: string; requestHash: string }>;
 };
 
 export type DevnetReceipt = {
   schemaVersion: "reddi.rap-mcp-bridge.devnet-payment-receipt.v1";
+  receiptId: string;
   quoteId: string;
   createdAt: string;
   boundary: "solana-devnet-only-no-mainnet-no-specialist-http-invocation";
   quoteTermsHash: string;
   spendCapLamports: number;
-  amounts: { downstreamAmountLamports: number; protocolFeeBps: 5; protocolFeeLamports: number; totalDebitLamports: number };
+  amounts: { downstreamAmountLamports: number; protocolFeeBps: 5; protocolFeeLamports: number; totalDebitLamports: number; payerTopUpLamports: number; specialistTopUpLamports: number; treasuryTopUpLamports: number; totalFunderAndPaymentSpendLamports: number };
   funding: Record<string, unknown>;
   wallets: { payer: string; specialist: string; protocolTreasury: string; funder: string };
   balances: Record<string, unknown>;
@@ -79,14 +80,17 @@ export class BridgeStore {
     const data = this.read();
     const prior = data.devnetIdempotency[idempotencyKey];
     if (!prior) return undefined;
-    const receipt = data.devnetReceipts.find((candidate) => candidate.quoteId === prior.quoteId);
+    const receipt = data.devnetReceipts.find((candidate) => candidate.receiptId === prior.receiptId);
     return receipt ? { requestHash: prior.requestHash, receipt } : undefined;
   }
 
   upsertDevnetReceipt(idempotencyKey: string, requestHash: string, receipt: DevnetReceipt): DevnetReceipt {
     const data = this.read();
+    if (data.devnetReceipts.some((candidate) => candidate.quoteId === receipt.quoteId)) {
+      throw new Error("quote_already_paid");
+    }
     data.devnetReceipts.push(receipt);
-    data.devnetIdempotency[idempotencyKey] = { quoteId: receipt.quoteId, requestHash };
+    data.devnetIdempotency[idempotencyKey] = { receiptId: receipt.receiptId, quoteId: receipt.quoteId, requestHash };
     this.write(data);
     return receipt;
   }

--- a/packages/rap-mcp-bridge/src/tools/devnet-payment.ts
+++ b/packages/rap-mcp-bridge/src/tools/devnet-payment.ts
@@ -16,7 +16,7 @@ import type { ReddiQuote } from "../schemas.js";
 import type { BridgeStore, DevnetReceipt } from "../store.js";
 
 const DEFAULT_DEVNET_RPC_URL = clusterApiUrl("devnet");
-const DEFAULT_MAX_TOTAL_DEBIT_LAMPORTS = 100_050;
+const DEFAULT_MAX_TOTAL_DEBIT_LAMPORTS = 3_300_000;
 const APPROVAL_PHRASE = "EXECUTE_DEVNET_RAP_PAYMENT";
 
 function keypairFor(profileId: string): Keypair {
@@ -59,8 +59,11 @@ function assertDevnetConfigured(config: BridgeConfig) {
 }
 
 function assertDevnetQuote(quote: ReddiQuote) {
-  if (quote.terms.network !== "solana-devnet" && quote.terms.network !== "local-surfpool") {
+  if (quote.terms.network !== "solana-devnet") {
     throw new Error("quote_not_devnet_eligible");
+  }
+  if (quote.terms.currency !== "SOL") {
+    throw new Error("quote_currency_must_be_SOL_for_devnet_lamport_payment");
   }
   if (quote.binding !== false || quote.quoteAuthority !== "bridge_synthetic") {
     throw new Error("unsupported_quote_authority");
@@ -91,19 +94,28 @@ export async function prepareDevnetPayment(args: { quoteId: string; maxTotalDebi
   assertDevnetQuote(quote);
   const funder = loadKeypair(config.devnetFunderKeypairPath);
   if (!funder) throw new Error("devnet_funder_keypair_unavailable");
-  const connection = new Connection(config.devnetRpcUrl ?? DEFAULT_DEVNET_RPC_URL, "confirmed");
+  const connection = new Connection(config.devnetRpcUrl || DEFAULT_DEVNET_RPC_URL, "confirmed");
   const { payer, specialist, treasury } = quoteDevnetProfile(quote);
   const downstreamAmountLamports = decimalAmountToLamports(quote.terms.amount);
   const protocolFeeLamports = feeLamportsFor(downstreamAmountLamports);
   const totalDebitLamports = downstreamAmountLamports + protocolFeeLamports;
-  const cap = args.maxTotalDebitLamports ?? config.devnetMaxTotalDebitLamports ?? DEFAULT_MAX_TOTAL_DEBIT_LAMPORTS;
+  const cap = Math.min(args.maxTotalDebitLamports ?? config.devnetMaxTotalDebitLamports ?? DEFAULT_MAX_TOTAL_DEBIT_LAMPORTS, config.devnetMaxTotalDebitLamports ?? DEFAULT_MAX_TOTAL_DEBIT_LAMPORTS);
+  const rentSafetyLamports = 1_000_000;
+  const payerLamports = await connection.getBalance(payer.publicKey);
+  const specialistLamports = await connection.getBalance(specialist.publicKey);
+  const protocolTreasuryLamports = await connection.getBalance(treasury.publicKey);
+  const funderLamports = await connection.getBalance(funder.publicKey);
+  const payerTopUpLamports = Math.max(0, rentSafetyLamports + totalDebitLamports + 20_000 - payerLamports);
+  const specialistTopUpLamports = Math.max(0, rentSafetyLamports - specialistLamports);
+  const treasuryTopUpLamports = Math.max(0, rentSafetyLamports - protocolTreasuryLamports);
+  const totalFunderAndPaymentSpendLamports = totalDebitLamports + payerTopUpLamports + specialistTopUpLamports + treasuryTopUpLamports;
   return {
     schemaVersion: "reddi.rap-mcp-bridge.devnet-payment-readiness.v1",
     quoteId: quote.quoteId,
     boundary: "solana-devnet-only-no-mainnet-no-specialist-http-invocation",
-    rpcUrl: config.devnetRpcUrl ?? DEFAULT_DEVNET_RPC_URL,
+    rpcUrl: config.devnetRpcUrl || DEFAULT_DEVNET_RPC_URL,
     capLamports: cap,
-    spendCapRespected: totalDebitLamports <= cap,
+    spendCapRespected: totalFunderAndPaymentSpendLamports <= cap,
     funderWallet: funder.publicKey.toBase58(),
     wallets: {
       payer: payer.publicKey.toBase58(),
@@ -111,12 +123,12 @@ export async function prepareDevnetPayment(args: { quoteId: string; maxTotalDebi
       protocolTreasury: treasury.publicKey.toBase58(),
     },
     balances: {
-      payerLamports: await connection.getBalance(payer.publicKey),
-      specialistLamports: await connection.getBalance(specialist.publicKey),
-      protocolTreasuryLamports: await connection.getBalance(treasury.publicKey),
-      funderLamports: await connection.getBalance(funder.publicKey),
+      payerLamports,
+      specialistLamports,
+      protocolTreasuryLamports,
+      funderLamports,
     },
-    amounts: { downstreamAmountLamports, protocolFeeBps: 5, protocolFeeLamports, totalDebitLamports },
+    amounts: { downstreamAmountLamports, protocolFeeBps: 5, protocolFeeLamports, totalDebitLamports, payerTopUpLamports, specialistTopUpLamports, treasuryTopUpLamports, totalFunderAndPaymentSpendLamports },
     executeRequiresApprovalPhrase: APPROVAL_PHRASE,
   };
 }
@@ -135,16 +147,24 @@ export async function executeDevnetPayment(args: { quoteId: string; idempotencyK
   }
   const funder = loadKeypair(config.devnetFunderKeypairPath);
   if (!funder) throw new Error("devnet_funder_keypair_unavailable");
-  const connection = new Connection(config.devnetRpcUrl ?? DEFAULT_DEVNET_RPC_URL, "confirmed");
+  const connection = new Connection(config.devnetRpcUrl || DEFAULT_DEVNET_RPC_URL, "confirmed");
   const { payer, specialist, treasury } = quoteDevnetProfile(quote);
   const downstreamAmountLamports = decimalAmountToLamports(quote.terms.amount);
   const protocolFeeLamports = feeLamportsFor(downstreamAmountLamports);
   const totalDebitLamports = downstreamAmountLamports + protocolFeeLamports;
   const cap = Math.min(args.maxTotalDebitLamports, config.devnetMaxTotalDebitLamports ?? DEFAULT_MAX_TOTAL_DEBIT_LAMPORTS);
-  if (totalDebitLamports > cap) throw new Error(`devnet_spend_cap_exceeded:${totalDebitLamports}>${cap}`);
+
+  if (store.listDevnetReceipts(quote.quoteId).length > 0) throw new Error("quote_already_paid");
 
   const rentSafetyLamports = 1_000_000;
-  const payerFunding = await ensureBalance(connection, funder, payer.publicKey, rentSafetyLamports + totalDebitLamports + 20_000, "payer_top_up");
+  const payerMinimumLamports = rentSafetyLamports + totalDebitLamports + 20_000;
+  const payerTopUpLamports = Math.max(0, payerMinimumLamports - await connection.getBalance(payer.publicKey));
+  const specialistTopUpLamports = Math.max(0, rentSafetyLamports - await connection.getBalance(specialist.publicKey));
+  const treasuryTopUpLamports = Math.max(0, rentSafetyLamports - await connection.getBalance(treasury.publicKey));
+  const totalFunderAndPaymentSpendLamports = totalDebitLamports + payerTopUpLamports + specialistTopUpLamports + treasuryTopUpLamports;
+  if (totalFunderAndPaymentSpendLamports > cap) throw new Error(`devnet_spend_cap_exceeded:${totalFunderAndPaymentSpendLamports}>${cap}`);
+
+  const payerFunding = await ensureBalance(connection, funder, payer.publicKey, payerMinimumLamports, "payer_top_up");
   const specialistSetup = await ensureBalance(connection, funder, specialist.publicKey, rentSafetyLamports, "specialist_rent_safety");
   const treasurySetup = await ensureBalance(connection, funder, treasury.publicKey, rentSafetyLamports, "treasury_rent_safety");
   const before = {
@@ -161,12 +181,13 @@ export async function executeDevnetPayment(args: { quoteId: string; idempotencyK
   };
   const receipt: DevnetReceipt = {
     schemaVersion: "reddi.rap-mcp-bridge.devnet-payment-receipt.v1",
+    receiptId: `devnet_receipt_${createHash("sha256").update(`${quote.quoteId}:${args.idempotencyKey}`).digest("hex").slice(0, 24)}`,
     quoteId: quote.quoteId,
     createdAt: new Date().toISOString(),
     boundary: "solana-devnet-only-no-mainnet-no-specialist-http-invocation",
     quoteTermsHash: quote.termsHash,
     spendCapLamports: cap,
-    amounts: { downstreamAmountLamports, protocolFeeBps: 5, protocolFeeLamports, totalDebitLamports },
+    amounts: { downstreamAmountLamports, protocolFeeBps: 5, protocolFeeLamports, totalDebitLamports, payerTopUpLamports, specialistTopUpLamports, treasuryTopUpLamports, totalFunderAndPaymentSpendLamports },
     funding: { payerFunding, specialistSetup, treasurySetup },
     wallets: {
       payer: payer.publicKey.toBase58(),

--- a/packages/rap-mcp-bridge/tests/config.test.ts
+++ b/packages/rap-mcp-bridge/tests/config.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { assertLocalRapBaseUrl, loadConfig } from "../src/config.js";
+import { assertDevnetRpcUrl, assertLocalRapBaseUrl, loadConfig } from "../src/config.js";
 
 test("allows only localhost RAP backend URLs in first PR", () => {
   assert.equal(assertLocalRapBaseUrl("http://localhost:3000/"), "http://localhost:3000");
@@ -15,4 +15,17 @@ test("loadConfig rejects arbitrary external backend URLs", () => {
     () => loadConfig({ REDDI_RAP_BASE_URL: "https://api.example.com", HOME: "/tmp/reddi-test" }),
     /unsupported_rap_base_url_host:api.example.com/,
   );
+});
+
+test("devnet RPC URL cannot point at mainnet or arbitrary hosts", () => {
+  assert.equal(assertDevnetRpcUrl("https://api.devnet.solana.com"), "https://api.devnet.solana.com");
+  assert.equal(assertDevnetRpcUrl("http://localhost:8899"), "http://localhost:8899");
+  assert.throws(() => assertDevnetRpcUrl("https://api.mainnet-beta.solana.com"), /mainnet_rpc_url_forbidden/);
+  assert.throws(() => assertDevnetRpcUrl("https://example.com"), /unsupported_devnet_rpc_url_host:example.com/);
+});
+
+test("devnet cap env must be positive safe integer", () => {
+  assert.equal(loadConfig({ HOME: "/tmp/reddi-test", RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS: "3200000" }).devnetMaxTotalDebitLamports, 3_200_000);
+  assert.throws(() => loadConfig({ HOME: "/tmp/reddi-test", RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS: "NaN" }), /invalid_positive_integer_env/);
+  assert.throws(() => loadConfig({ HOME: "/tmp/reddi-test", RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS: "-1" }), /invalid_positive_integer_env/);
 });

--- a/packages/rap-mcp-bridge/tests/devnet-mode.test.ts
+++ b/packages/rap-mcp-bridge/tests/devnet-mode.test.ts
@@ -27,16 +27,20 @@ test("default policy remains dry-run with exactly four safe tools", () => {
   ]);
 });
 
-test("devnet policy advertises payment tools only in explicit devnet mode", () => {
-  const config = loadConfig({ HOME: tmpdir(), REDDI_RAP_MCP_MODE: "devnet", RAP_MCP_DEVNET_PROOF_APPROVED: "1", RAP_MCP_DEVNET_FUNDER_KEYPAIR: "/tmp/funder.json" });
-  const policy = currentPolicy(config.policyMode);
-  assert.equal(config.policyMode, "devnet");
-  assert.equal(policy.allowPayment, true);
-  assert.ok(policy.toolNames.includes("reddi.prepare_devnet_payment"));
-  assert.ok(policy.toolNames.includes("reddi.execute_devnet_payment"));
-  assert.ok(policy.toolNames.includes("reddi.verify_devnet_receipt"));
-  assert.equal(policy.allowMainnet, false);
-  assert.equal(policy.allowInvoke, false);
+test("devnet policy advertises payment tools only when gates are ready", () => {
+  const gatedOff = currentPolicy("devnet", false);
+  assert.equal(gatedOff.mode, "dry_run");
+  assert.equal(gatedOff.allowPayment, false);
+  assert.ok(!gatedOff.toolNames.includes("reddi.execute_devnet_payment"));
+
+  const gatedOn = currentPolicy("devnet", true);
+  assert.equal(gatedOn.mode, "devnet");
+  assert.equal(gatedOn.allowPayment, true);
+  assert.ok(gatedOn.toolNames.includes("reddi.prepare_devnet_payment"));
+  assert.ok(gatedOn.toolNames.includes("reddi.execute_devnet_payment"));
+  assert.ok(gatedOn.toolNames.includes("reddi.verify_devnet_receipt"));
+  assert.equal(gatedOn.allowMainnet, false);
+  assert.equal(gatedOn.allowInvoke, false);
 });
 
 test("devnet execution rejects without explicit env approval", async () => {
@@ -53,7 +57,7 @@ test("devnet execution rejects without explicit env approval", async () => {
     }, store);
     const config = loadConfig({ HOME: tmpdir(), REDDI_RAP_MCP_MODE: "devnet", RAP_MCP_DEVNET_FUNDER_KEYPAIR: "/tmp/funder.json" });
     await assert.rejects(
-      executeDevnetPayment({ quoteId: quote.quoteId, idempotencyKey: "idem-1", maxTotalDebitLamports: 100_050, approvalPhrase: "EXECUTE_DEVNET_RAP_PAYMENT" }, config, store),
+      executeDevnetPayment({ quoteId: quote.quoteId, idempotencyKey: "idem-1", maxTotalDebitLamports: 3_300_000, approvalPhrase: "EXECUTE_DEVNET_RAP_PAYMENT" }, config, store),
       /RAP_MCP_DEVNET_PROOF_APPROVED/,
     );
   } finally {
@@ -75,9 +79,49 @@ test("devnet execution rejects without approval phrase before network access", a
     }, store);
     const config = loadConfig({ HOME: tmpdir(), REDDI_RAP_MCP_MODE: "devnet", RAP_MCP_DEVNET_PROOF_APPROVED: "1", RAP_MCP_DEVNET_FUNDER_KEYPAIR: "/tmp/funder.json" });
     await assert.rejects(
-      executeDevnetPayment({ quoteId: quote.quoteId, idempotencyKey: "idem-1", maxTotalDebitLamports: 100_050, approvalPhrase: "WRONG" as "EXECUTE_DEVNET_RAP_PAYMENT" }, config, store),
+      executeDevnetPayment({ quoteId: quote.quoteId, idempotencyKey: "idem-1", maxTotalDebitLamports: 3_300_000, approvalPhrase: "WRONG" as "EXECUTE_DEVNET_RAP_PAYMENT" }, config, store),
       /missing_devnet_execution_approval_phrase/,
     );
+  } finally {
+    cleanup();
+  }
+});
+
+test("devnet execution rejects non-devnet network and non-SOL quotes before network access", async () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const surfpoolQuote = requestQuote({ taskSummary: "local", capability: "research", amount: "0.0001", currency: "SOL", network: "local-surfpool", payloadClass: "prompt_summary", evidenceRefs: [] }, store);
+    const usdcQuote = requestQuote({ taskSummary: "usdc", capability: "research", amount: "0.0001", currency: "USDC", network: "solana-devnet", payloadClass: "prompt_summary", evidenceRefs: [] }, store);
+    const config = loadConfig({ HOME: tmpdir(), REDDI_RAP_MCP_MODE: "devnet", RAP_MCP_DEVNET_PROOF_APPROVED: "1", RAP_MCP_DEVNET_FUNDER_KEYPAIR: "/tmp/funder.json" });
+    await assert.rejects(executeDevnetPayment({ quoteId: surfpoolQuote.quoteId, idempotencyKey: "idem-1", maxTotalDebitLamports: 3_300_000, approvalPhrase: "EXECUTE_DEVNET_RAP_PAYMENT" }, config, store), /quote_not_devnet_eligible/);
+    await assert.rejects(executeDevnetPayment({ quoteId: usdcQuote.quoteId, idempotencyKey: "idem-2", maxTotalDebitLamports: 3_300_000, approvalPhrase: "EXECUTE_DEVNET_RAP_PAYMENT" }, config, store), /quote_currency_must_be_SOL/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("devnet receipt idempotency maps to exact receipt and blocks duplicate quote payment", () => {
+  const { store, cleanup } = tempStore();
+  try {
+    const receipt = {
+      receiptId: "receipt-1",
+      schemaVersion: "reddi.rap-mcp-bridge.devnet-payment-receipt.v1" as const,
+      quoteId: "quote-1",
+      createdAt: new Date().toISOString(),
+      boundary: "solana-devnet-only-no-mainnet-no-specialist-http-invocation" as const,
+      quoteTermsHash: "sha256:terms",
+      spendCapLamports: 3_300_000,
+      amounts: { downstreamAmountLamports: 100_000, protocolFeeBps: 5 as const, protocolFeeLamports: 50, totalDebitLamports: 100_050, payerTopUpLamports: 1, specialistTopUpLamports: 2, treasuryTopUpLamports: 3, totalFunderAndPaymentSpendLamports: 100_056 },
+      funding: {},
+      wallets: { payer: "payer", specialist: "specialist", protocolTreasury: "treasury", funder: "funder" },
+      balances: {},
+      transactions: { downstreamSignature: "downstream", feeSignature: "fee" },
+      verification: { devnetPaymentSemantics: "pass" as const, mainnetSettlement: "not_applicable" as const },
+      disclosureLedgerEntry: {},
+    };
+    store.upsertDevnetReceipt("idem-1", "hash-1", receipt);
+    assert.equal(store.getDevnetReceiptByIdempotency("idem-1")?.receipt.receiptId, "receipt-1");
+    assert.throws(() => store.upsertDevnetReceipt("idem-2", "hash-2", { ...receipt, receiptId: "receipt-2" }), /quote_already_paid/);
   } finally {
     cleanup();
   }


### PR DESCRIPTION
## Summary
- harden devnet MCP payment execution gates after PR #255
- reject mainnet/arbitrary RPC endpoints and non-devnet/non-SOL payment quotes
- include funder top-ups in spend-cap enforcement
- map devnet idempotency to exact receipt ids and block duplicate quote payments
- only expose devnet payment tools when explicit approval + funder gates are present

## Validation
- npm --prefix packages/rap-mcp-bridge test
- npm --prefix packages/rap-mcp-bridge run smoke:stdio
- RAP_MCP_DEVNET_PROOF_APPROVED=1 RAP_MCP_DEVNET_FUNDER_KEYPAIR=/Users/loki/.config/solana/blitz-dev.json npm --prefix packages/rap-mcp-bridge run smoke:devnet