### PR TITLE
feat: add hosted economic demo challenge probe

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,6 +6,10 @@
 
 
 
+## Latest Update — Economic-demo PR C hosted challenge probe underway (2026-05-08)
+
+Branch `feature/economic-demo-hosted-challenge-probe` adds a safe unpaid `POST /api/economic-demo/hosted-challenge-probe` lane. It probes exact allowlisted Coolify specialist endpoints for the webpage workflow (`planning-agent`, `content-creation-agent`, `code-generation-agent`, `verification-validation-agent`) and only observes fresh HTTP 402 x402 challenge headers. Guardrails: no `x402-payment` header, no payment retry, no signer material, no devnet/mainnet transfer, no settlement claim. Direct live probe verified all 4 endpoints returned `402` + `x402-request` on solana-devnet/USDC. Local validation passed: Jest hosted-probe unit test, lint, Playwright economic-demo e2e, product naming, and claim-boundary checks.
+
 ## Latest Update — Economic-demo PR B controlled live-run API underway (2026-05-08)
 
 Branch `feature/economic-demo-controlled-live-run` adds `POST /api/economic-demo/live-run` and `lib/economic-demo/live-run.ts`. The route returns a fresh run envelope with `runId`, timestamp, prompt hash, selected specialists, timeline, rendered-output previews, evidence pack reference, and explicit no-spend/no-settlement guardrails. `/economic-demo` now calls this route from `Run demo` and renders the controlled live-run envelope before the existing evidence drawer. This is still controlled hosted evidence: no signer material, no devnet/mainnet transfer, no paid provider call, and no production settlement claim. Validation passed: Jest live-run unit test, lint, Playwright economic-demo e2e, product naming, and claim-boundary checks.

--- a/app/api/economic-demo/hosted-challenge-probe/route.ts
+++ b/app/api/economic-demo/hosted-challenge-probe/route.ts
@@ -1,0 +1,12 @@
+import { runEconomicDemoHostedChallengeProbe } from "@/lib/economic-demo/hosted-challenge-probe";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const probe = await runEconomicDemoHostedChallengeProbe({ timeoutMs: 5_000 });
+  const status = probe.summary.allChallengesObserved ? 200 : 502;
+  return Response.json(
+    { ok: probe.summary.allChallengesObserved, probe },
+    { status },
+  );
+}

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -20,6 +20,7 @@ import {
   type WebpageLiveWorkflowEvidence,
 } from "@/lib/economic-demo/webpage-live-workflow-evidence";
 import type { EconomicDemoLedgerReconciliation } from "@/lib/economic-demo/ledger-reconciliation";
+import type { EconomicDemoHostedChallengeProbe } from "@/lib/economic-demo/hosted-challenge-probe";
 import type { EconomicDemoLiveRun } from "@/lib/economic-demo/live-run";
 import type { ResearchWorkflowDesign } from "@/lib/economic-demo/research-workflow-design";
 import type { PictureStoryboardDesign } from "@/lib/economic-demo/picture-storyboard-design";
@@ -135,6 +136,11 @@ export default function EconomicDemoPage() {
   >("idle");
   const [controlledLiveRun, setControlledLiveRun] =
     useState<EconomicDemoLiveRun | null>(null);
+  const [hostedChallengeProbe, setHostedChallengeProbe] =
+    useState<EconomicDemoHostedChallengeProbe | null>(null);
+  const [hostedChallengeProbeStatus, setHostedChallengeProbeStatus] = useState<
+    "idle" | "loading" | "loaded" | "error"
+  >("idle");
   const [paymentAsset, setPaymentAsset] = useState<"USDC" | "SOL">("USDC");
   const [runStarted, setRunStarted] = useState(false);
   const { connected, publicKey } = useWallet();
@@ -339,6 +345,27 @@ export default function EconomicDemoPage() {
     }
   }
 
