### PR TITLE
docs: refresh final recording packet

### DIFF
--- a/artifacts/final-recording-packet-20260507.md
+++ b/artifacts/final-recording-packet-20260507.md
@@ -1,6 +1,6 @@
 # Final Recording Packet — 2026-05-07
 
-Use clean `main` at `4cbed5f6` or later.
+Use clean `main` at `f3000708` or later.
 
 ## Entry points
 
@@ -9,7 +9,7 @@ Use clean `main` at `4cbed5f6` or later.
 - Proof map: `docs/COLOSSEUM-FINAL-QUASAR-PROOF-MAP-2026-05-06.md`
 - Proof hierarchy: `docs/ECONOMIC-DEMO-PROOF-HIERARCHY-2026-05-07.md`
 - Latest submission prep: `artifacts/economic-demo-submission-prep/latest/SUBMISSION-PREP.md`
-- Latest run report: `artifacts/economic-demo-run-report/20260507T074452Z/RUN-REPORT.md`
+- Latest run report: `artifacts/economic-demo-run-report/20260507T084258Z/run-report.json`
 - Latest Pay.sh / `reddi-x402` compatibility evidence: `artifacts/pay-sh-reddi-x402/20260507T064842Z/SUMMARY.md`
 - Umbra private-payment plan: `docs/UMBRA-PRIVACY-PAYMENTS-BOUNTY-FIT-2026-05-07.md`
 - Umbra private x402 adapter evidence: `artifacts/umbra-private-x402/20260507T074334Z/SUMMARY.md`
@@ -24,7 +24,7 @@ Use clean `main` at `4cbed5f6` or later.
 - `npm run evidence:pay-sh:reddi-x402 -- artifacts/pay-sh-reddi-x402/20260507T064842Z` — PASS
 - `npm run check:economic-demo:submission-prep` — PASS
 - `npm run check:quasar:submission` — PASS
-- Earlier clean-main gates: `npm run test:bdd:index` PASS; `git diff --check` PASS
+- Current clean-main gates: `npm run check:final-recording` PASS; `npm run check:submission:claim-boundaries` PASS; `npm run test:bdd:index` PASS; `git diff --check` PASS
 
 ## Recording language
 

--- a/docs/FINAL-RECORDING-REHEARSAL-RUNBOOK-2026-05-06.md
+++ b/docs/FINAL-RECORDING-REHEARSAL-RUNBOOK-2026-05-06.md
@@ -13,7 +13,7 @@ Record the Colosseum Frontier submission with Quasar-compiled Solana programs as
   - Reputation `nb9rLVjoHMibsgfRGgKuPqm6M8GVcH9r6bYNfg7Yiy6`
   - Attestation `CRGsWWkptdxsH6N6aWAyahLbuMsT58yM624EopEsv1Ex`
 - Do not claim mainnet-ready; architectural audit blockers remain.
-- MagicBlock PER/TEE has live Quasar-native delegation plus patched TEE private-authorization proof (`docs/MAGICBLOCK-QUASAR-TEE-REPRO-2026-05-07.md`, `docs/QUASAR-MAGICBLOCK-PER-BDD-PLAYBOOK-2026-05-07.md`) plus earlier PER/TEE boundary proof (`docs/MAGICBLOCK-PER-TEE-VALIDATION-2026-05-07.md`), but do not claim successful private payee lamport settlement.
+- MagicBlock PER/TEE has live Quasar-native delegation plus bounded Quasar-owned AgentVault settlement proof (`artifacts/quasar-per-agent-vault-settlement-smoke/20260508T031640Z/summary.json`, `docs/notes/MAGICBLOCK-COMMIT-SEMANTICS-LOOP-2026-05-08.md`) plus earlier PER/TEE boundary lineage (`docs/MAGICBLOCK-PER-TEE-VALIDATION-2026-05-07.md`), but do not claim arbitrary-wallet/private payee lamport settlement.
 - Do not claim successful public Jupiter devnet execution. Current safe Jupiter framing is: local Surfpool/mock-Jupiter invoke success plus public Jupiter quote/build/sign boundary. A real successful Jupiter swap requires separately approved mainnet-beta execution.
 - Legacy Anchor registrations/artifacts are reference-only.
 
@@ -69,7 +69,7 @@ npm run test:surfpool:quasar-critical
    - Surfpool localnet confidence passed.
    - x402/OpenRouter/Jupiter evidence is visible with exact boundaries.
    - Jupiter: Surfpool/mock-Jupiter is the successful no-real-funds visual; public Jupiter devnet is quote/build/sign boundary only.
-   - MagicBlock PER/TEE: Quasar-native permission/delegation succeeds live on devnet, and patched Quasar PER executes inside MagicBlock TEE for private authorization/commit evidence; successful private payee lamport settlement is not claimed. Successful live Jupiter swap is not a final claim unless separately run with explicit approval.
+   - MagicBlock PER/TEE: Quasar-native permission/delegation succeeds live on devnet, and bounded Quasar-owned AgentVault settlement through MagicBlock TEE is proven; arbitrary-wallet/private payee settlement is not claimed. Successful live Jupiter swap is not a final claim unless separately run with explicit approval.
    - Not mainnet-ready until architectural audit blockers are resolved and re-reviewed.
 
 ## Latest green evidence
