### PR TITLE
test: add marketplace demo readiness harness

### DIFF
--- a/docs/MARKETPLACE-DEMO-READINESS-HARNESS-2026-05-08.md
+++ b/docs/MARKETPLACE-DEMO-READINESS-HARNESS-2026-05-08.md
@@ -32,6 +32,12 @@ The harness writes:
 - per-step logs
 - copied Playwright recording video as `marketplace-recording.webm` when available
 
+Recording pace can be tuned with:
+
+```bash
+MARKETPLACE_RECORDING_PACE_MS=1500 npm run demo:marketplace:readiness -- --skip-surfpool
+```
+
 ## Fast mode
 
 Use this while iterating on UI/recording choreography:
@@ -71,7 +77,7 @@ The Playwright recording route follows:
 5. Attestor verification path.
 6. Economic demo proof/evidence page.
 
-The narration script should be based on the captured video and readiness artifacts, not aspirational copy.
+The narration script should be based on the captured video and readiness artifacts, not aspirational copy. A draft storyboard/script lives in `docs/MARKETPLACE-DEMO-STORYBOARD-2026-05-08.md`.
 
 ## Guardrails
 

--- a/docs/MARKETPLACE-DEMO-READINESS-HARNESS-2026-05-08.md
+++ b/docs/MARKETPLACE-DEMO-READINESS-HARNESS-2026-05-08.md
@@ -1,0 +1,82 @@
+# Marketplace Demo Readiness Harness — 2026-05-08
+
+## Purpose
+
+Provide one local-first gate before creating onboarding or hackathon demo collateral for the Reddi Agent Protocol prosumer marketplace funnel.
+
+The harness proves:
+
+1. BDD conversion flows still work.
+2. A Playwright recording journey can be captured.
+3. MCP bridge payment semantics pass on Surfpool.
+4. Economic demo payment/reputation semantics pass on Surfpool.
+5. Onboarding registration + attestation semantics pass on Surfpool.
+6. Bounded devnet proof is skipped unless explicitly requested.
+
+## Command
+
+```bash
+npm run demo:marketplace:readiness
+```
+
+Outputs go to:
+
+```text
+artifacts/marketplace-demo-readiness/<timestamp>/
+```
+
+The harness writes:
+
+- `summary.json`
+- `SUMMARY.md`
+- per-step logs
+- copied Playwright recording video as `marketplace-recording.webm` when available
+
+## Fast mode
+
+Use this while iterating on UI/recording choreography:
+
+```bash
+npm run demo:marketplace:readiness -- --skip-surfpool
+```
+
+This runs conversion BDD and recording only.
+
+## Plan-only mode
+
+Use this to inspect intended gates without running them:
+
+```bash
+npm run demo:marketplace:readiness -- --plan-only
+```
+
+## Bounded devnet mode
+
+Only after local Surfpool gates pass and the operator intentionally wants a bounded devnet proof:
+
+```bash
+npm run demo:marketplace:readiness -- --include-devnet
+```
+
+Devnet mode still does not imply mainnet readiness.
+
+## Recording journey
+
+The Playwright recording route follows:
+
+1. Homepage hero.
+2. MCP bridge for existing agent systems.
+3. Planner policy-before-payment path.
+4. Specialist `/register` monetization path with `reddi-x402`.
+5. Attestor verification path.
+6. Economic demo proof/evidence page.
+
+The narration script should be based on the captured video and readiness artifacts, not aspirational copy.
+
+## Guardrails
+
+- No mainnet execution.
+- Devnet proof is opt-in.
+- Surfpool local validator gates must pass before bounded devnet recording.
+- Keep Jupiter devnet execution framed as unreliable unless separately proven.
+- Keep wallet delegation bounded by spend cap, expiry, network, allowed specialists/programs, and receipt logging.

