### PR TITLE
fix: verify SPL receipt payee ownership end-to-end

### DIFF
--- a/packages/x402-solana/dist/payment.js
+++ b/packages/x402-solana/dist/payment.js
@@ -123,6 +123,8 @@ function normalizeReceipt(receipt) {
         signature: typeof record.signature === 'string' ? record.signature : undefined,
         txSignature: typeof record.txSignature === 'string' ? record.txSignature : undefined,
         payer: typeof record.payer === 'string' ? record.payer : undefined,
+        mint: typeof record.mint === 'string' ? record.mint : undefined,
+        destinationTokenAccount: typeof record.destinationTokenAccount === 'string' ? record.destinationTokenAccount : undefined,
         demo: record.demo === true,
     };
 }
@@ -246,17 +248,42 @@ function transactionHasTokenTransfer(parsed, receipt, challenge, expectedMint) {
         return false;
     const mint = expectedMint ?? receipt.mint;
     const expectedAmount = String(challenge.amount);
-    return parsed.transaction?.message?.instructions?.some((ix) => {
+    const instructions = parsed.transaction?.message?.instructions;
+    if (!Array.isArray(instructions))
+        return false;
+    return instructions.some((ix) => {
         const info = ix?.parsed?.info;
-        if (!['transfer', 'transferChecked'].includes(ix?.parsed?.type))
+        if (!info || !['transfer', 'transferChecked'].includes(ix?.parsed?.type))
             return false;
-        if (info?.mint && info.mint !== mint)
+        if (info.mint && info.mint !== mint)
             return false;
-        if (receipt.destinationTokenAccount && info?.destination !== receipt.destinationTokenAccount)
+        if (receipt.payer && info.authority && info.authority !== receipt.payer)
             return false;
-        const tokenAmount = info?.tokenAmount?.uiAmountString ?? info?.tokenAmount?.uiAmount ?? info?.amount;
-        return String(tokenAmount) === expectedAmount;
-    }) === true;
+        if (receipt.destinationTokenAccount && info.destination !== receipt.destinationTokenAccount)
+            return false;
+        const tokenAmount = info.tokenAmount?.uiAmountString ?? info.tokenAmount?.uiAmount ?? info.amount;
+        if (String(tokenAmount) !== expectedAmount)
+            return false;
+        const destination = typeof info.destination === 'string' ? info.destination : receipt.destinationTokenAccount;
+        if (!destination)
+            return false;
+        return transactionTokenAccountOwnedBy(parsed, destination, mint, challenge.payTo);
+    });
+}
+function transactionTokenAccountOwnedBy(parsed, tokenAccount, mint, owner) {
+    const accountKeys = parsed.transaction?.message?.accountKeys;
+    const postTokenBalances = parsed.meta?.postTokenBalances;
+    if (!Array.isArray(accountKeys) || !Array.isArray(postTokenBalances))
+        return false;
+    return postTokenBalances.some((balance) => {
+        if (balance?.owner !== owner)
+            return false;
+        if (mint && balance?.mint !== mint)
+            return false;
+        const key = accountKeys[balance?.accountIndex];
+        const pubkey = typeof key === 'string' ? key : key?.pubkey?.toString?.() ?? key?.toString?.();
+        return pubkey === tokenAccount;
+    });
 }
 /**
  * Send a payment via Solana SystemProgram.transfer.

--- a/packages/x402-solana/src/payment.ts
+++ b/packages/x402-solana/src/payment.ts
@@ -114,6 +114,8 @@ function normalizeReceipt(receipt: unknown): X402PaymentReceipt | undefined {
     signature: typeof record.signature === 'string' ? record.signature : undefined,
     txSignature: typeof record.txSignature === 'string' ? record.txSignature : undefined,
     payer: typeof record.payer === 'string' ? record.payer : undefined,
+    mint: typeof record.mint === 'string' ? record.mint : undefined,
+    destinationTokenAccount: typeof record.destinationTokenAccount === 'string' ? record.destinationTokenAccount : undefined,
     demo: record.demo === true,
   };
 }
@@ -246,14 +248,37 @@ function transactionHasTokenTransfer(parsed: any, receipt: X402PaymentReceipt, c
   if (!expectedMint && !receipt.mint) return false;
   const mint = expectedMint ?? receipt.mint;
   const expectedAmount = String(challenge.amount);
-  return parsed.transaction?.message?.instructions?.some((ix: any) => {
+  const instructions = parsed.transaction?.message?.instructions;
+  if (!Array.isArray(instructions)) return false;
+
+  return instructions.some((ix: any) => {
     const info = ix?.parsed?.info;
-    if (!['transfer', 'transferChecked'].includes(ix?.parsed?.type)) return false;
-    if (info?.mint && info.mint !== mint) return false;
-    if (receipt.destinationTokenAccount && info?.destination !== receipt.destinationTokenAccount) return false;
-    const tokenAmount = info?.tokenAmount?.uiAmountString ?? info?.tokenAmount?.uiAmount ?? info?.amount;
-    return String(tokenAmount) === expectedAmount;
-  }) === true;
+    if (!info || !['transfer', 'transferChecked'].includes(ix?.parsed?.type)) return false;
+    if (info.mint && info.mint !== mint) return false;
+    if (receipt.payer && info.authority && info.authority !== receipt.payer) return false;
+    if (receipt.destinationTokenAccount && info.destination !== receipt.destinationTokenAccount) return false;
+
+    const tokenAmount = info.tokenAmount?.uiAmountString ?? info.tokenAmount?.uiAmount ?? info.amount;
+    if (String(tokenAmount) !== expectedAmount) return false;
+
+    const destination = typeof info.destination === 'string' ? info.destination : receipt.destinationTokenAccount;
+    if (!destination) return false;
+    return transactionTokenAccountOwnedBy(parsed, destination, mint, challenge.payTo);
+  });
+}
+
+function transactionTokenAccountOwnedBy(parsed: any, tokenAccount: string, mint: string | undefined, owner: string): boolean {
+  const accountKeys = parsed.transaction?.message?.accountKeys;
+  const postTokenBalances = parsed.meta?.postTokenBalances;
+  if (!Array.isArray(accountKeys) || !Array.isArray(postTokenBalances)) return false;
+
+  return postTokenBalances.some((balance: any) => {
+    if (balance?.owner !== owner) return false;
+    if (mint && balance?.mint !== mint) return false;
+    const key = accountKeys[balance?.accountIndex];
+    const pubkey = typeof key === 'string' ? key : key?.pubkey?.toString?.() ?? key?.toString?.();
+    return pubkey === tokenAccount;
+  });
 }
 
 export interface SendPaymentOptions {

--- a/packages/x402-solana/tests/payment.test.ts
+++ b/packages/x402-solana/tests/payment.test.ts
@@ -197,7 +197,7 @@ describe('x402 Payment Module', () => {
       expect(result.ok).toBe(true);
     });
 
-    it('accepts a real USDC receipt when the parsed token transfer satisfies the challenge', async () => {
+    it('accepts a real USDC receipt when the parsed token transfer pays a token account owned by the challenged payee', async () => {
       const mint = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
       const verifier = new SolanaReceiptVerifier({
         allowRealPayment: true,
@@ -205,9 +205,44 @@ describe('x402 Payment Module', () => {
         connection: {
           async getParsedTransaction() {
             return {
-              meta: { err: null },
+              meta: {
+                err: null,
+                postTokenBalances: [{ accountIndex: 1, mint, owner: validAddress, uiTokenAmount: { uiAmountString: '1.03' } }],
+              },
               transaction: {
                 message: {
+                  accountKeys: [{ pubkey: { toString: () => 'source-token-account' } }, { pubkey: { toString: () => 'dest-token-account' } }],
+                  instructions: [
+                    {
+                      program: 'spl-token',
+                      parsed: { type: 'transferChecked', info: { mint, authority: otherValidAddress, destination: 'dest-token-account', tokenAmount: { uiAmountString: '0.03' } } },
+                    },
+                  ],
+                },
+              },
+            };
+          },
+        },
+      });
+      const result = await verifier.verifyReceipt({ network: 'solana-devnet', payTo: validAddress, amount: '0.03', currency: 'USDC', nonce: challenge.nonce, payer: otherValidAddress, signature: 'sig-usdc', destinationTokenAccount: 'dest-token-account' }, challenge);
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects a real USDC receipt when the transfer destination is not owned by the challenged payee', async () => {
+      const mint = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+      const verifier = new SolanaReceiptVerifier({
+        allowRealPayment: true,
+        usdcMint: mint,
+        connection: {
+          async getParsedTransaction() {
+            return {
+              meta: {
+                err: null,
+                postTokenBalances: [{ accountIndex: 1, mint, owner: otherValidAddress, uiTokenAmount: { uiAmountString: '1.03' } }],
+              },
+              transaction: {
+                message: {
+                  accountKeys: ['source-token-account', 'dest-token-account'],
                   instructions: [
                     {
                       program: 'spl-token',
@@ -220,8 +255,38 @@ describe('x402 Payment Module', () => {
           },
         },
       });
-      const result = await verifier.verifyReceipt({ network: 'solana-devnet', payTo: validAddress, amount: '0.03', currency: 'USDC', nonce: challenge.nonce, payer: otherValidAddress, signature: 'sig-usdc', destinationTokenAccount: 'dest-token-account' }, challenge);
-      expect(result.ok).toBe(true);
+      const result = await verifier.verifyReceipt({ network: 'solana-devnet', payTo: validAddress, amount: '0.03', currency: 'USDC', nonce: challenge.nonce, signature: 'sig-usdc' }, challenge);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe('invalid_receipt');
+    });
+
+    it('rejects caller-supplied destinationTokenAccount unless it matches the on-chain instruction destination', async () => {
+      const mint = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+      const verifier = new SolanaReceiptVerifier({
+        allowRealPayment: true,
+        usdcMint: mint,
+        connection: {
+          async getParsedTransaction() {
+            return {
+              meta: { err: null, postTokenBalances: [{ accountIndex: 1, mint, owner: validAddress }] },
+              transaction: {
+                message: {
+                  accountKeys: ['source-token-account', 'actual-dest-token-account'],
+                  instructions: [
+                    {
+                      program: 'spl-token',
+                      parsed: { type: 'transferChecked', info: { mint, destination: 'actual-dest-token-account', tokenAmount: { uiAmountString: '0.03' } } },
+                    },
+                  ],
+                },
+              },
+            };
+          },
+        },
+      });
+      const result = await verifier.verifyReceipt({ network: 'solana-devnet', payTo: validAddress, amount: '0.03', currency: 'USDC', nonce: challenge.nonce, signature: 'sig-usdc', destinationTokenAccount: 'claimed-dest-token-account' }, challenge);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe('invalid_receipt');
     });
   });
 


### PR DESCRIPTION
## Summary\n- preserve real receipt mint and destination token account fields during normalization\n- require USDC/SPL payment transactions to include a parsed token transfer whose destination token account is owned by the challenged payee\n- reject receipts where caller-supplied destination token account does not match the on-chain transfer destination\n\n## Validation\n- npm test --prefix packages/x402-solana -- --runInBand\n- npm run build --prefix packages/x402-solana\n- npm test --prefix packages/openrouter-specialists\n- npm run check:economic-demo:live-payment-gate\n- git diff --check\n\n## Boundary\nThis makes the specialist runtime verify real Solana/SPL receipt semantics end-to-end when ALLOW_REAL_X402_PAYMENT is enabled. Successful live paid completion is still blocked until the orchestrator wallet is topped up with devnet USDC.