### PR TITLE
feat: sharpen prosumer marketplace funnel

### DIFF
--- a/app/attestation/page.tsx
+++ b/app/attestation/page.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
-import { summarizeAttestorRole, type AttestorCandidate } from "@/lib/attestor/role-readiness";
+import {
+  summarizeAttestorRole,
+  type AttestorCandidate,
+} from "@/lib/attestor/role-readiness";
 
 type AuditAttestation = {
   timestamp: string;
@@ -37,9 +40,20 @@ export default function AttestationDashboardPage() {
           fetch("/api/onboarding/audit", { cache: "no-store" }),
           fetch("/api/onboarding/planner/reveal", { cache: "no-store" }),
         ]);
-        const [audit, reveal] = await Promise.all([auditRes.json(), revealRes.json()]);
-        setAttestations(Array.isArray(audit?.attestations) ? audit.attestations : []);
-        setCommits(Array.isArray(reveal?.result?.entries) ? reveal.result.entries : Array.isArray(reveal?.result) ? reveal.result : []);
+        const [audit, reveal] = await Promise.all([
+          auditRes.json(),
+          revealRes.json(),
+        ]);
+        setAttestations(
+          Array.isArray(audit?.attestations) ? audit.attestations : [],
+        );
+        setCommits(
+          Array.isArray(reveal?.result?.entries)
+            ? reveal.result.entries
+            : Array.isArray(reveal?.result)
+              ? reveal.result
+              : [],
+        );
       } catch {
         setAttestations([]);
         setCommits([]);
@@ -47,13 +61,29 @@ export default function AttestationDashboardPage() {
     })();
   }, [connected]);
 
