### PR TITLE
feat: add controlled economic demo live run

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,6 +6,10 @@
 
 
 
+## Latest Update — Economic-demo PR B controlled live-run API underway (2026-05-08)
+
+Branch `feature/economic-demo-controlled-live-run` adds `POST /api/economic-demo/live-run` and `lib/economic-demo/live-run.ts`. The route returns a fresh run envelope with `runId`, timestamp, prompt hash, selected specialists, timeline, rendered-output previews, evidence pack reference, and explicit no-spend/no-settlement guardrails. `/economic-demo` now calls this route from `Run demo` and renders the controlled live-run envelope before the existing evidence drawer. This is still controlled hosted evidence: no signer material, no devnet/mainnet transfer, no paid provider call, and no production settlement claim. Validation passed: Jest live-run unit test, lint, Playwright economic-demo e2e, product naming, and claim-boundary checks.
+
 ## Latest Update — Economic-demo PR A UX restructure underway (2026-05-08)
 
 Branch `feature/economic-demo-live-story-ux` implements the first Belle slice using existing evidence only: hero now leads with “Run a paid-agent workflow,” proof pills, one primary `Run demo` CTA, no-wallet default quote boundary, story spine, and a collapsed evidence archive. Wallet connect moved into an optional advanced user-devnet lane; historical/operator controls no longer dominate the first viewport. E2E updated to assert no wallet/pay button visible by default, archive controls collapsed, and hosted evidence rendered after `Run demo`. Validation passed: `npm run lint -- app/economic-demo/page.tsx e2e/economic-demo.spec.ts`, `npm run test:e2e -- e2e/economic-demo.spec.ts --project=chromium`, product naming check, and submission claim-boundary check.

--- a/app/api/economic-demo/live-run/route.ts
+++ b/app/api/economic-demo/live-run/route.ts
@@ -1,0 +1,26 @@
+import {
+  buildEconomicDemoLiveRun,
+  type EconomicDemoLiveRunRequest,
+} from "@/lib/economic-demo/live-run";
+
+export async function POST(request: Request) {
+  let payload: EconomicDemoLiveRunRequest = {};
+
+  try {
+    const contentType = request.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      payload = (await request.json()) as EconomicDemoLiveRunRequest;
+    }
+  } catch {
+    return Response.json({ ok: false, error: "invalid_json" }, { status: 400 });
+  }
+
+  if (payload.mode && payload.mode !== "controlled_hosted_evidence") {
+    return Response.json(
+      { ok: false, error: "unsupported_live_run_mode" },
+      { status: 400 },
+    );
+  }
+
+  return Response.json({ ok: true, run: buildEconomicDemoLiveRun(payload) });
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -20,6 +20,7 @@ import {
   type WebpageLiveWorkflowEvidence,
 } from "@/lib/economic-demo/webpage-live-workflow-evidence";
 import type { EconomicDemoLedgerReconciliation } from "@/lib/economic-demo/ledger-reconciliation";
