### PR TITLE
docs: add MagicBlock supersession notes

### DIFF
--- a/docs/MAGICBLOCK-PER-TEE-VALIDATION-2026-05-07.md
+++ b/docs/MAGICBLOCK-PER-TEE-VALIDATION-2026-05-07.md
@@ -1,8 +1,10 @@
 # MagicBlock PER/TEE Validation Lane — 2026-05-07
 
+> **2026-05-08 supersession note:** This page records the earlier validation lane before PR #274. Current MagicBlock claim boundary is stronger and narrower: bounded MagicBlock PER AgentVault settlement is proven for the Quasar-owned agent-vault route; arbitrary-wallet/private payee settlement remains unclaimed. Do not reuse the older broad no-settlement sentence without the AgentVault-route qualifier.
+
 ## Verdict
 
-A bounded MagicBlock validation lane was run after explicit approval and then re-run after patching the demo to use MagicBlock's `ConnectionMagicRouter` blockhash path. The project now has judge-visible MagicBlock evidence, but **successful live PER settlement is not claimed**.
+A bounded MagicBlock validation lane was run after explicit approval and then re-run after patching the demo to use MagicBlock's `ConnectionMagicRouter` blockhash path. This historical page captured judge-visible MagicBlock boundary evidence before the later AgentVault settlement proof landed.
 
 What we can honestly claim:
 
@@ -72,7 +74,7 @@ The validation exposed a real integration gap rather than a generic endpoint fai
 
 Use this wording:
 
-> “We integrated and live-tested the MagicBlock PER/TEE lane. The proof shows authenticated access to the TEE endpoint, a PER-routed settlement attempt with fallback disabled, and no public devnet visibility for a submitted TEE signature. The TEE rejected settlement because the current legacy escrow path still needs MagicBlock’s full permission/delegation hooks for PDA state, so we do not claim successful live PER settlement. The final demo remains Quasar-native, with MagicBlock shown as a validated integration boundary and concrete next-step privacy rail.”
+> Historical framing at this point was: “We integrated and live-tested the MagicBlock PER/TEE lane and found the missing permission/delegation lifecycle.” Current framing after PR #274 is: “Bounded MagicBlock PER AgentVault settlement is proven for the Quasar-owned agent-vault route; arbitrary-wallet/private payee settlement remains unclaimed.”
 
 Avoid these claims:
 

--- a/docs/PAYSH-AGENT-PAYMENTS-LEVERAGE-2026-05-07.md
+++ b/docs/PAYSH-AGENT-PAYMENTS-LEVERAGE-2026-05-07.md
@@ -176,7 +176,7 @@ Pay.sh appears faster to leverage because sandbox mode exists specifically for t
 
 ### Better bounty/commercial story than MagicBlock right now
 
-MagicBlock remains technically interesting: Quasar-native delegation and patched Quasar-on-MagicBlock-TEE private authorization now work, but private payee lamport settlement is not yet claimed. Pay.sh does not require private TEE settlement; it wraps HTTP payment flows and can sit above our existing app/API layer.
+MagicBlock remains technically interesting and stronger after PR #274: Quasar-native delegation plus bounded Quasar-owned AgentVault settlement through MagicBlock TEE are proven, but arbitrary-wallet/private payee lamport settlement is not yet claimed. Pay.sh does not require private TEE settlement; it wraps HTTP payment flows and can sit above our existing app/API layer.
 
 ## Recommended architecture
 

--- a/docs/QUASAR-NATIVE-MAGICBLOCK-PER-PLAN-2026-05-07.md
+++ b/docs/QUASAR-NATIVE-MAGICBLOCK-PER-PLAN-2026-05-07.md
@@ -1,5 +1,7 @@
 # Quasar-native MagicBlock PER plan — 2026-05-07
 
+> **2026-05-08 supersession note:** This plan is historical. PR #274 later proved bounded MagicBlock PER AgentVault settlement for the Quasar-owned agent-vault route (`artifacts/quasar-per-agent-vault-settlement-smoke/20260508T031640Z/summary.json`). Use this file for design lineage only; current submission copy must say arbitrary-wallet/private payee settlement remains unclaimed, not that MagicBlock is authorization-only or TEE-blocked.
+
 ## Executive summary
 
 Nissan's constraint is correct: for the bounty, the final path should not fall back to Anchor-compiled Solana programs. The right plan is to port MagicBlock's PER lifecycle into the Quasar escrow program as low-level Solana CPI + client routing, using MagicBlock's docs and SDK byte layouts as compatibility fixtures.
@@ -209,11 +211,11 @@ Exit: successful Quasar-native PER settlement evidence pack.
 
 ### Phase 5 — bounty/judge presentation / current boundary (0.5 day)
 
-- Update homepage ecosystem proof map: MagicBlock = Quasar-native permission/delegation proof, not successful PER settlement.
+- Historical original target: update homepage ecosystem proof map for Quasar-native permission/delegation only. Superseded current target: homepage ecosystem proof map says bounded AgentVault settlement is proven, while arbitrary-wallet/private payee settlement is unclaimed.
 - Update judge packet and final operator checklist to cite `docs/MAGICBLOCK-QUASAR-TEE-REPRO-2026-05-07.md`.
 - Add one screenshot/video capture if available.
 
-Exit: bounty submission can honestly claim Quasar-native MagicBlock delegation and a reproducible TEE execution blocker; it cannot claim successful PER settlement unless a later loop fixes TEE execution and reruns settlement evidence.
+Historical exit criterion, superseded: bounty submission can now honestly claim bounded Quasar-owned AgentVault settlement through MagicBlock PER. It still cannot claim arbitrary-wallet/private payee settlement unless a later loop implements and validates that separate route.
 
 ## Risks / mitigations
 


### PR DESCRIPTION
## Summary\n- add supersession notes to older MagicBlock validation/plan docs so search results point to the PR #274 AgentVault settlement truth\n- update Pay.sh comparison note to reflect bounded MagicBlock AgentVault settlement while preserving private-payee boundary\n- avoid rewriting historical artifacts wholesale\n\n## Validation\n- rg stale MagicBlock phrases across docs/artifacts/app/lib/packages/scripts (excluding guard patterns and experiment patch material)\n- npm run check:submission:claim-boundaries\n- npm run check:final-recording\n- git diff --check