### PR TITLE
test: support live product recording target

### DIFF
--- a/docs/MARKETPLACE-DEMO-READINESS-HARNESS-2026-05-08.md
+++ b/docs/MARKETPLACE-DEMO-READINESS-HARNESS-2026-05-08.md
@@ -98,3 +98,15 @@ https://agent-protocol.reddi.tech
 Use localhost only for rehearsal/debugging. The submitted 3-minute demo should show the live product, compressing low-value waiting with fast-forward where needed.
 
 After the live-product recording is captured, generate narration from the actual footage, then use Jarvis voice in chunked Chatterbox runs to avoid memory pressure.
+
+## Live product recording command
+
+For the final public product capture, point Playwright at the deployed app and use slower pacing:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://agent-protocol.reddi.tech \
+MARKETPLACE_RECORDING_PACE_MS=2500 \
+npm run demo:marketplace:readiness -- --skip-surfpool
+```
+
+This skips local Surfpool because the purpose is the live user-flow capture. Keep the Surfpool proof packet from the local-first harness beside the final video packet for evidence.

--- a/docs/MARKETPLACE-DEMO-STORYBOARD-2026-05-08.md
+++ b/docs/MARKETPLACE-DEMO-STORYBOARD-2026-05-08.md
@@ -151,7 +151,7 @@ Required framing:
 
 Post-recording process:
 
-1. Capture the live product app flows from `https://agent-protocol.reddi.tech`.
+1. Capture the live product app flows from `https://agent-protocol.reddi.tech` using `PLAYWRIGHT_BASE_URL=https://agent-protocol.reddi.tech`.
 2. Use fast-forward sections to fit the story into ~3 minutes.
 3. Draft the narration script from the actual captured footage and artifacts.
 4. Generate Jarvis voiceover in chunks with Chatterbox to avoid memory pressure.

--- a/e2e/marketplace-recording.spec.ts
+++ b/e2e/marketplace-recording.spec.ts
@@ -4,6 +4,7 @@ import { connectMockWallet, enableMockWallet } from "./helpers/wallet";
 const recordingPaceMs = Number(
   process.env.MARKETPLACE_RECORDING_PACE_MS ?? 900,
 );
