### PR TITLE
feat: add Quasar PER agent vault commit CPI

### DIFF
--- a/experiments/quasar-escrow-per/src/instructions/commit_agent_vault_per.rs
+++ b/experiments/quasar-escrow-per/src/instructions/commit_agent_vault_per.rs
@@ -1,0 +1,58 @@
+use {
+    crate::{
+        magicblock::{constants as mb_constants, layout as mb_layout},
+        state::AgentVault,
+    },
+    quasar_lang::prelude::*,
+};
+
+/// Accounts required to commit and undelegate a MagicBlock PER agent-vault permission.
+#[derive(Accounts)]
+pub struct CommitAgentVaultPer<'info> {
+    /// Agent wallet that owns the vault authority and pays commit costs.
+    pub authority: &'info mut Signer,
+    /// CHECK: AgentVault PDA is delegated by this point, so its base-layer owner is
+    /// MagicBlock's Delegation Program and the account data may be zeroed. Keep
+    /// PDA seed validation, but do not require this program to own/deserialise it.
+    #[account(mut, seeds = AgentVault::seeds(authority), bump)]
+    pub agent_vault: &'info mut UncheckedAccount,
+    /// CHECK: MagicBlock permission PDA for the vault/permissioned account.
+    pub permission: &'info mut UncheckedAccount,
+    /// CHECK: Validated against the pinned MagicBlock Permission Program before PDA signing.
+    pub permission_program: &'info UncheckedAccount,
+    /// CHECK: MagicBlock program used by commit+undelegate.
+    pub magic_program: &'info UncheckedAccount,
+    /// CHECK: MagicBlock context account used by commit+undelegate.
+    pub magic_context: &'info mut UncheckedAccount,
+}
+
+impl<'info> CommitAgentVaultPer<'info> {
+    #[inline(always)]
+    pub fn commit_agent_vault_per(
+        &mut self,
+        bumps: &CommitAgentVaultPerBumps,
+    ) -> Result<(), ProgramError> {
+        if *self.permission_program.address() != mb_constants::PERMISSION_PROGRAM_ID
+            || *self.magic_program.address() != mb_constants::MAGIC_PROGRAM_ID
+            || *self.magic_context.address() != mb_constants::MAGIC_CONTEXT_ID
+        {
+            return Err(ProgramError::InvalidArgument);
+        }
+
+        let bump = [bumps.agent_vault];
+        let seeds = [
+            Seed::from(&b"agent_vault"[..]),
+            Seed::from(self.authority.address().as_ref()),
+            Seed::from(&bump),
+        ];
+
+        let mut commit = DynCpiCall::<5, 8>::new(self.permission_program.address());
+        commit.push_account(self.authority.to_account_view(), true, true)?;
+        commit.push_account(self.agent_vault.to_account_view(), true, true)?;
+        commit.push_account(self.permission.to_account_view(), false, true)?;
+        commit.push_account(self.magic_program.to_account_view(), false, false)?;
+        commit.push_account(self.magic_context.to_account_view(), false, true)?;
+        commit.set_data(&mb_layout::commit_and_undelegate_permission_data())?;
+        commit.invoke_signed(&seeds)
+    }
+}

--- a/experiments/quasar-escrow-per/src/instructions/mod.rs
+++ b/experiments/quasar-escrow-per/src/instructions/mod.rs
@@ -1,4 +1,5 @@
 pub mod cancel;
+pub mod commit_agent_vault_per;
 pub mod commit_undelegate_per;
 pub mod delegate_agent_vault_per;
 pub mod delegate_per;
@@ -12,6 +13,7 @@ pub mod undelegate_callback;
 pub mod withdraw_agent_vault;
 
 pub use cancel::*;
+pub use commit_agent_vault_per::*;
 pub use commit_undelegate_per::*;
 pub use delegate_agent_vault_per::*;
 pub use delegate_per::*;

--- a/experiments/quasar-escrow-per/src/lib.rs
+++ b/experiments/quasar-escrow-per/src/lib.rs
@@ -15,6 +15,7 @@
 //! | `[81, 80, 69, 82, 67, 77, 73, 84]` | MagicBlock commit/undelegate PER CPI |
 //! | `[81, 80, 69, 82, 86, 65, 76, 84]` | Prepare self-custodied agent vault |
 //! | `[81, 80, 69, 82, 86, 68, 69, 76]` | MagicBlock delegate agent vault PER CPI |
+//! | `[81, 80, 69, 82, 86, 67, 77, 84]` | MagicBlock commit/undelegate agent vault PER CPI |
 //! | `[81, 80, 69, 82, 86, 84, 65, 75]` | Release escrow into agent vault |
 //! | `[81, 80, 69, 82, 86, 87, 68, 82]` | Withdraw from agent vault |
 //! | `[196, 28, 41, 206, 48, 37, 51, 167]` | MagicBlock undelegate callback |