--- a/docs/MARKETPLACE-DEMO-STORYBOARD-2026-05-08.md
+++ b/docs/MARKETPLACE-DEMO-STORYBOARD-2026-05-08.md
@@ -1,0 +1,130 @@
+# Marketplace Demo Storyboard — 2026-05-08
+
+## Source packet
+
+Use the readiness harness packet as the source of truth:
+
+```text
+artifacts/marketplace-demo-readiness/20260508T114520Z/summary.json
+artifacts/marketplace-demo-readiness/20260508T114520Z/marketplace-recording.webm
+```
+
+Fresh local Surfpool proof artifacts from the same run:
+
+- RAP MCP Bridge local payment semantics: `artifacts/rap-mcp-bridge-surfpool-local/20260508T114531Z/SUMMARY.md`
+- Economic demo local rehearsal: `artifacts/economic-demo-surfpool-rehearsal/20260508T114535Z/SUMMARY.md`
+- Onboarding/attestation local smoke: `artifacts/surfpool-onboarding/20260508-214541/SUMMARY.md`
+
+## Core claim
+
+Reddi Agent Protocol lets existing agent systems discover, quote, pay, verify, and disclose specialist-agent work without replacing the host framework.
+
+## Video beats
+
+### Beat 1 — Homepage promise
+
+Visual: homepage hero.
+
+Narration:
+
+> Reddi Agent Protocol is the marketplace rail for agent commerce. Existing agents can discover, pay, verify, and rate specialist agents instead of doing every task themselves.
+
+### Beat 2 — Existing agent systems connect through MCP
+
+Visual: click “Connect your agent system” and land on `/mcp-bridge-demo`.
+
+Narration:
+
+> If you already run OpenClaw, Claude Code, Codex, OpenSwarm-style agents, or a custom runtime, you can keep your orchestration stack. The MCP bridge gives those agents a safe quote-first path into specialist discovery.
+
+Boundary line:
+
+> The default mode is dry-run and quote-first. Payment and invocation are gated.
+
+### Beat 3 — Policy before payment
+
+Visual: planner path.
+
+Narration:
+
+> A consumer agent does not just call an endpoint. It resolves candidates by capability, price, trust, privacy mode, and budget policy before any x402 payment is attempted.
+
+### Beat 4 — Specialist monetization path
+
+Visual: `/register`.
+
+Narration:
+
+> Specialist builders can publish capabilities and pricing, add `reddi-x402` payment gates, and list their agents so consumer agents can hire them for scoped work.
+
+### Beat 5 — Attestor verification path
+
+Visual: `/attestation`, resolve attestor.
+
+Narration:
+
+> Attestor agents verify outputs, receipts, release criteria, and reputation updates. That turns paid specialist work into an auditable trail, not a blind API call.
+
+### Beat 6 — Economic demo proof
+
+Visual: `/economic-demo`, money + work graph and boundary copy.
+
+Narration:
+
+> The economic demo ties the story together: one request becomes quoted specialist work, payment evidence, attestation, and a disclosure ledger.
+
+Boundary line:
+
+> This recording is local-first. Surfpool validates the on-chain semantics before any bounded devnet proof. No mainnet execution is claimed.
+
+### Beat 7 — Surfpool proof packet
+
+Visual: terminal/artifact summary.
+
+Narration:
+
+> Before devnet, the readiness harness runs the conversion BDD, captures the recording journey, and proves MCP bridge, economic-demo, and onboarding-attestation flows on a local Surfpool validator.
+
+Show:
+
+```text
+npm run demo:marketplace:readiness
+```
+
+### Beat 8 — Optional bounded devnet follow-up
+
+Visual: command or runbook, not necessarily executed in the first video.
+
+Narration:
+
+> When the local gates are green, the same harness can opt into a bounded devnet proof. Devnet is explicit; mainnet remains out of scope unless separately approved and proven.
+
+Show:
+
+```text
+npm run demo:marketplace:readiness -- --include-devnet
+```
+
+## Suggested short script (60–90 seconds)
+
+> Your agent should not need to do every job itself. Reddi Agent Protocol gives existing agent systems a marketplace rail for specialist work: discover, quote, pay, verify, and disclose.
+>
+> Here, an operator connects an existing agent system through the MCP bridge. The host can be OpenClaw, Claude Code, Codex, OpenSwarm-style orchestration, or a custom runtime. The default path is quote-first and dry-run safe.
+>
+> In the planner, the consumer agent applies policy before payment: task type, spend cap, privacy mode, and attestation requirements. No specialist is paid just because it was discovered.
+>
+> Specialist builders can register their agents, publish capabilities and pricing, and add `reddi-x402` payment gates so other agents can hire them for scoped work.
+>
+> Attestor agents close the loop. They verify outputs, receipt chains, release criteria, and reputation updates so paid work becomes auditable evidence.
+>
+> Before recording or touching devnet, we run the full local readiness harness. It checks the conversion BDD, captures this Playwright journey, and proves the MCP bridge, economic-demo, and onboarding-attestation flows on Surfpool local validator.
+>
+> Once those local gates pass, a bounded devnet proof can be run explicitly. This demo does not claim mainnet execution. It shows the path from existing agent frameworks to paid specialist-agent commerce with safety gates and evidence built in.
+
+## Final recording checklist
+
+- Run `npm run demo:marketplace:readiness`.
+- Confirm `summary.json` has `ok: true`.
+- Confirm `marketplace-recording.webm` exists and is long enough for narration.
+- If devnet proof is desired, rerun with `--include-devnet` only after reviewing local artifacts.
+- Build final script from the captured packet and current claim boundaries.