+  async function probeHostedChallenges() {
+    setHostedChallengeProbeStatus("loading");
+    try {
+      const res = await fetch("/api/economic-demo/hosted-challenge-probe", {
+        method: "POST",
+      });
+      const payload = (await res.json()) as {
+        ok?: boolean;
+        probe?: EconomicDemoHostedChallengeProbe;
+      };
+      if (!res.ok || !payload.ok || !payload.probe) {
+        throw new Error("hosted_challenge_probe_failed");
+      }
+      setHostedChallengeProbe(payload.probe);
+      setHostedChallengeProbeStatus("loaded");
+    } catch {
+      setHostedChallengeProbe(null);
+      setHostedChallengeProbeStatus("error");
+    }
+  }
+
   return (
     <main className="min-h-screen bg-page">
       <section className="relative overflow-hidden border-b border-white/5">
@@ -386,6 +413,16 @@ export default function EconomicDemoPage() {
                   ? "Running demo…"
                   : "Run demo"}
               </button>
+              <button
+                type="button"
+                onClick={probeHostedChallenges}
+                disabled={hostedChallengeProbeStatus === "loading"}
+                className="rounded-lg border border-[#14F195]/30 bg-[#14F195]/10 px-5 py-3 text-sm font-semibold text-[#14F195] transition hover:bg-[#14F195]/15 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {hostedChallengeProbeStatus === "loading"
+                  ? "Probing hosted 402s…"
+                  : "Probe hosted 402s"}
+              </button>
               <a
                 href="#evidence-archive"
                 className="rounded-lg border border-white/15 bg-white/5 px-5 py-3 text-sm font-semibold text-gray-200 transition hover:border-[#14F195]/30 hover:text-[#14F195]"
