### PR TITLE
feat: add real x402 devnet receipt verifier

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,6 +6,10 @@
 
 
 
+## Latest Update — x402 real devnet receipt verifier underway (2026-05-08)
+
+Nissan approved Option A: autonomous orchestrator-owned devnet signer/funds should pay downstream specialists after user wallet funds/escrows the top-level request. Current blocker found: `@reddi/x402-solana sendPayment()` is still a mock receipt producer and hosted specialist verification only accepts explicit demo receipts unless real receipt verification is enabled. Branch `feature/x402-real-devnet-receipt-verifier` starts closing that gap by accepting hosted challenge shape (`payTo` + string amount), adding `SolanaReceiptVerifier` for real parsed Solana transactions, and wiring specialist runtime env flags `ALLOW_REAL_X402_PAYMENT`, `SOLANA_RPC_URL`, and `X402_USDC_DEVNET_MINT`. Validation so far: `npx tsc -p packages/x402-solana/tsconfig.json --noEmit`; `npm run build && NODE_PATH=$PWD/node_modules node --test dist/tests/runtime.test.js` in `packages/openrouter-specialists` passed 21/21. Package-local Jest is currently blocked because package-local `node_modules/ts-jest` is not installed in this workspace.
+
 ## Latest Update — Economic-demo PR E recording copy polish underway (2026-05-08)
 
 Branch `chore/economic-demo-recording-copy-polish` tightens judge-facing language to avoid overstating live paid execution. Hero now says `Inspect a controlled paid-agent workflow`; body says the judge probes hosted specialist x402 gates and inspects a controlled evidence trail. The proof pill says `Quasar devnet archive`, not `proof`, and the quote card payment claim says `controlled evidence only`. Local validation passed: lint, Playwright economic-demo e2e, product naming, and claim-boundary checks.

--- a/packages/openrouter-specialists/src/runtime.ts
+++ b/packages/openrouter-specialists/src/runtime.ts
@@ -4,10 +4,12 @@ import {
   defaultNonceReplayStore,
   DemoPaymentVerifier,
   parseX402PaymentHeader,
+  SolanaReceiptVerifier,
   type NonceReplayStore,
   type ReceiptVerificationResult,
   type X402Challenge,
 } from "@reddi/x402-solana";
+import { Connection } from "@solana/web3.js";
 import { buildAgentDependencyManifestDisclosure, buildAgenticWorkflowManifestDisclosure, buildDownstreamDisclosureLedger, buildNoDownstreamDisclosureLedger } from "./agentic-workflow-disclosure.js";
 import { buildAttestationPromptEnvelope, evaluateAttestation, normalizeAttestationRequest } from "./attestation.js";
 import { buildLiveDelegationAuditEnvelope } from "./delegation-audit.js";
@@ -31,6 +33,9 @@ export function createRuntimeConfig(env: NodeJS.ProcessEnv = process.env): Runti
     mockOpenRouter: env.OPENROUTER_MOCK === "1" || env.OPENROUTER_MOCK === "true",
     requirePayment: env.REQUIRE_X402_PAYMENT !== "false",
     allowDemoPayment: env.ALLOW_DEMO_X402_PAYMENT === "1" || env.ALLOW_DEMO_X402_PAYMENT === "true",
+    allowRealPayment: env.ALLOW_REAL_X402_PAYMENT === "1" || env.ALLOW_REAL_X402_PAYMENT === "true",
+    solanaRpcUrl: env.SOLANA_RPC_URL ?? "https://api.devnet.solana.com",
+    usdcDevnetMint: env.X402_USDC_DEVNET_MINT,
     enableAgentToAgentCalls: env.ENABLE_AGENT_TO_AGENT_CALLS === "1" || env.ENABLE_AGENT_TO_AGENT_CALLS === "true",
     enableLiveDelegationExecutor: env.ENABLE_LIVE_DELEGATION_EXECUTOR === "1" || env.ENABLE_LIVE_DELEGATION_EXECUTOR === "true",
     maxDownstreamCalls: env.MAX_DOWNSTREAM_CALLS ? Number.parseInt(env.MAX_DOWNSTREAM_CALLS, 10) : 0,