--- a/e2e/marketplace-recording.spec.ts
+++ b/e2e/marketplace-recording.spec.ts
@@ -1,6 +1,16 @@
 import { expect, test } from "@playwright/test";
 import { connectMockWallet, enableMockWallet } from "./helpers/wallet";
 
+const recordingPaceMs = Number(
+  process.env.MARKETPLACE_RECORDING_PACE_MS ?? 900,
+);
+
+async function recordingBeat(page: {
+  waitForTimeout: (ms: number) => Promise<void>;
+}) {
+  if (recordingPaceMs > 0) await page.waitForTimeout(recordingPaceMs);
+}
+
 test.describe("marketplace demo recording journey", () => {
   test("records existing-agent to specialist to attestor onboarding flow", async ({
     page,
@@ -13,6 +23,7 @@ test.describe("marketplace demo recording journey", () => {
         name: /let your agents hire trusted specialist agents/i,
       }),
     ).toBeVisible();
+    await recordingBeat(page);
 
     await page
       .getByRole("link", { name: "Connect your agent system", exact: true })
@@ -21,6 +32,7 @@ test.describe("marketplace demo recording journey", () => {
       page.getByRole("heading", { name: /Reddi Agent Protocol MCP Bridge/i }),
     ).toBeVisible();
     await expect(page.getByText(/local-first evidence trail/i)).toBeVisible();
+    await recordingBeat(page);
 
     await page.getByRole("link", { name: /try planner path/i }).click();
     await connectMockWallet(page);
@@ -41,6 +53,7 @@ test.describe("marketplace demo recording journey", () => {
       }),
     ).toBeVisible();
     await expect(page.getByText(/gate work with x402/i)).toBeVisible();
+    await recordingBeat(page);
 
     await page.route("**/api/onboarding/audit", async (route) => {
       await route.fulfill({
@@ -81,6 +94,7 @@ test.describe("marketplace demo recording journey", () => {
     ).toBeVisible();
     await page.getByRole("button", { name: /resolve attestor/i }).click();
     await expect(page.getByText(/resolved attestor/i)).toBeVisible();
+    await recordingBeat(page);
 
     await page.goto("/economic-demo");
     await expect(
@@ -88,5 +102,6 @@ test.describe("marketplace demo recording journey", () => {
     ).toBeVisible();
     await expect(page.getByText(/money \+ work graph/i)).toBeVisible();
     await expect(page.getByText(/boundary:/i).first()).toBeVisible();
+    await recordingBeat(page);
   });
 });

--- a/e2e/marketplace-recording.spec.ts
+++ b/e2e/marketplace-recording.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+import { connectMockWallet, enableMockWallet } from "./helpers/wallet";
+
+test.describe("marketplace demo recording journey", () => {
+  test("records existing-agent to specialist to attestor onboarding flow", async ({
+    page,
+  }) => {
+    await enableMockWallet(page);
+
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", {
+        name: /let your agents hire trusted specialist agents/i,
+      }),
+    ).toBeVisible();
+
+    await page
+      .getByRole("link", { name: "Connect your agent system", exact: true })
+      .click();
+    await expect(
+      page.getByRole("heading", { name: /Reddi Agent Protocol MCP Bridge/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/local-first evidence trail/i)).toBeVisible();
+
+    await page.getByRole("link", { name: /try planner path/i }).click();
+    await connectMockWallet(page);
+    await expect(
+      page.getByRole("heading", {
+        name: /connect your agent system to marketplace specialists/i,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/policy before payment/i).first(),
+    ).toBeVisible();
+
+    await page.goto("/register");
+    await connectMockWallet(page);
+    await expect(
+      page.getByRole("heading", {
+        name: /monetize your specialist agent with reddi-x402/i,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText(/gate work with x402/i)).toBeVisible();
+
+    await page.route("**/api/onboarding/audit", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ attestations: [] }),
+      });
+    });
+    await page.route("**/api/onboarding/planner/reveal", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, result: { entries: [] } }),
+      });
+    });
+    await page.route("**/api/planner/tools/resolve-attestor", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          count: 1,
+          candidate: {
+            walletAddress: "RecordingAttestor1111111111111111111111111111",
+            attestationAccuracy: 0.99,
+            reasons: ["receipt verifier", "demo-ready"],
+          },
+        }),
+      });
+    });
+
+    await page.goto("/attestation");
+    await connectMockWallet(page);
+    await expect(
+      page.getByRole("heading", {
+        name: /verify specialist work and earn trust/i,
+      }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: /resolve attestor/i }).click();
+    await expect(page.getByText(/resolved attestor/i)).toBeVisible();
+
+    await page.goto("/economic-demo");
+    await expect(
+      page.getByRole("heading", { name: /watch an agent hire specialists/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/money \+ work graph/i)).toBeVisible();
+    await expect(page.getByText(/boundary:/i).first()).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:e2e:dogfood": "playwright test e2e/dogfood.spec.ts",
     "test:e2e:wallet": "playwright test e2e/wallet-mock.spec.ts",
     "test:e2e:marketplace-conversion": "playwright test e2e/marketplace-conversion.spec.ts",
+    "test:e2e:marketplace-recording": "playwright test e2e/marketplace-recording.spec.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "demo:dogfood:capture": "./scripts/run-dogfood-demo-capture.sh",
@@ -72,6 +73,7 @@
     "evidence:rap-mcp-bridge:surfpool-plan": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON ./scripts/generate-rap-mcp-bridge-surfpool-proof.mjs",
     "smoke:rap-mcp-bridge:surfpool-local": "node ./scripts/run-rap-mcp-bridge-surfpool-local.mjs",
     "smoke:rap-mcp-bridge:devnet-proof": "node ./scripts/run-rap-mcp-bridge-devnet-proof.mjs",
+    "demo:marketplace:readiness": "node ./scripts/run-marketplace-demo-readiness.mjs",
     "evidence:torque:reputation-ranking": "node ./scripts/generate-torque-reputation-ranking-evidence.mjs",
     "smoke:umbra:devnet:receiver-claimable-utxo": "node ./scripts/run-umbra-devnet-receiver-claimable-utxo-smoke.mjs"
   },

