### PR TITLE
docs: remove stale MagicBlock wired phrasing

### DIFF
--- a/docs/verifiable-agent-protocol/colosseum-frontier-2026-04/QUASAR-DECISION-MEMO.md
+++ b/docs/verifiable-agent-protocol/colosseum-frontier-2026-04/QUASAR-DECISION-MEMO.md
@@ -80,7 +80,7 @@ The main submission at `reddi-agent-protocol-code` has:
 - DevOps already done (deployed to devnet)
 - Phase 3a/3b TypeScript plugins tested
 - Phase 4/4b reputation tested
-- Phase 5 MagicBlock PER wired
+- Historical Phase 5 MagicBlock integration notes (superseded; no current settlement claim)
 
 Migrating now would create regression risk without adding user-facing feature value. The judges can't tell from a live demo whether the program binary is 13 KB or 377 KB.
 


### PR DESCRIPTION
## Summary
- rewrite one superseded historical decision-memo bullet so it no longer says MagicBlock PER was wired as current reusable copy
- preserve the memo as historical evidence while making the current no-settlement boundary harder to miss

## Validation
- npm run check:submission:claim-boundaries
- git diff --check