### PR TITLE
docs: mark Anchor-era narrative as superseded

### DIFF
--- a/docs/verifiable-agent-protocol/colosseum-frontier-2026-04/NARRATIVE.md
+++ b/docs/verifiable-agent-protocol/colosseum-frontier-2026-04/NARRATIVE.md
@@ -158,7 +158,7 @@ The ask: **recognise Reddi Agent Protocol as the category winner for trustless a
 **"Is this just another payment wrapper with a new framework attached?"**
 No. The differentiator is the full trust stack — escrow + blind reputation + attestations — not Quasar by itself. Quasar is the performance evidence. The product story is the five-layer protocol.
 
-**"If Anchor is still the submission, why should we care about Quasar?"**
+**"Why should we care about Quasar specifically?"**
 Because the critical proof path now runs Quasar-native, and the supporting evidence shows why that matters for agent-commerce throughput and cost.
 
 **"Are you introducing submission risk by talking about a Beta framework?"**

--- a/docs/verifiable-agent-protocol/colosseum-frontier-2026-04/QUASAR-DECISION-MEMO.md
+++ b/docs/verifiable-agent-protocol/colosseum-frontier-2026-04/QUASAR-DECISION-MEMO.md
@@ -1,5 +1,6 @@
 # Quasar Escrow POC — Decision Memo
 
+> **2026-05-08 supersession note:** This memo is historical. The final critical submission path has since moved to Quasar-native devnet programs for escrow, registry, reputation, and attestation. Do not reuse the old “Keep Anchor” or “MagicBlock PER wired” language as current judge copy. Current MagicBlock claim boundary: Quasar-native permission/delegation succeeds live on devnet; successful PER settlement is not claimed because delegated Quasar program execution fails at MagicBlock TEE instruction start.
 _Date: 2026-04-11_
 _Author: Kit_
 _For: Loki / Nissan (Colosseum Frontier submission decision)_


### PR DESCRIPTION
## Summary
- remove leftover Anchor-era objection wording from the refreshed narrative
- mark the old Quasar decision memo as historical/superseded
- restate the current MagicBlock boundary: live Quasar-native delegation succeeds, successful PER settlement is not claimed

## Validation
- npm run check:submission:claim-boundaries
- git diff --check