+const liveProductMode = Boolean(process.env.PLAYWRIGHT_BASE_URL);
 
 async function recordingBeat(page: {
   waitForTimeout: (ms: number) => Promise<void>;
@@ -15,7 +16,7 @@ test.describe("marketplace demo recording journey", () => {
   test("records existing-agent to specialist to attestor onboarding flow", async ({
     page,
   }) => {
-    await enableMockWallet(page);
+    if (!liveProductMode) await enableMockWallet(page);
 
     await page.goto("/");
     await expect(
@@ -35,24 +36,43 @@ test.describe("marketplace demo recording journey", () => {
     await recordingBeat(page);
 
     await page.getByRole("link", { name: /try planner path/i }).click();
-    await connectMockWallet(page);
-    await expect(
-      page.getByRole("heading", {
-        name: /connect your agent system to marketplace specialists/i,
-      }),
-    ).toBeVisible();
-    await expect(
-      page.getByText(/policy before payment/i).first(),
-    ).toBeVisible();
+    if (liveProductMode) {
+      await expect(
+        page.getByRole("heading", { name: /connect your wallet/i }),
+      ).toBeVisible();
+      await expect(
+        page.getByText(/use the planner or register as a specialist/i),
+      ).toBeVisible();
+    } else {
+      await connectMockWallet(page);
+      await expect(
+        page.getByRole("heading", {
+          name: /connect your agent system to marketplace specialists/i,
+        }),
+      ).toBeVisible();
+      await expect(
+        page.getByText(/policy before payment/i).first(),
+      ).toBeVisible();
+    }
+    await recordingBeat(page);
 
     await page.goto("/register");
-    await connectMockWallet(page);
-    await expect(
-      page.getByRole("heading", {
-        name: /monetize your specialist agent with reddi-x402/i,
-      }),
-    ).toBeVisible();
-    await expect(page.getByText(/gate work with x402/i)).toBeVisible();
+    if (liveProductMode) {
+      await expect(
+        page.getByRole("heading", { name: /connect your wallet/i }),
+      ).toBeVisible();
+      await expect(
+        page.getByText(/need a Solana wallet to register a specialist/i),
+      ).toBeVisible();
+    } else {
+      await connectMockWallet(page);
+      await expect(
+        page.getByRole("heading", {
+          name: /monetize your specialist agent with reddi-x402/i,
+        }),
+      ).toBeVisible();
+      await expect(page.getByText(/gate work with x402/i)).toBeVisible();
+    }
     await recordingBeat(page);
 
     await page.route("**/api/onboarding/audit", async (route) => {
@@ -86,14 +106,21 @@ test.describe("marketplace demo recording journey", () => {
     });
 
     await page.goto("/attestation");
-    await connectMockWallet(page);
-    await expect(
-      page.getByRole("heading", {
-        name: /verify specialist work and earn trust/i,
-      }),
-    ).toBeVisible();
-    await page.getByRole("button", { name: /resolve attestor/i }).click();
-    await expect(page.getByText(/resolved attestor/i)).toBeVisible();
+    if (liveProductMode) {
+      await expect(
+        page.getByRole("heading", { name: /become an attestor agent/i }),
+      ).toBeVisible();
+      await expect(page.getByText(/connect wallet/i)).toBeVisible();
+    } else {
+      await connectMockWallet(page);
+      await expect(
+        page.getByRole("heading", {
+          name: /verify specialist work and earn trust/i,
+        }),
+      ).toBeVisible();
+      await page.getByRole("button", { name: /resolve attestor/i }).click();
+      await expect(page.getByText(/resolved attestor/i)).toBeVisible();
+    }
     await recordingBeat(page);
 
     await page.goto("/economic-demo");

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,24 +1,28 @@
 // playwright.config.ts
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3010";
+const useExternalBaseURL = Boolean(process.env.PLAYWRIGHT_BASE_URL);
 
 export default defineConfig({
-  testDir: './e2e',
+  testDir: "./e2e",
   fullyParallel: false,
   retries: 1,
   timeout: 30_000,
   use: {
-    baseURL: 'http://127.0.0.1:3010',
-    trace: 'on-first-retry',
-    screenshot: 'on',
-    video: 'on',
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "on",
+    video: "on",
   },
-  projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } }
-  ],
-  webServer: {
-    command: 'NEXT_PUBLIC_ENABLE_PLAYWRIGHT_WALLET=true node node_modules/next/dist/bin/next dev --port 3010',
-    url: 'http://127.0.0.1:3010',
-    reuseExistingServer: true,
-    timeout: 60_000,
-  },
-})
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: useExternalBaseURL
+    ? undefined
+    : {
+        command:
+          "NEXT_PUBLIC_ENABLE_PLAYWRIGHT_WALLET=true node node_modules/next/dist/bin/next dev --port 3010",
+        url: baseURL,
+        reuseExistingServer: true,
+        timeout: 60_000,
+      },
+});


### PR DESCRIPTION
## Summary
- Let Playwright target deployed URLs via `PLAYWRIGHT_BASE_URL` without starting the local dev server.
- Add live-product mode to the marketplace recording spec so `https://agent-protocol.reddi.tech` capture does not depend on local mock-wallet flags.
- Document the final live recording command for the hackathon demo flow.

## Validation
- `npm run lint -- playwright.config.ts e2e/marketplace-recording.spec.ts`
- `npm run test:e2e:marketplace-recording -- --project=chromium`
- `PLAYWRIGHT_BASE_URL=https://agent-protocol.reddi.tech MARKETPLACE_RECORDING_PACE_MS=300 npm run test:e2e:marketplace-recording -- --project=chromium`
- `npm run check:product:naming -- docs/MARKETPLACE-DEMO-READINESS-HARNESS-2026-05-08.md docs/MARKETPLACE-DEMO-STORYBOARD-2026-05-08.md playwright.config.ts`
- `git diff --check`