--- a/scripts/run-marketplace-demo-readiness.mjs
+++ b/scripts/run-marketplace-demo-readiness.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const timestamp = new Date()
+  .toISOString()
+  .replace(/[-:]/g, "")
+  .replace(/\.\d{3}Z$/, "Z");
+const outDir = join(
+  rootDir,
+  "artifacts",
+  "marketplace-demo-readiness",
+  timestamp,
+);
+mkdirSync(outDir, { recursive: true });
+
+const args = new Set(process.argv.slice(2));
+const includeDevnet = args.has("--include-devnet");
+const skipSurfpool = args.has("--skip-surfpool");
+const skipRecording = args.has("--skip-recording");
+const planOnly = args.has("--plan-only");
+
+const steps = [
+  {
+    id: "bdd_conversion",
+    label: "BDD conversion journeys",
+    command: "npm",
+    args: [
+      "run",
+      "test:e2e:marketplace-conversion",
+      "--",
+      "--project=chromium",
+    ],
+    required: true,
+  },
+  {
+    id: "recording_journey",
+    label: "Playwright recording journey",
+    command: "npm",
+    args: ["run", "test:e2e:marketplace-recording", "--", "--project=chromium"],
+    required: !skipRecording,
+    skipped: skipRecording,
+  },
+  {
+    id: "rap_mcp_surfpool_local",
+    label: "RAP MCP bridge Surfpool local proof",
+    command: "npm",
+    args: ["run", "smoke:rap-mcp-bridge:surfpool-local"],
+    required: !skipSurfpool,
+    skipped: skipSurfpool,
+  },
+  {
+    id: "economic_demo_surfpool",
+    label: "Economic demo Surfpool rehearsal",
+    command: "npm",
+    args: ["run", "smoke:economic-demo:surfpool"],
+    required: !skipSurfpool,
+    skipped: skipSurfpool,
+  },
+  {
+    id: "onboarding_attestation_surfpool",
+    label: "Onboarding/attestation Surfpool smoke",
+    command: "npm",
+    args: ["run", "test:surfpool:onboarding"],
+    required: !skipSurfpool,
+    skipped: skipSurfpool,
+  },
+  {
+    id: "bounded_devnet_proof",
+    label: "Bounded devnet proof (opt-in)",
+    command: "npm",
+    args: ["run", "smoke:rap-mcp-bridge:devnet-proof"],
+    required: includeDevnet,
+    skipped: !includeDevnet,
+  },
+];
+
+function findFiles(dir, predicate, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) findFiles(full, predicate, acc);
+    else if (predicate(full, stat))
+      acc.push({ path: full, mtimeMs: stat.mtimeMs });
+  }
+  return acc;
+}
+
+function copyLatestRecordingArtifact() {
+  const testResultsDir = join(rootDir, "test-results");
+  const videos = findFiles(
+    testResultsDir,
+    (file) =>
+      file.includes("marketplace-recording") && file.endsWith("video.webm"),
+  ).sort((a, b) => b.mtimeMs - a.mtimeMs);
+  if (videos.length === 0) return null;
+  const dest = join(outDir, "marketplace-recording.webm");
+  cpSync(videos[0].path, dest);
+  return { sourcePath: videos[0].path, artifactPath: dest };
+}
+
+function runStep(step) {
+  return new Promise((resolve) => {
+    const logPath = join(outDir, `${step.id}.log`);
+    if (step.skipped || !step.required) {
+      writeFileSync(logPath, `[marketplace-readiness] skipped ${step.label}\n`);
+      resolve({ ...step, status: "skipped", code: 0, logPath });
+      return;
+    }
+    const child = spawn(step.command, step.args, {
+      cwd: rootDir,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const chunks = [];
+    child.stdout.on("data", (chunk) => {
+      process.stdout.write(chunk);
+      chunks.push(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      process.stderr.write(chunk);
+      chunks.push(chunk);
+    });
+    child.on("close", (code) => {
+      writeFileSync(logPath, Buffer.concat(chunks));
+      resolve({ ...step, status: code === 0 ? "pass" : "fail", code, logPath });
+    });
+  });
+}
+
+async function main() {
+  const summary = {
+    schemaVersion: "reddi.marketplace-demo-readiness.v1",
+    generatedAt: new Date().toISOString(),
+    outDir,
+    mode: includeDevnet ? "local_plus_bounded_devnet" : "local_first_no_devnet",
+    guardrails: [
+      "BDD conversion journeys must pass before recording collateral is trusted",
+      "Surfpool local validator gates must pass before bounded devnet proof",
+      "Devnet proof is opt-in with --include-devnet",
+      "No mainnet execution",
+      "Recording script must be based on captured UI and artifacts, not aspirational copy",
+    ],
+    steps: [],
+  };
+
+  if (planOnly) {
+    summary.steps = steps.map((step) => ({
+      id: step.id,
+      label: step.label,
+      command: `${step.command} ${step.args.join(" ")}`,
+      skipped: step.skipped || !step.required,
+    }));
+    writeFileSync(
+      join(outDir, "summary.json"),
+      `${JSON.stringify(summary, null, 2)}\n`,
+    );
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  for (const step of steps) {
+    console.log(`\n[marketplace-readiness] >>> ${step.label}`);
+    const result = await runStep(step);
+    summary.steps.push({
+      id: result.id,
+      label: result.label,
+      status: result.status,
+      code: result.code,
+      logPath: result.logPath,
+    });
+    writeFileSync(
+      join(outDir, "summary.json"),
+      `${JSON.stringify(summary, null, 2)}\n`,
+    );
+    if (result.status === "fail") {
+      console.error(
+        `[marketplace-readiness] FAIL ${step.id}; see ${result.logPath}`,
+      );
+      process.exit(result.code || 1);
+    }
+  }
+
+  const ok = summary.steps.every(
+    (step) => step.status === "pass" || step.status === "skipped",
+  );
+  summary.recordingArtifact = copyLatestRecordingArtifact();
+  summary.ok = ok;
+  summary.next = includeDevnet
+    ? "Use Playwright video artifacts plus readiness summary to draft onboarding/hackathon demo script."
+    : "Review Surfpool artifacts, then rerun with --include-devnet only when bounded devnet proof is approved/desired.";
+  writeFileSync(
+    join(outDir, "summary.json"),
+    `${JSON.stringify(summary, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(outDir, "SUMMARY.md"),
+    `# Marketplace Demo Readiness\n\n- OK: ${ok}\n- Mode: ${summary.mode}\n- Generated: ${summary.generatedAt}\n- Output: ${outDir}\n- Recording artifact: ${summary.recordingArtifact?.artifactPath ?? "not captured"}\n\n## Steps\n\n${summary.steps.map((step) => `- ${step.status}: ${step.label} (${step.id})`).join("\n")}\n\n## Next\n\n${summary.next}\n`,
+  );
+  console.log(
+    JSON.stringify(
+      { ok, outDir, summaryPath: join(outDir, "summary.json") },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a Playwright recording journey that follows the intended onboarding/hackathon narrative: homepage → MCP bridge → planner policy path → specialist registration → attestor path → economic demo evidence.
- Add `scripts/run-marketplace-demo-readiness.mjs`, a local-first readiness harness that runs conversion BDD, recording capture, RAP MCP Bridge Surfpool proof, economic-demo Surfpool rehearsal, onboarding/attestation Surfpool smoke, and skips bounded devnet unless `--include-devnet` is passed.
- Add `docs/MARKETPLACE-DEMO-READINESS-HARNESS-2026-05-08.md` documenting fast mode, plan-only mode, bounded devnet mode, artifacts, and guardrails.
- Preserve the latest Playwright recording video into the readiness artifact directory as `marketplace-recording.webm`.

## Validation
- `npm run lint -- scripts/run-marketplace-demo-readiness.mjs e2e/marketplace-recording.spec.ts`
- `npm run check:product:naming -- docs/MARKETPLACE-DEMO-READINESS-HARNESS-2026-05-08.md scripts/run-marketplace-demo-readiness.mjs e2e/marketplace-recording.spec.ts package.json`
- `npm run test:e2e:marketplace-recording -- --project=chromium`
- `npm run demo:marketplace:readiness -- --skip-surfpool`
- `npm run smoke:rap-mcp-bridge:surfpool-local`
- `npm run smoke:economic-demo:surfpool`
- `npm run test:surfpool:onboarding`
- `npm run demo:marketplace:readiness`
- `git diff --check`

## Latest local readiness artifact
- `artifacts/marketplace-demo-readiness/20260508T114520Z/summary.json`
- `artifacts/marketplace-demo-readiness/20260508T114520Z/marketplace-recording.webm`

## Notes
- Stacked on PR #291 (`feature/prosumer-marketplace-landing-copy`).
- Default harness mode is local-first/no-devnet.
- Bounded devnet proof is opt-in via `--include-devnet`; no mainnet path.