+import type { EconomicDemoLiveRun } from "@/lib/economic-demo/live-run";
 import type { ResearchWorkflowDesign } from "@/lib/economic-demo/research-workflow-design";
 import type { PictureStoryboardDesign } from "@/lib/economic-demo/picture-storyboard-design";
 import {
@@ -132,6 +133,8 @@ export default function EconomicDemoPage() {
   const [pictureStoryboardStatus, setPictureStoryboardStatus] = useState<
     "idle" | "loading" | "loaded" | "error"
   >("idle");
+  const [controlledLiveRun, setControlledLiveRun] =
+    useState<EconomicDemoLiveRun | null>(null);
   const [paymentAsset, setPaymentAsset] = useState<"USDC" | "SOL">("USDC");
   const [runStarted, setRunStarted] = useState(false);
   const { connected, publicKey } = useWallet();
@@ -308,7 +311,32 @@ export default function EconomicDemoPage() {
 
   async function runControlledDemo() {
     setRunStarted(true);
-    await loadWebpageLiveEvidence();
+    setWebpageLiveEvidenceStatus("loading");
+    try {
+      const res = await fetch("/api/economic-demo/live-run", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          scenarioId: scenario.id,
+          prompt: scenario.prompt,
+          mode: "controlled_hosted_evidence",
+          clientRunNonce: `ui-${Date.now()}`,
+        }),
+      });
+      const payload = (await res.json()) as {
+        ok?: boolean;
+        run?: EconomicDemoLiveRun;
+      };
+      if (!res.ok || !payload.ok || !payload.run) {
+        throw new Error("controlled_live_run_failed");
+      }
+      setControlledLiveRun(payload.run);
+      setWebpageLiveEvidence(payload.run.evidence);
+      setWebpageLiveEvidenceStatus("loaded");
+    } catch {
+      setControlledLiveRun(null);
+      setWebpageLiveEvidenceStatus("error");
+    }
   }
 
   return (
@@ -598,13 +626,44 @@ export default function EconomicDemoPage() {
                     className="mt-4 rounded-lg border border-[#14F195]/30 bg-black/20 p-3"
                   >
                     <p className="text-xs uppercase tracking-wide text-[#14F195]">
-                      Run timeline started
+                      Controlled live-run timeline started
                     </p>
                     <p className="mt-2 text-sm leading-6 text-gray-200">
                       Prompt selected → quote boundary accepted → hosted x402
                       evidence requested → returned output and evidence drawer
                       shown below.
                     </p>
+                    {controlledLiveRun && (
+                      <div
+                        data-testid="controlled-live-run-envelope"
+                        className="mt-3 space-y-2"
+                      >
+                        <div className="rounded border border-white/10 bg-black/30 p-2 text-xs leading-5 text-gray-300">
+                          <p className="font-mono text-white">
+                            run: {controlledLiveRun.runId}
+                          </p>
+                          <p className="break-all">
+                            prompt hash: {controlledLiveRun.promptHash}
+                          </p>
+                          <p className="text-yellow-100">
+                            {controlledLiveRun.claimBoundary}
+                          </p>
+                        </div>
+                        <div className="grid gap-2 md:grid-cols-2">
+                          {controlledLiveRun.timeline.map((step) => (
+                            <div
+                              key={step.id}
+                              className="rounded border border-white/10 bg-white/5 p-2 text-xs leading-5 text-gray-300"
+                            >
+                              <p className="font-semibold text-white">
+                                {step.label}
+                              </p>
+                              <p>{step.detail}</p>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/e2e/economic-demo.spec.ts
+++ b/e2e/economic-demo.spec.ts
@@ -1,39 +1,81 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("/economic-demo judge-facing story", () => {
-  test("defaults to a no-wallet prompt-to-evidence flow with archive controls collapsed", async ({ page }) => {
+  test("defaults to a no-wallet prompt-to-evidence flow with archive controls collapsed", async ({
+    page,
+  }) => {
     await page.goto("/economic-demo");
 
-    await expect(page.getByRole("heading", { name: /run a paid-agent workflow/i })).toBeVisible();
-    await expect(page.getByText(/No wallet is required in the default judge path/i)).toBeVisible();
-    await expect(page.getByTestId("economic-proof-pills")).toContainText("30 hosted specialists");
-    await expect(page.getByTestId("economic-proof-pills")).toContainText("No wallet required by default");
+    await expect(
+      page.getByRole("heading", { name: /run a paid-agent workflow/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/No wallet is required in the default judge path/i),
+    ).toBeVisible();
+    await expect(page.getByTestId("economic-proof-pills")).toContainText(
+      "30 hosted specialists",
+    );
+    await expect(page.getByTestId("economic-proof-pills")).toContainText(
+      "No wallet required by default",
+    );
 
-    await expect(page.getByRole("button", { name: /^run demo$/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /open evidence archive/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^run demo$/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /open evidence archive/i }),
+    ).toBeVisible();
     await expect(page.getByText("Prompt template").first()).toBeVisible();
 
     const quote = page.getByTestId("economic-upfront-quote");
     await expect(quote).toBeVisible();
-    await expect(quote).toContainText("Controlled hosted demo · no wallet required");
+    await expect(quote).toContainText(
+      "Controlled hosted demo · no wallet required",
+    );
     await expect(quote).toContainText("payment claim");
     await expect(quote).toContainText("controlled / devnet only");
     await expect(quote).toContainText("does not claim mainnet payment");
 
-    await expect(page.getByText(/connect wallet only for bounded devnet mode/i)).not.toBeVisible();
-    await expect(page.getByRole("button", { name: /pay .* and run/i })).not.toBeVisible();
+    await expect(
+      page.getByText(/connect wallet only for bounded devnet mode/i),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /pay .* and run/i }),
+    ).not.toBeVisible();
 
     const archive = page.getByTestId("economic-evidence-archive");
     await expect(archive).toBeVisible();
-    await expect(archive).toContainText("Evidence archive and operator controls");
-    await expect(page.getByRole("button", { name: /build dry-run economic graph/i })).not.toBeVisible();
+    await expect(archive).toContainText(
+      "Evidence archive and operator controls",
+    );
+    await expect(
+      page.getByRole("button", { name: /build dry-run economic graph/i }),
+    ).not.toBeVisible();
 
     await page.getByRole("button", { name: /^run demo$/i }).click();
-    await expect(page.getByTestId("live-run-status")).toContainText("Run timeline started");
+    await expect(page.getByTestId("live-run-status")).toContainText(
+      "Controlled live-run timeline started",
+    );
+    await expect(
+      page.getByTestId("controlled-live-run-envelope"),
+    ).toContainText("prompt hash: sha256:");
+    await expect(
+      page.getByTestId("controlled-live-run-envelope"),
+    ).toContainText("no production settlement claim");
+    await expect(
+      page.getByTestId("controlled-live-run-envelope"),
+    ).toContainText("x402 challenges observed");
     await expect(page.getByTestId("economic-final-output")).toBeVisible();
-    await expect(page.getByTestId("webpage-live-workflow-evidence")).toBeVisible();
-    await expect(page.getByTestId("webpage-live-workflow-evidence")).toContainText("multi_edge_paid_workflow_reached");
+    await expect(
+      page.getByTestId("webpage-live-workflow-evidence"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("webpage-live-workflow-evidence"),
+    ).toContainText("multi_edge_paid_workflow_reached");
 
-    await page.screenshot({ path: "artifacts/playwright-economic-demo/judge-story-flow.png", fullPage: true });
+    await page.screenshot({
+      path: "artifacts/playwright-economic-demo/judge-story-flow.png",
+      fullPage: true,
+    });
   });
 });

--- a/lib/__tests__/economic-demo-live-run.test.ts
+++ b/lib/__tests__/economic-demo-live-run.test.ts
@@ -1,0 +1,68 @@
+import {
+  buildEconomicDemoLiveRun,
+  ECONOMIC_DEMO_LIVE_RUN_SCHEMA_VERSION,
+} from "@/lib/economic-demo/live-run";
+
+describe("economic demo controlled live run", () => {
+  it("builds a fresh no-spend run envelope from allowlisted evidence", () => {
+    const run = buildEconomicDemoLiveRun({
+      scenarioId: "webpage",
+      prompt: "Design a landing page for a trustless AI agent marketplace.",
+      clientRunNonce: "judge-visible-nonce",
+    });
+
+    expect(run.schemaVersion).toBe(ECONOMIC_DEMO_LIVE_RUN_SCHEMA_VERSION);
+    expect(run.runId).toMatch(/^economic-demo-/);
+    expect(run.mode).toBe("controlled_hosted_evidence");
+    expect(run.clientRunNonce).toBe("judge-visible-nonce");
+    expect(run.promptHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(
+      run.selectedSpecialists.map((specialist) => specialist.profileId),
+    ).toEqual([
+      "planning-agent",
+      "content-creation-agent",
+      "code-generation-agent",
+      "verification-validation-agent",
+    ]);
+    expect(
+      run.selectedSpecialists.every(
+        (specialist) => specialist.challengeStatus === 402,
+      ),
+    ).toBe(true);
+    expect(
+      run.selectedSpecialists.every(
+        (specialist) => specialist.completionStatus === 200,
+      ),
+    ).toBe(true);
+    expect(run.timeline.map((step) => step.id)).toEqual([
+      "prompt_hash_created",
+      "specialists_selected",
+      "x402_challenges_observed",
+      "controlled_receipts_satisfied",
+      "outputs_returned",
+      "attestor_verdict_returned",
+      "evidence_pack_attached",
+    ]);
+    expect(run.output.previews.length).toBe(4);
+    expect(run.guardrails).toMatchObject({
+      exactAllowlistedEndpointsOnly: true,
+      noSignerMaterialUsed: true,
+      noSignatureAttemptedByRoute: true,
+      noDevnetTransferFromRoute: true,
+      noPaidProviderCallFromRoute: true,
+      controlledDemoReceiptsOnly: true,
+      noProductionSettlementClaim: true,
+    });
+    expect(run.claimBoundary).toContain("no production settlement claim");
+  });
+
+  it("bounds prompt and nonce input", () => {
+    const run = buildEconomicDemoLiveRun({
+      prompt: "x".repeat(1_200),
+      clientRunNonce: "n".repeat(200),
+    });
+
+    expect(run.prompt).toHaveLength(800);
+    expect(run.clientRunNonce).toHaveLength(120);
+  });
+});

--- a/lib/economic-demo/live-run.ts
+++ b/lib/economic-demo/live-run.ts
@@ -1,0 +1,208 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  economicDemoScenarios,
+  type EconomicDemoScenarioId,
+} from "@/lib/economic-demo/fixture";
+import {
+  getDisclosureLedgerEvidenceStatus,
+  type WebpageLiveWorkflowEvidence,
+} from "@/lib/economic-demo/webpage-live-workflow-evidence";
+import { getWebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence-server";
+
+export const ECONOMIC_DEMO_LIVE_RUN_SCHEMA_VERSION =
+  "reddi.economic-demo.controlled-live-run.v1" as const;
+export const ECONOMIC_DEMO_LIVE_RUN_MAX_PROMPT_CHARS = 800;
+
+export type EconomicDemoLiveRunMode = "controlled_hosted_evidence";
+
+export type EconomicDemoLiveRunRequest = {
+  scenarioId?: EconomicDemoScenarioId;
+  prompt?: string;
+  mode?: EconomicDemoLiveRunMode;
+  clientRunNonce?: string;
+};
+
+export type EconomicDemoLiveRunTimelineStep = {
+  id:
+    | "prompt_hash_created"
+    | "specialists_selected"
+    | "x402_challenges_observed"
+    | "controlled_receipts_satisfied"
+    | "outputs_returned"
+    | "attestor_verdict_returned"
+    | "evidence_pack_attached";
+  label: string;
+  status: "complete";
+  timestamp: string;
+  detail: string;
+};
+
+export type EconomicDemoLiveRun = {
+  schemaVersion: typeof ECONOMIC_DEMO_LIVE_RUN_SCHEMA_VERSION;
+  runId: string;
+  generatedAt: string;
+  mode: EconomicDemoLiveRunMode;
+  scenarioId: EconomicDemoScenarioId;
+  prompt: string;
+  promptHash: string;
+  clientRunNonce: string | null;
+  selectedSpecialists: Array<{
+    step: number;
+    profileId: string;
+    capability: string;
+    endpoint: string;
+    challengeStatus: 402;
+    completionStatus: 200;
+    outputPreview: string;
+  }>;
+  timeline: EconomicDemoLiveRunTimelineStep[];
+  output: {
+    type: "webpage" | "article" | "image-brief";
+    summary: string;
+    previews: string[];
+  };
+  evidence: WebpageLiveWorkflowEvidence;
+  disclosureLedger: ReturnType<typeof getDisclosureLedgerEvidenceStatus>;
+  guardrails: {
+    exactAllowlistedEndpointsOnly: true;
+    noSignerMaterialUsed: true;
+    noSignatureAttemptedByRoute: true;
+    noDevnetTransferFromRoute: true;
+    noPaidProviderCallFromRoute: true;
+    controlledDemoReceiptsOnly: true;
+    noProductionSettlementClaim: true;
+  };
+  claimBoundary: string;
+};
+
+function hashPrompt(prompt: string) {
+  return `sha256:${createHash("sha256").update(prompt).digest("hex")}`;
+}
+
+function sanitizePrompt(prompt: unknown, fallback: string) {
+  if (typeof prompt !== "string") return fallback;
+  const trimmed = prompt.trim();
+  if (!trimmed) return fallback;
+  return trimmed.slice(0, ECONOMIC_DEMO_LIVE_RUN_MAX_PROMPT_CHARS);
+}
+
+function scenarioFor(id: unknown) {
+  if (typeof id === "string") {
+    const found = economicDemoScenarios.find((scenario) => scenario.id === id);
+    if (found) return found;
+  }
+  return economicDemoScenarios[0];
+}
+
+export function buildEconomicDemoLiveRun(
+  request: EconomicDemoLiveRunRequest = {},
+): EconomicDemoLiveRun {
+  const scenario = scenarioFor(request.scenarioId);
+  const prompt = sanitizePrompt(request.prompt, scenario.prompt);
+  const generatedAt = new Date().toISOString();
+  const evidence = getWebpageLiveWorkflowEvidence();
+  const disclosureLedger = getDisclosureLedgerEvidenceStatus(
+    evidence.disclosureLedgerSummary,
+  );
+  const selectedSpecialists = evidence.edges.map((edge) => ({
+    step: edge.step,
+    profileId: edge.profileId,
+    capability: edge.capability,
+    endpoint: edge.endpoint,
+    challengeStatus: edge.unpaidChallenge.status,
+    completionStatus: edge.paidCompletion.status,
+    outputPreview: edge.paidCompletion.outputPreview,
+  }));
+
+  const timeline: EconomicDemoLiveRunTimelineStep[] = [
+    {
+      id: "prompt_hash_created",
+      label: "Prompt hash created",
+      status: "complete",
+      timestamp: generatedAt,
+      detail: hashPrompt(prompt),
+    },
+    {
+      id: "specialists_selected",
+      label: "Specialists selected",
+      status: "complete",
+      timestamp: generatedAt,
+      detail: selectedSpecialists.map((edge) => edge.profileId).join(" → "),
+    },
+    {
+      id: "x402_challenges_observed",
+      label: "x402 challenges observed",
+      status: "complete",
+      timestamp: generatedAt,
+      detail: `${selectedSpecialists.length} allowlisted hosted specialist endpoints returned recorded HTTP 402 challenge evidence.`,
+    },
+    {
+      id: "controlled_receipts_satisfied",
+      label: "Controlled receipts satisfied",
+      status: "complete",
+      timestamp: generatedAt,
+      detail:
+        "Controlled demo receipts reached paid completions in the evidence pack; this is not production settlement.",
+    },
+    {
+      id: "outputs_returned",
+      label: "Specialist outputs returned",
+      status: "complete",
+      timestamp: generatedAt,
+      detail: `${selectedSpecialists.length} output previews attached for the judge-facing run envelope.`,
+    },
+    {
+      id: "attestor_verdict_returned",
+      label: "Attestor verdict returned",
+      status: "complete",
+      timestamp: generatedAt,
+      detail:
+        evidence.edges.at(-1)?.paidCompletion.outputPreview ??
+        "Verification specialist returned release guidance.",
+    },
+    {
+      id: "evidence_pack_attached",
+      label: "Evidence pack attached",
+      status: "complete",
+      timestamp: generatedAt,
+      detail:
+        evidence.latestEvidencePack?.artifactPath ??
+        evidence.sourceArtifactPath,
+    },
+  ];
+
+  return {
+    schemaVersion: ECONOMIC_DEMO_LIVE_RUN_SCHEMA_VERSION,
+    runId: `economic-demo-${randomUUID()}`,
+    generatedAt,
+    mode: request.mode ?? "controlled_hosted_evidence",
+    scenarioId: scenario.id,
+    prompt,
+    promptHash: hashPrompt(prompt),
+    clientRunNonce:
+      typeof request.clientRunNonce === "string"
+        ? request.clientRunNonce.slice(0, 120)
+        : null,
+    selectedSpecialists,
+    timeline,
+    output: {
+      type: scenario.finalOutputType,
+      summary: scenario.finalOutputSummary,
+      previews: selectedSpecialists.map((edge) => edge.outputPreview),
+    },
+    evidence,
+    disclosureLedger,
+    guardrails: {
+      exactAllowlistedEndpointsOnly: true,
+      noSignerMaterialUsed: true,
+      noSignatureAttemptedByRoute: true,
+      noDevnetTransferFromRoute: true,
+      noPaidProviderCallFromRoute: true,
+      controlledDemoReceiptsOnly: true,
+      noProductionSettlementClaim: true,
+    },
+    claimBoundary:
+      "Controlled hosted evidence run: no signer material, no devnet/mainnet transfer, no paid provider call, and no production settlement claim. Historical evidence is labeled separately from fresh route execution.",
+  };
+}


### PR DESCRIPTION
## Summary\n- Adds POST /api/economic-demo/live-run for a fresh controlled run envelope: run id, prompt hash, specialist chain, timeline, output previews, and evidence pack reference\n- Wires /economic-demo Run demo to the new route and renders the returned envelope before the evidence drawer\n- Adds Jest coverage for the no-spend live-run envelope and updates Playwright coverage\n\n## Validation\n- npx jest lib/__tests__/economic-demo-live-run.test.ts --runInBand\n- npm run lint -- app/economic-demo/page.tsx app/api/economic-demo/live-run/route.ts lib/economic-demo/live-run.ts lib/__tests__/economic-demo-live-run.test.ts e2e/economic-demo.spec.ts\n- npm run test:e2e -- e2e/economic-demo.spec.ts --project=chromium\n- npm run check:product:naming -- app/economic-demo/page.tsx app/api/economic-demo/live-run/route.ts lib/economic-demo/live-run.ts e2e/economic-demo.spec.ts\n- npm run check:submission:claim-boundaries\n\n## Claim boundaries\n- Controlled hosted evidence only\n- No signer material\n- No devnet/mainnet transfer\n- No paid provider call\n- No production settlement claim\n- Historical evidence remains labelled separately