@@ -77,6 +77,9 @@ npm run test:surfpool:quasar-critical
 - PR #244 merged to main as `bbfa0a92`; post-merge main Quasar Program Tests run `25447650320` passed.
 - PR #246 merged to main as `6f0b33c4`: `/economic-demo` UI labels the signed devnet budget-lane tx as **not** a Jupiter swap receipt.
 - PR #247 merged to main as `a51fab80`: generated run report now uses `Jupiter quote and budget-lane proof` / `live_quote_plus_signed_devnet_budget_lane`, not executed devnet swap language.
+- PR #274 merged to main as `c8362f38`: bounded MagicBlock PER AgentVault settlement proof passed with `baseVaultSettled.ok=true` and withdraw-after-settlement success.
+- PR #275 merged to main as `1debc2f3`: active submission docs and guard align to the AgentVault-only MagicBlock claim boundary.
+- PR #276 merged to main as `f3000708`: older MagicBlock docs have supersession notes to avoid stale authorization-only framing.
 - Devnet Reputation upgrade tx: `24bf49dnB9YCiqS6uT21jnQHRy9RveTquffBSNjhUpeHPE663kf7PEMCMch5k4ZR9sADxYUWvVijufEN993PVzqg`.
 - Latest full devnet Quasar A→B→C PASS in 6516ms:
   - Escrow lock tx `22XLto6VVbfYGZfRPvR65KNVEyztw4HAm1c7gPbWNXWpcNbqBdtNHFpAEeGL4L8T6UodT2fxan4yxYdPNb8hDzhx`

--- a/docs/RECORDING-SUBMISSION-HANDOFF-2026-05-07.md
+++ b/docs/RECORDING-SUBMISSION-HANDOFF-2026-05-07.md
@@ -2,14 +2,14 @@
 
 ## Current clean baseline
 
-Use `main` at `4cbed5f6` or later before this handoff patch, and the next commit containing this handoff once merged/pushed.
+Use clean `main` at `f3000708` or later.
 
 ## Demo entrypoint
 
 - Route: `/economic-demo`
 - Final recording packet: `artifacts/final-recording-packet-20260507.md`
-- Latest run report: `artifacts/economic-demo-run-report/20260507T074452Z/RUN-REPORT.md`
-- Latest submission prep: `artifacts/economic-demo-submission-prep/20260507T074659Z/SUBMISSION-PREP.md`
+- Latest run report: `artifacts/economic-demo-run-report/20260507T084258Z/run-report.json`
+- Latest submission prep: `artifacts/economic-demo-submission-prep/latest/SUBMISSION-PREP.md`
 - Umbra private-payment plan: `docs/UMBRA-PRIVACY-PAYMENTS-BOUNTY-FIT-2026-05-07.md`
 - Umbra private x402 adapter evidence: `artifacts/umbra-private-x402/20260507T074334Z/SUMMARY.md`
 
@@ -44,8 +44,8 @@ Use `main` at `4cbed5f6` or later before this handoff patch, and the next commit
 - `npm run check:final-recording` — PASS.
 
 - `npm run check:product:naming` — PASS, 15 files.
-- `npm run check:submission:claim-boundaries` — PASS, 5 packet surfaces.
-- `npm run check:economic-demo:submission-prep` — PASS, 12 evidence paths.
+- `npm run check:submission:claim-boundaries` — PASS, 7 packet surfaces.
+- `npm run check:economic-demo:submission-prep` — PASS, 14 evidence paths.
 - `npm run evidence:pay-sh:reddi-x402 -- artifacts/pay-sh-reddi-x402/20260507T064842Z` — PASS.
 - `npm run report:economic-demo:run` — PASS with `payShReddix402Compatibility=true`.
 - `npm run test:bdd:index` — PASS.
@@ -64,4 +64,4 @@ Use `main` at `4cbed5f6` or later before this handoff patch, and the next commit
 
 ## Current recommendation
 
-This is ready for recording/submission handoff from the evidence-boundary perspective. If we want an even stronger packet, the next step is not more copy polishing; it is either approval-gated Umbra SDK/devnet smoke, approved mainnet/Jupiter execution, Pay.sh maintainer clarification for sessions/splits, or deeper MagicBlock TEE compatibility work.
+This is ready for recording/submission handoff from the evidence-boundary perspective. If we want an even stronger packet, the next step is not more copy polishing; it is either approval-gated Umbra SDK/devnet expansion, approved mainnet/Jupiter execution, Pay.sh maintainer clarification for sessions/splits, or extending the proven MagicBlock AgentVault route into delegated-payee/private settlement.


### PR DESCRIPTION
## Summary\n- update final recording packet and handoff baseline from old hash to current clean main f3000708\n- update latest run-report/submission-prep pointers\n- refresh runbook MagicBlock wording to bounded Quasar-owned AgentVault settlement while keeping arbitrary-wallet/private payee settlement unclaimed\n\n## Validation\n- npm run check:submission:claim-boundaries\n- npm run check:final-recording\n- npm run check:product:naming\n- git diff --check\n\nNote: check:final-recording regenerates Umbra evidence timestamps; reverted timestamp-only artifact churn before commit.