@@ -97,8 +102,15 @@ export async function verifyPayment(input: {
         : randomUUID();
   if (!receiptNonce) return { ok: false, reason: "invalid_nonce", message: "x402 payment nonce is required" };
   const challenge = buildProfileChallenge(input.profile, input.config, receiptNonce, input.endpointPath);
-  const verifier = new DemoPaymentVerifier(input.config.allowDemoPayment === true);
-  return verifier.verifyReceipt(parsed, challenge, input.replayStore);
+  const demoResult = await new DemoPaymentVerifier(input.config.allowDemoPayment === true).verifyReceipt(parsed, challenge, input.replayStore);
+  if (demoResult.ok || !input.config.allowRealPayment) return demoResult;
+
+  const realVerifier = new SolanaReceiptVerifier({
+    allowRealPayment: true,
+    connection: new Connection(input.config.solanaRpcUrl ?? "https://api.devnet.solana.com"),
+    usdcMint: input.config.usdcDevnetMint,
+  });
+  return realVerifier.verifyReceipt(parsed, challenge, input.replayStore);
 }
 
 export function marketplaceMetadata(profile: SpecialistProfile, config: RuntimeConfig): Record<string, unknown> {

--- a/packages/openrouter-specialists/src/types.ts
+++ b/packages/openrouter-specialists/src/types.ts
@@ -32,6 +32,9 @@ export interface RuntimeConfig {
   mockOpenRouter: boolean;
   requirePayment: boolean;
   allowDemoPayment?: boolean;
+  allowRealPayment?: boolean;
+  solanaRpcUrl?: string;
+  usdcDevnetMint?: string;
   enableAgentToAgentCalls?: boolean;
   enableLiveDelegationExecutor?: boolean;
   maxDownstreamCalls?: number;

--- a/packages/x402-solana/dist/payment.d.ts
+++ b/packages/x402-solana/dist/payment.d.ts
@@ -27,6 +27,20 @@ export declare class DemoPaymentVerifier implements ReceiptVerifier {
     constructor(allowDemoPayment: boolean);
     verifyReceipt(receipt: unknown, challenge: X402Challenge, replayStore?: NonceReplayStore): Promise<ReceiptVerificationResult>;
 }
+export interface ParsedTransactionConnection {
+    getParsedTransaction(signature: string, options?: unknown): Promise<any>;
+}
+export interface SolanaReceiptVerifierOptions {
+    allowRealPayment: boolean;
+    connection: ParsedTransactionConnection;
+    /** Required when verifying USDC/SPL-token receipts. */
+    usdcMint?: string;
+}
+export declare class SolanaReceiptVerifier implements ReceiptVerifier {
+    private readonly options;
+    constructor(options: SolanaReceiptVerifierOptions);
+    verifyReceipt(receiptInput: unknown, challenge: X402Challenge, replayStore?: NonceReplayStore): Promise<ReceiptVerificationResult>;
+}
 export interface SendPaymentOptions {
     swapClient?: SwapClient;
     slippageBps?: number;

--- a/packages/x402-solana/dist/payment.js
+++ b/packages/x402-solana/dist/payment.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.DemoPaymentVerifier = exports.isValidPaymentAddress = void 0;
+exports.SolanaReceiptVerifier = exports.DemoPaymentVerifier = exports.isValidPaymentAddress = void 0;
 exports.isValidSolanaPublicKey = isValidSolanaPublicKey;
 exports.buildX402Challenge = buildX402Challenge;
 exports.parseX402Header = parseX402Header;
@@ -50,21 +50,26 @@ function buildX402Challenge(input) {
 function parseX402Header(header) {
     try {
         const parsed = JSON.parse(header);
-        if (typeof parsed.amount !== 'number' || parsed.amount <= 0)
+        const amount = typeof parsed.amount === 'number' ? parsed.amount : typeof parsed.amount === 'string' ? Number(parsed.amount) : Number.NaN;
+        if (!Number.isFinite(amount) || amount <= 0)
             throw new Error('amount must be a positive number');
         if (!parsed.currency || typeof parsed.currency !== 'string')
             throw new Error('currency is required (e.g., "SOL")');
-        if (!parsed.paymentAddress || typeof parsed.paymentAddress !== 'string')
+        const paymentAddress = typeof parsed.paymentAddress === 'string' ? parsed.paymentAddress : typeof parsed.payTo === 'string' ? parsed.payTo : undefined;
+        if (!paymentAddress)
             throw new Error('paymentAddress is required');
         if (!parsed.nonce || typeof parsed.nonce !== 'string')
             throw new Error('nonce is required');
-        if (!isValidSolanaPublicKey(parsed.paymentAddress))
+        if (!isValidSolanaPublicKey(paymentAddress))
             throw new Error('paymentAddress must be a valid Solana public key');
         return {
-            amount: parsed.amount,
+            amount,
             currency: parsed.currency,
-            paymentAddress: parsed.paymentAddress,
+            paymentAddress,
             nonce: parsed.nonce,
+            network: typeof parsed.network === 'string' ? parsed.network : undefined,
+            endpoint: typeof parsed.endpoint === 'string' ? parsed.endpoint : undefined,
+            memo: typeof parsed.memo === 'string' ? parsed.memo : undefined,
             payerCurrency: typeof parsed.payerCurrency === 'string' ? parsed.payerCurrency : undefined,
             payerAddress: typeof parsed.payerAddress === 'string' ? parsed.payerAddress : undefined,
             autoSwap: typeof parsed.autoSwap === 'boolean' ? parsed.autoSwap : false,
@@ -171,6 +176,88 @@ class DemoPaymentVerifier {
     }
 }
 exports.DemoPaymentVerifier = DemoPaymentVerifier;
+class SolanaReceiptVerifier {
+    constructor(options) {
+        this.options = options;
+    }
+    async verifyReceipt(receiptInput, challenge, replayStore) {
+        if (!this.options.allowRealPayment) {
+            return { ok: false, reason: 'unsupported_receipt', message: 'real Solana receipt verification is disabled' };
+        }
+        const receipt = normalizeReceipt(receiptInput);
+        if (!receipt || receipt.demo)
+            return { ok: false, reason: 'invalid_receipt', message: 'real Solana receipt is required' };
+        const base = validateReceiptShape(receipt, challenge);
+        if (base)
+            return base;
+        const signature = receipt.signature ?? receipt.txSignature;
+        if (!signature)
+            return { ok: false, reason: 'invalid_receipt', message: 'receipt signature is required' };
+        const parsed = await this.options.connection.getParsedTransaction(signature, {
+            commitment: 'confirmed',
+            maxSupportedTransactionVersion: 0,
+        });
+        if (!parsed?.meta || parsed.meta.err)
+            return { ok: false, reason: 'invalid_receipt', message: 'transaction is missing or failed' };
+        const paid = challenge.currency === 'SOL'
+            ? transactionHasSolTransfer(parsed, receipt.payer, challenge.payTo, Number(challenge.amount))
+            : challenge.currency === 'USDC'
+                ? transactionHasTokenTransfer(parsed, receipt, challenge, this.options.usdcMint)
+                : false;
+        if (!paid)
+            return { ok: false, reason: 'invalid_receipt', message: 'transaction does not satisfy x402 challenge payment terms' };
+        if (replayStore) {
+            const accepted = await replayStore.checkAndStore(receipt.nonce);
+            if (!accepted)
+                return { ok: false, reason: 'duplicate_nonce', message: 'receipt nonce has already been used', actual: receipt.nonce };
+        }
+        return { ok: true, receipt, demo: false };
+    }
+}
+exports.SolanaReceiptVerifier = SolanaReceiptVerifier;
+function validateReceiptShape(receipt, challenge) {
+    if (receipt.network !== challenge.network)
+        return { ok: false, reason: 'wrong_network', message: 'receipt network does not match challenge', expected: challenge.network, actual: receipt.network };
+    if (!isValidSolanaPublicKey(receipt.payTo))
+        return { ok: false, reason: 'invalid_payee', message: 'receipt payTo is not a valid Solana public key', actual: receipt.payTo };
+    if (receipt.payTo !== challenge.payTo)
+        return { ok: false, reason: 'wrong_payee', message: 'receipt payee does not match challenge', expected: challenge.payTo, actual: receipt.payTo };
+    if (String(receipt.amount) !== String(challenge.amount))
+        return { ok: false, reason: 'wrong_amount', message: 'receipt amount does not match challenge', expected: challenge.amount, actual: receipt.amount };
+    if (receipt.currency !== challenge.currency)
+        return { ok: false, reason: 'wrong_currency', message: 'receipt currency does not match challenge', expected: challenge.currency, actual: receipt.currency };
+    if (receipt.nonce !== challenge.nonce)
+        return { ok: false, reason: 'invalid_nonce', message: 'receipt nonce does not match challenge', expected: challenge.nonce, actual: receipt.nonce };
+    return undefined;
+}
+function transactionHasSolTransfer(parsed, payer, payTo, amountSol) {
+    const lamports = Math.ceil(amountSol * web3_js_1.LAMPORTS_PER_SOL);
+    return parsed.transaction?.message?.instructions?.some((ix) => {
+        const info = ix?.parsed?.info;
+        return ix?.programId?.toString?.() === web3_js_1.SystemProgram.programId.toBase58()
+            && ix?.parsed?.type === 'transfer'
+            && (!payer || info?.source === payer)
+            && info?.destination === payTo
+            && Number(info?.lamports) >= lamports;
+    }) === true;
+}
+function transactionHasTokenTransfer(parsed, receipt, challenge, expectedMint) {
+    if (!expectedMint && !receipt.mint)
+        return false;
+    const mint = expectedMint ?? receipt.mint;
+    const expectedAmount = String(challenge.amount);
+    return parsed.transaction?.message?.instructions?.some((ix) => {
+        const info = ix?.parsed?.info;
+        if (!['transfer', 'transferChecked'].includes(ix?.parsed?.type))
+            return false;
+        if (info?.mint && info.mint !== mint)
+            return false;
+        if (receipt.destinationTokenAccount && info?.destination !== receipt.destinationTokenAccount)
+            return false;
+        const tokenAmount = info?.tokenAmount?.uiAmountString ?? info?.tokenAmount?.uiAmount ?? info?.amount;
+        return String(tokenAmount) === expectedAmount;
+    }) === true;
+}
 /**
  * Send a payment via Solana SystemProgram.transfer.
  * In this package version, this remains a test stub; no funding transactions are submitted.

--- a/packages/x402-solana/dist/types.d.ts
+++ b/packages/x402-solana/dist/types.d.ts
@@ -7,6 +7,9 @@ export interface X402Request {
     currency: string;
     paymentAddress: string;
     nonce: string;
+    network?: SolanaPaymentNetwork;
+    endpoint?: string;
+    memo?: string;
     payerCurrency?: string;
     payerAddress?: string;
     autoSwap?: boolean;
@@ -38,6 +41,8 @@ export interface X402PaymentReceipt {
     signature?: string;
     txSignature?: string;
     payer?: string;
+    mint?: string;
+    destinationTokenAccount?: string;
     demo?: boolean;
 }
 /**

--- a/packages/x402-solana/src/payment.ts
+++ b/packages/x402-solana/src/payment.ts
@@ -1,4 +1,4 @@
-import { PublicKey } from '@solana/web3.js';
+import { LAMPORTS_PER_SOL, PublicKey, SystemProgram } from '@solana/web3.js';
 import { needsAutoSwap, resolveMint, SwapClient } from './jupiter';
 import { X402Request, PaymentReceipt } from './types';
 import type {
@@ -48,16 +48,21 @@ export function buildX402Challenge(input: X402ChallengeInput): X402Challenge {
 export function parseX402Header(header: string): X402Request {
   try {
     const parsed = JSON.parse(header);
-    if (typeof parsed.amount !== 'number' || parsed.amount <= 0) throw new Error('amount must be a positive number');
+    const amount = typeof parsed.amount === 'number' ? parsed.amount : typeof parsed.amount === 'string' ? Number(parsed.amount) : Number.NaN;
+    if (!Number.isFinite(amount) || amount <= 0) throw new Error('amount must be a positive number');
     if (!parsed.currency || typeof parsed.currency !== 'string') throw new Error('currency is required (e.g., "SOL")');
-    if (!parsed.paymentAddress || typeof parsed.paymentAddress !== 'string') throw new Error('paymentAddress is required');
+    const paymentAddress = typeof parsed.paymentAddress === 'string' ? parsed.paymentAddress : typeof parsed.payTo === 'string' ? parsed.payTo : undefined;
+    if (!paymentAddress) throw new Error('paymentAddress is required');
     if (!parsed.nonce || typeof parsed.nonce !== 'string') throw new Error('nonce is required');
-    if (!isValidSolanaPublicKey(parsed.paymentAddress)) throw new Error('paymentAddress must be a valid Solana public key');
+    if (!isValidSolanaPublicKey(paymentAddress)) throw new Error('paymentAddress must be a valid Solana public key');
     return {
-      amount: parsed.amount,
+      amount,
       currency: parsed.currency,
-      paymentAddress: parsed.paymentAddress,
+      paymentAddress,
       nonce: parsed.nonce,
+      network: typeof parsed.network === 'string' ? parsed.network : undefined,
+      endpoint: typeof parsed.endpoint === 'string' ? parsed.endpoint : undefined,
+      memo: typeof parsed.memo === 'string' ? parsed.memo : undefined,
       payerCurrency: typeof parsed.payerCurrency === 'string' ? parsed.payerCurrency : undefined,
       payerAddress: typeof parsed.payerAddress === 'string' ? parsed.payerAddress : undefined,
       autoSwap: typeof parsed.autoSwap === 'boolean' ? parsed.autoSwap : false,
@@ -167,6 +172,88 @@ export class DemoPaymentVerifier implements ReceiptVerifier {
   verifyReceipt(receipt: unknown, challenge: X402Challenge, replayStore?: NonceReplayStore): Promise<ReceiptVerificationResult> {
     return verifyDemoPaymentReceipt({ receipt, challenge, allowDemoPayment: this.allowDemoPayment, replayStore });
   }
+}
+
+export interface ParsedTransactionConnection {
+  getParsedTransaction(signature: string, options?: unknown): Promise<any>;
+}
+
+export interface SolanaReceiptVerifierOptions {
+  allowRealPayment: boolean;
+  connection: ParsedTransactionConnection;
+  /** Required when verifying USDC/SPL-token receipts. */
+  usdcMint?: string;
+}
+
+export class SolanaReceiptVerifier implements ReceiptVerifier {
+  constructor(private readonly options: SolanaReceiptVerifierOptions) {}
+
+  async verifyReceipt(receiptInput: unknown, challenge: X402Challenge, replayStore?: NonceReplayStore): Promise<ReceiptVerificationResult> {
+    if (!this.options.allowRealPayment) {
+      return { ok: false, reason: 'unsupported_receipt', message: 'real Solana receipt verification is disabled' };
+    }
+    const receipt = normalizeReceipt(receiptInput);
+    if (!receipt || receipt.demo) return { ok: false, reason: 'invalid_receipt', message: 'real Solana receipt is required' };
+    const base = validateReceiptShape(receipt, challenge);
+    if (base) return base;
+    const signature = receipt.signature ?? receipt.txSignature;
+    if (!signature) return { ok: false, reason: 'invalid_receipt', message: 'receipt signature is required' };
+
+    const parsed = await this.options.connection.getParsedTransaction(signature, {
+      commitment: 'confirmed',
+      maxSupportedTransactionVersion: 0,
+    });
+    if (!parsed?.meta || parsed.meta.err) return { ok: false, reason: 'invalid_receipt', message: 'transaction is missing or failed' };
+
+    const paid = challenge.currency === 'SOL'
+      ? transactionHasSolTransfer(parsed, receipt.payer, challenge.payTo, Number(challenge.amount))
+      : challenge.currency === 'USDC'
+        ? transactionHasTokenTransfer(parsed, receipt, challenge, this.options.usdcMint)
+        : false;
+    if (!paid) return { ok: false, reason: 'invalid_receipt', message: 'transaction does not satisfy x402 challenge payment terms' };
+
+    if (replayStore) {
+      const accepted = await replayStore.checkAndStore(receipt.nonce);
+      if (!accepted) return { ok: false, reason: 'duplicate_nonce', message: 'receipt nonce has already been used', actual: receipt.nonce };
+    }
+    return { ok: true, receipt, demo: false };
+  }
+}
+
+function validateReceiptShape(receipt: X402PaymentReceipt, challenge: X402Challenge): ReceiptVerificationResult | undefined {
+  if (receipt.network !== challenge.network) return { ok: false, reason: 'wrong_network', message: 'receipt network does not match challenge', expected: challenge.network, actual: receipt.network };
+  if (!isValidSolanaPublicKey(receipt.payTo)) return { ok: false, reason: 'invalid_payee', message: 'receipt payTo is not a valid Solana public key', actual: receipt.payTo };
+  if (receipt.payTo !== challenge.payTo) return { ok: false, reason: 'wrong_payee', message: 'receipt payee does not match challenge', expected: challenge.payTo, actual: receipt.payTo };
+  if (String(receipt.amount) !== String(challenge.amount)) return { ok: false, reason: 'wrong_amount', message: 'receipt amount does not match challenge', expected: challenge.amount, actual: receipt.amount };
+  if (receipt.currency !== challenge.currency) return { ok: false, reason: 'wrong_currency', message: 'receipt currency does not match challenge', expected: challenge.currency, actual: receipt.currency };
+  if (receipt.nonce !== challenge.nonce) return { ok: false, reason: 'invalid_nonce', message: 'receipt nonce does not match challenge', expected: challenge.nonce, actual: receipt.nonce };
+  return undefined;
+}
+
+function transactionHasSolTransfer(parsed: any, payer: string | undefined, payTo: string, amountSol: number): boolean {
+  const lamports = Math.ceil(amountSol * LAMPORTS_PER_SOL);
+  return parsed.transaction?.message?.instructions?.some((ix: any) => {
+    const info = ix?.parsed?.info;
+    return ix?.programId?.toString?.() === SystemProgram.programId.toBase58()
+      && ix?.parsed?.type === 'transfer'
+      && (!payer || info?.source === payer)
+      && info?.destination === payTo
+      && Number(info?.lamports) >= lamports;
+  }) === true;
+}
+
+function transactionHasTokenTransfer(parsed: any, receipt: X402PaymentReceipt, challenge: X402Challenge, expectedMint?: string): boolean {
+  if (!expectedMint && !receipt.mint) return false;
+  const mint = expectedMint ?? receipt.mint;
+  const expectedAmount = String(challenge.amount);
+  return parsed.transaction?.message?.instructions?.some((ix: any) => {
+    const info = ix?.parsed?.info;
+    if (!['transfer', 'transferChecked'].includes(ix?.parsed?.type)) return false;
+    if (info?.mint && info.mint !== mint) return false;
+    if (receipt.destinationTokenAccount && info?.destination !== receipt.destinationTokenAccount) return false;
+    const tokenAmount = info?.tokenAmount?.uiAmountString ?? info?.tokenAmount?.uiAmount ?? info?.amount;
+    return String(tokenAmount) === expectedAmount;
+  }) === true;
 }
 
 export interface SendPaymentOptions {

--- a/packages/x402-solana/src/types.ts
+++ b/packages/x402-solana/src/types.ts
@@ -7,6 +7,9 @@ export interface X402Request {
   currency: string;
   paymentAddress: string;
   nonce: string;
+  network?: SolanaPaymentNetwork;
+  endpoint?: string;
+  memo?: string;
   payerCurrency?: string;
   payerAddress?: string;
   autoSwap?: boolean;
@@ -42,6 +45,8 @@ export interface X402PaymentReceipt {
   signature?: string;
   txSignature?: string;
   payer?: string;
+  mint?: string;
+  destinationTokenAccount?: string;
   demo?: boolean;
 }
 

--- a/packages/x402-solana/tests/payment.test.ts
+++ b/packages/x402-solana/tests/payment.test.ts
@@ -5,6 +5,7 @@ import {
   sendPayment,
   isValidPaymentAddress,
   isValidSolanaPublicKey,
+  SolanaReceiptVerifier,
 } from '../src/payment';
 import {
   checkAndStoreNonce,
@@ -30,6 +31,16 @@ describe('x402 Payment Module', () => {
       expect(result.currency).toBe('SOL');
       expect(result.paymentAddress).toBe(validAddress);
       expect(result.nonce).toBe('abc123');
+    });
+
+    it('should parse hosted x402 challenge shape with payTo and string amount', () => {
+      const header = JSON.stringify({ version: '1', network: 'solana-devnet', payTo: validAddress, amount: '0.03', currency: 'USDC', endpoint: 'https://example.test/v1/chat/completions', nonce: 'abc123' });
+      const result = parseX402Header(header);
+      expect(result.amount).toBe(0.03);
+      expect(result.currency).toBe('USDC');
+      expect(result.paymentAddress).toBe(validAddress);
+      expect(result.network).toBe('solana-devnet');
+      expect(result.endpoint).toBe('https://example.test/v1/chat/completions');
     });
 
     it('should reject zero amount', () => {
@@ -146,11 +157,71 @@ describe('x402 Payment Module', () => {
       if (!structuredToken.ok) expect(structuredToken.reason).toBe('invalid_receipt');
     });
 
-    it('rejects non-demo structured receipts until real settlement verification exists', async () => {
+    it('rejects non-demo structured receipts in demo-only verifier', async () => {
       const verifier = new DemoPaymentVerifier(true);
       const unsigned = await verifier.verifyReceipt({ ...challenge, signature: 'caller-authored' }, challenge);
       expect(unsigned.ok).toBe(false);
       if (!unsigned.ok) expect(unsigned.reason).toBe('unsupported_receipt');
+    });
+
+    it('accepts a real SOL receipt when the parsed transaction satisfies the challenge', async () => {
+      const solChallenge = buildX402Challenge({
+        network: 'solana-devnet',
+        payTo: validAddress,
+        amount: 0.001,
+        currency: 'SOL',
+        endpoint: 'https://planning.example.test/v1/chat/completions',
+        nonce: 'nonce-sol',
+      });
+      const verifier = new SolanaReceiptVerifier({
+        allowRealPayment: true,
+        connection: {
+          async getParsedTransaction() {
+            return {
+              meta: { err: null },
+              transaction: {
+                message: {
+                  instructions: [
+                    {
+                      programId: { toString: () => '11111111111111111111111111111111' },
+                      parsed: { type: 'transfer', info: { source: otherValidAddress, destination: validAddress, lamports: 1_000_000 } },
+                    },
+                  ],
+                },
+              },
+            };
+          },
+        },
+      });
+      const result = await verifier.verifyReceipt({ network: 'solana-devnet', payTo: validAddress, amount: 0.001, currency: 'SOL', nonce: 'nonce-sol', payer: otherValidAddress, signature: 'sig-sol' }, solChallenge);
+      expect(result.ok).toBe(true);
+    });
+
+    it('accepts a real USDC receipt when the parsed token transfer satisfies the challenge', async () => {
+      const mint = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+      const verifier = new SolanaReceiptVerifier({
+        allowRealPayment: true,
+        usdcMint: mint,
+        connection: {
+          async getParsedTransaction() {
+            return {
+              meta: { err: null },
+              transaction: {
+                message: {
+                  instructions: [
+                    {
+                      program: 'spl-token',
+                      parsed: { type: 'transferChecked', info: { mint, destination: 'dest-token-account', tokenAmount: { uiAmountString: '0.03' } } },
+                    },
+                  ],
+                },
+              },
+            };
+          },
+        },
+      });
+      const result = await verifier.verifyReceipt({ network: 'solana-devnet', payTo: validAddress, amount: '0.03', currency: 'USDC', nonce: challenge.nonce, payer: otherValidAddress, signature: 'sig-usdc', destinationTokenAccount: 'dest-token-account' }, challenge);
+      expect(result.ok).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Starts the Option A live paid lane by adding real Solana receipt verification below the UI layer
- Parses hosted x402 challenge shape (`payTo` + string amount) in `@reddi/x402-solana`
- Adds `SolanaReceiptVerifier` for parsed SOL and USDC/SPL transfer receipts
- Wires specialist runtime flags: `ALLOW_REAL_X402_PAYMENT`, `SOLANA_RPC_URL`, and `X402_USDC_DEVNET_MINT`
- Keeps demo receipts fail-closed unless explicitly enabled

## Why this first
The hosted endpoints already issue fresh x402 challenges, but real paid completion was blocked because specialist verification only accepted explicit demo receipts and `sendPayment()` is still a mock receipt producer. This PR closes the verification half before adding the orchestrator signer/sender lane.

## Validation
- `npx tsc -p packages/x402-solana/tsconfig.json --noEmit`
- `cd packages/openrouter-specialists && npm run build && NODE_PATH=$PWD/node_modules node --test dist/tests/runtime.test.js`

## Known local test note
- `npm --prefix packages/x402-solana test -- --runInBand tests/payment.test.ts` is blocked in this workspace because package-local `node_modules/ts-jest` is not installed; TypeScript compile was used as the gate for that package.