@@ -393,6 +430,55 @@ export default function EconomicDemoPage() {
                 Open evidence archive
               </a>
             </div>
+            {hostedChallengeProbeStatus !== "idle" && (
+              <div
+                data-testid="hosted-challenge-probe"
+                className="rounded-xl border border-[#14F195]/25 bg-black/30 p-4 text-sm leading-6 text-gray-200"
+              >
+                <p className="text-xs uppercase tracking-wide text-[#14F195]">
+                  Fresh unpaid hosted endpoint probe
+                </p>
+                {hostedChallengeProbeStatus === "error" && (
+                  <p className="mt-2 text-yellow-100">
+                    Probe did not complete cleanly. No payment retry was
+                    attempted.
+                  </p>
+                )}
+                {hostedChallengeProbe && (
+                  <div className="mt-3 space-y-3">
+                    <p>
+                      Observed {hostedChallengeProbe.summary.ok}/
+                      {hostedChallengeProbe.summary.requested} allowlisted x402
+                      challenges. {hostedChallengeProbe.claimBoundary}
+                    </p>
+                    <div className="grid gap-2 md:grid-cols-2">
+                      {hostedChallengeProbe.results.map((result) => (
+                        <div
+                          key={result.profileId}
+                          className="rounded-lg border border-white/10 bg-white/5 p-3 text-xs leading-5"
+                        >
+                          <p className="font-semibold text-white">
+                            {result.profileId} · HTTP {result.httpStatus ?? "—"}
+                          </p>
+                          <p className="break-all text-gray-400">
+                            {result.endpoint}
+                          </p>
+                          <p
+                            className={
+                              result.ok ? "text-[#14F195]" : "text-yellow-100"
+                            }
+                          >
+                            {result.ok
+                              ? `x402 ${result.challenge?.network} ${result.challenge?.amount} ${result.challenge?.currency}`
+                              : result.error}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
             <div className="flex flex-wrap gap-3">
               {economicDemoScenarios.map((candidate) => (
                 <button

--- a/e2e/economic-demo.spec.ts
+++ b/e2e/economic-demo.spec.ts
@@ -4,6 +4,61 @@ test.describe("/economic-demo judge-facing story", () => {
   test("defaults to a no-wallet prompt-to-evidence flow with archive controls collapsed", async ({
     page,
   }) => {
+    await page.route(
+      "**/api/economic-demo/hosted-challenge-probe",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            probe: {
+              schemaVersion: "reddi.economic-demo.hosted-challenge-probe.v1",
+              generatedAt: "2026-05-08T00:00:00.000Z",
+              mode: "unpaid_402_challenge_probe",
+              summary: {
+                requested: 4,
+                ok: 4,
+                failed: 0,
+                allChallengesObserved: true,
+              },
+              guardrails: {
+                exactAllowlistedEndpointsOnly: true,
+                noX402PaymentHeaderSent: true,
+                noPaymentRetryAttempted: true,
+                noSignerMaterialUsed: true,
+                noDevnetTransfer: true,
+                noMainnetTransfer: true,
+              },
+              claimBoundary:
+                "Fresh unpaid hosted endpoint probe only: observes HTTP 402 x402 challenges from exact allowlisted Coolify specialist endpoints; sends no x402-payment header, performs no paid retry, uses no signer material, and makes no transfer or settlement claim.",
+              results: [
+                "planning-agent",
+                "content-creation-agent",
+                "code-generation-agent",
+                "verification-validation-agent",
+              ].map((profileId) => ({
+                profileId,
+                endpoint: `https://reddi-${profileId}.preview.reddi.tech/v1/chat/completions`,
+                ok: true,
+                observedAt: "2026-05-08T00:00:00.000Z",
+                httpStatus: 402,
+                x402HeaderPresent: true,
+                challenge: {
+                  version: "1",
+                  network: "solana-devnet",
+                  amount: "0.03",
+                  currency: "USDC",
+                  noncePresent: true,
+                },
+                error: null,
+              })),
+            },
+          }),
+        });
+      },
+    );
+
     await page.goto("/economic-demo");
 
     await expect(
@@ -25,6 +80,13 @@ test.describe("/economic-demo judge-facing story", () => {
     await expect(
       page.getByRole("link", { name: /open evidence archive/i }),
     ).toBeVisible();
+    await page.getByRole("button", { name: /probe hosted 402s/i }).click();
+    await expect(page.getByTestId("hosted-challenge-probe")).toContainText(
+      "Observed 4/4 allowlisted x402 challenges",
+    );
+    await expect(page.getByTestId("hosted-challenge-probe")).toContainText(
+      "no x402-payment header",
+    );
     await expect(page.getByText("Prompt template").first()).toBeVisible();
 
     const quote = page.getByTestId("economic-upfront-quote");

--- a/lib/__tests__/economic-demo-hosted-challenge-probe.test.ts
+++ b/lib/__tests__/economic-demo-hosted-challenge-probe.test.ts
@@ -1,0 +1,80 @@
+import {
+  ECONOMIC_DEMO_PROBE_PROFILE_IDS,
+  runEconomicDemoHostedChallengeProbe,
+} from "@/lib/economic-demo/hosted-challenge-probe";
+import { openRouterWalletByProfileId } from "@/lib/economic-demo/openrouter-endpoints";
+
+describe("economic demo hosted challenge probe", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("observes unpaid 402 x402 challenges without sending payment headers", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    global.fetch = jest.fn(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        const endpoint = String(url);
+        calls.push({ url: endpoint, init });
+        const profileId = ECONOMIC_DEMO_PROBE_PROFILE_IDS.find((candidate) =>
+          endpoint.includes(candidate.replace("-agent", "")),
+        );
+        const resolvedProfileId = profileId ?? "verification-validation-agent";
+        return new Response(
+          JSON.stringify({ error: { code: "payment_required" } }),
+          {
+            status: 402,
+            headers: {
+              "content-type": "application/json",
+              "x402-request": JSON.stringify({
+                version: "1",
+                network: "solana-devnet",
+                payTo: openRouterWalletByProfileId[resolvedProfileId],
+                amount: "0.03",
+                currency: "USDC",
+                endpoint,
+                nonce: `nonce-${resolvedProfileId}`,
+                memo: `reddi:${resolvedProfileId}:/v1/chat/completions`,
+              }),
+            },
+          },
+        );
+      },
+    ) as jest.Mock;
+
+    const probe = await runEconomicDemoHostedChallengeProbe({
+      timeoutMs: 1_000,
+    });
+
+    expect(probe.summary).toEqual({
+      requested: 4,
+      ok: 4,
+      failed: 0,
+      allChallengesObserved: true,
+    });
+    expect(probe.results.map((result) => result.httpStatus)).toEqual([
+      402, 402, 402, 402,
+    ]);
+    expect(probe.results.every((result) => result.x402HeaderPresent)).toBe(
+      true,
+    );
+    expect(probe.guardrails).toMatchObject({
+      exactAllowlistedEndpointsOnly: true,
+      noX402PaymentHeaderSent: true,
+      noPaymentRetryAttempted: true,
+      noSignerMaterialUsed: true,
+      noDevnetTransfer: true,
+      noMainnetTransfer: true,
+    });
+    expect(probe.claimBoundary).toContain(
+      "Fresh unpaid hosted endpoint probe only",
+    );
+    for (const call of calls) {
+      const headers = new Headers(call.init?.headers);
+      expect(headers.has("x402-payment")).toBe(false);
+      expect(headers.has("authorization")).toBe(false);
+    }
+  });
+});

--- a/lib/economic-demo/hosted-challenge-probe.ts
+++ b/lib/economic-demo/hosted-challenge-probe.ts
@@ -1,0 +1,197 @@
+import { openRouterAll30EndpointEvidence } from "@/lib/economic-demo/openrouter-endpoints";
+
+export const ECONOMIC_DEMO_HOSTED_CHALLENGE_PROBE_SCHEMA_VERSION =
+  "reddi.economic-demo.hosted-challenge-probe.v1" as const;
+
+export const ECONOMIC_DEMO_PROBE_PROFILE_IDS = [
+  "planning-agent",
+  "content-creation-agent",
+  "code-generation-agent",
+  "verification-validation-agent",
+] as const;
+
+export type EconomicDemoProbeProfileId =
+  (typeof ECONOMIC_DEMO_PROBE_PROFILE_IDS)[number];
+
+export type EconomicDemoHostedChallengeProbeResult = {
+  profileId: EconomicDemoProbeProfileId;
+  endpoint: string;
+  ok: boolean;
+  observedAt: string;
+  httpStatus: number | null;
+  x402HeaderPresent: boolean;
+  challenge: {
+    version?: string;
+    network?: string;
+    payTo?: string;
+    amount?: string;
+    currency?: string;
+    endpoint?: string;
+    noncePresent: boolean;
+    memo?: string;
+  } | null;
+  error: string | null;
+};
+
+export type EconomicDemoHostedChallengeProbe = {
+  schemaVersion: typeof ECONOMIC_DEMO_HOSTED_CHALLENGE_PROBE_SCHEMA_VERSION;
+  generatedAt: string;
+  mode: "unpaid_402_challenge_probe";
+  results: EconomicDemoHostedChallengeProbeResult[];
+  summary: {
+    requested: number;
+    ok: number;
+    failed: number;
+    allChallengesObserved: boolean;
+  };
+  guardrails: {
+    exactAllowlistedEndpointsOnly: true;
+    noX402PaymentHeaderSent: true;
+    noPaymentRetryAttempted: true;
+    noSignerMaterialUsed: true;
+    noDevnetTransfer: true;
+    noMainnetTransfer: true;
+  };
+  claimBoundary: string;
+};
+
+const allowlistedEndpoints = Object.fromEntries(
+  openRouterAll30EndpointEvidence.map((entry) => [entry.profileId, entry]),
+) as Record<string, (typeof openRouterAll30EndpointEvidence)[number]>;
+
+function parseChallengeHeader(header: string | null) {
+  if (!header) return null;
+  try {
+    const parsed = JSON.parse(header) as Record<string, unknown>;
+    return {
+      version: typeof parsed.version === "string" ? parsed.version : undefined,
+      network: typeof parsed.network === "string" ? parsed.network : undefined,
+      payTo: typeof parsed.payTo === "string" ? parsed.payTo : undefined,
+      amount: typeof parsed.amount === "string" ? parsed.amount : undefined,
+      currency:
+        typeof parsed.currency === "string" ? parsed.currency : undefined,
+      endpoint:
+        typeof parsed.endpoint === "string" ? parsed.endpoint : undefined,
+      noncePresent: typeof parsed.nonce === "string" && parsed.nonce.length > 0,
+      memo: typeof parsed.memo === "string" ? parsed.memo : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function challengeMatchesAllowlist(
+  profileId: EconomicDemoProbeProfileId,
+  endpoint: string,
+  challenge: EconomicDemoHostedChallengeProbeResult["challenge"],
+) {
+  if (!challenge) return false;
+  const expected = allowlistedEndpoints[profileId];
+  return (
+    challenge.network === "solana-devnet" &&
+    challenge.currency === "USDC" &&
+    challenge.payTo === expected.walletAddress &&
+    challenge.endpoint === endpoint &&
+    challenge.noncePresent
+  );
+}
+
+async function probeOne(
+  profileId: EconomicDemoProbeProfileId,
+  timeoutMs: number,
+): Promise<EconomicDemoHostedChallengeProbeResult> {
+  const entry = allowlistedEndpoints[profileId];
+  const observedAt = new Date().toISOString();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(entry.endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: profileId,
+        messages: [
+          {
+            role: "user",
+            content:
+              "Economic demo unpaid challenge probe only. Do not execute paid work.",
+          },
+        ],
+        max_tokens: 1,
+      }),
+      signal: controller.signal,
+      cache: "no-store",
+    });
+    const challenge = parseChallengeHeader(
+      response.headers.get("x402-request"),
+    );
+    const ok =
+      response.status === 402 &&
+      response.headers.has("x402-request") &&
+      challengeMatchesAllowlist(profileId, entry.endpoint, challenge);
+
+    return {
+      profileId,
+      endpoint: entry.endpoint,
+      ok,
+      observedAt,
+      httpStatus: response.status,
+      x402HeaderPresent: response.headers.has("x402-request"),
+      challenge,
+      error: ok ? null : "challenge_did_not_match_allowlist",
+    };
+  } catch (error) {
+    return {
+      profileId,
+      endpoint: entry.endpoint,
+      ok: false,
+      observedAt,
+      httpStatus: null,
+      x402HeaderPresent: false,
+      challenge: null,
+      error: error instanceof Error ? error.name : "probe_failed",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function runEconomicDemoHostedChallengeProbe(options?: {
+  timeoutMs?: number;
+}): Promise<EconomicDemoHostedChallengeProbe> {
+  const timeoutMs = Math.min(
+    Math.max(options?.timeoutMs ?? 5_000, 1_000),
+    8_000,
+  );
+  const generatedAt = new Date().toISOString();
+  const results = await Promise.all(
+    ECONOMIC_DEMO_PROBE_PROFILE_IDS.map((profileId) =>
+      probeOne(profileId, timeoutMs),
+    ),
+  );
+  const ok = results.filter((result) => result.ok).length;
+
+  return {
+    schemaVersion: ECONOMIC_DEMO_HOSTED_CHALLENGE_PROBE_SCHEMA_VERSION,
+    generatedAt,
+    mode: "unpaid_402_challenge_probe",
+    results,
+    summary: {
+      requested: results.length,
+      ok,
+      failed: results.length - ok,
+      allChallengesObserved: ok === results.length,
+    },
+    guardrails: {
+      exactAllowlistedEndpointsOnly: true,
+      noX402PaymentHeaderSent: true,
+      noPaymentRetryAttempted: true,
+      noSignerMaterialUsed: true,
+      noDevnetTransfer: true,
+      noMainnetTransfer: true,
+    },
+    claimBoundary:
+      "Fresh unpaid hosted endpoint probe only: observes HTTP 402 x402 challenges from exact allowlisted Coolify specialist endpoints; sends no x402-payment header, performs no paid retry, uses no signer material, and makes no transfer or settlement claim.",
+  };
+}


### PR DESCRIPTION
## Summary\n- Adds a safe unpaid hosted challenge probe API for the economic demo\n- Probes exact allowlisted Coolify specialist endpoints for fresh HTTP 402 x402 challenges\n- Adds a judge-facing UI control and Playwright coverage for the probe result\n- Adds Jest coverage asserting no x402-payment/auth header is sent and no payment retry/signing/transfer is represented\n\n## Live probe evidence\nDirect unpaid probes returned HTTP 402 + x402-request for:\n- planning-agent\n- content-creation-agent\n- code-generation-agent\n- verification-validation-agent\n\n## Validation\n- npx jest lib/__tests__/economic-demo-hosted-challenge-probe.test.ts --runInBand\n- npm run lint -- app/economic-demo/page.tsx app/api/economic-demo/hosted-challenge-probe/route.ts lib/economic-demo/hosted-challenge-probe.ts lib/__tests__/economic-demo-hosted-challenge-probe.test.ts e2e/economic-demo.spec.ts\n- npm run test:e2e -- e2e/economic-demo.spec.ts --project=chromium\n- npm run check:product:naming -- app/economic-demo/page.tsx app/api/economic-demo/hosted-challenge-probe/route.ts lib/economic-demo/hosted-challenge-probe.ts e2e/economic-demo.spec.ts\n- npm run check:submission:claim-boundaries\n\n## Claim boundaries\n- Unpaid 402 challenge observation only\n- No x402-payment header\n- No payment retry\n- No signer material\n- No devnet/mainnet transfer\n- No production settlement claim