### PR TITLE
fix: preflight economic demo devnet USDC balance

### DIFF
--- a/lib/economic-demo/live-paid-devnet-run.ts
+++ b/lib/economic-demo/live-paid-devnet-run.ts
@@ -10,6 +10,7 @@ import {
 import {
   createAssociatedTokenAccountIdempotentInstruction,
   createTransferCheckedInstruction,
+  getAccount,
   getAssociatedTokenAddressSync,
 } from "@solana/spl-token";
 
@@ -189,6 +190,16 @@ async function payUsdcChallenge(input: {
   amount: number;
 }) {
   const sourceTokenAccount = getAssociatedTokenAddressSync(input.mint, input.signer.publicKey);
+  const requiredBaseUnits = usdcToBaseUnits(input.amount);
+  try {
+    const sourceAccount = await getAccount(input.connection, sourceTokenAccount, "confirmed");
+    if (sourceAccount.amount < requiredBaseUnits) {
+      throw new Error("insufficient_devnet_usdc");
+    }
+  } catch {
+    throw new Error(`orchestrator wallet lacks enough devnet USDC for challenge: required ${input.amount} USDC`);
+  }
+
   const destinationTokenAccount = getAssociatedTokenAddressSync(input.mint, input.payTo);
   const tx = new Transaction().add(
     createAssociatedTokenAccountIdempotentInstruction(


### PR DESCRIPTION
## Summary\n- fail the live paid devnet lane closed with a clear blocker when the orchestrator wallet lacks devnet USDC\n- avoid leaking raw signer material or noisy Solana simulation logs in the demo response\n\n## Validation\n- npm run lint -- lib/economic-demo/live-paid-devnet-run.ts lib/__tests__/economic-demo-live-paid-devnet-run.test.ts\n- npx jest lib/__tests__/economic-demo-live-paid-devnet-run.test.ts --runInBand\n- live local armed run blocks cleanly at planning-agent with: orchestrator wallet lacks enough devnet USDC for challenge: required 0.03 USDC