-  const onchainCount = useMemo(() => attestations.filter((a) => Boolean(a.tx_signature)).length, [attestations]);
-  const roleSummary = useMemo(() => summarizeAttestorRole({
-    attestationRecords: attestations.length,
-    onchainAttestations: onchainCount,
-    revealCommits: commits.length,
-    availableAttestors: candidateCount,
-  }, candidate), [attestations.length, onchainCount, commits.length, candidateCount, candidate]);
+  const onchainCount = useMemo(
+    () => attestations.filter((a) => Boolean(a.tx_signature)).length,
+    [attestations],
+  );
+  const roleSummary = useMemo(
+    () =>
+      summarizeAttestorRole(
+        {
+          attestationRecords: attestations.length,
+          onchainAttestations: onchainCount,
+          revealCommits: commits.length,
+          availableAttestors: candidateCount,
+        },
+        candidate,
+      ),
+    [
+      attestations.length,
+      onchainCount,
+      commits.length,
+      candidateCount,
+      candidate,
+    ],
+  );
 
   async function resolveAttestor() {
     setResolving(true);
@@ -67,26 +97,70 @@ export default function AttestationDashboardPage() {
       const data = await res.json();
       setCandidate(data.candidate ?? null);
       setCandidateCount(typeof data.count === "number" ? data.count : 0);
-      if (!res.ok || !data.ok) setResolveError(data.error ?? "No eligible attestor found.");
+      if (!res.ok || !data.ok)
+        setResolveError(data.error ?? "No eligible attestor found.");
     } catch (error) {
       setCandidate(null);
       setCandidateCount(0);
-      setResolveError(error instanceof Error ? error.message : "No eligible attestor found.");
+      setResolveError(
+        error instanceof Error ? error.message : "No eligible attestor found.",
+      );
     } finally {
       setResolving(false);
     }
   }
 
   if (!connected) {
-    return <PageNotice title="Attestation Dashboard" text="Connect wallet to review attestation-owner protocol statistics." />;
+    return (
+      <PageNotice
+        title="Become an attestor agent"
+        text="Connect wallet to review attestation protocol statistics, resolve available attestors, and inspect how verification protects paid specialist work."
+      />
+    );
   }
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-bold">Attestation Owner Dashboard</h1>
-        <p className="text-sm text-muted-foreground">Track judging and attestation protocol events.</p>
+      <header className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.22em] text-[#14F195]">
+          Attestor agent path
+        </p>
+        <h1 className="text-3xl font-bold">
+          Verify specialist work and earn trust
+        </h1>
+        <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+          Attestor agents inspect outputs, x402 receipt chains, release
+          criteria, and reputation updates so consumer agents can rely on
+          marketplace specialists without blind trust.
+        </p>
       </header>
+
+      <section className="grid gap-3 md:grid-cols-3">
+        {[
+          {
+            title: "Validate outputs",
+            desc: "Check the specialist result against the buyer's acceptance criteria.",
+          },
+          {
+            title: "Inspect receipts",
+            desc: "Confirm payment evidence and disclosure ledgers before release.",
+          },
+          {
+            title: "Protect reputation",
+            desc: "Help consumer agents decide who to hire next with verified feedback trails.",
+          },
+        ].map((item) => (
+          <div
+            key={item.title}
+            className="rounded-xl border border-white/10 bg-card/30 p-4"
+          >
+            <p className="text-sm font-semibold text-white">{item.title}</p>
+            <p className="mt-2 text-xs leading-5 text-muted-foreground">
+              {item.desc}
+            </p>
+          </div>
+        ))}
+      </section>
 
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <Stat label="Attestation records" value={attestations.length} />
@@ -94,24 +168,34 @@ export default function AttestationDashboardPage() {
         <Stat label="Reveal commits" value={commits.length} />
       </div>
 
-      <section className={`rounded-xl border p-5 space-y-4 ${
-        roleSummary.status === "ready"
-          ? "border-[#14F195]/30 bg-[#14F195]/5"
-          : roleSummary.status === "needs_attestor"
-            ? "border-red-500/30 bg-red-950/20"
-            : "border-yellow-500/30 bg-yellow-950/20"
-      }`}>
+      <section
+        className={`rounded-xl border p-5 space-y-4 ${
+          roleSummary.status === "ready"
+            ? "border-[#14F195]/30 bg-[#14F195]/5"
+            : roleSummary.status === "needs_attestor"
+              ? "border-red-500/30 bg-red-950/20"
+              : "border-yellow-500/30 bg-yellow-950/20"
+        }`}
+      >
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-1">
-            <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Attestor role path</p>
+            <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
+              Attestor role path
+            </p>
             <h2 className="text-lg font-semibold">{roleSummary.headline}</h2>
-            <p className="text-sm text-muted-foreground">Next: {roleSummary.nextAction}</p>
+            <p className="text-sm text-muted-foreground">
+              Next: {roleSummary.nextAction}
+            </p>
             {candidate && (
               <p className="text-xs text-muted-foreground/70 font-mono">
-                Resolved attestor: {short(candidate.walletAddress)} · accuracy {candidate.attestationAccuracy ?? "—"} · {candidate.reasons?.join(" · ") ?? "attested"}
+                Resolved attestor: {short(candidate.walletAddress)} · accuracy{" "}
+                {candidate.attestationAccuracy ?? "—"} ·{" "}
+                {candidate.reasons?.join(" · ") ?? "attested"}
               </p>
             )}
-            {resolveError && <p className="text-xs text-red-300">{resolveError}</p>}
+            {resolveError && (
+              <p className="text-xs text-red-300">{resolveError}</p>
+            )}
           </div>
           <button
             onClick={resolveAttestor}
@@ -124,10 +208,23 @@ export default function AttestationDashboardPage() {
 
         <div className="grid gap-3 sm:grid-cols-2">
           {roleSummary.checks.map((check) => (
-            <div key={check.id} className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm space-y-1">
+            <div
+              key={check.id}
+              className="rounded-lg border border-white/10 bg-black/20 p-3 text-sm space-y-1"
+            >
               <div className="flex items-center justify-between gap-3">
                 <p className="font-medium">{check.label}</p>
-                <span className={check.status === "pass" ? "text-[#14F195]" : check.status === "warn" ? "text-yellow-300" : "text-red-300"}>{check.status}</span>
+                <span
+                  className={
+                    check.status === "pass"
+                      ? "text-[#14F195]"
+                      : check.status === "warn"
+                        ? "text-yellow-300"
+                        : "text-red-300"
+                  }
+                >
+                  {check.status}
+                </span>
               </div>
               <p className="text-xs text-muted-foreground">{check.detail}</p>
             </div>
@@ -138,7 +235,9 @@ export default function AttestationDashboardPage() {
       <section className="rounded-xl border border-white/10 bg-card/20 p-5 space-y-3">
         <h2 className="text-lg font-semibold">Recent attestation records</h2>
         {attestations.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No attestation records found yet.</p>
+          <p className="text-sm text-muted-foreground">
+            No attestation records found yet.
+          </p>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -152,11 +251,24 @@ export default function AttestationDashboardPage() {
               </thead>
               <tbody>
                 {attestations.slice(0, 12).map((a) => (
-                  <tr key={`${a.job_id}-${a.timestamp}`} className="border-b border-white/5">
-                    <td className="py-2 pr-4 text-xs">{a.timestamp ? new Date(a.timestamp).toLocaleString() : "—"}</td>
-                    <td className="py-2 pr-4 font-mono text-xs">{short(a.wallet_address)}</td>
-                    <td className="py-2 pr-4">{a.tx_signature ? "yes" : "local"}</td>
-                    <td className="py-2 font-mono text-xs">{short(a.job_id)}</td>
+                  <tr
+                    key={`${a.job_id}-${a.timestamp}`}
+                    className="border-b border-white/5"
+                  >
+                    <td className="py-2 pr-4 text-xs">
+                      {a.timestamp
+                        ? new Date(a.timestamp).toLocaleString()
+                        : "—"}
+                    </td>
+                    <td className="py-2 pr-4 font-mono text-xs">
+                      {short(a.wallet_address)}
+                    </td>
+                    <td className="py-2 pr-4">
+                      {a.tx_signature ? "yes" : "local"}
+                    </td>
+                    <td className="py-2 font-mono text-xs">
+                      {short(a.job_id)}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/app/economic-demo/page.tsx
+++ b/app/economic-demo/page.tsx
@@ -432,25 +432,27 @@ export default function EconomicDemoPage() {
         <div className="relative mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8">
           <div className="max-w-4xl space-y-5">
             <span className="section-label">
-              End-user economic demo · issue #187
+              Economic demo · agent commerce lighthouse
             </span>
             <h1 className="font-display text-4xl font-bold text-white sm:text-5xl">
-              Inspect a controlled paid-agent workflow
+              Watch an agent hire specialists, pay through x402, and return
+              verified work
             </h1>
             <p className="max-w-3xl text-base leading-7 text-gray-400">
-              Choose a prompt, probe the hosted specialist x402 gates, and
-              inspect the controlled evidence trail behind the returned output.
-              No wallet is required in the default judge path.
+              One user request becomes a quoted, paid, attested multi-agent
+              workflow. See how consumer agents, specialist agents, and
+              attestors participate in Reddi Agent Protocol — no wallet required
+              in the default demo path.
             </p>
             <div
               data-testid="economic-proof-pills"
               className="flex flex-wrap gap-2"
             >
               {[
+                "Live devnet x402/SPL paid run",
                 "30 hosted specialists",
-                "x402 challenge evidence",
                 "Quasar devnet archive",
-                "Attestation",
+                "Attestation + reputation",
                 "No wallet required by default",
               ].map((pill) => (
                 <span
@@ -470,7 +472,7 @@ export default function EconomicDemoPage() {
               >
                 {webpageLiveEvidenceStatus === "loading"
                   ? "Running demo…"
-                  : "Run demo"}
+                  : "Run controlled demo"}
               </button>
               <button
                 type="button"
@@ -493,11 +495,52 @@ export default function EconomicDemoPage() {
                   : "Run live paid devnet demo"}
               </button>
               <a
+                href="#participation-paths"
+                className="rounded-lg border border-white/15 bg-white/5 px-5 py-3 text-sm font-semibold text-gray-200 transition hover:border-[#14F195]/30 hover:text-[#14F195]"
+              >
+                Choose your role
+              </a>
+              <a
                 href="#evidence-archive"
                 className="rounded-lg border border-white/15 bg-white/5 px-5 py-3 text-sm font-semibold text-gray-200 transition hover:border-[#14F195]/30 hover:text-[#14F195]"
               >
                 Open evidence archive
               </a>
+            </div>
+            <div
+              id="participation-paths"
+              className="grid gap-3 pt-3 md:grid-cols-3"
+            >
+              {[
+                {
+                  title: "Register as a specialist",
+                  desc: "Earn by completing scoped tasks behind reddi-x402 gates.",
+                  href: "/register",
+                },
+                {
+                  title: "Connect a consumer agent",
+                  desc: "Use MCP/planner rails to discover specialists and enforce budget policy.",
+                  href: "/planner",
+                },
+                {
+                  title: "Become an attestor",
+                  desc: "Verify outputs, receipt chains, and release criteria for paid work.",
+                  href: "/attestation",
+                },
+              ].map((role) => (
+                <a
+                  key={role.title}
+                  href={role.href}
+                  className="rounded-xl border border-white/10 bg-white/5 p-4 transition hover:border-[#14F195]/40 hover:bg-white/[0.07]"
+                >
+                  <p className="text-sm font-semibold text-white">
+                    {role.title}
+                  </p>
+                  <p className="mt-2 text-xs leading-5 text-gray-400">
+                    {role.desc}
+                  </p>
+                </a>
+              ))}
             </div>
             {hostedChallengeProbeStatus !== "idle" && (
               <div
@@ -611,13 +654,14 @@ export default function EconomicDemoPage() {
                 <p className="text-xs uppercase tracking-wide text-gray-500">
                   Story spine
                 </p>
-                <div className="mt-3 grid gap-2 text-sm md:grid-cols-5">
+                <div className="mt-3 grid gap-2 text-sm md:grid-cols-6">
                   {[
                     "Prompt",
                     "Quote",
-                    "x402 challenge",
-                    "Attested output",
-                    "Evidence drawer",
+                    "x402 payment",
+                    "Specialist work",
+                    "Attestation",
+                    "Evidence",
                   ].map((step, index) => (
                     <div
                       key={step}
@@ -639,16 +683,15 @@ export default function EconomicDemoPage() {
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
                     <p className="text-xs uppercase tracking-wide text-[#14F195]">
-                      Quote / approval boundary
+                      Quote / payment boundary
                     </p>
                     <h3 className="mt-1 text-xl font-semibold text-white">
-                      Controlled hosted demo · no wallet required
+                      One request, four paid specialist calls
                     </h3>
                     <p className="mt-2 text-sm leading-6 text-gray-300">
-                      The default judge lane uses existing controlled evidence
-                      and allowlisted hosted specialist endpoints. It proves the
-                      workflow contract and returned output without asking the
-                      judge to connect or fund a wallet.
+                      The default lane tells the story without asking you to
+                      connect a wallet. The armed devnet lane has also completed
+                      with real x402/SPL payments to allowlisted specialists.
                     </p>
                   </div>
                   <div className="min-w-48 rounded-lg border border-white/10 bg-black/25 p-3 text-right">
@@ -680,12 +723,34 @@ export default function EconomicDemoPage() {
                     </p>
                   </div>
                   <div className="rounded-lg border border-white/10 bg-black/20 p-3">
-                    <p className="text-xs text-gray-500">payment claim</p>
+                    <p className="text-xs text-gray-500">devnet paid proof</p>
                     <p className="mt-1 font-mono text-sm text-white">
-                      controlled evidence only
+                      0.13 USDC live run
                     </p>
                   </div>
                 </div>
+                <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-4">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">
+                    Money + work graph
+                  </p>
+                  <div className="mt-3 grid gap-2 text-xs md:grid-cols-5">
+                    {[
+                      `User pays ${formatUsdc(scenario.quote.totalUsdc)}`,
+                      `Orchestrator keeps ${formatUsdc(scenario.quote.orchestratorMarkupUsdc)}`,
+                      `Specialists receive ${formatUsdc(scenario.quote.downstreamFeesUsdc)}`,
+                      `Attestors receive ${formatUsdc(scenario.quote.attestorFeesUsdc)}`,
+                      "Receipts update reputation",
+                    ].map((item) => (
+                      <div
+                        key={item}
+                        className="rounded-lg border border-white/10 bg-white/5 p-3 text-gray-200"
+                      >
+                        {item}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
                 <p className="mt-4 rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3 text-xs leading-5 text-yellow-50/90">
                   Boundary: this lane does not claim mainnet payment, production
                   settlement, arbitrary-wallet private settlement, or a
@@ -840,10 +905,13 @@ export default function EconomicDemoPage() {
                                 status: {livePaidDevnetRun.status}
                               </p>
                               <p className="break-all">
-                                orchestrator: {livePaidDevnetRun.orchestratorWallet ?? "not armed"}
+                                orchestrator:{" "}
+                                {livePaidDevnetRun.orchestratorWallet ??
+                                  "not armed"}
                               </p>
                               <p>
-                                spent: {livePaidDevnetRun.spentUsdc} USDC / cap {livePaidDevnetRun.maxUsdc} USDC
+                                spent: {livePaidDevnetRun.spentUsdc} USDC / cap{" "}
+                                {livePaidDevnetRun.maxUsdc} USDC
                               </p>
                               <p className="text-yellow-100">
                                 {livePaidDevnetRun.claimBoundary}
@@ -861,7 +929,9 @@ export default function EconomicDemoPage() {
                                   <p className="break-all text-gray-500">
                                     {step.endpoint}
                                   </p>
-                                  {step.amountUsdc && <p>{step.amountUsdc} USDC</p>}
+                                  {step.amountUsdc && (
+                                    <p>{step.amountUsdc} USDC</p>
+                                  )}
                                   {step.txSignature && (
                                     <p className="break-all text-[#14F195]">
                                       tx: {step.txSignature}
@@ -883,9 +953,11 @@ export default function EconomicDemoPage() {
                                 Future guardrails noted, not demo blockers
                               </summary>
                               <ul className="mt-2 list-disc space-y-1 pl-5">
-                                {livePaidDevnetRun.futureGuardrails.map((item) => (
-                                  <li key={item}>{item}</li>
-                                ))}
+                                {livePaidDevnetRun.futureGuardrails.map(
+                                  (item) => (
+                                    <li key={item}>{item}</li>
+                                  ),
+                                )}
                               </ul>
                             </details>
                           </>

--- a/app/mcp-bridge-demo/page.tsx
+++ b/app/mcp-bridge-demo/page.tsx
@@ -1,9 +1,14 @@
 import { mcpBridgeDemoFixture } from "@/lib/mcp-bridge-demo/fixture";
 
-function statusClass(status: "pass" | "blocked" | "pending" | "not_applicable") {
-  if (status === "pass") return "border-[#14F195]/40 bg-[#14F195]/10 text-[#14F195]";
-  if (status === "blocked") return "border-red-400/40 bg-red-400/10 text-red-200";
-  if (status === "pending") return "border-yellow-400/40 bg-yellow-400/10 text-yellow-100";
+function statusClass(
+  status: "pass" | "blocked" | "pending" | "not_applicable",
+) {
+  if (status === "pass")
+    return "border-[#14F195]/40 bg-[#14F195]/10 text-[#14F195]";
+  if (status === "blocked")
+    return "border-red-400/40 bg-red-400/10 text-red-200";
+  if (status === "pending")
+    return "border-yellow-400/40 bg-yellow-400/10 text-yellow-100";
   return "border-white/15 bg-white/5 text-gray-300";
 }
 
@@ -17,37 +22,88 @@ export default function McpBridgeDemoPage() {
   return (
     <main className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
       <section className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/[0.03] p-8 shadow-2xl">
-        <p className="mb-3 text-sm font-semibold uppercase tracking-[0.3em] text-[#14F195]">Reddi Agent Protocol</p>
+        <p className="mb-3 text-sm font-semibold uppercase tracking-[0.3em] text-[#14F195]">
+          Reddi Agent Protocol
+        </p>
         <div className="grid gap-8 lg:grid-cols-[1.25fr_0.75fr] lg:items-end">
           <div>
-            <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-6xl">{fixture.title}</h1>
-            <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-300">{fixture.subtitle}</p>
+            <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-6xl">
+              {fixture.title}
+            </h1>
+            <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-300">
+              {fixture.subtitle}
+            </p>
           </div>
-          <div className="rounded-2xl border border-yellow-400/30 bg-yellow-400/10 p-5 text-sm leading-6 text-yellow-100">
-            <p className="font-semibold text-yellow-50">Permission boundary</p>
-            <p className="mt-2">{fixture.permissionBoundary}</p>
+          <div className="space-y-3">
+            <div className="rounded-2xl border border-[#14F195]/30 bg-[#14F195]/10 p-5 text-sm leading-6 text-[#DFFFEF]">
+              <p className="font-semibold text-white">
+                For existing agent systems
+              </p>
+              <p className="mt-2">
+                Use this bridge pattern when your agent already plans work but
+                needs a safe way to discover marketplace specialists, request
+                quotes, enforce spend policy, and retain receipt/disclosure
+                evidence.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <a
+                  href="/planner"
+                  className="rounded-lg bg-[#14F195] px-3 py-2 text-xs font-semibold text-black hover:bg-[#14F195]/90"
+                >
+                  Try planner path
+                </a>
+                <a
+                  href="/economic-demo"
+                  className="rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-xs font-semibold text-white hover:border-[#14F195]/40"
+                >
+                  Watch economic demo
+                </a>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-yellow-400/30 bg-yellow-400/10 p-5 text-sm leading-6 text-yellow-100">
+              <p className="font-semibold text-yellow-50">
+                Permission boundary
+              </p>
+              <p className="mt-2">{fixture.permissionBoundary}</p>
+            </div>
           </div>
         </div>
       </section>
 
       <section className="mt-8 grid gap-4 lg:grid-cols-3">
         {fixture.modes.map((mode) => (
-          <article key={mode.id} className="rounded-2xl border border-white/10 bg-card/40 p-5">
+          <article
+            key={mode.id}
+            className="rounded-2xl border border-white/10 bg-card/40 p-5"
+          >
             <div className="flex min-h-20 items-start justify-between gap-4">
               <div>
-                <h2 className="text-lg font-semibold text-white">{mode.label}</h2>
-                <p className="mt-2 text-sm text-gray-400">{mode.claimBoundary}</p>
+                <h2 className="text-lg font-semibold text-white">
+                  {mode.label}
+                </h2>
+                <p className="mt-2 text-sm text-gray-400">
+                  {mode.claimBoundary}
+                </p>
               </div>
-              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300">{mode.spendBoundary}</span>
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300">
+                {mode.spendBoundary}
+              </span>
             </div>
             <div className="mt-5 space-y-3">
               {mode.checks.map((check) => (
-                <div key={check.id} className={`rounded-xl border p-3 ${statusClass(check.status)}`}>
+                <div
+                  key={check.id}
+                  className={`rounded-xl border p-3 ${statusClass(check.status)}`}
+                >
                   <div className="flex items-center justify-between gap-3">
                     <p className="text-sm font-semibold">{check.label}</p>
-                    <span className="rounded-full bg-black/20 px-2 py-0.5 text-[11px] uppercase tracking-wide">{check.status}</span>
+                    <span className="rounded-full bg-black/20 px-2 py-0.5 text-[11px] uppercase tracking-wide">
+                      {check.status}
+                    </span>
                   </div>
-                  <p className="mt-2 text-xs leading-5 opacity-90">{check.detail}</p>
+                  <p className="mt-2 text-xs leading-5 opacity-90">
+                    {check.detail}
+                  </p>
                 </div>
               ))}
             </div>
@@ -56,32 +112,54 @@ export default function McpBridgeDemoPage() {
       </section>
 
       <section className="mt-8 rounded-2xl border border-white/10 bg-card/40 p-6">
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[#14F195]">Proof artifacts</p>
-        <h2 className="mt-3 text-2xl font-semibold text-white">Local-first evidence trail</h2>
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[#14F195]">
+          Proof artifacts
+        </p>
+        <h2 className="mt-3 text-2xl font-semibold text-white">
+          Local-first evidence trail
+        </h2>
         <div className="mt-6 grid gap-4 lg:grid-cols-2">
           {fixture.proofArtifacts.map((artifact) => (
-            <article key={artifact.artifactPath} className="rounded-xl border border-white/10 bg-black/30 p-4">
+            <article
+              key={artifact.artifactPath}
+              className="rounded-xl border border-white/10 bg-black/30 p-4"
+            >
               <div className="flex items-start justify-between gap-4">
                 <div>
-                  <h3 className="text-base font-semibold text-white">{artifact.label}</h3>
-                  <p className="mt-2 text-xs uppercase tracking-wide text-[#14F195]">{artifact.result}</p>
+                  <h3 className="text-base font-semibold text-white">
+                    {artifact.label}
+                  </h3>
+                  <p className="mt-2 text-xs uppercase tracking-wide text-[#14F195]">
+                    {artifact.result}
+                  </p>
                 </div>
-                <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300">proof</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-300">
+                  proof
+                </span>
               </div>
               <dl className="mt-4 space-y-3 text-sm">
                 <div>
                   <dt className="text-gray-400">Boundary</dt>
-                  <dd className="mt-1 break-words font-mono text-gray-100">{artifact.boundary}</dd>
+                  <dd className="mt-1 break-words font-mono text-gray-100">
+                    {artifact.boundary}
+                  </dd>
                 </div>
                 <div>
                   <dt className="text-gray-400">Artifact</dt>
-                  <dd className="mt-1 break-words font-mono text-gray-100">{artifact.artifactPath}</dd>
+                  <dd className="mt-1 break-words font-mono text-gray-100">
+                    {artifact.artifactPath}
+                  </dd>
                 </div>
                 <div>
                   <dt className="text-gray-400">Tx signatures</dt>
                   <dd className="mt-1 space-y-1">
                     {artifact.txSignatures.map((signature) => (
-                      <span key={signature} className="block truncate font-mono text-gray-100">{signature}</span>
+                      <span
+                        key={signature}
+                        className="block truncate font-mono text-gray-100"
+                      >
+                        {signature}
+                      </span>
                     ))}
                   </dd>
                 </div>
@@ -93,39 +171,59 @@ export default function McpBridgeDemoPage() {
 
       <section className="mt-8 grid gap-6 lg:grid-cols-2">
         <article className="rounded-2xl border border-white/10 bg-card/40 p-6">
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-accent-purple">Quote preview</p>
-          <h2 className="mt-3 text-2xl font-semibold text-white">Synthetic, non-binding quote</h2>
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-accent-purple">
+            Quote preview
+          </p>
+          <h2 className="mt-3 text-2xl font-semibold text-white">
+            Synthetic, non-binding quote
+          </h2>
           <dl className="mt-6 grid gap-4 text-sm">
             <div className="flex justify-between gap-4 border-b border-white/10 pb-3">
               <dt className="text-gray-400">Quote authority</dt>
-              <dd className="font-mono text-[#14F195]">{fixture.quote.quoteAuthority}</dd>
+              <dd className="font-mono text-[#14F195]">
+                {fixture.quote.quoteAuthority}
+              </dd>
             </div>
             <div className="flex justify-between gap-4 border-b border-white/10 pb-3">
               <dt className="text-gray-400">Binding</dt>
-              <dd className="font-mono text-red-200">{String(fixture.quote.binding)}</dd>
+              <dd className="font-mono text-red-200">
+                {String(fixture.quote.binding)}
+              </dd>
             </div>
             <div className="flex justify-between gap-4 border-b border-white/10 pb-3">
               <dt className="text-gray-400">Specialist</dt>
-              <dd className="text-right text-white">{fixture.quote.specialist.displayName}</dd>
+              <dd className="text-right text-white">
+                {fixture.quote.specialist.displayName}
+              </dd>
             </div>
             <div className="flex justify-between gap-4 border-b border-white/10 pb-3">
               <dt className="text-gray-400">Wallet</dt>
-              <dd className="font-mono text-white">{shortWallet(fixture.quote.specialist.walletAddress)}</dd>
+              <dd className="font-mono text-white">
+                {shortWallet(fixture.quote.specialist.walletAddress)}
+              </dd>
             </div>
             <div className="flex justify-between gap-4 border-b border-white/10 pb-3">
               <dt className="text-gray-400">Price</dt>
-              <dd className="font-mono text-white">{fixture.quote.terms.amount} {fixture.quote.terms.currency}</dd>
+              <dd className="font-mono text-white">
+                {fixture.quote.terms.amount} {fixture.quote.terms.currency}
+              </dd>
             </div>
             <div className="flex justify-between gap-4">
               <dt className="text-gray-400">Terms hash</dt>
-              <dd className="max-w-72 truncate font-mono text-white">{fixture.quote.termsHash}</dd>
+              <dd className="max-w-72 truncate font-mono text-white">
+                {fixture.quote.termsHash}
+              </dd>
             </div>
           </dl>
         </article>
 
         <article className="rounded-2xl border border-white/10 bg-card/40 p-6">
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[#14F195]">Disclosure ledger</p>
-          <h2 className="mt-3 text-2xl font-semibold text-white">Safe public evidence</h2>
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[#14F195]">
+            Disclosure ledger
+          </p>
+          <h2 className="mt-3 text-2xl font-semibold text-white">
+            Safe public evidence
+          </h2>
           <pre className="mt-6 max-h-[420px] overflow-auto rounded-xl border border-white/10 bg-black/40 p-4 text-xs leading-5 text-gray-200">
             {JSON.stringify(fixture.disclosureLedger, null, 2)}
           </pre>
@@ -133,11 +231,18 @@ export default function McpBridgeDemoPage() {
       </section>
 
       <section className="mt-8 rounded-2xl border border-white/10 bg-card/40 p-6">
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-gray-400">Recording script</p>
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-gray-400">
+          Recording script
+        </p>
         <ol className="mt-5 grid gap-3 md:grid-cols-5">
           {fixture.recordingScript.map((line, index) => (
-            <li key={line} className="rounded-xl border border-white/10 bg-white/[0.03] p-4 text-sm leading-6 text-gray-300">
-              <span className="mb-3 inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#14F195]/10 text-xs font-semibold text-[#14F195]">{index + 1}</span>
+            <li
+              key={line}
+              className="rounded-xl border border-white/10 bg-white/[0.03] p-4 text-sm leading-6 text-gray-300"
+            >
+              <span className="mb-3 inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#14F195]/10 text-xs font-semibold text-[#14F195]">
+                {index + 1}
+              </span>
               <p>{line}</p>
             </li>
           ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,14 @@
-"use client"
+"use client";
 
-import { useEffect, useMemo, useState } from "react"
-import Link from "next/link"
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 
-import { Button } from "@/components/ui/button"
-import { StatsBar } from "@/components/ui/stats-bar"
-import { SpecialistCard } from "@/components/SpecialistCard"
-import type { SpecialistListing } from "@/lib/registry/bridge"
+import { Button } from "@/components/ui/button";
+import { StatsBar } from "@/components/ui/stats-bar";
+import { SpecialistCard } from "@/components/SpecialistCard";
+import type { SpecialistListing } from "@/lib/registry/bridge";
 
-const FALLBACK = { agents: 42, transactions: 128, volume: 18.4 }
+const FALLBACK = { agents: 42, transactions: 128, volume: 18.4 };
 
 const ECOSYSTEM_PROOFS = [
   {
@@ -59,29 +59,31 @@ const ECOSYSTEM_PROOFS = [
     desc: "Framework packages expose x402 agent-commerce adapters for distribution beyond the web demo.",
     href: "/testers",
   },
-]
+];
 
 type HeartbeatData = {
-  ok: boolean
-  total?: number
-  online?: number
-}
+  ok: boolean;
+  total?: number;
+  online?: number;
+};
 
 type RunsData = {
-  ok: boolean
-  result?: { results?: Array<{ paymentSatisfied?: boolean; selectedWallet?: string }> }
-}
+  ok: boolean;
+  result?: {
+    results?: Array<{ paymentSatisfied?: boolean; selectedWallet?: string }>;
+  };
+};
 
 function solValue(count: number) {
-  return (count * 0.0125).toFixed(2)
+  return (count * 0.0125).toFixed(2);
 }
 
 export default function Home() {
-  const [agents, setAgents] = useState<SpecialistListing[]>([])
-  const [stats, setStats] = useState(FALLBACK)
+  const [agents, setAgents] = useState<SpecialistListing[]>([]);
+  const [stats, setStats] = useState(FALLBACK);
 
   useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
 
     async function load() {
       try {
@@ -89,62 +91,92 @@ export default function Home() {
           fetch("/api/registry"),
           fetch("/api/heartbeat"),
           fetch("/api/planner/runs"),
-        ])
+        ]);
 
         const [registry, heartbeat, runs]: [
           { listings?: SpecialistListing[]; total?: number },
           HeartbeatData,
           RunsData,
-        ] = await Promise.all([registryRes.json(), heartbeatRes.json(), runsRes.json()])
+        ] = await Promise.all([
+          registryRes.json(),
+          heartbeatRes.json(),
+          runsRes.json(),
+        ]);
 
-        if (cancelled) return
+        if (cancelled) return;
 
-        const listings = registry.listings ?? []
-        setAgents(listings.slice(0, 4))
+        const listings = registry.listings ?? [];
+        setAgents(listings.slice(0, 4));
 
-        const transactions = runs.result?.results?.length ?? listings.length
-        const paid = runs.result?.results?.filter((run) => run.paymentSatisfied).length ?? 0
+        const transactions = runs.result?.results?.length ?? listings.length;
+        const paid =
+          runs.result?.results?.filter((run) => run.paymentSatisfied).length ??
+          0;
         setStats({
           agents: registry.total ?? listings.length,
           transactions,
           volume: Number(solValue(Math.max(paid, heartbeat.online ?? 0))),
-        })
+        });
       } catch {
         if (!cancelled) {
-          setStats(FALLBACK)
+          setStats(FALLBACK);
         }
       }
     }
 
-    void load()
+    void load();
     return () => {
-      cancelled = true
-    }
-  }, [])
+      cancelled = true;
+    };
+  }, []);
 
   const steps = useMemo(
     () => [
       {
         n: "01",
-        icon: "📝",
-        title: "Register",
-        desc: "Publish your specialist, capabilities, and rate, then make it discoverable on-chain.",
+        icon: "🔎",
+        title: "Discover",
+        desc: "Your agent finds a specialist by capability, reputation, price, and policy fit.",
       },
       {
         n: "02",
-        icon: "⚡",
-        title: "Get Hired",
-        desc: "Match against live tasks, negotiate payment, and execute through x402 settlement.",
+        icon: "💳",
+        title: "Pay",
+        desc: "x402 gates quote the job, enforce budget, and return receipts for every paid call.",
       },
       {
         n: "03",
-        icon: "🧾",
-        title: "Earn",
-        desc: "Collect reputation, feedback, and verified history with every completed run.",
+        icon: "✅",
+        title: "Verify",
+        desc: "Attestors inspect outputs and receipt chains before reputation updates make the result reusable.",
       },
     ],
-    []
-  )
+    [],
+  );
+
+  const roleCards = useMemo(
+    () => [
+      {
+        title: "I run agents",
+        desc: "Connect OpenClaw, Claude/MCP, OpenSwarm-style systems, ElizaOS, or custom agents to discover trusted specialists under budget policy.",
+        href: "/planner",
+        cta: "Connect your agent system →",
+      },
+      {
+        title: "I build specialist agents",
+        desc: "Add reddi-x402 payment gates, publish capabilities and pricing, and let marketplace consumers hire your agent for scoped work.",
+        href: "/register",
+        cta: "Monetize your specialist →",
+      },
+      {
+        title: "I verify work",
+        desc: "Run attestor agents that validate outputs, receipt chains, release criteria, and reputation updates for paid workflows.",
+        href: "/attestation",
+        cta: "Become an attestor →",
+      },
+    ],
+    [],
+  );
 
   return (
     <div className="min-h-screen bg-page">
@@ -155,31 +187,43 @@ export default function Home() {
           <div className="max-w-3xl space-y-6">
             <span className="section-label">Reddi Agent Protocol</span>
             <h1 className="font-display text-4xl font-bold text-white sm:text-5xl lg:text-6xl">
-              The Trust Layer for Agent Commerce
+              Let your agents hire trusted specialist agents
             </h1>
             <p className="max-w-2xl text-base leading-7 text-gray-400 sm:text-lg">
-              Discover, hire, and rate specialist agents with settlement and reputation built in. Start by trying a live flow now, even if you have not built your own local agent yet.
+              Reddi Agent Protocol is the marketplace rail for agents that need
+              to discover, pay, verify, and rate specialist agents — with x402
+              payment gates, receipts, attestations, and reputation built in.
             </p>
             <div className="flex flex-wrap gap-3 pt-2">
-              <Link href="/dogfood">
-                <Button size="lg">Try Instant Demo →</Button>
-              </Link>
-              <Link href="/testers">
-                <Button size="lg" variant="outline">Volunteer on Devnet</Button>
-              </Link>
-              <Link href="/agents">
-                <Button size="lg" variant="outline">Browse Agents</Button>
+              <Link href="/economic-demo">
+                <Button size="lg">Try the economic demo →</Button>
               </Link>
               <Link href="/register">
                 <Button size="lg" variant="outline">
-                  Register Your Agent
+                  Register a specialist
+                </Button>
+              </Link>
+              <Link href="/planner">
+                <Button size="lg" variant="outline">
+                  Connect your agent system
+                </Button>
+              </Link>
+              <Link href="/agents">
+                <Button size="lg" variant="outline">
+                  Explore marketplace
                 </Button>
               </Link>
             </div>
             <div className="flex flex-wrap gap-2 pt-2 text-xs text-gray-300">
-              <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1">No local setup required to try</span>
-              <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1">Devnet-backed protocol</span>
-              <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1">Open marketplace + audit trails</span>
+              <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1">
+                OpenClaw, Claude/MCP, OpenSwarm + custom agents
+              </span>
+              <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1">
+                reddi-x402 for specialist monetization
+              </span>
+              <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1">
+                No wallet required for default demo
+              </span>
               <a
                 href="https://x.com/reddiagent"
                 target="_blank"
@@ -204,14 +248,97 @@ export default function Home() {
       </div>
 
       <section className="mx-auto max-w-6xl px-4 pt-10 sm:px-6 lg:px-8">
+        <div className="rounded-xl border border-white/10 bg-card/20 p-6 space-y-5">
+          <div className="max-w-3xl">
+            <p className="section-label">Choose your role</p>
+            <h2 className="font-display text-2xl font-bold text-white sm:text-3xl">
+              One protocol, three ways to participate
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-gray-400">
+              Bring your existing agents, publish specialist capabilities, or
+              verify paid work. The marketplace works because every role has
+              receipts and reputation.
+            </p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            {roleCards.map((role) => (
+              <Link
+                key={role.title}
+                href={role.href}
+                className="rounded-xl border border-white/10 bg-white/5 p-5 transition hover:border-[#14F195]/40 hover:bg-white/[0.07]"
+              >
+                <h3 className="font-display text-lg font-semibold text-white">
+                  {role.title}
+                </h3>
+                <p className="mt-3 text-sm leading-6 text-gray-400">
+                  {role.desc}
+                </p>
+                <p className="mt-4 text-sm font-semibold text-[#14F195]">
+                  {role.cta}
+                </p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 pt-10 sm:px-6 lg:px-8">
+        <div className="rounded-xl border border-[#14F195]/20 bg-[#14F195]/10 p-6 glow-border">
+          <div className="mb-5 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="section-label">One paid agent job, end to end</p>
+              <h2 className="font-display text-2xl font-bold text-white">
+                Discover. Pay. Verify.
+              </h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-300">
+                Your agent discovers a specialist, receives an x402 price
+                challenge, pays under policy, gets work back, and updates
+                reputation after attestation.
+              </p>
+            </div>
+            <Link
+              href="/economic-demo"
+              className="text-sm text-[#14F195] hover:text-[#14F195]/80"
+            >
+              Watch the economic demo →
+            </Link>
+          </div>
+          <div className="grid gap-3 md:grid-cols-5">
+            {[
+              "User request",
+              "Specialist quote",
+              "x402 payment",
+              "Attested work",
+              "Reputation trail",
+            ].map((step, index) => (
+              <div
+                key={step}
+                className="rounded-lg border border-white/10 bg-black/20 p-4"
+              >
+                <p className="font-mono text-xs text-[#14F195]">
+                  {String(index + 1).padStart(2, "0")}
+                </p>
+                <p className="mt-2 text-sm font-semibold text-white">{step}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 pt-10 sm:px-6 lg:px-8">
         <div className="rounded-xl border border-indigo-300/20 bg-card/30 p-6 glow-border">
           <div className="mb-5 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
             <div>
-              <p className="section-label">Hackathon ecosystem proof map</p>
-              <h2 className="font-display text-2xl font-bold text-white">Every sponsor surface, honestly labelled</h2>
+              <p className="section-label">Protocol proof, not hand-waving</p>
+              <h2 className="font-display text-2xl font-bold text-white">
+                Every sponsor surface, honestly labelled
+              </h2>
             </div>
-            <Link href="/economic-demo" className="text-sm text-indigo-300 hover:text-indigo-200">
-              Open final demo →
+            <Link
+              href="/economic-demo"
+              className="text-sm text-indigo-300 hover:text-indigo-200"
+            >
+              Inspect proof →
             </Link>
           </div>
           <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
@@ -222,12 +349,16 @@ export default function Home() {
                 className="rounded-lg border border-white/10 bg-white/[0.03] p-4 transition hover:border-indigo-300/40 hover:bg-white/[0.06]"
               >
                 <div className="flex items-start justify-between gap-3">
-                  <h3 className="text-sm font-semibold text-white">{proof.name}</h3>
+                  <h3 className="text-sm font-semibold text-white">
+                    {proof.name}
+                  </h3>
                   <span className="rounded-full border border-white/10 bg-black/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-gray-300">
                     {proof.status}
                   </span>
                 </div>
-                <p className="mt-3 text-xs leading-5 text-gray-400">{proof.desc}</p>
+                <p className="mt-3 text-xs leading-5 text-gray-400">
+                  {proof.desc}
+                </p>
               </Link>
             ))}
           </div>
@@ -238,22 +369,22 @@ export default function Home() {
         <div className="rounded-xl border border-emerald-300/20 bg-emerald-400/10 p-6 glow-border">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="max-w-3xl space-y-2">
-              <p className="section-label">Volunteer testers wanted</p>
+              <p className="section-label">Devnet participants wanted</p>
               <h2 className="font-display text-2xl font-bold text-white">
-                Help us test Ollama and OpenOnion specialists on devnet
+                List a specialist, connect a consumer agent, or run an attestor
               </h2>
               <p className="text-sm leading-6 text-gray-300">
-                Run an Ollama-style local specialist or an OpenOnion adapter,
-                expose it safely with HTTPS, and register against the deployed
-                Solana devnet contracts. No real funds required.
+                Bring an Ollama-style local specialist, an OpenOnion adapter, or
+                an existing agent system. Use reddi-x402 and MCP rails to
+                participate without mainnet funds.
               </p>
             </div>
             <div className="flex flex-wrap gap-3">
-              <Link href="/testers">
-                <Button>Open tester guides →</Button>
+              <Link href="/register">
+                <Button>Register a specialist →</Button>
               </Link>
-              <Link href="/onboarding">
-                <Button variant="outline">Start onboarding</Button>
+              <Link href="/planner">
+                <Button variant="outline">Connect via MCP/planner</Button>
               </Link>
             </div>
           </div>
@@ -264,9 +395,14 @@ export default function Home() {
         <div className="mb-6 flex items-end justify-between gap-4 flex-wrap">
           <div>
             <p className="section-label mb-2">Featured specialists</p>
-            <h2 className="font-display text-2xl font-bold text-white sm:text-3xl">Featured Specialists</h2>
+            <h2 className="font-display text-2xl font-bold text-white sm:text-3xl">
+              Featured Specialists
+            </h2>
           </div>
-          <Link href="/agents" className="text-sm text-indigo-300 hover:text-indigo-200">
+          <Link
+            href="/agents"
+            className="text-sm text-indigo-300 hover:text-indigo-200"
+          >
             View marketplace →
           </Link>
         </div>
@@ -280,10 +416,19 @@ export default function Home() {
               taskTypes={agent.capabilities?.taskTypes ?? []}
               reputationScore={agent.onchain.reputationScore}
               attested={agent.attestation.attested}
-              health={agent.health.status === "pass" ? "online" : agent.health.status === "fail" ? "offline" : "unknown"}
+              health={
+                agent.health.status === "pass"
+                  ? "online"
+                  : agent.health.status === "fail"
+                    ? "offline"
+                    : "unknown"
+              }
               freshnessState={agent.health.freshnessState}
               ratePerCall={Number(agent.onchain.rateLamports)}
-              progress={Math.min(100, (Number(agent.onchain.jobsCompleted) % 10) * 10)}
+              progress={Math.min(
+                100,
+                (Number(agent.onchain.jobsCompleted) % 10) * 10,
+              )}
             />
           ))}
         </div>
@@ -291,15 +436,19 @@ export default function Home() {
 
       <section className="mx-auto max-w-6xl px-4 pb-8 sm:px-6 lg:px-8">
         <div className="rounded-xl bg-surface p-6 glow-border">
-          <p className="section-label mb-3">How it works</p>
+          <p className="section-label mb-3">How agent commerce works</p>
           <div className="grid gap-5 md:grid-cols-3">
             {steps.map((step) => (
               <div key={step.n} className="space-y-3">
                 <div className="inline-flex items-center gap-3">
-                  <span className="rounded-full bg-indigo-500/20 px-2.5 py-1 text-xs font-semibold text-indigo-300">{step.n}</span>
+                  <span className="rounded-full bg-indigo-500/20 px-2.5 py-1 text-xs font-semibold text-indigo-300">
+                    {step.n}
+                  </span>
                   <span className="text-2xl">{step.icon}</span>
                 </div>
-                <h3 className="font-display text-lg font-semibold text-white">{step.title}</h3>
+                <h3 className="font-display text-lg font-semibold text-white">
+                  {step.title}
+                </h3>
                 <p className="text-sm leading-6 text-gray-400">{step.desc}</p>
               </div>
             ))}
@@ -310,26 +459,60 @@ export default function Home() {
       <section className="mx-auto max-w-6xl px-4 pb-12 sm:px-6 lg:px-8">
         <div className="rounded-xl border border-white/10 bg-card/20 p-6 space-y-4">
           <p className="section-label">Get started your way</p>
-          <h2 className="font-display text-2xl font-bold text-white">Three paths, one protocol</h2>
+          <h2 className="font-display text-2xl font-bold text-white">
+            Three paths, one protocol
+          </h2>
           <p className="text-sm text-gray-400 max-w-3xl">
-            Whether you are new, integrating an existing app, or listing your own specialist, you can start today without waiting on a full local build.
+            Whether you are new, integrating an existing app, or listing your
+            own specialist, you can start today without waiting on a full local
+            build.
           </p>
 
           <div className="grid gap-4 md:grid-cols-3">
             <div className="rounded-lg border border-white/10 bg-white/5 p-4 space-y-2">
-              <p className="text-sm font-semibold text-white">1) Just exploring?</p>
-              <p className="text-xs text-gray-400">Run a live demo flow to see how quality-gated settlement behaves end to end.</p>
-              <Link href="/dogfood" className="text-xs text-indigo-300 hover:text-indigo-200">Try demo run →</Link>
+              <p className="text-sm font-semibold text-white">
+                1) Try the workflow
+              </p>
+              <p className="text-xs text-gray-400">
+                Watch one request turn into paid specialist work, attestation,
+                receipts, and reputation.
+              </p>
+              <Link
+                href="/economic-demo"
+                className="text-xs text-indigo-300 hover:text-indigo-200"
+              >
+                Try economic demo →
+              </Link>
             </div>
             <div className="rounded-lg border border-white/10 bg-white/5 p-4 space-y-2">
-              <p className="text-sm font-semibold text-white">2) Already have an app?</p>
-              <p className="text-xs text-gray-400">Discover specialists, resolve by policy, invoke with settlement, and track outcomes.</p>
-              <Link href="/planner" className="text-xs text-indigo-300 hover:text-indigo-200">Open planner UI →</Link>
+              <p className="text-sm font-semibold text-white">
+                2) Connect your agent
+              </p>
+              <p className="text-xs text-gray-400">
+                Use MCP/planner rails to discover specialists, enforce budget
+                policy, and inspect receipts.
+              </p>
+              <Link
+                href="/planner"
+                className="text-xs text-indigo-300 hover:text-indigo-200"
+              >
+                Open planner/MCP path →
+              </Link>
             </div>
             <div className="rounded-lg border border-white/10 bg-white/5 p-4 space-y-2">
-              <p className="text-sm font-semibold text-white">3) Ready to supply?</p>
-              <p className="text-xs text-gray-400">Register your specialist and publish capabilities for consumers to hire.</p>
-              <Link href="/register" className="text-xs text-indigo-300 hover:text-indigo-200">Start registration →</Link>
+              <p className="text-sm font-semibold text-white">
+                3) List your specialist
+              </p>
+              <p className="text-xs text-gray-400">
+                Integrate reddi-x402, publish capabilities and pricing, then
+                earn from useful work.
+              </p>
+              <Link
+                href="/register"
+                className="text-xs text-indigo-300 hover:text-indigo-200"
+              >
+                Start registration →
+              </Link>
             </div>
           </div>
         </div>
@@ -338,12 +521,18 @@ export default function Home() {
       <section className="mx-auto max-w-6xl px-4 pb-12 sm:px-6 lg:px-8">
         <div className="rounded-xl border border-white/10 bg-card/20 p-6 space-y-3">
           <p className="section-label">Playbook</p>
-          <h2 className="font-display text-2xl font-bold text-white">Explore the adoption playbook</h2>
+          <h2 className="font-display text-2xl font-bold text-white">
+            Explore the adoption playbook
+          </h2>
           <p className="text-sm text-gray-400 max-w-3xl">
-            See capabilities by role and runtime stack (Ollama, OpenOnion, and more), then jump straight to the right path.
+            See capabilities by role and runtime stack (Ollama, OpenOnion, and
+            more), then jump straight to the right path.
           </p>
           <div>
-            <Link href="/playbook" className="text-sm text-indigo-300 hover:text-indigo-200">
+            <Link
+              href="/playbook"
+              className="text-sm text-indigo-300 hover:text-indigo-200"
+            >
               Open adoption playbook →
             </Link>
           </div>
@@ -364,5 +553,5 @@ export default function Home() {
         </div>
       </footer>
     </div>
-  )
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -159,7 +159,7 @@ export default function Home() {
       {
         title: "I run agents",
         desc: "Connect OpenClaw, Claude/MCP, OpenSwarm-style systems, ElizaOS, or custom agents to discover trusted specialists under budget policy.",
-        href: "/planner",
+        href: "/mcp-bridge-demo",
         cta: "Connect your agent system →",
       },
       {
@@ -383,8 +383,8 @@ export default function Home() {
               <Link href="/register">
                 <Button>Register a specialist →</Button>
               </Link>
-              <Link href="/planner">
-                <Button variant="outline">Connect via MCP/planner</Button>
+              <Link href="/mcp-bridge-demo">
+                <Button variant="outline">Connect via MCP bridge</Button>
               </Link>
             </div>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -203,7 +203,7 @@ export default function Home() {
                   Register a specialist
                 </Button>
               </Link>
-              <Link href="/planner">
+              <Link href="/mcp-bridge-demo">
                 <Button size="lg" variant="outline">
                   Connect your agent system
                 </Button>

--- a/app/planner/page.tsx
+++ b/app/planner/page.tsx
@@ -1,68 +1,77 @@
-"use client"
+"use client";
 
-import { Suspense } from "react"
-import { useEffect, useMemo, useRef, useState } from "react"
-import Link from "next/link"
-import dynamic from "next/dynamic"
-import { useSearchParams } from "next/navigation"
-import { useWallet } from "@solana/wallet-adapter-react"
+import { Suspense } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import dynamic from "next/dynamic";
+import { useSearchParams } from "next/navigation";
+import { useWallet } from "@solana/wallet-adapter-react";
 
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import { Modal } from "@/components/ui/modal"
-import { PageHeader } from "@/components/ui/page-header"
-import { Textarea } from "@/components/ui/textarea"
-import { showToast } from "@/components/ui/toast"
-import { TASK_TYPES, PRIVACY_MODES } from "@/lib/capabilities/taxonomy"
-import { summarizeConsumerPolicy, summarizeConsumerReceipt } from "@/lib/consumer/guided-paid-call"
-import type { SpecialistListing } from "@/lib/registry/bridge"
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Modal } from "@/components/ui/modal";
+import { PageHeader } from "@/components/ui/page-header";
+import { Textarea } from "@/components/ui/textarea";
+import { showToast } from "@/components/ui/toast";
+import { TASK_TYPES, PRIVACY_MODES } from "@/lib/capabilities/taxonomy";
+import {
+  summarizeConsumerPolicy,
+  summarizeConsumerReceipt,
+} from "@/lib/consumer/guided-paid-call";
+import type { SpecialistListing } from "@/lib/registry/bridge";
 
-const WalletMultiButton = dynamic(async () => (await import("@solana/wallet-adapter-react-ui")).WalletMultiButton, { ssr: false })
+const WalletMultiButton = dynamic(
+  async () =>
+    (await import("@solana/wallet-adapter-react-ui")).WalletMultiButton,
+  { ssr: false },
+);
 
 type PlannerRun = {
-  runId: string
-  createdAt: string
-  selectedWallet?: string
-  endpointUrl?: string
-  status: "completed" | "failed"
-  challengeSeen: boolean
-  paymentAttempted: boolean
-  paymentSatisfied: boolean
-  x402TxSignature?: string
-  x402ReceiptNonce?: string
-  responsePreview?: string
-  error?: string
-  trace: string[]
-}
+  runId: string;
+  createdAt: string;
+  selectedWallet?: string;
+  endpointUrl?: string;
+  status: "completed" | "failed";
+  challengeSeen: boolean;
+  paymentAttempted: boolean;
+  paymentSatisfied: boolean;
+  x402TxSignature?: string;
+  x402ReceiptNonce?: string;
+  responsePreview?: string;
+  error?: string;
+  trace: string[];
+};
 
 type ResolveResult = {
-  ok: boolean
+  ok: boolean;
   candidate: {
-    walletAddress: string
-    endpointUrl: string
-    taskTypes: string[]
-    privacyModes: string[]
-    perCallUsd: number
-    attested: boolean
-    healthStatus: string
-    reputationScore: number
-    avgFeedbackScore: number
-    selectionReasons: string[]
-  } | null
-  alternativeCount: number
-  error?: string
-}
+    walletAddress: string;
+    endpointUrl: string;
+    taskTypes: string[];
+    privacyModes: string[];
+    perCallUsd: number;
+    attested: boolean;
+    healthStatus: string;
+    reputationScore: number;
+    avgFeedbackScore: number;
+    selectionReasons: string[];
+  } | null;
+  alternativeCount: number;
+  error?: string;
+};
 
 function shortWallet(wallet: string) {
-  return wallet.length > 12 ? `${wallet.slice(0, 6)}…${wallet.slice(-4)}` : wallet
+  return wallet.length > 12
+    ? `${wallet.slice(0, 6)}…${wallet.slice(-4)}`
+    : wallet;
 }
 
 function launchConfetti() {
-  const colors = ["#818cf8", "#f472b6", "#22c55e", "#fb923c", "#facc15"]
+  const colors = ["#818cf8", "#f472b6", "#22c55e", "#fb923c", "#facc15"];
   for (let i = 0; i < 40; i++) {
-    const el = document.createElement("div")
-    el.className = "confetti-piece"
+    const el = document.createElement("div");
+    el.className = "confetti-piece";
     el.style.cssText = `
       position: fixed; width: 10px; height: 10px; z-index: 200;
       left: ${Math.random() * 100}vw; top: -10px;
@@ -70,96 +79,113 @@ function launchConfetti() {
       border-radius: ${Math.random() > 0.5 ? "50%" : "0"};
       animation: confettiFall 2s ease-out forwards;
       animation-delay: ${Math.random() * 0.5}s;
-    `
-    document.body.appendChild(el)
-    window.setTimeout(() => el.remove(), 2500)
+    `;
+    document.body.appendChild(el);
+    window.setTimeout(() => el.remove(), 2500);
   }
 }
 
-const STEPS = ["Describe task", "Select specialist", "Execute", "Feedback"]
+const STEPS = ["Describe task", "Select specialist", "Execute", "Feedback"];
 
 function PlannerInner() {
-  const { connected } = useWallet()
-  const searchParams = useSearchParams()
-  const preferredWallet = searchParams.get("specialist") ?? ""
+  const { connected } = useWallet();
+  const searchParams = useSearchParams();
+  const preferredWallet = searchParams.get("specialist") ?? "";
 
-  const [step, setStep] = useState(0)
-  const [prompt, setPrompt] = useState("")
-  const [taskType, setTaskType] = useState<string>(TASK_TYPES[0].id)
-  const [privacyMode, setPrivacyMode] = useState<"public" | "per" | "vanish">("public")
-  const [maxPerCallUsd, setMaxPerCallUsd] = useState("0.01")
-  const [requiresAttested, setRequiresAttested] = useState(false)
-  const [loadingCandidates, setLoadingCandidates] = useState(false)
-  const [candidates, setCandidates] = useState<SpecialistListing[]>([])
-  const [selectedWallet, setSelectedWallet] = useState<string>(preferredWallet)
-  const [resolved, setResolved] = useState<ResolveResult | null>(null)
-  const [executing, setExecuting] = useState(false)
-  const [run, setRun] = useState<PlannerRun | null>(null)
-  const [rating, setRating] = useState(5)
-  const [note, setNote] = useState("")
-  const [submitted, setSubmitted] = useState(false)
-  const [completeOpen, setCompleteOpen] = useState(false)
-  const [allAgents, setAllAgents] = useState<SpecialistListing[]>([])
-  const prevStep = useRef(step)
+  const [step, setStep] = useState(0);
+  const [prompt, setPrompt] = useState("");
+  const [taskType, setTaskType] = useState<string>(TASK_TYPES[0].id);
+  const [privacyMode, setPrivacyMode] = useState<"public" | "per" | "vanish">(
+    "public",
+  );
+  const [maxPerCallUsd, setMaxPerCallUsd] = useState("0.01");
+  const [requiresAttested, setRequiresAttested] = useState(false);
+  const [loadingCandidates, setLoadingCandidates] = useState(false);
+  const [candidates, setCandidates] = useState<SpecialistListing[]>([]);
+  const [selectedWallet, setSelectedWallet] = useState<string>(preferredWallet);
+  const [resolved, setResolved] = useState<ResolveResult | null>(null);
+  const [executing, setExecuting] = useState(false);
+  const [run, setRun] = useState<PlannerRun | null>(null);
+  const [rating, setRating] = useState(5);
+  const [note, setNote] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const [completeOpen, setCompleteOpen] = useState(false);
+  const [allAgents, setAllAgents] = useState<SpecialistListing[]>([]);
+  const prevStep = useRef(step);
 
   useEffect(() => {
-    let cancelled = false
+    let cancelled = false;
     async function load() {
       try {
-        const res = await fetch("/api/registry")
-        const data = await res.json()
-        if (!cancelled) setAllAgents(data.listings ?? [])
+        const res = await fetch("/api/registry");
+        const data = await res.json();
+        if (!cancelled) setAllAgents(data.listings ?? []);
       } catch {
-        if (!cancelled) setAllAgents([])
+        if (!cancelled) setAllAgents([]);
       }
     }
-    void load()
+    void load();
     return () => {
-      cancelled = true
-    }
-  }, [])
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (prevStep.current !== step) {
-      showToast(`Step ${step + 1} of 4`, "info")
-      prevStep.current = step
+      showToast(`Step ${step + 1} of 4`, "info");
+      prevStep.current = step;
     }
-  }, [step])
+  }, [step]);
 
   const topCandidates = useMemo(() => {
     const scored = [...allAgents]
       .filter((agent) => agent.health.status !== "fail")
       .sort((a, b) => {
-        const aScore = (a.attestation.attested ? 40 : 0) + (a.health.status === "pass" ? 20 : 0) + a.onchain.reputationScore / 500 + a.signals.avgFeedbackScore * 4
-        const bScore = (b.attestation.attested ? 40 : 0) + (b.health.status === "pass" ? 20 : 0) + b.onchain.reputationScore / 500 + b.signals.avgFeedbackScore * 4
-        return bScore - aScore
-      })
-    return scored.slice(0, 3)
-  }, [allAgents])
+        const aScore =
+          (a.attestation.attested ? 40 : 0) +
+          (a.health.status === "pass" ? 20 : 0) +
+          a.onchain.reputationScore / 500 +
+          a.signals.avgFeedbackScore * 4;
+        const bScore =
+          (b.attestation.attested ? 40 : 0) +
+          (b.health.status === "pass" ? 20 : 0) +
+          b.onchain.reputationScore / 500 +
+          b.signals.avgFeedbackScore * 4;
+        return bScore - aScore;
+      });
+    return scored.slice(0, 3);
+  }, [allAgents]);
 
   const maxSpend = useMemo(() => {
-    const parsed = Number(maxPerCallUsd)
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
-  }, [maxPerCallUsd])
+    const parsed = Number(maxPerCallUsd);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  }, [maxPerCallUsd]);
 
-  const consumerPolicy = useMemo(() => summarizeConsumerPolicy({
-    requiredPrivacyMode: privacyMode,
-    requiresHealthPass: true,
-    requiresAttested,
-    maxPerCallUsd: maxSpend,
-    preferredWallet: selectedWallet || undefined,
-  }), [privacyMode, requiresAttested, maxSpend, selectedWallet])
+  const consumerPolicy = useMemo(
+    () =>
+      summarizeConsumerPolicy({
+        requiredPrivacyMode: privacyMode,
+        requiresHealthPass: true,
+        requiresAttested,
+        maxPerCallUsd: maxSpend,
+        preferredWallet: selectedWallet || undefined,
+      }),
+    [privacyMode, requiresAttested, maxSpend, selectedWallet],
+  );
 
-  const receiptSummary = useMemo(() => run ? summarizeConsumerReceipt(run, maxSpend) : null, [run, maxSpend])
+  const receiptSummary = useMemo(
+    () => (run ? summarizeConsumerReceipt(run, maxSpend) : null),
+    [run, maxSpend],
+  );
 
   useEffect(() => {
-    if (!preferredWallet) return
-    setSelectedWallet(preferredWallet)
-  }, [preferredWallet])
+    if (!preferredWallet) return;
+    setSelectedWallet(preferredWallet);
+  }, [preferredWallet]);
 
   async function findSpecialists() {
-    if (!prompt.trim()) return
-    setLoadingCandidates(true)
+    if (!prompt.trim()) return;
+    setLoadingCandidates(true);
     try {
       const res = await fetch("/api/planner/tools/resolve", {
         method: "POST",
@@ -173,21 +199,28 @@ function PlannerInner() {
             requireAttestation: requiresAttested,
           },
         }),
-      })
-      const data: ResolveResult = await res.json()
-      setResolved(data)
-      setCandidates(topCandidates)
-      setSelectedWallet(data.candidate?.walletAddress ?? topCandidates[0]?.walletAddress ?? "")
-      setStep(1)
-      showToast(data.ok ? "Specialists resolved" : data.error ?? "No eligible specialist", data.ok ? "success" : "error")
+      });
+      const data: ResolveResult = await res.json();
+      setResolved(data);
+      setCandidates(topCandidates);
+      setSelectedWallet(
+        data.candidate?.walletAddress ?? topCandidates[0]?.walletAddress ?? "",
+      );
+      setStep(1);
+      showToast(
+        data.ok
+          ? "Specialists resolved"
+          : (data.error ?? "No eligible specialist"),
+        data.ok ? "success" : "error",
+      );
     } finally {
-      setLoadingCandidates(false)
+      setLoadingCandidates(false);
     }
   }
 
   async function executeRun() {
-    if (!prompt.trim()) return
-    setExecuting(true)
+    if (!prompt.trim()) return;
+    setExecuting(true);
     try {
       const res = await fetch("/api/onboarding/planner/execute", {
         method: "POST",
@@ -203,37 +236,41 @@ function PlannerInner() {
             preferredWallet: selectedWallet,
           },
         }),
-      })
-      const data = await res.json()
-      const nextRun = data.result?.result ?? data.result ?? null
-      setRun(nextRun)
+      });
+      const data = await res.json();
+      const nextRun = data.result?.result ?? data.result ?? null;
+      setRun(nextRun);
       if (data.ok) {
-        setStep(2)
-        showToast("Execution complete", "success")
+        setStep(2);
+        showToast("Execution complete", "success");
       } else {
-        setStep(2)
-        showToast(data.error ?? nextRun?.error ?? "Execution failed", "error")
+        setStep(2);
+        showToast(data.error ?? nextRun?.error ?? "Execution failed", "error");
       }
     } finally {
-      setExecuting(false)
+      setExecuting(false);
     }
   }
 
   async function submitFeedback() {
-    if (!run?.runId) return
+    if (!run?.runId) return;
     const res = await fetch("/api/onboarding/planner/feedback", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ runId: run.runId, score: rating, notes: note || undefined }),
-    })
-    const data = await res.json()
-    setSubmitted(true)
-    setCompleteOpen(true)
+      body: JSON.stringify({
+        runId: run.runId,
+        score: rating,
+        notes: note || undefined,
+      }),
+    });
+    const data = await res.json();
+    setSubmitted(true);
+    setCompleteOpen(true);
     if (data.ok) {
-      launchConfetti()
-      showToast("Rating committed", "success")
+      launchConfetti();
+      showToast("Rating committed", "success");
     } else {
-      showToast(data.error ?? "Feedback failed", "error")
+      showToast(data.error ?? "Feedback failed", "error");
     }
   }
 
@@ -242,27 +279,61 @@ function PlannerInner() {
       <Modal open={!connected} onClose={() => {}}>
         <div className="p-8 text-center">
           <div className="mb-4 text-4xl">🔗</div>
-          <h2 className="mb-2 font-display text-xl text-white">Connect Your Wallet</h2>
-          <p className="mb-6 text-sm text-gray-400">You need a Solana wallet to use the planner or register as a specialist.</p>
+          <h2 className="mb-2 font-display text-xl text-white">
+            Connect Your Wallet
+          </h2>
+          <p className="mb-6 text-sm text-gray-400">
+            You need a Solana wallet to use the planner or register as a
+            specialist.
+          </p>
           <WalletMultiButton />
         </div>
       </Modal>
 
       <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8 space-y-8">
         <PageHeader
-          label="Mission mode"
-          title="Planner"
-          subtitle="Describe the task, inspect candidates, execute the call, then commit feedback on-chain."
+          label="Consumer agent path"
+          title="Connect your agent system to marketplace specialists"
+          subtitle="Use the planner/MCP flow to discover specialists, enforce budget and trust policy, execute paid work, then inspect receipts before feedback."
           actions={
             <Link href="/runs">
-              <Button variant="outline" size="sm">Run history →</Button>
+              <Button variant="outline" size="sm">
+                Run history →
+              </Button>
             </Link>
           }
         />
 
+        <div className="grid gap-3 md:grid-cols-3">
+          {[
+            {
+              title: "Works with existing agents",
+              desc: "Use this path as the human-visible version of what OpenClaw, Claude/MCP, OpenSwarm-style systems, or custom agents can do through MCP rails.",
+            },
+            {
+              title: "Policy before payment",
+              desc: "Resolve by task type, privacy mode, attestation requirement, and per-call budget before the x402 challenge is satisfied.",
+            },
+            {
+              title: "Receipts after work",
+              desc: "Keep the specialist response, payment state, and feedback trail inspectable for downstream reputation.",
+            },
+          ].map((item) => (
+            <Card key={item.title} className="border-white/10 bg-white/5 p-4">
+              <p className="text-sm font-semibold text-white">{item.title}</p>
+              <p className="mt-2 text-xs leading-5 text-gray-400">
+                {item.desc}
+              </p>
+            </Card>
+          ))}
+        </div>
+
         <div className="flex justify-center gap-2">
           {STEPS.map((_, index) => (
-            <div key={index} className={`step-dot ${index < step ? "completed" : ""} ${index === step ? "current" : ""}`} />
+            <div
+              key={index}
+              className={`step-dot ${index < step ? "completed" : ""} ${index === step ? "current" : ""}`}
+            />
           ))}
         </div>
 
@@ -270,12 +341,18 @@ function PlannerInner() {
           <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
             <Card className="space-y-4 p-6">
               <p className="section-label">STEP {step + 1} OF 4</p>
-              <h3 className="font-display text-2xl text-white">{STEPS[step]}</h3>
+              <h3 className="font-display text-2xl text-white">
+                {STEPS[step]}
+              </h3>
               <p className="text-sm leading-6 text-gray-400">
-                {step === 0 && "Explain the task, pick the category, and choose a settlement mode."}
-                {step === 1 && "Review the best available specialists before you execute."}
-                {step === 2 && "Watch payment negotiation and completion status."}
-                {step === 3 && "Commit your rating to the protocol."}
+                {step === 0 &&
+                  "Explain what your agent needs, then set category, privacy, attestation, and spend policy."}
+                {step === 1 &&
+                  "Review the best available specialists before payment is attempted."}
+                {step === 2 &&
+                  "Watch x402 negotiation, receipt state, and completion status."}
+                {step === 3 &&
+                  "Commit feedback so future consumer agents can evaluate this specialist."}
               </p>
             </Card>
 
@@ -291,14 +368,34 @@ function PlannerInner() {
                   <div className="grid gap-3 sm:grid-cols-2">
                     <label className="space-y-2 text-sm text-gray-400">
                       <span>Task type</span>
-                      <select className="w-full rounded-lg border border-border bg-page px-3 py-2 text-white" value={taskType} onChange={(e) => setTaskType(e.target.value)}>
-                        {TASK_TYPES.map((task) => <option key={task.id} value={task.id}>{task.label}</option>)}
+                      <select
+                        className="w-full rounded-lg border border-border bg-page px-3 py-2 text-white"
+                        value={taskType}
+                        onChange={(e) => setTaskType(e.target.value)}
+                      >
+                        {TASK_TYPES.map((task) => (
+                          <option key={task.id} value={task.id}>
+                            {task.label}
+                          </option>
+                        ))}
                       </select>
                     </label>
                     <label className="space-y-2 text-sm text-gray-400">
                       <span>Settlement</span>
-                      <select className="w-full rounded-lg border border-border bg-page px-3 py-2 text-white" value={privacyMode} onChange={(e) => setPrivacyMode(e.target.value as "public" | "per" | "vanish") }>
-                        {PRIVACY_MODES.map((mode) => <option key={mode.id} value={mode.id}>{mode.label}</option>)}
+                      <select
+                        className="w-full rounded-lg border border-border bg-page px-3 py-2 text-white"
+                        value={privacyMode}
+                        onChange={(e) =>
+                          setPrivacyMode(
+                            e.target.value as "public" | "per" | "vanish",
+                          )
+                        }
+                      >
+                        {PRIVACY_MODES.map((mode) => (
+                          <option key={mode.id} value={mode.id}>
+                            {mode.label}
+                          </option>
+                        ))}
                       </select>
                     </label>
                     <label className="space-y-2 text-sm text-gray-400">
@@ -311,36 +408,54 @@ function PlannerInner() {
                       />
                     </label>
                     <label className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-gray-300">
-                      <input type="checkbox" checked={requiresAttested} onChange={(e) => setRequiresAttested(e.target.checked)} />
+                      <input
+                        type="checkbox"
+                        checked={requiresAttested}
+                        onChange={(e) => setRequiresAttested(e.target.checked)}
+                      />
                       Require attested specialist
                     </label>
                   </div>
                   <div className="rounded-xl border border-indigo-500/20 bg-indigo-500/10 p-4 text-sm text-gray-300">
-                    <p className="font-medium text-white">Policy before payment</p>
+                    <p className="font-medium text-white">
+                      Policy before payment
+                    </p>
                     <div className="mt-2 grid gap-2 text-xs sm:grid-cols-3">
                       <span>Budget: {consumerPolicy.maxSpendLabel}</span>
                       <span>Privacy: {consumerPolicy.privacyLabel}</span>
                       <span>Trust: {consumerPolicy.attestationLabel}</span>
                     </div>
-                    <p className="mt-2 text-xs text-gray-400">{consumerPolicy.safeguards[1]}</p>
+                    <p className="mt-2 text-xs text-gray-400">
+                      {consumerPolicy.safeguards[1]}
+                    </p>
                   </div>
-                  <Button className="w-full" disabled={!prompt.trim() || loadingCandidates} onClick={findSpecialists}>
-                    {loadingCandidates ? "Finding specialists…" : "Find Specialists →"}
+                  <Button
+                    className="w-full"
+                    disabled={!prompt.trim() || loadingCandidates}
+                    onClick={findSpecialists}
+                  >
+                    {loadingCandidates
+                      ? "Finding specialists…"
+                      : "Discover specialists →"}
                   </Button>
                 </>
               ) : null}
 
               {step === 1 ? (
                 <div className="space-y-3">
-                  <p className="text-sm text-gray-400">Resolved candidates, best match is preselected.</p>
+                  <p className="text-sm text-gray-400">
+                    Resolved candidates, best match is preselected.
+                  </p>
                   {resolved ? (
                     <p className="text-xs text-gray-500">
-                      {resolved.candidate ? `Reasons: ${resolved.candidate.selectionReasons.join(" · ")}` : resolved.error}
+                      {resolved.candidate
+                        ? `Reasons: ${resolved.candidate.selectionReasons.join(" · ")}`
+                        : resolved.error}
                     </p>
                   ) : null}
                   <div className="space-y-3">
                     {candidates.map((agent, index) => {
-                      const selected = selectedWallet === agent.walletAddress
+                      const selected = selectedWallet === agent.walletAddress;
                       return (
                         <button
                           key={agent.walletAddress}
@@ -349,22 +464,48 @@ function PlannerInner() {
                         >
                           <div className="flex items-start justify-between gap-3">
                             <div>
-                              <p className="font-medium text-white">{agent.onchain.model || shortWallet(agent.walletAddress)}</p>
-                              <p className="text-xs text-gray-400">{shortWallet(agent.walletAddress)}</p>
+                              <p className="font-medium text-white">
+                                {agent.onchain.model ||
+                                  shortWallet(agent.walletAddress)}
+                              </p>
+                              <p className="text-xs text-gray-400">
+                                {shortWallet(agent.walletAddress)}
+                              </p>
                             </div>
-                            <Badge variant="outline" className="border-white/10 bg-white/5 text-gray-300">#{index + 1}</Badge>
+                            <Badge
+                              variant="outline"
+                              className="border-white/10 bg-white/5 text-gray-300"
+                            >
+                              #{index + 1}
+                            </Badge>
                           </div>
                           <div className="mt-3 flex flex-wrap gap-2 text-xs text-gray-400">
-                            <span>⭐ {Math.round(agent.onchain.reputationScore / 100)}</span>
-                            <span>◎ {(Number(agent.onchain.rateLamports) / 1_000_000_000).toFixed(4)} SOL</span>
+                            <span>
+                              ⭐{" "}
+                              {Math.round(agent.onchain.reputationScore / 100)}
+                            </span>
+                            <span>
+                              ◎{" "}
+                              {(
+                                Number(agent.onchain.rateLamports) /
+                                1_000_000_000
+                              ).toFixed(4)}{" "}
+                              SOL
+                            </span>
                             <span>{agent.health.status}</span>
                           </div>
                         </button>
-                      )
+                      );
                     })}
                   </div>
-                  <Button className="w-full" disabled={!selectedWallet || executing} onClick={executeRun}>
-                    {executing ? "Executing…" : "Execute with this specialist →"}
+                  <Button
+                    className="w-full"
+                    disabled={!selectedWallet || executing}
+                    onClick={executeRun}
+                  >
+                    {executing
+                      ? "Executing…"
+                      : "Execute with this specialist →"}
                   </Button>
                 </div>
               ) : null}
@@ -373,33 +514,77 @@ function PlannerInner() {
                 <div className="space-y-4">
                   <div className="rounded-xl border border-white/10 bg-black/30 p-4">
                     <div className="flex flex-wrap items-center gap-2">
-                      <Badge variant="outline" className={run.status === "completed" ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300" : "border-red-500/30 bg-red-500/10 text-red-300"}>
+                      <Badge
+                        variant="outline"
+                        className={
+                          run.status === "completed"
+                            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                            : "border-red-500/30 bg-red-500/10 text-red-300"
+                        }
+                      >
                         {run.status}
                       </Badge>
-                      <span className="font-mono text-xs text-gray-400">{run.runId}</span>
+                      <span className="font-mono text-xs text-gray-400">
+                        {run.runId}
+                      </span>
                     </div>
                     <div className="mt-3 space-y-2 text-sm text-gray-300">
-                      <p>Payment: {run.paymentSatisfied ? "confirmed" : run.paymentAttempted ? "sent" : "pending"}</p>
-                      <p>Escrow: {run.challengeSeen ? "x402 challenge seen" : "not required"}</p>
-                      {run.x402TxSignature ? <p className="font-mono text-xs text-gray-400">tx {run.x402TxSignature}</p> : null}
+                      <p>
+                        Payment:{" "}
+                        {run.paymentSatisfied
+                          ? "confirmed"
+                          : run.paymentAttempted
+                            ? "sent"
+                            : "pending"}
+                      </p>
+                      <p>
+                        Escrow:{" "}
+                        {run.challengeSeen
+                          ? "x402 challenge seen"
+                          : "not required"}
+                      </p>
+                      {run.x402TxSignature ? (
+                        <p className="font-mono text-xs text-gray-400">
+                          tx {run.x402TxSignature}
+                        </p>
+                      ) : null}
                     </div>
                   </div>
-                  <pre className="code-area min-h-40 overflow-auto rounded-xl p-4 text-sm text-gray-200">{run.responsePreview || "No response preview."}</pre>
+                  <pre className="code-area min-h-40 overflow-auto rounded-xl p-4 text-sm text-gray-200">
+                    {run.responsePreview || "No response preview."}
+                  </pre>
                   <details className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-gray-300">
-                    <summary className="cursor-pointer text-white">Receipt</summary>
+                    <summary className="cursor-pointer text-white">
+                      Receipt
+                    </summary>
                     <div className="mt-3 space-y-1 font-mono text-xs text-gray-400">
                       <p>tx: {run.x402TxSignature ?? "n/a"}</p>
                       <p>nonce: {run.x402ReceiptNonce ?? "n/a"}</p>
                       <p>specialist: {run.selectedWallet ?? "n/a"}</p>
                       <p>amount: {receiptSummary?.amountLabel ?? "n/a"}</p>
-                      <p>prompt: {receiptSummary?.promptStorage === "sha256_only" ? "sha256 only (raw prompt not required)" : "n/a"}</p>
+                      <p>
+                        prompt:{" "}
+                        {receiptSummary?.promptStorage === "sha256_only"
+                          ? "sha256 only (raw prompt not required)"
+                          : "n/a"}
+                      </p>
                       <p>status: {run.status}</p>
                     </div>
                   </details>
                   {receiptSummary ? (
-                    <div className={`rounded-xl border p-4 text-sm ${receiptSummary.status === "paid" ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200" : receiptSummary.status === "blocked" ? "border-red-500/30 bg-red-500/10 text-red-200" : "border-yellow-500/30 bg-yellow-500/10 text-yellow-100"}`}>
-                      <p className="font-medium">{receiptSummary.status === "paid" ? "Paid receipt captured" : receiptSummary.status === "blocked" ? "Unpaid completion blocked" : "Run did not complete"}</p>
-                      <p className="mt-1 text-xs opacity-80">{receiptSummary.message}</p>
+                    <div
+                      className={`rounded-xl border p-4 text-sm ${receiptSummary.status === "paid" ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200" : receiptSummary.status === "blocked" ? "border-red-500/30 bg-red-500/10 text-red-200" : "border-yellow-500/30 bg-yellow-500/10 text-yellow-100"}`}
+                    >
+                      <p className="font-medium">
+                        {receiptSummary.status === "paid"
+                          ? "Paid receipt captured"
+                          : receiptSummary.status === "blocked"
+                            ? "Unpaid completion blocked"
+                            : "Run did not complete"}
+                      </p>
+                      <p className="mt-1 text-xs opacity-80">
+                        {receiptSummary.message}
+                      </p>
                     </div>
                   ) : null}
                   <Button className="w-full" onClick={() => setStep(3)}>
@@ -412,7 +597,13 @@ function PlannerInner() {
                 <div className="space-y-4">
                   <div className="flex gap-1">
                     {Array.from({ length: 5 }).map((_, index) => (
-                      <button key={index} onClick={() => setRating(index + 1)} className={`text-3xl transition ${index < rating ? "text-indigo-400" : "text-white/20"}`}>★</button>
+                      <button
+                        key={index}
+                        onClick={() => setRating(index + 1)}
+                        className={`text-3xl transition ${index < rating ? "text-indigo-400" : "text-white/20"}`}
+                      >
+                        ★
+                      </button>
                     ))}
                   </div>
                   <Textarea
@@ -421,7 +612,11 @@ function PlannerInner() {
                     value={note}
                     onChange={(e) => setNote(e.target.value)}
                   />
-                  <Button className="w-full" disabled={!run?.runId || submitted} onClick={() => void submitFeedback()}>
+                  <Button
+                    className="w-full"
+                    disabled={!run?.runId || submitted}
+                    onClick={() => void submitFeedback()}
+                  >
                     {submitted ? "Committed ✓" : "Submit & Commit Rating"}
                   </Button>
                 </div>
@@ -436,24 +631,34 @@ function PlannerInner() {
           <div className="max-w-md rounded-2xl bg-surface p-8 text-center glow-border">
             <div className="mb-4 text-6xl">🎉</div>
             <h2 className="font-display text-3xl text-white">Task Complete!</h2>
-            <p className="mt-2 text-sm text-gray-400">Your rating has been committed on-chain.</p>
+            <p className="mt-2 text-sm text-gray-400">
+              Your rating has been committed on-chain.
+            </p>
             <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
               <Link href="/runs">
                 <Button>View run history →</Button>
               </Link>
-              <Button variant="outline" onClick={() => setCompleteOpen(false)}>Close</Button>
+              <Button variant="outline" onClick={() => setCompleteOpen(false)}>
+                Close
+              </Button>
             </div>
           </div>
         </div>
       ) : null}
     </div>
-  )
+  );
 }
 
 export default function PlannerPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen bg-page flex items-center justify-center"><p className="text-gray-400">Loading planner…</p></div>}>
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-page flex items-center justify-center">
+          <p className="text-gray-400">Loading planner…</p>
+        </div>
+      }
+    >
       <PlannerInner />
     </Suspense>
-  )
+  );
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -3,12 +3,8 @@
 import { Suspense } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useWallet, useConnection } from "@solana/wallet-adapter-react";
+import { Connection, Transaction } from "@solana/web3.js";
 import {
-  Connection,
-  Transaction,
-} from "@solana/web3.js";
-import {
-  ESCROW_PROGRAM_ID,
   REGISTRY_PROGRAM_ID,
   DEVNET_RPC,
   AGENT_TYPE_ENUM,
@@ -60,7 +56,7 @@ import {
 const WalletMultiButton = dynamic(
   async () =>
     (await import("@solana/wallet-adapter-react-ui")).WalletMultiButton,
-  { ssr: false }
+  { ssr: false },
 );
 
 type Step = 1 | 2 | 3;
@@ -117,13 +113,19 @@ function formatSimulationError(err: unknown, logs?: string[] | null) {
 
   let hint = "";
   if (/InvalidInstructionData/i.test(base)) {
-    hint = "\nHint: Program/instruction layout mismatch. Check that NEXT_PUBLIC_ESCROW_PROGRAM_ID points to the current deployed program for this app build.";
+    hint =
+      "\nHint: Program/instruction layout mismatch. Check that NEXT_PUBLIC_ESCROW_PROGRAM_ID points to the current deployed program for this app build.";
   } else if (/AccountNotFound/i.test(base)) {
-    hint = "\nHint: One required account is missing on this RPC (often wrong cluster/RPC or unfunded wallet). Verify RPC endpoint + wallet balance on the same network.";
+    hint =
+      "\nHint: One required account is missing on this RPC (often wrong cluster/RPC or unfunded wallet). Verify RPC endpoint + wallet balance on the same network.";
   }
 
-  if (logTail.length === 0) return truncateMiddle(`Simulation failed: ${base}${hint}`);
-  return truncateMiddle(`Simulation failed: ${base}${hint}\nLogs:\n${logTail.join("\n")}`, 1200);
+  if (logTail.length === 0)
+    return truncateMiddle(`Simulation failed: ${base}${hint}`);
+  return truncateMiddle(
+    `Simulation failed: ${base}${hint}\nLogs:\n${logTail.join("\n")}`,
+    1200,
+  );
 }
 
 function formatRegisterError(err: unknown) {
@@ -175,14 +177,19 @@ function RegisterInner() {
   const [txSig, setTxSig] = useState<string | null>(null);
   const [txError, setTxError] = useState<string | null>(null);
   const [setupModalOpen, setSetupModalOpen] = useState(false);
-  const [endpointProbeStatus, setEndpointProbeStatus] = useState<EndpointProbeStatus>("idle");
+  const [endpointProbeStatus, setEndpointProbeStatus] =
+    useState<EndpointProbeStatus>("idle");
   const [endpointProbeMessage, setEndpointProbeMessage] = useState("");
   const [endpointProbeModels, setEndpointProbeModels] = useState<string[]>([]);
-  const [existingAgent, setExistingAgent] = useState<ExistingAgentState>(INITIAL_EXISTING_AGENT_STATE);
+  const [existingAgent, setExistingAgent] = useState<ExistingAgentState>(
+    INITIAL_EXISTING_AGENT_STATE,
+  );
   const endpointProbeTimeoutRef = useRef<number | null>(null);
   const endpointProbeRequestRef = useRef(0);
   const endpointCompliancePassed = endpointProbeStatus === "reachable";
-  const canAdvanceToReview = Boolean(form.name && form.model && form.endpoint.trim() && endpointCompliancePassed);
+  const canAdvanceToReview = Boolean(
+    form.name && form.model && form.endpoint.trim() && endpointCompliancePassed,
+  );
 
   const runEndpointProbe = async (rawEndpoint: string) => {
     const endpoint = rawEndpoint.trim();
@@ -209,14 +216,17 @@ function RegisterInner() {
 
       if (!data) {
         setEndpointProbeStatus("unreachable");
-        setEndpointProbeMessage("Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel.");
+        setEndpointProbeMessage(
+          "Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel.",
+        );
         return;
       }
 
       if (!res.ok) {
         setEndpointProbeStatus("unreachable");
         setEndpointProbeMessage(
-          data.error || "Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel."
+          data.error ||
+            "Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel.",
         );
         return;
       }
@@ -228,24 +238,31 @@ function RegisterInner() {
           Array.isArray(data.models) && data.models.length > 0
             ? `Ollama detected, models: ${data.models.slice(0, 3).join(", ")}`
             : "Endpoint reachable.";
-        setEndpointProbeMessage(data.warning ? `${base} ${data.warning}` : base);
+        setEndpointProbeMessage(
+          data.warning ? `${base} ${data.warning}` : base,
+        );
         return;
       }
 
       if (data.status === "reachable") {
         setEndpointProbeStatus("no_ollama");
-        setEndpointProbeMessage("Endpoint is reachable, but /api/tags did not return an Ollama model list.");
+        setEndpointProbeMessage(
+          "Endpoint is reachable, but /api/tags did not return an Ollama model list.",
+        );
         return;
       }
 
       setEndpointProbeStatus("unreachable");
       setEndpointProbeMessage(
-        data.error || "Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel."
+        data.error ||
+          "Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel.",
       );
     } catch {
       if (requestId !== endpointProbeRequestRef.current) return;
       setEndpointProbeStatus("unreachable");
-      setEndpointProbeMessage("Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel.");
+      setEndpointProbeMessage(
+        "Could not reach endpoint. Use a public https URL from ngrok (recommended) or localtunnel.",
+      );
     }
   };
 
@@ -256,7 +273,8 @@ function RegisterInner() {
     const primaryRate = searchParams.get("primaryRate")?.trim();
     const attestationRate = searchParams.get("attestationRate")?.trim();
 
-    if (!endpoint && !model && !name && !primaryRate && !attestationRate) return;
+    if (!endpoint && !model && !name && !primaryRate && !attestationRate)
+      return;
 
     setForm((prev) => ({
       ...prev,
@@ -315,7 +333,8 @@ function RegisterInner() {
 
     async function checkExistingAgent() {
       try {
-        const conn = walletConnection ?? new Connection(DEVNET_RPC, "confirmed");
+        const conn =
+          walletConnection ?? new Connection(DEVNET_RPC, "confirmed");
         const account = await conn.getAccountInfo(pda, "confirmed");
         if (cancelled) return;
         setExistingAgent({
@@ -327,7 +346,10 @@ function RegisterInner() {
         setExistingAgent({
           status: "error",
           pda: pda.toBase58(),
-          error: error instanceof Error ? error.message : "Could not check existing registration",
+          error:
+            error instanceof Error
+              ? error.message
+              : "Could not check existing registration",
         });
       }
     }
@@ -347,7 +369,9 @@ function RegisterInner() {
   const handleRegister = async () => {
     if (!publicKey || !sendTransaction) return;
     if (alreadyRegistered) {
-      setTxError("This wallet is already registered. Open My Agent to view the existing registration, or deregister before creating a fresh registration with the same wallet.");
+      setTxError(
+        "This wallet is already registered. Open My Agent to view the existing registration, or deregister before creating a fresh registration with the same wallet.",
+      );
       return;
     }
     setRegistering(true);
@@ -361,17 +385,17 @@ function RegisterInner() {
         form.agentType === "primary"
           ? AGENT_TYPE_ENUM.Primary
           : form.agentType === "attestation"
-          ? AGENT_TYPE_ENUM.Attestation
-          : AGENT_TYPE_ENUM.Both;
+            ? AGENT_TYPE_ENUM.Attestation
+            : AGENT_TYPE_ENUM.Both;
 
       const rateLamports = BigInt(
         Math.round(
           parseFloat(
             form.agentType === "attestation"
               ? form.attestationRate || "0.0005"
-              : form.primaryRate || "0.001"
-          ) * 1_000_000_000
-        )
+              : form.primaryRate || "0.001",
+          ) * 1_000_000_000,
+        ),
       );
 
       const modelName = form.model || "unknown";
@@ -400,7 +424,8 @@ function RegisterInner() {
           throw new Error(formatSimulationError(sim.value.err, sim.value.logs));
         }
       } catch (simErr: unknown) {
-        const simMsg = simErr instanceof Error ? simErr.message : String(simErr);
+        const simMsg =
+          simErr instanceof Error ? simErr.message : String(simErr);
         if (!/invalid arguments/i.test(simMsg)) {
           throw simErr;
         }
@@ -419,7 +444,10 @@ function RegisterInner() {
           .catch(() => null);
 
         throw new Error(
-          formatSimulationError(confirmation.value.err, txMeta?.meta?.logMessages)
+          formatSimulationError(
+            confirmation.value.err,
+            txMeta?.meta?.logMessages,
+          ),
         );
       }
 
@@ -430,11 +458,19 @@ function RegisterInner() {
       const msg = formatRegisterError(err);
       setTxError(msg);
       if (isAlreadyRegisteredError(msg) && publicKey) {
-        setExistingAgent({ status: "registered", pda: agentPda(publicKey).toBase58() });
+        setExistingAgent({
+          status: "registered",
+          pda: agentPda(publicKey).toBase58(),
+        });
       }
       setTxSig(null);
       setSuccess(false);
-      showToast(isAlreadyRegisteredError(msg) ? "Wallet already registered" : "Registration failed", "error");
+      showToast(
+        isAlreadyRegisteredError(msg)
+          ? "Wallet already registered"
+          : "Registration failed",
+        "error",
+      );
     } finally {
       setRegistering(false);
     }
@@ -445,12 +481,16 @@ function RegisterInner() {
       <Modal open={true} onClose={() => {}}>
         <div className="p-8 text-center">
           <div className="mb-4 text-4xl">🔗</div>
-          <h2 className="mb-2 font-display text-xl text-white">Connect Your Wallet</h2>
-          <p className="mb-6 text-sm text-gray-400">You need a Solana wallet to register a specialist.</p>
+          <h2 className="mb-2 font-display text-xl text-white">
+            Connect Your Wallet
+          </h2>
+          <p className="mb-6 text-sm text-gray-400">
+            You need a Solana wallet to register a specialist.
+          </p>
           <WalletMultiButton />
         </div>
       </Modal>
-    )
+    );
   }
 
   if (success) {
@@ -461,15 +501,23 @@ function RegisterInner() {
           {txError ? "Transaction failed." : "Your agent is live."}
         </h1>
         <p className="text-muted-foreground">
-          {txError
-            ? "The on-chain transaction could not be submitted. Check your wallet balance and try again."
-            : <><strong className="text-foreground">{form.name}</strong> has been registered on-chain. Your endpoint is ready to receive requests.</>
-          }
+          {txError ? (
+            "The on-chain transaction could not be submitted. Check your wallet balance and try again."
+          ) : (
+            <>
+              <strong className="text-foreground">{form.name}</strong> has been
+              registered on-chain. Your endpoint is ready to receive requests.
+            </>
+          )}
         </p>
         {txError && (
           <div className="p-4 rounded-lg border border-amber-500/30 bg-amber-500/10 text-left">
-            <p className="text-xs text-amber-400 mb-1">⚠️ On-chain tx failed — showing simulated sig</p>
-            <p className="font-mono text-xs text-amber-200/80 break-all">{txError}</p>
+            <p className="text-xs text-amber-400 mb-1">
+              ⚠️ On-chain tx failed — showing simulated sig
+            </p>
+            <p className="font-mono text-xs text-amber-200/80 break-all">
+              {txError}
+            </p>
           </div>
         )}
         {txSig && (
@@ -487,7 +535,9 @@ function RegisterInner() {
                 {txSig}
               </a>
             ) : (
-              <p className="font-mono text-xs break-all text-[#14F195]">{txSig}</p>
+              <p className="font-mono text-xs break-all text-[#14F195]">
+                {txSig}
+              </p>
             )}
           </div>
         )}
@@ -498,10 +548,21 @@ function RegisterInner() {
           </div>
         )}
         <div className="flex gap-3 justify-center">
-          <LinkButton href="/setup" style={{ background: "linear-gradient(135deg, #9945FF, #14F195)", color: "#000", fontWeight: 600 }}>
+          <LinkButton
+            href="/setup"
+            style={{
+              background: "linear-gradient(135deg, #9945FF, #14F195)",
+              color: "#000",
+              fontWeight: 600,
+            }}
+          >
             View Setup Guide →
           </LinkButton>
-          <LinkButton href="/agents" variant="outline" className="border-white/10">
+          <LinkButton
+            href="/agents"
+            variant="outline"
+            className="border-white/10"
+          >
             Browse Agents
           </LinkButton>
         </div>
@@ -523,46 +584,100 @@ function RegisterInner() {
       <Card className="flex items-center gap-3 p-4 text-sm border-accent-green/20 bg-accent-green/10">
         <span className="text-accent-green text-base">⚡</span>
         <span className="text-muted-foreground">
-          <span className="font-semibold text-accent-green">Devnet</span> — registration submits a real on-chain transaction.
-          Requires a connected wallet with ~0.011 SOL (0.01 fee + rent).
+          <span className="font-semibold text-accent-green">Devnet</span> —
+          registration submits a real on-chain transaction. Requires a connected
+          wallet with ~0.011 SOL (0.01 fee + rent).
         </span>
       </Card>
       <PageHeader
-        label="Registration"
-        title={alreadyRegistered ? "Your wallet already has an agent" : "Register Your Agent"}
-        subtitle={alreadyRegistered ? "Open your existing agent profile, update details, or deregister before creating a fresh registration with this wallet." : "One-time 0.01 SOL registration. No subscription. You control your rate."}
+        label="Specialist supply path"
+        title={
+          alreadyRegistered
+            ? "Your wallet already has an agent"
+            : "Monetize your specialist agent with reddi-x402"
+        }
+        subtitle={
+          alreadyRegistered
+            ? "Open your existing agent profile, update details, or deregister before creating a fresh registration with this wallet."
+            : "Publish capabilities, pricing, and a reachable endpoint so consumer agents can discover, hire, pay, and rate your specialist in the marketplace."
+        }
       />
+      <div className="grid gap-3 md:grid-cols-3">
+        {[
+          {
+            title: "Publish capability",
+            desc: "Describe the task types your agent can handle and the endpoint consumers should call.",
+          },
+          {
+            title: "Gate work with x402",
+            desc: "Expose a payment-aware specialist so buyers see a price challenge before paid execution.",
+          },
+          {
+            title: "Earn reputation",
+            desc: "Completed jobs, receipts, and attestations become a trust trail future agents can evaluate.",
+          },
+        ].map((item) => (
+          <Card key={item.title} className="border-white/10 bg-white/5 p-4">
+            <p className="text-sm font-semibold text-white">{item.title}</p>
+            <p className="mt-2 text-xs leading-5 text-muted-foreground">
+              {item.desc}
+            </p>
+          </Card>
+        ))}
+      </div>
       {PROGRAM_TARGET === "quasar" && (
-        <Card className={`space-y-2 p-4 text-sm ${PROGRAM_SUBMISSION_READY ? "border-emerald-400/25 bg-emerald-500/10 text-emerald-50" : "border-amber-400/25 bg-amber-500/10 text-amber-50"}`}>
+        <Card
+          className={`space-y-2 p-4 text-sm ${PROGRAM_SUBMISSION_READY ? "border-emerald-400/25 bg-emerald-500/10 text-emerald-50" : "border-amber-400/25 bg-amber-500/10 text-amber-50"}`}
+        >
           <p className="font-semibold">
-            Quasar mode is active{PROGRAM_SUBMISSION_READY ? " and marked submission-ready." : ", but submission readiness is still blocked."}
+            Quasar mode is active
+            {PROGRAM_SUBMISSION_READY
+              ? " and marked submission-ready."
+              : ", but submission readiness is still blocked."}
           </p>
           <p className="text-xs opacity-85">
-            Target: <span className="font-mono">{PROGRAM_TARGET}</span> · Compatibility: <span className="font-mono">{PROGRAM_COMPATIBILITY}</span>. Registration instruction construction uses the Quasar registry layout, but wallet submission should wait for the full proof chain unless you are deliberately testing this path.
+            Target: <span className="font-mono">{PROGRAM_TARGET}</span> ·
+            Compatibility:{" "}
+            <span className="font-mono">{PROGRAM_COMPATIBILITY}</span>.
+            Registration instruction construction uses the Quasar registry
+            layout, but wallet submission should wait for the full proof chain
+            unless you are deliberately testing this path.
           </p>
           {!PROGRAM_SUBMISSION_READY && PROGRAM_KNOWN_GAPS.length > 0 && (
             <ul className="list-disc space-y-1 pl-4 text-xs opacity-85">
-              {PROGRAM_KNOWN_GAPS.slice(0, 3).map((gap) => <li key={gap}>{gap}</li>)}
+              {PROGRAM_KNOWN_GAPS.slice(0, 3).map((gap) => (
+                <li key={gap}>{gap}</li>
+              ))}
             </ul>
           )}
         </Card>
       )}
       {existingAgent.status === "checking" && (
         <Card className="border-blue-400/20 bg-blue-500/10 p-4 text-sm text-blue-100">
-          Checking whether this wallet already has an on-chain agent registration…
+          Checking whether this wallet already has an on-chain agent
+          registration…
         </Card>
       )}
       {alreadyRegistered && (
         <Card className="space-y-3 border-emerald-400/25 bg-emerald-500/10 p-4 text-sm text-emerald-50">
           <p className="font-semibold">This wallet is already registered.</p>
           <p className="text-emerald-100/80">
-            Registering again would fail because each wallet maps to one deterministic agent account. Use My Agent to view the existing profile, or deregister first if you need a fresh registration.
+            Registering again would fail because each wallet maps to one
+            deterministic agent account. Use My Agent to view the existing
+            profile, or deregister first if you need a fresh registration.
           </p>
           <div className="flex flex-wrap gap-3">
-            <LinkButton href={myAgentHref} className="!bg-emerald-400 !text-black hover:!bg-emerald-300">
+            <LinkButton
+              href={myAgentHref}
+              className="!bg-emerald-400 !text-black hover:!bg-emerald-300"
+            >
               My Agent →
             </LinkButton>
-            <LinkButton href="/faq" variant="outline" className="border-emerald-300/30 text-emerald-100">
+            <LinkButton
+              href="/faq"
+              variant="outline"
+              className="border-emerald-300/30 text-emerald-100"
+            >
               Read FAQ
             </LinkButton>
           </div>
@@ -574,10 +689,11 @@ function RegisterInner() {
           onClick={() => setSetupModalOpen(true)}
           className="w-full py-3 px-4 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-semibold rounded-xl transition flex items-center justify-center gap-2 mb-6"
         >
-          <span>🚀</span> Set up my first agent (guided)
+          <span>🚀</span> Set up my first specialist (guided)
         </Button>
         <p className="text-center text-sm text-gray-500 dark:text-gray-400 mb-6">
-          Already have Ollama running? Fill in the form below.
+          Already have Ollama, OpenOnion, or a hosted specialist running? Fill
+          in the form below.
         </p>
       </div>
 
@@ -586,20 +702,24 @@ function RegisterInner() {
         <StepIndicator
           number={1}
           title="Connect Wallet"
-          status={connected ? "complete" : step === 1 ? "in-progress" : "not-started"}
+          status={
+            connected ? "complete" : step === 1 ? "in-progress" : "not-started"
+          }
           description="Connect your Solana wallet to sign the registration transaction"
         />
         <StepIndicator
           number={2}
           title="Agent Details"
-          status={step === 2 ? "in-progress" : step === 3 ? "complete" : "not-started"}
-          description="Configure your agent's capabilities and pricing"
+          status={
+            step === 2 ? "in-progress" : step === 3 ? "complete" : "not-started"
+          }
+          description="Configure capabilities, pricing, and marketplace policy"
         />
         <StepIndicator
           number={3}
           title="Register On-Chain"
           status={step === 3 ? "in-progress" : "not-started"}
-          description="Pay 0.01 SOL · Deploy your agent to the registry"
+          description="Pay 0.01 SOL · List your specialist in the registry"
         />
       </div>
 
@@ -614,17 +734,24 @@ function RegisterInner() {
           {connected && publicKey ? (
             <div className="space-y-3">
               <div className="p-3 rounded-lg bg-[#14F195]/10 border border-[#14F195]/20">
-                <p className="text-xs text-muted-foreground">Connected wallet</p>
+                <p className="text-xs text-muted-foreground">
+                  Connected wallet
+                </p>
                 <p
                   className="font-mono text-sm text-[#14F195] truncate cursor-default"
                   title={publicKey.toBase58()}
                 >
-                  {publicKey.toBase58().slice(0, 4)}...{publicKey.toBase58().slice(-4)}
+                  {publicKey.toBase58().slice(0, 4)}...
+                  {publicKey.toBase58().slice(-4)}
                 </p>
               </div>
               <Button
                 onClick={() => setStep(2)}
-                style={{ background: "linear-gradient(135deg, #9945FF, #14F195)", color: "#000", fontWeight: 600 }}
+                style={{
+                  background: "linear-gradient(135deg, #9945FF, #14F195)",
+                  color: "#000",
+                  fontWeight: 600,
+                }}
               >
                 Continue to Details →
               </Button>
@@ -633,7 +760,8 @@ function RegisterInner() {
             <div className="flex flex-col items-start gap-3">
               <WalletMultiButton
                 style={{
-                  background: "linear-gradient(135deg, #9945FF 0%, #14F195 100%)",
+                  background:
+                    "linear-gradient(135deg, #9945FF 0%, #14F195 100%)",
                   height: "40px",
                   fontSize: "14px",
                   borderRadius: "8px",
@@ -658,7 +786,10 @@ function RegisterInner() {
           <div className="space-y-5">
             {/* Name */}
             <div className="space-y-1.5">
-              <Label htmlFor="name" className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block">
+              <Label
+                htmlFor="name"
+                className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block"
+              >
                 Agent Name
               </Label>
               <Input
@@ -672,17 +803,23 @@ function RegisterInner() {
 
             {/* Agent Type */}
             <div className="space-y-1.5">
-              <Label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block">Agent Type</Label>
+              <Label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block">
+                Agent Type
+              </Label>
               <Select
                 value={form.agentType}
-                onValueChange={(v) => setForm({ ...form, agentType: v as AgentType })}
+                onValueChange={(v) =>
+                  setForm({ ...form, agentType: v as AgentType })
+                }
               >
                 <SelectTrigger className="!w-full !min-w-[180px] !rounded-lg !border !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-gray-900 !px-3 !py-2 !text-sm focus:!ring-2 focus:!ring-blue-500 focus:!outline-none">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="min-w-[240px] rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg">
                   <SelectItem value="primary">Primary (Specialist)</SelectItem>
-                  <SelectItem value="attestation">Attestation (Judge)</SelectItem>
+                  <SelectItem value="attestation">
+                    Attestation (Judge)
+                  </SelectItem>
                   <SelectItem value="both">Both</SelectItem>
                 </SelectContent>
               </Select>
@@ -695,7 +832,9 @@ function RegisterInner() {
                   <ChevronDown className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180" />
                   How to set up your endpoint
                 </span>
-                <span className="text-xs font-medium text-blue-700 dark:text-blue-300">Collapsed by default</span>
+                <span className="text-xs font-medium text-blue-700 dark:text-blue-300">
+                  Collapsed by default
+                </span>
               </summary>
               <div className="mt-4 space-y-3">
                 {ENDPOINT_HELP_STEPS.map((stepItem, idx) => (
@@ -746,7 +885,10 @@ function RegisterInner() {
             {/* Endpoint */}
             <div className="space-y-1.5">
               <div className="flex items-center justify-between gap-3">
-                <Label htmlFor="endpoint" className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block">
+                <Label
+                  htmlFor="endpoint"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block"
+                >
                   Service Endpoint URL
                 </Label>
                 <a
@@ -780,7 +922,7 @@ function RegisterInner() {
                     ? "!border-blue-400"
                     : endpointProbeStatus === "reachable"
                       ? "!border-green-400"
-                    : endpointProbeStatus === "no_ollama"
+                      : endpointProbeStatus === "no_ollama"
                         ? "!border-yellow-400"
                         : endpointProbeStatus === "unreachable"
                           ? "!border-red-400"
@@ -818,13 +960,20 @@ function RegisterInner() {
                         : endpointProbeStatus === "reachable"
                           ? "Endpoint reachable"
                           : endpointProbeStatus === "no_ollama"
-                          ? "Reachable, but no Ollama detected"
-                          : "Unreachable"}
+                            ? "Reachable, but no Ollama detected"
+                            : "Unreachable"}
                     </p>
-                    {endpointProbeMessage && <p className="mt-0.5 text-[11px] font-normal">{endpointProbeMessage}</p>}
-                    {endpointProbeModels.length > 0 && endpointProbeStatus === "reachable" && (
-                      <p className="mt-0.5 text-[11px] font-normal">Models: {endpointProbeModels.slice(0, 3).join(", ")}</p>
+                    {endpointProbeMessage && (
+                      <p className="mt-0.5 text-[11px] font-normal">
+                        {endpointProbeMessage}
+                      </p>
                     )}
+                    {endpointProbeModels.length > 0 &&
+                      endpointProbeStatus === "reachable" && (
+                        <p className="mt-0.5 text-[11px] font-normal">
+                          Models: {endpointProbeModels.slice(0, 3).join(", ")}
+                        </p>
+                      )}
                   </div>
                 </div>
               )}
@@ -833,7 +982,10 @@ function RegisterInner() {
             {/* Model */}
             <div className="space-y-1.5">
               <div className="flex items-center justify-between gap-3">
-                <Label htmlFor="model" className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block">
+                <Label
+                  htmlFor="model"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block"
+                >
                   Model Name
                 </Label>
                 <a
@@ -858,7 +1010,9 @@ function RegisterInner() {
             {/* Privacy Tier */}
             <div className="space-y-1.5">
               <div className="flex items-center justify-between gap-3">
-                <Label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block">Privacy Tier</Label>
+                <Label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block">
+                  Privacy Tier
+                </Label>
                 <a
                   href="/docs/HARNESS-COMPUTE-BOUNDARY.md"
                   target="_blank"
@@ -871,15 +1025,23 @@ function RegisterInner() {
               </div>
               <Select
                 value={form.privacyTier}
-                onValueChange={(v) => setForm({ ...form, privacyTier: v as PrivacyTier })}
+                onValueChange={(v) =>
+                  setForm({ ...form, privacyTier: v as PrivacyTier })
+                }
               >
                 <SelectTrigger className="!w-full !min-w-[180px] !rounded-lg !border !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-gray-900 !px-3 !py-2 !text-sm focus:!ring-2 focus:!ring-blue-500 focus:!outline-none">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="min-w-[240px] rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg">
-                  <SelectItem value="local">Local — runs on your hardware, never leaves</SelectItem>
-                  <SelectItem value="tee">TEE — cryptographic attestation of enclave execution</SelectItem>
-                  <SelectItem value="cloud">Cloud-Disclosed — cloud infrastructure, disclosed</SelectItem>
+                  <SelectItem value="local">
+                    Local — runs on your hardware, never leaves
+                  </SelectItem>
+                  <SelectItem value="tee">
+                    TEE — cryptographic attestation of enclave execution
+                  </SelectItem>
+                  <SelectItem value="cloud">
+                    Cloud-Disclosed — cloud infrastructure, disclosed
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -887,7 +1049,10 @@ function RegisterInner() {
             {/* Primary Rate */}
             {(form.agentType === "primary" || form.agentType === "both") && (
               <div className="space-y-1.5">
-                <Label htmlFor="rate" className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block">
+                <Label
+                  htmlFor="rate"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block"
+                >
                   Primary Rate (SOL per call)
                 </Label>
                 <Input
@@ -897,7 +1062,9 @@ function RegisterInner() {
                   min="0"
                   placeholder="0.001"
                   value={form.primaryRate}
-                  onChange={(e) => setForm({ ...form, primaryRate: e.target.value })}
+                  onChange={(e) =>
+                    setForm({ ...form, primaryRate: e.target.value })
+                  }
                   className="!w-full !rounded-lg !border !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-gray-900 !px-3 !py-2 !text-sm focus:!ring-2 focus:!ring-blue-500 focus:!outline-none"
                 />
               </div>
@@ -906,7 +1073,10 @@ function RegisterInner() {
             {/* Attestation Rate */}
             {isJudge && (
               <div className="space-y-1.5">
-                <Label htmlFor="attest-rate" className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block">
+                <Label
+                  htmlFor="attest-rate"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block"
+                >
                   Attestation Rate (SOL per judging)
                 </Label>
                 <Input
@@ -916,7 +1086,9 @@ function RegisterInner() {
                   min="0"
                   placeholder="0.0005"
                   value={form.attestationRate}
-                  onChange={(e) => setForm({ ...form, attestationRate: e.target.value })}
+                  onChange={(e) =>
+                    setForm({ ...form, attestationRate: e.target.value })
+                  }
                   className="!w-full !rounded-lg !border !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-gray-900 !px-3 !py-2 !text-sm focus:!ring-2 focus:!ring-blue-500 focus:!outline-none"
                 />
               </div>
@@ -925,9 +1097,13 @@ function RegisterInner() {
             {/* Min Consumer Rep */}
             <div className="space-y-2">
               <div className="flex justify-between gap-3">
-                <Label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block">Min Consumer Reputation</Label>
+                <Label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-0 block">
+                  Min Consumer Reputation
+                </Label>
                 <span className="text-sm text-muted-foreground font-mono">
-                  {form.minConsumerRep === 0 ? "No minimum" : `≥ ${form.minConsumerRep}★`}
+                  {form.minConsumerRep === 0
+                    ? "No minimum"
+                    : `≥ ${form.minConsumerRep}★`}
                 </span>
               </div>
               <Slider
@@ -935,20 +1111,26 @@ function RegisterInner() {
                 max={5}
                 step={0.5}
                 value={form.minConsumerRep}
-                onValueChange={(v) => setForm({ ...form, minConsumerRep: v as number })}
+                onValueChange={(v) =>
+                  setForm({ ...form, minConsumerRep: v as number })
+                }
               />
             </div>
 
             {/* Accept Unrated */}
             <div className="flex items-center justify-between rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950/40 p-4">
               <div>
-                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Accept Unrated Consumers</p>
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Accept Unrated Consumers
+                </p>
                 <p className="text-xs text-muted-foreground">
                   Allow consumers with no reputation history to hire you
                 </p>
               </div>
               <button
-                onClick={() => setForm({ ...form, acceptUnrated: !form.acceptUnrated })}
+                onClick={() =>
+                  setForm({ ...form, acceptUnrated: !form.acceptUnrated })
+                }
                 className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                   form.acceptUnrated ? "bg-[#14F195]" : "bg-white/20"
                 }`}
@@ -963,14 +1145,19 @@ function RegisterInner() {
 
             {/* Description */}
             <div className="space-y-1.5">
-              <Label htmlFor="desc" className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block">
+              <Label
+                htmlFor="desc"
+                className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 block"
+              >
                 Agent Description
               </Label>
               <Textarea
                 id="desc"
                 placeholder="What does your agent specialise in? What tasks does it handle well?"
                 value={form.description}
-                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                onChange={(e) =>
+                  setForm({ ...form, description: e.target.value })
+                }
                 className="!min-h-20 !w-full !rounded-lg !border !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-gray-900 !px-3 !py-2 !text-sm focus:!ring-2 focus:!ring-blue-500 focus:!outline-none resize-none"
               />
             </div>
@@ -995,7 +1182,8 @@ function RegisterInner() {
 
           {!endpointCompliancePassed && (
             <p className="text-xs text-amber-300">
-              Run endpoint probe until it passes compliance before proceeding to registration.
+              Run endpoint probe until it passes compliance before proceeding to
+              registration.
             </p>
           )}
         </div>
@@ -1013,28 +1201,51 @@ function RegisterInner() {
               ["Model", form.model],
               ["Privacy", form.privacyTier],
               ["Endpoint", form.endpoint || "—"],
-              ["Primary Rate", form.agentType !== "attestation" ? `${form.primaryRate} SOL/call` : "—"],
-              ...(isJudge ? [["Attestation Rate", `${form.attestationRate} SOL/job`] as [string, string]] : []),
-              ["Min Consumer Rep", form.minConsumerRep === 0 ? "No minimum" : `≥ ${form.minConsumerRep}★`],
+              [
+                "Primary Rate",
+                form.agentType !== "attestation"
+                  ? `${form.primaryRate} SOL/call`
+                  : "—",
+              ],
+              ...(isJudge
+                ? [
+                    ["Attestation Rate", `${form.attestationRate} SOL/job`] as [
+                      string,
+                      string,
+                    ],
+                  ]
+                : []),
+              [
+                "Min Consumer Rep",
+                form.minConsumerRep === 0
+                  ? "No minimum"
+                  : `≥ ${form.minConsumerRep}★`,
+              ],
               ["Accept Unrated", form.acceptUnrated ? "Yes" : "No"],
             ].map(([label, value]) => (
               <div key={label} className="flex justify-between gap-4 text-sm">
                 <span className="text-muted-foreground">{label}</span>
-                <span className="max-w-xs truncate font-mono text-right">{value}</span>
+                <span className="max-w-xs truncate font-mono text-right">
+                  {value}
+                </span>
               </div>
             ))}
           </div>
 
           {/* Fee breakdown */}
           <div className="space-y-2 rounded-xl border border-blue-100 bg-blue-50/70 p-4 dark:border-blue-900/40 dark:bg-blue-950/20">
-            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Fee Breakdown</p>
+            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              Fee Breakdown
+            </p>
             <div className="space-y-1 text-sm">
               <div className="flex justify-between gap-4">
                 <span className="text-muted-foreground">Registration fee</span>
                 <span className="font-mono">{REGISTRATION_FEE_SOL} SOL</span>
               </div>
               <div className="flex justify-between gap-4">
-                <span className="text-muted-foreground">Account rent (~0.00057 SOL)</span>
+                <span className="text-muted-foreground">
+                  Account rent (~0.00057 SOL)
+                </span>
                 <span className="font-mono">{RENT_SOL} SOL</span>
               </div>
               <div className="flex justify-between gap-4 border-t border-blue-200 pt-1 font-semibold dark:border-blue-900/40">
@@ -1048,19 +1259,47 @@ function RegisterInner() {
 
           {/* Instruction preview + network diagnostics */}
           <div className="space-y-2 rounded-xl border border-gray-200 bg-gray-50 p-4 text-xs font-mono dark:border-gray-700 dark:bg-gray-950/50">
-            <p className="text-xs text-muted-foreground">Instruction being built:</p>
+            <p className="text-xs text-muted-foreground">
+              Instruction being built:
+            </p>
             <p className="text-green-400">register_agent(</p>
-            <p className="pl-4 text-foreground/80">agent_type: {form.agentType === "primary" ? 0 : form.agentType === "attestation" ? 1 : 2},</p>
-            <p className="pl-4 text-foreground/80">model: &quot;{form.model || "unknown"}&quot;,</p>
-            <p className="pl-4 text-foreground/80">rate_lamports: {Math.round(parseFloat((form.agentType === "attestation" ? form.attestationRate : form.primaryRate) || "0") * 1e9)},</p>
-            <p className="pl-4 text-foreground/80">min_reputation: {form.minConsumerRep},</p>
+            <p className="pl-4 text-foreground/80">
+              agent_type:{" "}
+              {form.agentType === "primary"
+                ? 0
+                : form.agentType === "attestation"
+                  ? 1
+                  : 2}
+              ,
+            </p>
+            <p className="pl-4 text-foreground/80">
+              model: &quot;{form.model || "unknown"}&quot;,
+            </p>
+            <p className="pl-4 text-foreground/80">
+              rate_lamports:{" "}
+              {Math.round(
+                parseFloat(
+                  (form.agentType === "attestation"
+                    ? form.attestationRate
+                    : form.primaryRate) || "0",
+                ) * 1e9,
+              )}
+              ,
+            </p>
+            <p className="pl-4 text-foreground/80">
+              min_reputation: {form.minConsumerRep},
+            </p>
             <p className="text-green-400">)</p>
 
             <div className="mt-2 rounded border border-amber-500/30 bg-amber-500/10 p-2 text-[11px] text-amber-200">
               <p className="font-semibold">Active network diagnostics</p>
               <p>RPC: {activeRpc}</p>
               <p>Program: {activeProgramId}</p>
-              <p className="mt-1 opacity-90">If registration returns InvalidInstructionData, verify this program ID matches the currently deployed protocol program for this app build.</p>
+              <p className="mt-1 opacity-90">
+                If registration returns InvalidInstructionData, verify this
+                program ID matches the currently deployed protocol program for
+                this app build.
+              </p>
             </div>
           </div>
 
@@ -1082,38 +1321,70 @@ function RegisterInner() {
             ) : (
               <Button
                 onClick={handleRegister}
-                disabled={registering || !endpointCompliancePassed || existingAgent.status === "checking"}
+                disabled={
+                  registering ||
+                  !endpointCompliancePassed ||
+                  existingAgent.status === "checking"
+                }
                 className="w-full !rounded-lg !bg-blue-600 !px-4 !py-2.5 !font-semibold !text-white !transition hover:!bg-blue-700 disabled:!bg-blue-300"
               >
-                {registering ? "Registering..." : existingAgent.status === "checking" ? "Checking registration..." : !endpointCompliancePassed ? "Probe endpoint compliance first" : "Register Agent (0.01 SOL)"}
+                {registering
+                  ? "Registering..."
+                  : existingAgent.status === "checking"
+                    ? "Checking registration..."
+                    : !endpointCompliancePassed
+                      ? "Probe endpoint compliance first"
+                      : "Register Agent (0.01 SOL)"}
               </Button>
             )}
           </div>
           {txError && (
-            <div className={`rounded-lg border p-3 ${isAlreadyRegisteredError(txError) || alreadyRegistered ? "border-emerald-500/30 bg-emerald-500/10" : "border-red-500/30 bg-red-500/10"}`}>
-              <p className={`text-xs font-semibold ${isAlreadyRegisteredError(txError) || alreadyRegistered ? "text-emerald-300" : "text-red-300"}`}>
-                {isAlreadyRegisteredError(txError) || alreadyRegistered ? "This wallet is already registered" : "Registration transaction failed"}
+            <div
+              className={`rounded-lg border p-3 ${isAlreadyRegisteredError(txError) || alreadyRegistered ? "border-emerald-500/30 bg-emerald-500/10" : "border-red-500/30 bg-red-500/10"}`}
+            >
+              <p
+                className={`text-xs font-semibold ${isAlreadyRegisteredError(txError) || alreadyRegistered ? "text-emerald-300" : "text-red-300"}`}
+              >
+                {isAlreadyRegisteredError(txError) || alreadyRegistered
+                  ? "This wallet is already registered"
+                  : "Registration transaction failed"}
               </p>
               {isAlreadyRegisteredError(txError) || alreadyRegistered ? (
                 <div className="mt-1 space-y-2 text-xs text-emerald-100/80">
                   <p>
-                    Each wallet maps to one deterministic agent account. Open your existing agent profile, update its details, or deregister before registering again with this wallet.
+                    Each wallet maps to one deterministic agent account. Open
+                    your existing agent profile, update its details, or
+                    deregister before registering again with this wallet.
                   </p>
                   <div className="flex flex-wrap gap-2">
-                    <LinkButton href={myAgentHref} size="sm" className="!bg-emerald-400 !text-black hover:!bg-emerald-300">
+                    <LinkButton
+                      href={myAgentHref}
+                      size="sm"
+                      className="!bg-emerald-400 !text-black hover:!bg-emerald-300"
+                    >
                       My Agent →
                     </LinkButton>
-                    <LinkButton href="/faq" size="sm" variant="outline" className="border-emerald-300/30 text-emerald-100">
+                    <LinkButton
+                      href="/faq"
+                      size="sm"
+                      variant="outline"
+                      className="border-emerald-300/30 text-emerald-100"
+                    >
                       FAQ
                     </LinkButton>
                   </div>
                 </div>
               ) : (
                 <p className="mt-1 text-xs text-red-100/80">
-                  Check the error details below, then retry. Common causes are low SOL balance, stale blockhash, or program revert.
+                  Check the error details below, then retry. Common causes are
+                  low SOL balance, stale blockhash, or program revert.
                 </p>
               )}
-              <pre className={`mt-2 whitespace-pre-wrap break-words font-mono text-xs ${isAlreadyRegisteredError(txError) || alreadyRegistered ? "text-emerald-100/90" : "text-red-100/90"}`}>{txError}</pre>
+              <pre
+                className={`mt-2 whitespace-pre-wrap break-words font-mono text-xs ${isAlreadyRegisteredError(txError) || alreadyRegistered ? "text-emerald-100/90" : "text-red-100/90"}`}
+              >
+                {txError}
+              </pre>
             </div>
           )}
         </div>
@@ -1124,7 +1395,13 @@ function RegisterInner() {
 
 export default function RegisterPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen bg-page flex items-center justify-center"><p className="text-gray-400">Loading…</p></div>}>
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-page flex items-center justify-center">
+          <p className="text-gray-400">Loading…</p>
+        </div>
+      }
+    >
       <RegisterInner />
     </Suspense>
   );

--- a/docs/AGENT-FRAMEWORK-MCP-X402-ONBOARDING-2026-05-08.md
+++ b/docs/AGENT-FRAMEWORK-MCP-X402-ONBOARDING-2026-05-08.md
@@ -1,0 +1,197 @@
+# Agent Framework Onboarding — MCP + reddi-x402
+
+_Date: 2026-05-08 AEST_
+
+## Purpose
+
+Help users with existing agent frameworks add Reddi Agent Protocol as a specialist discovery, quote, payment, verification, and disclosure layer without replacing their current orchestration stack.
+
+Target hosts:
+
+- OpenClaw
+- OpenSwarm-style orchestrators
+- Claude Code / Claude Desktop MCP clients
+- Codex / OpenAI-style coding agents
+- Custom agent runtimes
+
+## Safety model
+
+Default behavior is quote-first and dry-run-safe.
+
+1. Discover specialists.
+2. Request a quote.
+3. Check budget, trust, privacy, and human approval policy.
+4. Pay/invoke only when explicitly enabled.
+5. Verify receipt and output evidence.
+6. Export disclosure ledger when specialist output influences final work.
+
+Never silently spend. Never send private payloads by default. Never rely on unverified paid output as authoritative evidence.
+
+## MCP server setup
+
+Use the Reddi Agent Protocol MCP bridge when the host supports MCP.
+
+Example config:
+
+```json
+{
+  "mcpServers": {
+    "reddi-agent-protocol": {
+      "command": "node",
+      "args": ["/absolute/path/to/packages/rap-mcp-bridge/dist/src/server.js"],
+      "env": {
+        "REDDI_RAP_BASE_URL": "http://localhost:3000",
+        "REDDI_MCP_POLICY_MODE": "dry_run",
+        "REDDI_MCP_ALLOW_INVOKE": "false",
+        "REDDI_MCP_ALLOW_PAYMENT": "false",
+        "REDDI_MCP_HOST_FRAMEWORK": "claude"
+      }
+    }
+  }
+}
+```
+
+Expected tools in dry-run mode:
+
+- `reddi.discover_specialists`
+- `reddi.request_quote`
+- `reddi.verify_receipt`
+- `reddi.export_disclosure_ledger`
+
+Payment/invocation tools must not be exposed until local Surfpool rehearsal and explicit devnet approval gates pass.
+
+## OpenClaw instructions
+
+Add a project skill or playbook that tells OpenClaw:
+
+```md
+When a task might benefit from paid external specialist agents, use Reddi Agent Protocol MCP tools.
+
+Rules:
+
+- Read the project STATUS.md first.
+- Discover specialists before quoting.
+- Request quote before any paid work.
+- In dry-run mode, stop after quote and export disclosure ledger plan.
+- For live/devnet mode, require explicit approval, spend cap, network allowlist, and receipt logging.
+- Log quotes, approvals, payment receipts, specialist outputs, and disclosure ledgers to project artifacts.
+- Update STATUS.md and memory after any payment or externally sourced specialist output.
+```
+
+Recommended OpenClaw default:
+
+```bash
+REDDI_MCP_POLICY_MODE=dry_run
+REDDI_MCP_ALLOW_PAYMENT=false
+REDDI_MCP_ALLOW_INVOKE=false
+```
+
+## OpenSwarm-style instructions
+
+Patch the orchestrator instructions/AGENTS file:
+
+```md
+Use Reddi Agent Protocol as an external paid-specialist marketplace, not as the primary orchestrator.
+
+Flow:
+
+1. Use `reddi.discover_specialists` for external capability discovery.
+2. Use `reddi.request_quote` for terms and budget.
+3. If quote requires spend, stop for approval unless a bounded spend policy is already active.
+4. Invoke/pay only when Reddi Agent Protocol policy exposes those tools and the user approved the spend.
+5. Verify receipts and include the disclosure ledger in final artifacts.
+```
+
+Demo prompt:
+
+> Build a market brief using paid research only if the quote is under $2, evidence is verifiable, and the disclosure ledger can be included.
+
+Dry-run expected result: the swarm should mention that a specialist quote was available but not paid/invoked.
+
+## Claude Code / Claude Desktop
+
+Use the MCP config above. Add this host prompt:
+
+```md
+You have Reddi Agent Protocol tools for external paid specialist agents.
+Use discovery and quote tools freely in dry-run mode.
+Do not invoke or pay unless the user explicitly approves the exact quote, network, spend cap, and data-sharing boundary.
+Verify receipts before relying on paid specialist output.
+Include disclosure ledger details when specialist output influences final work.
+```
+
+## Codex / custom agents
+
+If MCP is unavailable, use a thin wrapper around Reddi Agent Protocol HTTP endpoints with the same policy sequence:
+
+```text
+resolve/discover -> request quote -> approval -> pay/invoke if enabled -> verify -> export disclosure ledger
+```
+
+Do not call arbitrary specialist URLs directly from the agent runtime. Use the bridge or backend allowlist so payment, receipt, and disclosure state stays auditable.
+
+## reddi-x402 for specialist agents
+
+Specialist builders use `reddi-x402` to put a payment gate in front of their agent endpoint.
+
+Minimum specialist path:
+
+1. Run a useful specialist endpoint.
+2. Add x402 challenge middleware using `reddi-x402`.
+3. Publish capability, rate, health, and endpoint metadata.
+4. Register the specialist on devnet.
+5. Return receipts/evidence that consumer agents can verify.
+
+Specialist endpoint contract:
+
+- no payment header -> return x402 challenge
+- valid payment receipt -> execute scoped work
+- invalid receipt -> reject closed
+- include receipt references in response metadata
+
+## Consumer-agent wallet delegation
+
+Consumer agents should not receive unlimited wallet authority.
+
+Recommended delegation shape:
+
+- owner wallet stays human/operator-controlled
+- agent receives a bounded delegate/session authority
+- caps: max per call, max total, expiry time, allowed network, allowed specialist registry/program IDs
+- payment receipts must be logged
+- unused authority should expire or be revoked
+
+For demos, prefer:
+
+1. dry-run quote mode
+2. Surfpool local validator mode
+3. bounded devnet mode with tiny caps
+4. mainnet only with separate explicit approval
+
+## Demo collateral plan
+
+Before recording:
+
+```bash
+npm run test:e2e:marketplace-conversion -- --project=chromium
+npm run smoke:rap-mcp-bridge:surfpool-local
+npm run smoke:economic-demo:surfpool
+npm run smoke:rap-mcp-bridge:devnet-proof
+```
+
+Record the session only after BDD and Surfpool pass. The script should follow the actual recording:
+
+1. Existing agent framework connects through MCP.
+2. Consumer agent discovers and quotes specialists.
+3. Specialist path shows how builders monetize through `reddi-x402`.
+4. Surfpool proof shows local on-chain semantics.
+5. Devnet proof shows bounded real-network evidence.
+6. Attestor path verifies receipts/output/reputation.
+
+## Boundaries
+
+- Do not claim mainnet settlement unless separately approved and proven.
+- Do not claim arbitrary specialist invocation without allowlist/gating.
+- Do not claim Jupiter devnet execution as reliable.
+- Do not expose secrets/private payloads by default.
+- Do not bypass human approval for paid execution.

--- a/docs/LANDING-PAGE-MESSAGING-PLAN-2026-05-08.md
+++ b/docs/LANDING-PAGE-MESSAGING-PLAN-2026-05-08.md
@@ -44,12 +44,64 @@ Core verbs:
 - Add a simple money/work graph before dense evidence.
 - Keep boundary honesty, but consolidate it instead of repeating operator warnings above the story.
 
-### Slice 3 — Validation
+### Slice 3 — BDD conversion gates
 
-- Run focused lint on `app/page.tsx` and `app/economic-demo/page.tsx`.
-- Run product naming check on changed files.
-- Run claim-boundary check.
-- Run Playwright economic-demo smoke if time permits.
+Before any final demo recording, add and run BDD-style Playwright checks for the four role journeys:
+
+- `/register` — specialist builder understands monetization, `reddi-x402` gating, capability publishing, and reputation path before wallet registration.
+- `/planner` — consumer-agent operator sees existing-agent-system framing, policy-before-payment, receipts-after-work, and cannot discover specialists without a task prompt.
+- `/mcp-bridge-demo` — MCP adopter sees the bridge as the existing-agent-system integration path, with links to planner and economic demo plus local-first proof artifacts.
+- `/attestation` — attestor sees output validation, receipt inspection, reputation protection, and can resolve an attestor candidate against mocked planner APIs.
+
+Command:
+
+```bash
+npm run test:e2e:marketplace-conversion -- --project=chromium
+```
+
+### Slice 4 — Surfpool local validator rehearsal
+
+Before any devnet recording, prove the on-chain parts locally in Surfpool so the demo has a deterministic safety gate:
+
+- Register/listing path: specialist registration PDA/instruction construction and registry state expectations.
+- Consumer/planner path: quote/terms hash, payment-intent semantics, receipt/disclosure-ledger export.
+- MCP bridge path: quote-only governance first, then local payment semantics only after dry-run assertions pass.
+- Attestor path: attestation/reputation update semantics and release/verification boundary.
+
+Commands already available for the first rehearsal layer:
+
+```bash
+npm run smoke:rap-mcp-bridge:surfpool-local
+npm run smoke:economic-demo:surfpool
+npm run test:surfpool:onboarding
+```
+
+If any Surfpool lane fails, stop and fix locally before touching devnet.
+
+### Slice 5 — Bounded devnet proof + recorded collateral
+
+After BDD and Surfpool pass, run one final bounded devnet proof and record the user-facing journey for onboarding/hackathon collateral:
+
+1. Run the devnet proof with explicit spend caps and no mainnet/Jupiter execution claims.
+2. Capture the browser journey with Playwright video or Peekaboo:
+   - homepage → `/mcp-bridge-demo`
+   - planner/consumer policy path
+   - specialist `/register` path
+   - attestor `/attestation` path
+   - `/economic-demo` final proof/evidence lane
+3. Save recording artifacts under `artifacts/final-recording-*/` with command logs and claim-boundary notes.
+4. Build the narration script from the recorded flow, not from aspirational copy.
+
+### Slice 6 — Framework onboarding documentation
+
+Add user docs for existing agent frameworks:
+
+- OpenClaw skill/playbook setup for the Reddi Agent Protocol MCP bridge.
+- OpenSwarm AGENTS/instructions patch for quote-first paid specialists.
+- Claude Code / Claude Desktop MCP config.
+- Codex / custom agent setup where MCP or HTTP wrappers are available.
+- `reddi-x402` package usage for specialist payment gates and consumer-agent spend delegation.
+- Wallet delegation guidance: consumer wallet remains owner, agent receives a bounded delegate/session authority with explicit caps, expiry, allowed specialists/networks, and receipt logging.
 
 ## Guardrails
 

--- a/docs/LANDING-PAGE-MESSAGING-PLAN-2026-05-08.md
+++ b/docs/LANDING-PAGE-MESSAGING-PLAN-2026-05-08.md
@@ -1,0 +1,60 @@
+# Landing Page + Economic Demo Messaging Plan — 2026-05-08
+
+## Goal
+
+Reframe the public Reddi Agent Protocol experience around the prosumer/builder job-to-be-done: agents should be able to discover, pay, verify, and rate specialist agents.
+
+The site should convert three audiences:
+
+1. **Existing agent-system users** — OpenClaw, Claude/MCP, OpenSwarm-style systems, ElizaOS, local/custom agents that need external specialist capability.
+2. **Specialist builders** — teams or prosumers running useful agents who can integrate `reddi-x402`, publish capability/rate metadata, and earn from marketplace work.
+3. **Attestor/consumer agents** — agents that verify outputs, receipt chains, and release criteria, or consume specialists under policy.
+
+## Positioning
+
+Primary frame:
+
+> Let your agents hire trusted specialist agents.
+
+Supporting frame:
+
+> Reddi Agent Protocol is the marketplace rail for agent commerce: discovery, x402 payment gates, receipts, attestations, and reputation trails for existing agent systems.
+
+Core verbs:
+
+> Discover. Pay. Verify.
+
+## Implementation slices
+
+### Slice 1 — Homepage conversion hierarchy
+
+- Replace abstract hero emphasis with concrete agent-commerce promise.
+- Make `/economic-demo` the primary CTA.
+- Add explicit secondary CTAs for `Register a specialist` and `Connect your agent system`.
+- Surface MCP/existing agent system support above the fold.
+- Move sponsor proof lower and rename it as proof, not the story.
+- Replace “Volunteer testers wanted” with “Devnet participants wanted”.
+- Add role cards: run agents, build specialists, verify work.
+
+### Slice 2 — Economic demo as lighthouse story
+
+- Rename demo hero from operator/audit framing to “watch an agent hire specialists”.
+- Put the narrative loop first: prompt → quote → x402 payment → specialists → attestation → evidence.
+- Add visible participation CTAs: specialist, attestor, consumer agent.
+- Add a simple money/work graph before dense evidence.
+- Keep boundary honesty, but consolidate it instead of repeating operator warnings above the story.
+
+### Slice 3 — Validation
+
+- Run focused lint on `app/page.tsx` and `app/economic-demo/page.tsx`.
+- Run product naming check on changed files.
+- Run claim-boundary check.
+- Run Playwright economic-demo smoke if time permits.
+
+## Guardrails
+
+- Keep product name as **Reddi Agent Protocol** and package as **`reddi-x402`**.
+- Do not claim mainnet settlement.
+- Do not claim reliable Jupiter devnet swap execution; keep it labelled as boundary/simulation unless mainnet is explicitly approved.
+- Do not trigger paid live runs from page load.
+- Keep `/economic-demo` default lane no-wallet unless user explicitly chooses bounded devnet/live mode.

--- a/e2e/economic-demo.spec.ts
+++ b/e2e/economic-demo.spec.ts
@@ -63,11 +63,11 @@ test.describe("/economic-demo judge-facing story", () => {
 
     await expect(
       page.getByRole("heading", {
-        name: /inspect a controlled paid-agent workflow/i,
+        name: /watch an agent hire specialists/i,
       }),
     ).toBeVisible();
     await expect(
-      page.getByText(/No wallet is required in the default judge path/i),
+      page.getByText(/no wallet required in the default demo path/i),
     ).toBeVisible();
     await expect(page.getByTestId("economic-proof-pills")).toContainText(
       "30 hosted specialists",
@@ -77,7 +77,7 @@ test.describe("/economic-demo judge-facing story", () => {
     );
 
     await expect(
-      page.getByRole("button", { name: /^run demo$/i }),
+      page.getByRole("button", { name: /^run controlled demo$/i }),
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: /open evidence archive/i }),
@@ -90,10 +90,11 @@ test.describe("/economic-demo judge-facing story", () => {
     const quote = page.getByTestId("economic-upfront-quote");
     await expect(quote).toBeVisible();
     await expect(quote).toContainText(
-      "Controlled hosted demo · no wallet required",
+      "One request, four paid specialist calls",
     );
-    await expect(quote).toContainText("payment claim");
-    await expect(quote).toContainText("controlled evidence only");
+    await expect(quote).toContainText("devnet paid proof");
+    await expect(quote).toContainText("0.13 USDC live run");
+    await expect(quote).toContainText("Money + work graph");
     await expect(quote).toContainText("does not claim mainnet payment");
 
     await expect(
@@ -112,7 +113,7 @@ test.describe("/economic-demo judge-facing story", () => {
       page.getByRole("button", { name: /build dry-run economic graph/i }),
     ).not.toBeVisible();
 
-    await page.getByRole("button", { name: /^run demo$/i }).click();
+    await page.getByRole("button", { name: /^run controlled demo$/i }).click();
     await expect(page.getByTestId("live-run-status")).toContainText(
       "Controlled live-run timeline started",
     );

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,25 +1,41 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from "@playwright/test";
 
-test.describe('Home page', () => {
-  test('loads and shows hero headline', async ({ page }) => {
-    await page.goto('/')
-    await expect(page).toHaveTitle(/Reddi Agent Protocol|AI agents/i)
-    await expect(page.getByRole('heading', { name: /the trust layer for agent commerce/i })).toBeVisible()
-  })
+test.describe("Home page", () => {
+  test("loads and shows hero headline", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/Reddi Agent Protocol|AI agents/i);
+    await expect(
+      page.getByRole("heading", {
+        name: /let your agents hire trusted specialist agents/i,
+      }),
+    ).toBeVisible();
+  });
 
-  test('hero has two CTAs', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.getByRole('link', { name: /register your agent/i })).toBeVisible()
-    await expect(page.getByRole('link', { name: /browse agents →/i })).toBeVisible()
-  })
+  test("hero has conversion CTAs", async ({ page }) => {
+    await page.goto("/");
+    const hero = page.locator("section").first();
+    await expect(
+      hero.getByRole("link", { name: /try the economic demo/i }),
+    ).toBeVisible();
+    await expect(
+      hero.getByRole("link", { name: /register a specialist/i }),
+    ).toBeVisible();
+    await expect(
+      hero.getByRole("link", { name: /connect your agent system/i }),
+    ).toBeVisible();
+  });
 
-  test('navbar has marketplace link', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.getByRole('navigation').getByRole('link', { name: /marketplace/i })).toBeVisible()
-  })
+  test("navbar has marketplace link", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("navigation").getByRole("link", { name: /marketplace/i }),
+    ).toBeVisible();
+  });
 
-  test('footer contains correct tagline', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.getByText(/Trust the protocol, not the pitch\./i).first()).toBeVisible()
-  })
-})
+  test("footer contains correct tagline", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByText(/Trust the protocol, not the pitch\./i).first(),
+    ).toBeVisible();
+  });
+});

--- a/e2e/marketplace-conversion.spec.ts
+++ b/e2e/marketplace-conversion.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test } from "@playwright/test";
+import { connectMockWallet, enableMockWallet } from "./helpers/wallet";
+
+/**
+ * BDD: Prosumer marketplace conversion paths
+ *
+ * Goal: prove the four onboarding journeys stay understandable before we run
+ * local Surfpool rehearsal, bounded devnet proof, and recorded demo capture.
+ */
+test.describe("prosumer marketplace conversion journeys", () => {
+  test("specialist builder can understand the /register monetization path", async ({
+    page,
+  }) => {
+    await enableMockWallet(page);
+    await page.goto("/register");
+    await connectMockWallet(page);
+
+    await expect(
+      page.getByRole("heading", {
+        name: /monetize your specialist agent with reddi-x402/i,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText(/publish capabilities/i)).toBeVisible();
+    await expect(page.getByText(/gate work with x402/i)).toBeVisible();
+    await expect(page.getByText(/earn reputation/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /set up my first specialist/i }),
+    ).toBeVisible();
+  });
+
+  test("consumer agent operator can inspect /planner policy before payment", async ({
+    page,
+  }) => {
+    await enableMockWallet(page);
+    await page.goto("/planner");
+    await connectMockWallet(page);
+
+    await expect(
+      page.getByRole("heading", {
+        name: /connect your agent system to marketplace specialists/i,
+      }),
+    ).toBeVisible();
+    const main = page.getByRole("main");
+    await expect(
+      main.getByText(/works with existing agents/i).first(),
+    ).toBeVisible();
+    await expect(
+      main.getByText(/policy before payment/i).first(),
+    ).toBeVisible();
+    await expect(main.getByText(/receipts after work/i).first()).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /discover specialists/i }),
+    ).toBeDisabled();
+  });
+
+  test("MCP adopter can follow /mcp-bridge-demo from bridge to planner and proof", async ({
+    page,
+  }) => {
+    await page.goto("/mcp-bridge-demo");
+
+    await expect(
+      page.getByRole("heading", { name: /Reddi Agent Protocol MCP Bridge/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/for existing agent systems/i)).toBeVisible();
+    await expect(page.getByText(/permission boundary/i)).toBeVisible();
+    await expect(page.getByText(/local-first evidence trail/i)).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /try planner path/i }),
+    ).toHaveAttribute("href", "/planner");
+    await expect(
+      page.getByRole("link", { name: /watch economic demo/i }),
+    ).toHaveAttribute("href", "/economic-demo");
+  });
+
+  test("attestor can inspect verification role path and resolve readiness", async ({
+    page,
+  }) => {
+    await enableMockWallet(page);
+    await page.route("**/api/onboarding/audit", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          attestations: [
+            {
+              timestamp: "2026-05-08T00:00:00.000Z",
+              job_id: "bdd-attestation-001",
+              tx_signature: "BddAttestation111111111111111111111111111111111",
+              local_only: false,
+              wallet_address: "BddAttestor1111111111111111111111111111111111",
+              endpoint_url:
+                "https://attestor.example/.well-known/reddi-agent.json",
+            },
+          ],
+        }),
+      });
+    });
+    await page.route("**/api/onboarding/planner/reveal", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          result: {
+            entries: [
+              {
+                runId: "bdd-reveal-001",
+                revealedAt: "2026-05-08T00:01:00.000Z",
+                revealTxSignature:
+                  "BddReveal1111111111111111111111111111111111",
+                specialistWallet: "BddSpecialist111111111111111111111111111111",
+              },
+            ],
+          },
+        }),
+      });
+    });
+    await page.route("**/api/planner/tools/resolve-attestor", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          count: 1,
+          candidate: {
+            walletAddress: "BddAttestor1111111111111111111111111111111111",
+            attestationAccuracy: 0.98,
+            reasons: ["receipt verifier", "high accuracy"],
+          },
+        }),
+      });
+    });
+
+    await page.goto("/attestation");
+    await connectMockWallet(page);
+
+    await expect(
+      page.getByRole("heading", {
+        name: /verify specialist work and earn trust/i,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText(/validate outputs/i)).toBeVisible();
+    await expect(page.getByText(/inspect receipts/i)).toBeVisible();
+    await expect(page.getByText(/protect reputation/i)).toBeVisible();
+
+    await page.getByRole("button", { name: /resolve attestor/i }).click();
+    await expect(page.getByText(/resolved attestor/i)).toBeVisible();
+    await expect(page.getByText(/receipt verifier/i)).toBeVisible();
+  });
+});

--- a/lib/mcp-bridge-demo/fixture.ts
+++ b/lib/mcp-bridge-demo/fixture.ts
@@ -124,7 +124,7 @@ export const mcpBridgeDemoFixture: McpBridgeDemoFixture = {
           label: "Discover specialists",
           status: "pass",
           detail:
-            "RAP registry/planner can rank eligible specialists by capability, price, health, and trust signals.",
+            "The Reddi Agent Protocol registry/planner can rank eligible specialists by capability, price, health, and trust signals.",
         },
         {
           id: "quote",
@@ -235,7 +235,7 @@ export const mcpBridgeDemoFixture: McpBridgeDemoFixture = {
   },
   recordingScript: [
     "Agent swarms can orchestrate work, but paid specialist work needs pricing, policy, receipts, and disclosure.",
-    "The RAP MCP Bridge lets any MCP host discover candidates and request a quote before spend.",
+    "The MCP bridge lets any MCP host discover candidates and request a quote before spend.",
     "This first quote is synthetic and non-binding. The policy correctly blocks payment and invocation.",
     "Next, the same flow must be proven locally on Surfpool before a bounded devnet spend is allowed.",
     "The final artifact is not just content — it includes a disclosure ledger describing who was hired, what was paid, and what verification boundary applies.",

--- a/lib/mcp-bridge-demo/fixture.ts
+++ b/lib/mcp-bridge-demo/fixture.ts
@@ -2,7 +2,10 @@ import { buildRapMcpBridgeSurfpoolProof } from "@/lib/mcp-bridge-demo/surfpool-p
 
 const surfpoolProof = buildRapMcpBridgeSurfpoolProof();
 
-export type McpBridgeDemoMode = "quote_only" | "surfpool_local" | "devnet_ready";
+export type McpBridgeDemoMode =
+  | "quote_only"
+  | "surfpool_local"
+  | "devnet_ready";
 
 export type McpBridgeDemoCheck = {
   id: string;
@@ -80,16 +83,17 @@ export type McpBridgeDemoFixture = {
 
 export const mcpBridgeDemoFixture: McpBridgeDemoFixture = {
   generatedAt: "2026-05-08T00:00:00+10:00",
-  title: "RAP MCP Bridge",
+  title: "Reddi Agent Protocol MCP Bridge",
   subtitle:
-    "A payment and verification bridge that lets OpenSwarm, OpenClaw, Cursor, and Claude discover, quote, verify, and disclose paid specialist-agent work.",
+    "A payment and verification bridge that lets OpenClaw, Claude/MCP agents, OpenSwarm-style systems, Cursor, and custom agent stacks discover, quote, verify, and disclose paid specialist-agent work.",
   permissionBoundary:
     "Devnet spends are allowed only after the same flow is proven in the local Surfpool validator environment. Mainnet is out of scope.",
   proofArtifacts: [
     {
       label: "Surfpool local transaction proof",
       boundary: "local_validator_only_no_devnet_no_mainnet",
-      artifactPath: "artifacts/rap-mcp-bridge-surfpool-local/20260507T145133Z/SUMMARY.md",
+      artifactPath:
+        "artifacts/rap-mcp-bridge-surfpool-local/20260507T145133Z/SUMMARY.md",
       result: "local payment semantics: pass",
       txSignatures: [
         "5KFhkP2tHHEQ5RVVRJymbmKrMVWCF4Vu9RTioVc5eqd3chEdW7CxRtuhAZ6fxU6fSzzQX3pUXLEthURkQSymu4P6",
@@ -99,7 +103,8 @@ export const mcpBridgeDemoFixture: McpBridgeDemoFixture = {
     {
       label: "Bounded devnet payment proof",
       boundary: "solana_devnet_only_no_mainnet_no_specialist_http_invocation",
-      artifactPath: "artifacts/rap-mcp-bridge-devnet-proof/20260507T145907Z/SUMMARY.md",
+      artifactPath:
+        "artifacts/rap-mcp-bridge-devnet-proof/20260507T145907Z/SUMMARY.md",
       result: "devnet payment semantics: pass; cap: 100050 lamports",
       txSignatures: [
         "62CP7sHi9KyUDbnVFgM5WCvwiSq2p5WCkThsTkNrpqYnUxLGN9QNRDjye1nBDB7UWjgqtonoYbuKxawjzAvWrUgD",
@@ -118,59 +123,68 @@ export const mcpBridgeDemoFixture: McpBridgeDemoFixture = {
           id: "discover",
           label: "Discover specialists",
           status: "pass",
-          detail: "RAP registry/planner can rank eligible specialists by capability, price, health, and trust signals.",
+          detail:
+            "RAP registry/planner can rank eligible specialists by capability, price, health, and trust signals.",
         },
         {
           id: "quote",
           label: "Synthetic quote",
           status: "pass",
-          detail: "Quote is explicitly bridge_synthetic and non-binding; it is a governance artifact, not a commercial commitment.",
+          detail:
+            "Quote is explicitly bridge_synthetic and non-binding; it is a governance artifact, not a commercial commitment.",
         },
         {
           id: "payment",
           label: "Payment",
           status: "blocked",
-          detail: "Dry-run MCP policy blocks all payment and invoke tools in the first PR.",
+          detail:
+            "Dry-run MCP policy blocks all payment and invoke tools in the first PR.",
         },
       ],
     },
     {
       id: "surfpool_local",
       label: "2. Surfpool local proof",
-      claimBoundary: "Local validator proof only. No devnet/mainnet settlement claimed.",
+      claimBoundary:
+        "Local validator proof only. No devnet/mainnet settlement claimed.",
       spendBoundary: "Local test-validator semantics",
       checks: [
         {
           id: "local-settlement",
           label: "Local settlement semantics",
           status: "pass",
-          detail: "Local Surfpool artifact proves quote → local transfer semantics → receipt → disclosure ledger before devnet.",
+          detail:
+            "Local Surfpool artifact proves quote → local transfer semantics → receipt → disclosure ledger before devnet.",
         },
         {
           id: "local-verifier",
           label: "Local verifier",
           status: "pass",
-          detail: "Local verifier passed with specialist credit and 0.05% protocol fee semantics.",
+          detail:
+            "Local verifier passed with specialist credit and 0.05% protocol fee semantics.",
         },
       ],
     },
     {
       id: "devnet_ready",
       label: "3. Bounded devnet proof",
-      claimBoundary: "Devnet proof only after Surfpool succeeds and is reviewed.",
+      claimBoundary:
+        "Devnet proof only after Surfpool succeeds and is reviewed.",
       spendBoundary: "Explicit bounded devnet spend; no mainnet",
       checks: [
         {
           id: "surfpool-gate",
           label: "Surfpool gate",
           status: "pass",
-          detail: "Surfpool proof artifact exists; bounded devnet proof was executed separately under a tiny spend cap.",
+          detail:
+            "Surfpool proof artifact exists; bounded devnet proof was executed separately under a tiny spend cap.",
         },
         {
           id: "devnet-receipt",
           label: "Devnet receipt verification",
           status: "pass",
-          detail: "Bounded devnet proof captured tx signatures, terms hash, spend cap, payment boundary, and disclosure ledger entry.",
+          detail:
+            "Bounded devnet proof captured tx signatures, terms hash, spend cap, payment boundary, and disclosure ledger entry.",
         },
       ],
     },
@@ -212,7 +226,10 @@ export const mcpBridgeDemoFixture: McpBridgeDemoFixture = {
         currency: "USDC",
         network: "demo",
         verificationStatus: "planned",
-        evidenceRefs: ["quote_demo_mcp_bridge_research_001", surfpoolProof.quote.termsHash],
+        evidenceRefs: [
+          "quote_demo_mcp_bridge_research_001",
+          surfpoolProof.quote.termsHash,
+        ],
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:e2e": "playwright test",
     "test:e2e:dogfood": "playwright test e2e/dogfood.spec.ts",
     "test:e2e:wallet": "playwright test e2e/wallet-mock.spec.ts",
+    "test:e2e:marketplace-conversion": "playwright test e2e/marketplace-conversion.spec.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "demo:dogfood:capture": "./scripts/run-dogfood-demo-capture.sh",


### PR DESCRIPTION
## Summary
- Reframe the homepage around the prosumer marketplace story: agents discover, pay, verify, and rate trusted specialist agents.
- Make `/economic-demo` the lighthouse proof path with clearer role CTAs, money/work/attestation story spine, and preserved devnet/mainnet claim boundaries.
- Clarify role conversion paths: `/register` for specialist monetization with `reddi-x402`, `/planner` for consumer-agent policy discovery, `/attestation` for verification agents, and `/mcp-bridge-demo` for existing agent-system adoption.
- Add `docs/LANDING-PAGE-MESSAGING-PLAN-2026-05-08.md` as the implementation plan/retrospective artifact.
- Refresh home/economic-demo e2e expectations around the new messaging and CTA structure.

## Validation
- `npm run lint -- app/page.tsx app/economic-demo/page.tsx app/register/page.tsx app/planner/page.tsx app/attestation/page.tsx app/mcp-bridge-demo/page.tsx e2e/home.spec.ts e2e/economic-demo.spec.ts`
- `npm run check:product:naming -- app/page.tsx app/economic-demo/page.tsx app/register/page.tsx app/planner/page.tsx app/attestation/page.tsx app/mcp-bridge-demo/page.tsx lib/mcp-bridge-demo/fixture.ts docs/LANDING-PAGE-MESSAGING-PLAN-2026-05-08.md`
- `npm run check:submission:claim-boundaries`
- `npm run test:e2e -- e2e/home.spec.ts e2e/economic-demo.spec.ts --project=chromium` (5/5)
- `git diff --check`

## Notes
- Claims remain bounded to devnet/local/demo evidence where applicable.
- Homepage “Connect your agent system” now routes to `/mcp-bridge-demo` instead of dropping users directly into the planner.
