### PR TITLE
feat: fold hosted probe into economic demo run

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,6 +6,10 @@
 
 
 
+## Latest Update — Economic-demo PR D single-run proof flow underway (2026-05-08)
+
+Branch `feature/economic-demo-single-run-proof-flow` folds the hosted 402 challenge probe into the primary `Run demo` action. The judge now gets one main flow: prompt/quote → fresh unpaid hosted 402 probe → controlled live-run envelope → rendered output/evidence drawer. Probe failure is non-blocking for controlled evidence rendering and is shown as a warning; no payment retry/signing/transfer is attempted. Local validation passed: lint, Playwright economic-demo e2e, product naming, and claim-boundary checks.
+
 ## Latest Update — Economic-demo PR C hosted challenge probe underway (2026-05-08)
 
 Branch `feature/economic-demo-hosted-challenge-probe` adds a safe unpaid `POST /api/economic-demo/hosted-challenge-probe` lane. It probes exact allowlisted Coolify specialist endpoints for the webpage workflow (`planning-agent`, `content-creation-agent`, `code-generation-agent`, `verification-validation-agent`) and only observes fresh HTTP 402 x402 challenge headers. Guardrails: no `x402-payment` header, no payment retry, no signer material, no devnet/mainnet transfer, no settlement claim. Direct live probe verified all 4 endpoints returned `402` + `x402-request` on solana-devnet/USDC. Local validation passed: Jest hosted-probe unit test, lint, Playwright economic-demo e2e, product naming, and claim-boundary checks.

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -317,7 +317,31 @@ export default function EconomicDemoPage() {
 
   async function runControlledDemo() {
     setRunStarted(true);
+    setHostedChallengeProbeStatus("loading");
     setWebpageLiveEvidenceStatus("loading");
+    try {
+      const probeRes = await fetch(
+        "/api/economic-demo/hosted-challenge-probe",
+        {
+          method: "POST",
+        },
+      );
+      const probePayload = (await probeRes.json()) as {
+        ok?: boolean;
+        probe?: EconomicDemoHostedChallengeProbe;
+      };
+      if (probeRes.ok && probePayload.ok && probePayload.probe) {
+        setHostedChallengeProbe(probePayload.probe);
+        setHostedChallengeProbeStatus("loaded");
+      } else {
+        setHostedChallengeProbe(null);
+        setHostedChallengeProbeStatus("error");
+      }
+    } catch {
+      setHostedChallengeProbe(null);
+      setHostedChallengeProbeStatus("error");
+    }
+
     try {
       const res = await fetch("/api/economic-demo/live-run", {
         method: "POST",
@@ -716,8 +740,8 @@ export default function EconomicDemoPage() {
                     </p>
                     <p className="mt-2 text-sm leading-6 text-gray-200">
                       Prompt selected → quote boundary accepted → hosted x402
-                      evidence requested → returned output and evidence drawer
-                      shown below.
+                      challenge probes observed → returned output and evidence
+                      drawer shown below.
                     </p>
                     {controlledLiveRun && (
                       <div

--- a/e2e/economic-demo.spec.ts
+++ b/e2e/economic-demo.spec.ts
@@ -80,13 +80,9 @@ test.describe("/economic-demo judge-facing story", () => {
     await expect(
       page.getByRole("link", { name: /open evidence archive/i }),
     ).toBeVisible();
-    await page.getByRole("button", { name: /probe hosted 402s/i }).click();
-    await expect(page.getByTestId("hosted-challenge-probe")).toContainText(
-      "Observed 4/4 allowlisted x402 challenges",
-    );
-    await expect(page.getByTestId("hosted-challenge-probe")).toContainText(
-      "no x402-payment header",
-    );
+    await expect(
+      page.getByRole("button", { name: /probe hosted 402s/i }),
+    ).toBeVisible();
     await expect(page.getByText("Prompt template").first()).toBeVisible();
 
     const quote = page.getByTestId("economic-upfront-quote");
@@ -117,6 +113,12 @@ test.describe("/economic-demo judge-facing story", () => {
     await page.getByRole("button", { name: /^run demo$/i }).click();
     await expect(page.getByTestId("live-run-status")).toContainText(
       "Controlled live-run timeline started",
+    );
+    await expect(page.getByTestId("hosted-challenge-probe")).toContainText(
+      "Observed 4/4 allowlisted x402 challenges",
+    );
+    await expect(page.getByTestId("hosted-challenge-probe")).toContainText(
+      "no x402-payment header",
     );
     await expect(
       page.getByTestId("controlled-live-run-envelope"),


### PR DESCRIPTION
## Summary\n- Folds the hosted unpaid 402 challenge probe into the primary Run demo action\n- Keeps the standalone Probe hosted 402s control for explicit re-checks\n- Updates the judge flow copy and Playwright coverage so one run shows fresh hosted challenge proof plus the controlled run envelope\n- Probe failure is non-blocking for controlled evidence rendering and is shown as a warning\n\n## Validation\n- npm run lint -- app/economic-demo/page.tsx e2e/economic-demo.spec.ts\n- npm run test:e2e -- e2e/economic-demo.spec.ts --project=chromium\n- npm run check:product:naming -- app/economic-demo/page.tsx e2e/economic-demo.spec.ts\n- npm run check:submission:claim-boundaries\n\n## Claim boundaries\n- Hosted probe remains unpaid 402 observation only\n- No x402-payment header\n- No payment retry\n- No signer material\n- No devnet/mainnet transfer\n- No production settlement claim