@@ -92,6 +93,12 @@ mod quasar_escrow_per_poc {
     #[instruction(discriminator = [81, 80, 69, 82, 86, 68, 69, 76])]
     pub fn delegate_agent_vault_per(ctx: Ctx<DelegateAgentVaultPer>) -> Result<(), ProgramError> {
         ctx.accounts.delegate_agent_vault_per(&ctx.bumps)
+    }
+
+    /// Commit and undelegate a self-custodied agent vault from MagicBlock PER.
+    #[instruction(discriminator = [81, 80, 69, 82, 86, 67, 77, 84])]
+    pub fn commit_agent_vault_per(ctx: Ctx<CommitAgentVaultPer>) -> Result<(), ProgramError> {
+        ctx.accounts.commit_agent_vault_per(&ctx.bumps)
     }
 
     /// Credit an escrow release into the payee's self-custodied agent vault.

--- a/experiments/quasar-escrow-per/src/magicblock/constants.rs
+++ b/experiments/quasar-escrow-per/src/magicblock/constants.rs
@@ -18,9 +18,17 @@ pub const DELEGATION_PROGRAM_ID: Address = Address::new_from_array([
 
 /// MagicBlock program used by commit+undelegate permission.
 pub const MAGIC_PROGRAM_ID_STR: &str = "Magic11111111111111111111111111111111111111";
+pub const MAGIC_PROGRAM_ID: Address = Address::new_from_array([
+    5, 69, 180, 36, 176, 218, 112, 149, 236, 185, 214, 222, 195, 119, 215, 40, 145, 182, 231,
+    142, 146, 234, 18, 214, 223, 187, 58, 64, 0, 0, 0, 0,
+]);
 
 /// MagicBlock context account used by commit+undelegate permission.
 pub const MAGIC_CONTEXT_ID_STR: &str = "MagicContext1111111111111111111111111111111";
+pub const MAGIC_CONTEXT_ID: Address = Address::new_from_array([
+    5, 69, 180, 36, 196, 165, 40, 191, 95, 180, 3, 47, 68, 82, 130, 142, 187, 56, 171, 193,
+    210, 220, 151, 247, 63, 139, 148, 84, 128, 0, 0, 0,
+]);
 
 /// Devnet TEE validator currently listed in MagicBlock private PER docs.
 pub const DEVNET_TEE_VALIDATOR_STR: &str = "MTEWGuqxUpYZGFJQcp8tLN7x5v9BSeoFHYWQQ3n3xzo";

--- a/experiments/quasar-escrow-per/src/tests.rs
+++ b/experiments/quasar-escrow-per/src/tests.rs
@@ -269,6 +269,28 @@ fn delegate_agent_vault_per_ix(
     }
 }
 
+fn commit_agent_vault_per_ix(
+    authority: Pubkey,
+    vault: Pubkey,
+    permission: Pubkey,
+    permission_program: Pubkey,
+    magic_program: Pubkey,
+    magic_context: Pubkey,
+) -> Instruction {
+    Instruction {
+        program_id: crate::ID,
+        accounts: vec![
+            AccountMeta::new(authority, true),
+            AccountMeta::new(vault, false),
+            AccountMeta::new(permission, false),
+            AccountMeta::new_readonly(permission_program, false),
+            AccountMeta::new_readonly(magic_program, false),
+            AccountMeta::new(magic_context, false),
+        ],
+        data: vec![81, 80, 69, 82, 86, 67, 77, 84], // QPERVCMT
+    }
+}
+
 fn undelegate_callback_ix(escrow: Pubkey) -> Instruction {
     Instruction {
         program_id: crate::ID,
@@ -1329,5 +1351,148 @@ fn test_delegate_agent_vault_per_rejects_wrong_owner_program() {
     assert!(
         result.is_err(),
         "wrong owner program must be rejected before vault PDA signing"
+    );
+}
+
+/// Test 20: vault commit rejects an unpinned Permission Program before PDA signing.
+#[test]
+fn test_commit_agent_vault_per_rejects_wrong_permission_program() {
+    let mut svm = setup();
+
+    let agent = Pubkey::new_unique();
+    let vault = agent_vault_pda(&agent);
+    let permission = Pubkey::new_unique();
+    let wrong_permission_program = Pubkey::new_unique();
+    let magic_program = Pubkey::new_unique();
+    let magic_context = Pubkey::new_unique();
+
+    let result = svm.process_instruction(
+        &commit_agent_vault_per_ix(
+            agent,
+            vault,
+            permission,
+            wrong_permission_program,
+            magic_program,
+            magic_context,
+        ),
+        &[
+            funded(agent),
+            empty(vault),
+            empty(permission),
+            empty(wrong_permission_program),
+            empty(magic_program),
+            empty(magic_context),
+        ],
+    );
+
+    assert!(
+        result.is_err(),
+        "wrong Permission Program must be rejected before vault commit PDA signing"
+    );
+}
+
+/// Test 21: vault commit is pinned to the authority-derived AgentVault PDA.
+#[test]
+fn test_commit_agent_vault_per_rejects_wrong_vault_pda() {
+    let mut svm = setup();
+
+    let agent = Pubkey::new_unique();
+    let wrong_vault = Pubkey::new_unique();
+    let permission = Pubkey::new_unique();
+    let magic_program = Pubkey::new_unique();
+    let magic_context = Pubkey::new_unique();
+
+    let result = svm.process_instruction(
+        &commit_agent_vault_per_ix(
+            agent,
+            wrong_vault,
+            permission,
+            crate::magicblock::constants::PERMISSION_PROGRAM_ID,
+            magic_program,
+            magic_context,
+        ),
+        &[
+            funded(agent),
+            empty(wrong_vault),
+            empty(permission),
+            empty(crate::magicblock::constants::PERMISSION_PROGRAM_ID),
+            empty(magic_program),
+            empty(magic_context),
+        ],
+    );
+
+    assert!(
+        result.is_err(),
+        "vault commit must reject a vault PDA not derived from the authority"
+    );
+}
+
+/// Test 22: vault commit rejects an unpinned MagicBlock program before PDA signing.
+#[test]
+fn test_commit_agent_vault_per_rejects_wrong_magic_program() {
+    let mut svm = setup();
+
+    let agent = Pubkey::new_unique();
+    let vault = agent_vault_pda(&agent);
+    let permission = Pubkey::new_unique();
+    let wrong_magic_program = Pubkey::new_unique();
+
+    let result = svm.process_instruction(
+        &commit_agent_vault_per_ix(
+            agent,
+            vault,
+            permission,
+            crate::magicblock::constants::PERMISSION_PROGRAM_ID,
+            wrong_magic_program,
+            crate::magicblock::constants::MAGIC_CONTEXT_ID,
+        ),
+        &[
+            funded(agent),
+            empty(vault),
+            empty(permission),
+            empty(crate::magicblock::constants::PERMISSION_PROGRAM_ID),
+            empty(wrong_magic_program),
+            empty(crate::magicblock::constants::MAGIC_CONTEXT_ID),
+        ],
+    );
+
+    assert!(
+        result.is_err(),
+        "wrong MagicBlock program must be rejected before vault commit PDA signing"
+    );
+}
+
+/// Test 23: vault commit rejects an unpinned MagicBlock context before PDA signing.
+#[test]
+fn test_commit_agent_vault_per_rejects_wrong_magic_context() {
+    let mut svm = setup();
+
+    let agent = Pubkey::new_unique();
+    let vault = agent_vault_pda(&agent);
+    let permission = Pubkey::new_unique();
+    let wrong_magic_context = Pubkey::new_unique();
+
+    let result = svm.process_instruction(
+        &commit_agent_vault_per_ix(
+            agent,
+            vault,
+            permission,
+            crate::magicblock::constants::PERMISSION_PROGRAM_ID,
+            crate::magicblock::constants::MAGIC_PROGRAM_ID,
+            wrong_magic_context,
+        ),
+        &[
+            funded(agent),
+            empty(vault),
+            empty(permission),
+            empty(crate::magicblock::constants::PERMISSION_PROGRAM_ID),
+            empty(crate::magicblock::constants::MAGIC_PROGRAM_ID),
+            empty(wrong_magic_context),
+        ],
+    );
+
+    assert!(
+        result.is_err(),
+        "wrong MagicBlock context must be rejected before vault commit PDA signing"
     );
 }


### PR DESCRIPTION
## Summary

- Adds B3.1 raw MagicBlock agent-vault commit instruction: `commit_agent_vault_per` (`QPERVCMT`).
- Uses the authority-derived `AgentVault` PDA signer seeds while keeping the vault unchecked because delegated base-layer mirrors are owned/zeroed by MagicBlock.
- Pins the MagicBlock Permission Program before PDA signing/CPI.
- Adds QuasarSVM regressions for wrong Permission Program and wrong authority/vault PDA.

## Validation

- `PATH="$HOME/.cargo/bin:$PATH" cargo build-sbf --manifest-path experiments/quasar-escrow-per/Cargo.toml`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --manifest-path experiments/quasar-escrow-per/Cargo.toml` — 34 passed
- `npm run check:quasar:per-abi` — 13 PER instructions, 8-byte discriminators
- `npm run check:submission:claim-boundaries`
- `git diff --check`

## Claim boundary

This PR adds the raw vault commit CPI surface only. It does **not** claim base-layer vault settlement until a devnet/MagicBlock smoke proves base vault post-state and withdrawal evidence.
