### PR TITLE
feat: add gated devnet x402 specialist calls to RAP MCP bridge

### DIFF
--- a/docs/CLAUDE-CODE-MCP-X402-HANDOFF-2026-05-09.md
+++ b/docs/CLAUDE-CODE-MCP-X402-HANDOFF-2026-05-09.md
@@ -1,0 +1,77 @@
+# Claude Code MCP x402 — Handoff Note
+
+_Date: 2026-05-09 AEST_
+
+## Branch
+
+`feature/claude-code-mcp-x402-demo`
+
+Local commits over `main`:
+
+1. `6045db55 feat: add gated devnet x402 MCP specialist demo`
+2. `8b5b75e7 docs: enforce Reddi Agent Protocol naming in MCP demo`
+3. `95db7b14 docs: point PR readiness at strict naming capture`
+
+A follow-up local commit may include the Loop 43 final-gate test robustness fix and this handoff note.
+
+## Canonical demo artifact
+
+Use this bundle for review/submission handoff:
+
+`artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live.zip`
+
+SHA256:
+
+`b293e26fdbe8d30c5791a8e263541393b9302131961e83414ef8f164049584b0`
+
+Do **not** use older locked-screen, replay, or pre-strict-naming captures except as historical troubleshooting notes.
+
+## Product naming rule
+
+- Product name: **Reddi Agent Protocol**.
+- Short form: **RAP**.
+- Avoid standalone “Reddi” as the product name.
+- Literal URLs/package IDs may contain `reddi`.
+- Recording start line: `Starting Claude Code with Reddi Agent Protocol MCP tools...`
+
+## Canonical recording proof
+
+- Receipt: `x402_specialist_0460d1e4214ab0f0ddb7d667`
+- Devnet tx: `3oVM9kKqMME6J4sufvWRT5s6F1N9HcLnUGTDeLbxXQNyuAEkC7Nt4JxKs9aoxun7FVTCvzeS4Pwt2PqPMwF1oGGV`
+- Amount: `0.05 USDC`
+- Cap: `60000` micro-USDC
+- Boundary: `solana-devnet-only-no-mainnet`
+- Video: `154.9s`, `1440x810`, `1549` frames
+
+## Final local gates from Loop 43
+
+Passed:
+
+```bash
+npm run build --prefix packages/x402-solana
+npm test --prefix packages/x402-solana -- --runInBand
+npm run build --prefix packages/rap-mcp-bridge
+npm test --prefix packages/rap-mcp-bridge
+npm --prefix packages/rap-mcp-bridge run smoke:x402-tool-list
+bash -n scripts/run-claude-code-mcp-x402-recording-demo.sh
+unzip -t artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live.zip
+```
+
+Forbidden shorthand scan passed for:
+
+- `Reddi MCP`
+- `Reddi paid`
+- `Reddi backend`
+- `Reddi code-generation`
+
+## Loop 43 retrospective
+
+The final gate caught a flaky privacy test in `packages/x402-solana/tests/client.test.ts`. The original assertion checked that the serialized readiness output did not contain `String(keypair.secretKey[0])`, but that short numeric fragment can naturally occur inside safe numeric fields such as `150000`.
+
+The fix now checks the actual risk boundary: the serialized output must not contain the full secret-key JSON array or base64-encoded secret key.
+
+## External actions still pending approval
+
+- Push branch to GitHub.
+- Open PR.
+- Upload/share final bundle outside the local workspace.

--- a/docs/CLAUDE-CODE-MCP-X402-LIVE-INVOKE-SPEC-2026-05-09.md
+++ b/docs/CLAUDE-CODE-MCP-X402-LIVE-INVOKE-SPEC-2026-05-09.md
@@ -1,0 +1,311 @@
+# Claude Code MCP Live x402 Specialist Invocation Spec
+
+_Date: 2026-05-09 AEST_
+
+## Purpose
+
+Turn the Peekaboo recording plan into an implementation-ready slice: Claude Code CLI registers the RAP MCP bridge, discovers a marketplace specialist, pays the selected specialist through a bounded devnet x402 flow, verifies the receipt, and uses the paid specialist response in the final Claude answer.
+
+This spec is intentionally narrow. It is not a mainnet payment path and it must not expose keypair material.
+
+## Evidence found in repo
+
+### RAP MCP bridge
+
+`packages/rap-mcp-bridge/src/server.ts` currently registers:
+
+- `reddi.discover_specialists`
+- `reddi.request_quote`
+- `reddi.verify_receipt`
+- `reddi.export_disclosure_ledger`
+
+When devnet gates are enabled it also registers:
+
+- `reddi.prepare_devnet_payment`
+- `reddi.execute_devnet_payment`
+- `reddi.verify_devnet_receipt`
+
+Current limitation: `packages/rap-mcp-bridge/src/tools/devnet-payment.ts` is bounded Solana devnet SOL-transfer semantics for bridge-generated synthetic quotes and its receipt boundary says `solana-devnet-only-no-mainnet-no-specialist-http-invocation`.
+
+### x402 package
+
+`packages/x402-solana/src/payment.ts` already includes:
+
+- `buildX402Challenge()`
+- `parseX402PaymentHeader()`
+- `DemoPaymentVerifier`
+- `SolanaReceiptVerifier`
+
+Important limitation: `sendPayment()` is currently documented as a test stub and returns mock signatures; it does **not** submit funding transactions. The specialist-side real verifier can inspect parsed devnet transactions when `ALLOW_REAL_X402_PAYMENT=true`, but a consumer-side devnet USDC payer helper is missing.
+
+### Hosted OpenRouter specialists
+
+`packages/openrouter-specialists/src/runtime.ts` supports x402 challenges and specialist-side receipt verification:
+
+- unpaid calls return HTTP 402 with `x402-request`
+- paid calls accept `x402-payment`
+- demo receipts are gated by `ALLOW_DEMO_X402_PAYMENT`
+- real receipt verification is gated by `ALLOW_REAL_X402_PAYMENT`
+- real verification uses `SolanaReceiptVerifier`, RPC URL, and devnet USDC mint
+
+Therefore the missing demo-critical piece is not Claude registration; it is the consumer-side MCP tool that can answer a 402 challenge with a real bounded devnet USDC payment receipt and retry the specialist endpoint.
+
+## Proposed PR slice
+
+Add a **consumer-side devnet x402 payer** plus MCP tools around it.
+
+### New package helper
+
+Add to `packages/x402-solana`:
+
+- `src/client.ts` or `src/payer.ts`
+
+Export functions:
+
+```ts
+prepareDevnetUsdcPayment(input): Promise<DevnetUsdcPaymentReadiness>
+executeDevnetUsdcPayment(input): Promise<X402PaymentReceipt>
+```
+
+Minimum behaviour:
+
+1. Load a Solana keypair from an explicit path.
+2. Reject mainnet RPC URLs and non-devnet network challenges.
+3. Parse/validate x402 challenge:
+   - `network === "solana-devnet"`
+   - `currency === "USDC"`
+   - valid `payTo`
+   - positive amount
+   - nonce present
+   - endpoint allowlisted
+4. Check payer SOL balance for fees.
+5. Check payer devnet USDC associated token account balance.
+6. Compute or create destination associated token account for payee/mint.
+7. Enforce max micro-USDC spend cap.
+8. Submit SPL token transfer / transferChecked.
+9. Return `X402PaymentReceipt`:
+
+```json
+{
+  "network": "solana-devnet",
+  "payTo": "<specialist-wallet>",
+  "amount": "0.05",
+  "currency": "USDC",
+  "nonce": "<challenge-nonce>",
+  "signature": "<devnet-tx>",
+  "payer": "<demo-wallet-pubkey>",
+  "mint": "<devnet-usdc-mint>",
+  "destinationTokenAccount": "<payee-ata>"
+}
+```
+
+No secrets in return values, logs, artifacts, or thrown messages.
+
+### New MCP schemas
+
+Add to `packages/rap-mcp-bridge/src/schemas.ts`:
+
+- `prepareX402SpecialistCallInputSchema`
+- `executeX402SpecialistCallInputSchema`
+- `verifyX402SpecialistReceiptInputSchema`
+
+Suggested inputs:
+
+```ts
+{
+  quoteId: z.string().max(160),
+  endpoint: z.string().url(),
+  method: z.literal("POST").default("POST"),
+  body: z.record(z.unknown()),
+  maxUsdcMicroUnits: z.number().int().positive().max(1_000_000),
+}
+```
+
+Execute adds:
+
+```ts
+{
+  idempotencyKey: z.string().min(1).max(128),
+  approvalPhrase: z.literal("EXECUTE_DEVNET_X402_SPECIALIST_CALL")
+}
+```
+
+### New MCP tools
+
+Register only when the following gates are enabled:
+
+```bash
+REDDI_RAP_MCP_MODE=devnet
+RAP_MCP_DEVNET_PROOF_APPROVED=1
+RAP_MCP_ALLOW_SPECIALIST_INVOKE=1
+RAP_MCP_DEVNET_WALLET_KEYPAIR=/path/to/demo-devnet-wallet.json
+RAP_MCP_DEVNET_RPC_URL=https://api.devnet.solana.com
+RAP_MCP_DEVNET_USDC_MINT=<devnet-usdc-mint>
+RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS=150000
+RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST=https://reddi-code-generation.preview.reddi.tech/v1/chat/completions,...
+```
+
+Tools:
+
+1. `reddi.prepare_x402_specialist_call`
+   - non-mutating readiness check
+   - performs unpaid request or accepts provided x402 challenge
+   - checks endpoint allowlist, challenge terms, wallet public key, SOL/USDC balances, destination ATA, spend cap
+   - returns `ready: true|false`, no secret material
+
+2. `reddi.execute_x402_specialist_call`
+   - requires `EXECUTE_DEVNET_X402_SPECIALIST_CALL`
+   - idempotent by `idempotencyKey`
+   - performs unpaid request to capture HTTP 402 challenge
+   - executes devnet USDC transfer with `@reddi/x402-solana`
+   - retries endpoint with `x402-payment` receipt header
+   - requires HTTP 200 before marking complete
+   - stores receipt + response hash + bounded output preview
+
+3. `reddi.verify_x402_specialist_receipt`
+   - reuses `SolanaReceiptVerifier`
+   - verifies tx, payee, mint, amount, nonce, endpoint terms where possible
+   - returns `verified: true|false`, boundary, and receipt refs
+
+4. Extend `reddi.export_disclosure_ledger`
+   - include live x402 specialist receipt entries:
+     - quote id
+     - specialist endpoint id/profile id where known
+     - capability
+     - request/task hash
+     - payment signature
+     - verifier status
+     - output hash
+     - `mainnetSettlement: not_applicable`
+
+## Endpoint and quote selection for the recording
+
+Use one exact allowlisted hosted specialist first, ideally the code-generation specialist because prior readiness artifacts show canonical x402 challenge behaviour:
+
+- endpoint: `https://reddi-code-generation.preview.reddi.tech/v1/chat/completions`
+- network: `solana-devnet`
+- currency: `USDC`
+- amount observed previously: `0.05`
+
+Claude can still call `reddi.discover_specialists` first. For recording stability, the prompt should instruct it to choose an allowlisted specialist under the cap.
+
+## Smoke test script
+
+Add:
+
+```bash
+packages/rap-mcp-bridge/scripts/smoke-live-x402-specialist.mjs
+```
+
+Script gates:
+
+- exits blocked unless `RAP_MCP_LIVE_X402_SPECIALIST_SMOKE=1`
+- requires explicit wallet keypair path
+- prints public wallet address only
+- writes git-ignored artifact under:
+  - `artifacts/claude-code-mcp-x402-peekaboo-demo/<timestamp>/smoke-summary.json`
+
+Pass criteria:
+
+1. Bridge tool list contains `reddi.prepare_x402_specialist_call` and `reddi.execute_x402_specialist_call`.
+2. Unpaid specialist request returns HTTP 402 with valid x402 challenge.
+3. Readiness says spend cap respected.
+4. Devnet USDC tx confirmed.
+5. Paid retry returns HTTP 200.
+6. Receipt verifies.
+7. Disclosure ledger exports one live x402 entry.
+
+## Test plan
+
+Unit tests:
+
+- config rejects mainnet RPC
+- config rejects missing wallet keypair
+- config rejects missing USDC mint
+- config rejects non-allowlisted endpoint
+- prepare is non-mutating
+- execute requires approval phrase
+- execute enforces idempotency
+- execute enforces max spend cap
+- receipt verification rejects wrong payee/mint/amount/nonce
+- no returned object includes private key material
+
+Package gates:
+
+```bash
+npm test --prefix packages/x402-solana
+npm test --prefix packages/rap-mcp-bridge
+npm run build --prefix packages/x402-solana
+npm run build --prefix packages/rap-mcp-bridge
+```
+
+Live smoke gate only after wallet funding is confirmed and Nissan-approved:
+
+```bash
+RAP_MCP_LIVE_X402_SPECIALIST_SMOKE=1 \
+RAP_MCP_DEVNET_PROOF_APPROVED=1 \
+RAP_MCP_ALLOW_SPECIALIST_INVOKE=1 \
+RAP_MCP_DEVNET_WALLET_KEYPAIR=/path/to/demo-devnet-wallet.json \
+RAP_MCP_DEVNET_RPC_URL=https://api.devnet.solana.com \
+RAP_MCP_DEVNET_USDC_MINT=<devnet-usdc-mint> \
+RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS=150000 \
+npm --prefix packages/rap-mcp-bridge run smoke:live-x402-specialist
+```
+
+## Claude Code registration after implementation
+
+```bash
+claude mcp add reddi-rap-devnet \
+  -e REDDI_RAP_BASE_URL=http://localhost:3000 \
+  -e REDDI_RAP_MCP_MODE=devnet \
+  -e REDDI_MCP_HOST_FRAMEWORK=claude \
+  -e REDDI_MCP_AGENT_NAME=claude-code-demo \
+  -e RAP_MCP_DEVNET_PROOF_APPROVED=1 \
+  -e RAP_MCP_ALLOW_SPECIALIST_INVOKE=1 \
+  -e RAP_MCP_DEVNET_WALLET_KEYPAIR=/path/to/demo-devnet-wallet.json \
+  -e RAP_MCP_DEVNET_RPC_URL=https://api.devnet.solana.com \
+  -e RAP_MCP_DEVNET_USDC_MINT=<devnet-usdc-mint> \
+  -e RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS=150000 \
+  -e RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST=https://reddi-code-generation.preview.reddi.tech/v1/chat/completions \
+  -- node /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code/packages/rap-mcp-bridge/dist/src/server.js
+```
+
+## Recording readiness checklist
+
+Before Peekaboo:
+
+- [ ] Demo devnet wallet is dedicated and funded only with small SOL/USDC amounts.
+- [ ] Hosted specialist has `ALLOW_REAL_X402_PAYMENT=true` and correct devnet USDC mint configured.
+- [ ] MCP live x402 specialist smoke passes.
+- [ ] Claude Code MCP registration verified with `claude mcp get reddi-rap-devnet`.
+- [ ] No keypair JSON or secret env values visible on screen.
+- [ ] Output artifact path created.
+- [ ] Claim boundary displayed or narrated: devnet-only, bounded, no mainnet.
+
+## Retrospective
+
+The retry clarified the exact missing layer. The repo already has specialist-side x402 challenge/verification and MCP registration support, but `@reddi/x402-solana` is not yet a consumer payer. So the next implementation loop should start in `packages/x402-solana` with a devnet USDC payer helper, then wire MCP tools around it. Starting directly in Claude would produce a nice-looking but false demo; starting with the payer helper gives us a recording that can survive judge scrutiny.
+
+## Implementation update — 2026-05-09 Loop 24
+
+Local no-spend implementation now exists for the Claude Code MCP x402 specialist path:
+
+- `@reddi/x402-solana` has a devnet USDC payer helper and Solana SPL-token adapter boundary.
+- `@reddi/rap-mcp-bridge` now gates and exposes:
+  - `reddi.prepare_x402_specialist_call`
+  - `reddi.execute_x402_specialist_call`
+  - `reddi.verify_x402_specialist_receipt`
+- Disclosure ledger export accepts `x402ReceiptIds` for verified specialist-call evidence.
+- Tests prove prepare/execute/verify/ledger with fake fetch + fake transfer adapter only.
+
+Validation passed:
+
+```bash
+npm test --prefix packages/rap-mcp-bridge
+npm test --prefix packages/x402-solana -- --runInBand
+npm run build --prefix packages/rap-mcp-bridge
+npm run build --prefix packages/x402-solana
+```
+
+Remaining blocker before recording a live clip: explicit funded demo devnet wallet approval and a live smoke against an allowlisted specialist endpoint. Until that approval, the implemented path remains no-spend/local-test evidence only.
+

--- a/docs/CLAUDE-CODE-MCP-X402-PEEKABOO-DEMO-PLAN-2026-05-09.md
+++ b/docs/CLAUDE-CODE-MCP-X402-PEEKABOO-DEMO-PLAN-2026-05-09.md
@@ -1,0 +1,254 @@
+# Claude Code MCP + reddi-x402 Peekaboo Demo Plan
+
+_Date: 2026-05-09 AEST_
+
+## Goal
+
+Record a Peekaboo screen demo where Claude Code CLI is equipped with Reddi Agent Protocol via MCP, then uses the marketplace to discover a specialist agent and produce a prompt response that incorporates that specialist's paid output.
+
+Desired visible story:
+
+1. Register the RAP MCP server with Claude Code CLI.
+2. Start Claude Code with the RAP MCP server available.
+3. Ask Claude Code for an answer that should benefit from a specialist agent.
+4. Claude Code discovers marketplace specialists.
+5. Claude Code selects one specialist, requests quote/payment terms, and executes the x402-paid call.
+6. Payment uses a bounded Solana devnet wallet with devnet SOL + devnet USDC.
+7. Claude Code verifies the receipt / evidence and formulates the final response with a disclosure ledger.
+
+## Evidence-safe boundary
+
+This must be recorded as **devnet-only**.
+
+Do not claim:
+
+- mainnet settlement
+- unlimited wallet delegation
+- arbitrary specialist invocation
+- arbitrary-wallet/private MagicBlock settlement
+- Jupiter devnet swap success
+- that every marketplace specialist was live-paid
+
+Do claim only after validation:
+
+- Claude Code can register/use the RAP MCP bridge.
+- The bridge can discover/quote marketplace specialists.
+- A bounded devnet wallet can pay a selected x402 specialist call.
+- The final response includes specialist disclosure and receipt evidence.
+
+## Current repo reality / gap analysis
+
+Existing support:
+
+- `packages/rap-mcp-bridge` exists and builds.
+- Claude/Cursor config shape already documented.
+- Claude Code CLI is installed locally and supports `claude mcp add`.
+- RAP MCP bridge currently exposes dry-run tools by default:
+  - `reddi.discover_specialists`
+  - `reddi.request_quote`
+  - `reddi.verify_receipt`
+  - `reddi.export_disclosure_ledger`
+- In devnet mode, the bridge also exposes:
+  - `reddi.prepare_devnet_payment`
+  - `reddi.execute_devnet_payment`
+  - `reddi.verify_devnet_receipt`
+- Devnet MCP payment tools are explicitly bounded and opt-in.
+
+Important gap:
+
+- The current devnet MCP payment implementation is synthetic SOL-lamport payment semantics and explicitly says `no-specialist-http-invocation`.
+- The requested demo needs an actual marketplace specialist invocation plus x402 payment using `reddi-x402` / Solana devnet USDC.
+- Therefore this demo needs one additional implementation slice before recording: **Claude MCP live x402 specialist invocation**.
+
+## Proposed implementation slice: MCP live x402 specialist invocation
+
+Add an explicitly gated tool, name TBD:
+
+- `reddi.invoke_marketplace_specialist`
+  - or `reddi.execute_x402_specialist_call`
+
+### Required gates
+
+Expose the tool only when all are true:
+
+```bash
+REDDI_RAP_MCP_MODE=devnet
+RAP_MCP_DEVNET_PROOF_APPROVED=1
+RAP_MCP_ALLOW_SPECIALIST_INVOKE=1
+RAP_MCP_DEVNET_WALLET_KEYPAIR=/path/to/devnet-consumer-keypair.json
+RAP_MCP_DEVNET_RPC_URL=https://api.devnet.solana.com
+RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS=150000   # example: 0.150000 USDC
+REDDI_MCP_HOST_FRAMEWORK=claude
+```
+
+Optional later route instead of local keypair:
+
+```bash
+RAP_MCP_WALLET_AUTHORITY_MODE=wallet-router
+RAP_MCP_WALLET_ROUTER_URL=http://127.0.0.1:<port>
+RAP_MCP_WALLET_ROUTER_SESSION=<opaque-session-id>
+```
+
+Recommendation for first recording: use a local devnet keypair path with tiny funded balances, not a wallet-router. It is easier to validate and less likely to fail during recording.
+
+### Wallet safety rules
+
+- Never print the keypair secret.
+- Never open the keypair JSON on screen.
+- Show only the public wallet address, devnet balances, spend cap, and transaction signatures.
+- Wallet must be a dedicated demo devnet wallet, not a personal/operator wallet.
+- Wallet must hold only the minimum required devnet SOL and devnet USDC.
+- Tool must enforce max per-call and max total spend caps.
+- Tool must reject mainnet RPC URLs.
+- Tool must reject non-allowlisted specialist endpoints.
+- Tool must write receipt + disclosure ledger to local artifact store.
+
+### Functional flow
+
+1. `reddi.discover_specialists`
+   - Finds marketplace specialists from local RAP backend.
+2. `reddi.request_quote`
+   - Returns quote with endpoint, wallet, amount, token/network, terms hash.
+3. `reddi.prepare_x402_payment`
+   - Non-mutating readiness check.
+   - Verifies wallet public key, SOL balance, USDC balance/token account, quote amount, spend cap, and allowlist.
+4. `reddi.execute_x402_specialist_call`
+   - Requires exact approval phrase, e.g. `EXECUTE_DEVNET_X402_SPECIALIST_CALL`.
+   - Creates/sends devnet USDC payment using `reddi-x402` compatible header/receipt flow.
+   - Calls the selected specialist endpoint with the x402 payment header.
+   - Captures HTTP 402 challenge, payment transaction, HTTP 200 completion, output preview/hash.
+5. `reddi.verify_x402_receipt`
+   - Verifies devnet tx, recipient, mint, amount, quote id/terms hash where possible.
+6. `reddi.export_disclosure_ledger`
+   - Includes specialist id, capability, quote, payment tx, verification status, output hash, and boundary.
+
+## Claude Code CLI registration command for recording
+
+Build first:
+
+```bash
+npm --prefix packages/rap-mcp-bridge run build
+```
+
+Register the MCP server in Claude Code CLI:
+
+```bash
+claude mcp add reddi-rap-devnet \
+  -e REDDI_RAP_BASE_URL=http://localhost:3000 \
+  -e REDDI_RAP_MCP_MODE=devnet \
+  -e REDDI_MCP_HOST_FRAMEWORK=claude \
+  -e REDDI_MCP_AGENT_NAME=claude-code-demo \
+  -e RAP_MCP_DEVNET_PROOF_APPROVED=1 \
+  -e RAP_MCP_ALLOW_SPECIALIST_INVOKE=1 \
+  -e RAP_MCP_DEVNET_WALLET_KEYPAIR=/path/to/demo-devnet-wallet.json \
+  -e RAP_MCP_DEVNET_RPC_URL=https://api.devnet.solana.com \
+  -e RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS=150000 \
+  -- node /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code/packages/rap-mcp-bridge/dist/src/server.js
+```
+
+For recording, hide or avoid showing the full keypair path if it includes sensitive directory names. It is safe to show public wallet address and balances.
+
+## Claude prompt for the demo
+
+Use a prompt that naturally needs a specialist, but does not require private data:
+
+```text
+Use Reddi Agent Protocol to find a specialist agent that can help produce a concise launch-market positioning answer for machine-payable specialist agents.
+
+Requirements:
+- Discover marketplace specialists first.
+- Pick one specialist with a quote under 0.05 devnet USDC.
+- If payment is required, use the configured devnet x402 wallet only if the tool reports the spend cap is respected.
+- Verify the receipt before relying on the specialist output.
+- Final answer must include: the chosen specialist, what it contributed, the payment/receipt boundary, and a disclosure ledger summary.
+```
+
+## Peekaboo recording storyboard
+
+Target length: 60–100 seconds.
+
+1. Terminal: show repo and build success.
+2. Terminal: run `claude mcp add ...` and `claude mcp list` / `claude mcp get reddi-rap-devnet`.
+3. Terminal: show dedicated devnet wallet public address and balances only.
+4. Terminal: start Claude Code prompt.
+5. Claude output: discovery tool call / specialist candidates.
+6. Claude output: quote + spend cap respected.
+7. Claude output: x402 payment execution / tx signature / HTTP 200 specialist result.
+8. Claude output: receipt verification + disclosure ledger.
+9. Claude final answer: response visibly incorporates specialist contribution.
+10. Optional terminal: show saved evidence artifact path.
+
+## Validation gates before recording
+
+Do not record until all pass:
+
+```bash
+npm --prefix packages/rap-mcp-bridge run test
+npm --prefix packages/rap-mcp-bridge run smoke:stdio
+RAP_MCP_DEVNET_PROOF_APPROVED=1 \
+RAP_MCP_DEVNET_WALLET_KEYPAIR=/path/to/demo-devnet-wallet.json \
+RAP_MCP_ALLOW_SPECIALIST_INVOKE=1 \
+npm --prefix packages/rap-mcp-bridge run smoke:devnet-x402-specialist
+```
+
+If the live x402 specialist smoke does not exist yet, implement it before recording.
+
+## Recording command sketch
+
+```bash
+mkdir -p artifacts/claude-code-mcp-x402-peekaboo-demo/$(date -u +%Y%m%dT%H%M%SZ)
+peekaboo record --screen --output artifacts/claude-code-mcp-x402-peekaboo-demo/<timestamp>/claude-code-mcp-x402-demo.mp4
+```
+
+Use the actual Peekaboo command variant already validated on this machine if syntax differs.
+
+## Retrospective rule for this loop
+
+If the first implementation attempt reveals that `reddi-x402` is currently specialist-side middleware only and not a consumer wallet client, split the work:
+
+1. Add a consumer-side x402 payment client/helper to `reddi-x402` or a sibling package.
+2. Then wire the MCP bridge invocation tool to that helper.
+3. Only record after the end-to-end smoke proves `402 challenge -> devnet USDC payment -> 200 specialist response`.
+
+Do not fake the payment or use the older synthetic SOL-only MCP receipt as if it were this requested flow.
+
+## Implementation update — 2026-05-09 Loop 24
+
+Local no-spend implementation now exists for the Claude Code MCP x402 specialist path:
+
+- `@reddi/x402-solana` has a devnet USDC payer helper and Solana SPL-token adapter boundary.
+- `@reddi/rap-mcp-bridge` now gates and exposes:
+  - `reddi.prepare_x402_specialist_call`
+  - `reddi.execute_x402_specialist_call`
+  - `reddi.verify_x402_specialist_receipt`
+- Disclosure ledger export accepts `x402ReceiptIds` for verified specialist-call evidence.
+- Tests prove prepare/execute/verify/ledger with fake fetch + fake transfer adapter only.
+
+Validation passed:
+
+```bash
+npm test --prefix packages/rap-mcp-bridge
+npm test --prefix packages/x402-solana -- --runInBand
+npm run build --prefix packages/rap-mcp-bridge
+npm run build --prefix packages/x402-solana
+```
+
+## Implementation update — 2026-05-09 Loops 27–30
+
+The proof ladder is now complete and recording instructions are packaged in `docs/CLAUDE-CODE-MCP-X402-RECORDING-RUNBOOK-2026-05-09.md`.
+
+Completed evidence:
+
+- Surfpool/local validator x402 E2E proof: `artifacts/rap-mcp-bridge-x402-surfpool-local/20260508T214434Z/SUMMARY.md`
+- Devnet funding preflight: `artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T214759Z-devnet-funding-preflight/SUMMARY.md`
+- Live devnet x402 specialist smoke: `artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T214912Z-live-x402-specialist-smoke/SUMMARY.md`
+
+Live smoke result:
+
+- Receipt: `x402_specialist_e12428767c48f25a1e5ae5c3`
+- Devnet tx: `1g3B6EBdBcAVWQaGU3EWGLuSGYBnuFCU4MN7Vbn8SUZtEDczF5eSxRxjgZR3rUhsna5WxQjWPzbWAW6VbzfwKj9`
+- Payer USDC: `0.87 → 0.82`
+- Ledger entries: `1`
+
+Recording boundary remains devnet-only, exact endpoint allowlist, `60000` micro-USDC cap, no mainnet claims, and no private key material on screen or in artifacts.
+

--- a/docs/CLAUDE-CODE-MCP-X402-PR-BODY-2026-05-09.md
+++ b/docs/CLAUDE-CODE-MCP-X402-PR-BODY-2026-05-09.md
@@ -1,0 +1,87 @@
+## Summary
+
+Adds a gated devnet x402 specialist invocation path for Claude Code MCP demos.
+
+This includes:
+
+- consumer-side devnet USDC x402 payer helper in `@reddi/x402-solana`
+- gated Reddi Agent Protocol MCP tools for prepare/execute/verify specialist calls
+- x402 receipt storage and disclosure-ledger export support
+- Surfpool/local x402 end-to-end smoke
+- gated live devnet specialist smoke
+- Claude Code recording script/runbooks
+- strict Reddi Agent Protocol/RAP naming guards
+- canonical true-live Claude Code demo bundle
+
+## Product naming
+
+Product name is **Reddi Agent Protocol**. Short form is **RAP**. Avoid standalone “Reddi” as the product name except inside literal URLs/package identifiers.
+
+The canonical recording start line is:
+
+> Starting Claude Code with Reddi Agent Protocol MCP tools...
+
+## Canonical demo artifact
+
+Use this bundle for review:
+
+`artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live.zip`
+
+SHA256:
+
+`b293e26fdbe8d30c5791a8e263541393b9302131961e83414ef8f164049584b0`
+
+Supersedes older locked-screen, replay, and pre-strict-naming captures.
+
+## Canonical recording proof
+
+- Receipt: `x402_specialist_0460d1e4214ab0f0ddb7d667`
+- Devnet tx: `3oVM9kKqMME6J4sufvWRT5s6F1N9HcLnUGTDeLbxXQNyuAEkC7Nt4JxKs9aoxun7FVTCvzeS4Pwt2PqPMwF1oGGV`
+- Amount: `0.05 USDC`
+- Cap: `60000` micro-USDC
+- Boundary: `solana-devnet-only-no-mainnet`
+- Video: `154.9s`, `1440x810`, `1549` frames
+
+## Safety
+
+- Default bridge remains dry-run only.
+- x402 specialist tools are hidden unless devnet mode + proof approval + invoke gate are configured.
+- Execute requires exact approval phrase `EXECUTE_DEVNET_X402_SPECIALIST_CALL`.
+- Mainnet RPC URLs are rejected.
+- Specialist endpoint must exactly match allowlist.
+- Per-call cap is enforced in micro-USDC.
+- No private key material is returned in tool outputs or artifacts.
+- Surfpool local validator proof was run before devnet spend.
+- Live smoke and canonical recording are devnet-only.
+
+## Validation
+
+Passed locally in Loop 43:
+
+```bash
+npm run build --prefix packages/x402-solana
+npm test --prefix packages/x402-solana -- --runInBand
+npm run build --prefix packages/rap-mcp-bridge
+npm test --prefix packages/rap-mcp-bridge
+npm --prefix packages/rap-mcp-bridge run smoke:x402-tool-list
+bash -n scripts/run-claude-code-mcp-x402-recording-demo.sh
+unzip -t artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live.zip
+```
+
+Results:
+
+- x402-solana tests: 34/34 pass
+- RAP MCP bridge tests: 26/26 pass
+- x402 tool-list smoke: pass
+- forbidden shorthand naming scan: pass
+
+## Notes for reviewer
+
+This PR intentionally does not enable arbitrary paid marketplace endpoint execution. The demo path is exact-allowlisted, devnet-only, explicitly gated, capped, and receipt/disclosure-ledger backed.
+
+The final local branch currently has these commits over `main`:
+
+1. `6045db55 feat: add gated devnet x402 MCP specialist demo`
+2. `8b5b75e7 docs: enforce Reddi Agent Protocol naming in MCP demo`
+3. `95db7b14 docs: point PR readiness at strict naming capture`
+4. `09775348 test: harden x402 secret leakage assertion`

--- a/docs/CLAUDE-CODE-MCP-X402-PR-READINESS-2026-05-09.md
+++ b/docs/CLAUDE-CODE-MCP-X402-PR-READINESS-2026-05-09.md
@@ -1,0 +1,110 @@
+# Claude Code MCP x402 — PR Readiness
+
+_Date: 2026-05-09 AEST_
+
+## Scope
+
+This slice turns the RAP MCP bridge from safe dry-run/demo scaffolding into a gated devnet x402 specialist-call path for recording Claude Code using a paid specialist.
+
+## Code/package changes
+
+### `@reddi/x402-solana`
+
+- Adds consumer-side devnet USDC payer helper in `src/client.ts`.
+- Exports:
+  - `createSolanaDevnetUsdcPaymentClient(connection)`
+  - `prepareDevnetUsdcPayment(...)`
+  - `executeDevnetUsdcPayment(...)`
+  - `challengeFromX402RequestHeader(...)`
+- Enforces:
+  - no mainnet RPC URL
+  - `network === solana-devnet`
+  - `currency === USDC`
+  - valid payee and mint public keys
+  - exact endpoint allowlist
+  - max micro-USDC cap
+  - explicit wallet keypair path
+  - approval phrase for execution
+
+### `@reddi/rap-mcp-bridge`
+
+- Adds gated x402 specialist MCP tools:
+  - `reddi.prepare_x402_specialist_call`
+  - `reddi.execute_x402_specialist_call`
+  - `reddi.verify_x402_specialist_receipt`
+- Adds x402 receipt storage and disclosure-ledger export by `x402ReceiptIds`.
+- Adds smoke scripts:
+  - `smoke:x402-tool-list`
+  - `smoke:x402-surfpool-local`
+  - `smoke:live-x402-specialist`
+
+## Documentation changes
+
+- `docs/CLAUDE-CODE-MCP-X402-LIVE-INVOKE-SPEC-2026-05-09.md`
+- `docs/CLAUDE-CODE-MCP-X402-PEEKABOO-DEMO-PLAN-2026-05-09.md`
+- `docs/CLAUDE-CODE-MCP-X402-RECORDING-RUNBOOK-2026-05-09.md`
+
+## Proof artifacts
+
+- Surfpool/local E2E:
+  - `artifacts/rap-mcp-bridge-x402-surfpool-local/20260508T214434Z/SUMMARY.md`
+- Devnet funding preflight:
+  - `artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T214759Z-devnet-funding-preflight/SUMMARY.md`
+- Live hosted specialist smoke:
+  - `artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T214912Z-live-x402-specialist-smoke/SUMMARY.md`
+
+Live smoke receipt:
+
+- Receipt: `x402_specialist_e12428767c48f25a1e5ae5c3`
+- Devnet tx: `1g3B6EBdBcAVWQaGU3EWGLuSGYBnuFCU4MN7Vbn8SUZtEDczF5eSxRxjgZR3rUhsna5WxQjWPzbWAW6VbzfwKj9`
+- Payer USDC: `0.87 → 0.82`
+
+## Validation
+
+Passed:
+
+```bash
+npm run build --prefix packages/x402-solana
+npm test --prefix packages/x402-solana -- --runInBand
+npm run build --prefix packages/rap-mcp-bridge
+npm test --prefix packages/rap-mcp-bridge
+npm --prefix packages/rap-mcp-bridge run smoke:x402-tool-list
+npm run check:product:naming -- docs/CLAUDE-CODE-MCP-X402-RECORDING-RUNBOOK-2026-05-09.md docs/CLAUDE-CODE-MCP-X402-PEEKABOO-DEMO-PLAN-2026-05-09.md
+```
+
+Live smoke passed separately with explicit gate:
+
+```bash
+RAP_MCP_LIVE_X402_SPECIALIST_SMOKE=1 \
+RAP_MCP_DEVNET_WALLET_KEYPAIR=/Users/loki/.config/solana/id.json \
+RAP_MCP_DEVNET_RPC_URL=https://api.devnet.solana.com \
+RAP_MCP_DEVNET_USDC_MINT=4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU \
+RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS=60000 \
+npm --prefix packages/rap-mcp-bridge run smoke:live-x402-specialist
+```
+
+## Safety checklist
+
+- [x] Default bridge remains dry-run only.
+- [x] x402 specialist tools are hidden unless devnet mode + proof approval + invoke gate are configured.
+- [x] Execute requires exact approval phrase `EXECUTE_DEVNET_X402_SPECIALIST_CALL`.
+- [x] Mainnet RPC URLs are rejected.
+- [x] Specialist endpoint must exactly match allowlist.
+- [x] Per-call cap is enforced in micro-USDC.
+- [x] No private key material returned in tool outputs or artifacts.
+- [x] Surfpool local validator proof was run before devnet spend.
+- [x] Live smoke is devnet-only and recorded as such.
+
+## Known limitations / follow-up
+
+- Current recording path uses the default devnet CLI keypair as demo payer; next improvement is a dedicated low-balance demo-only keypair or wallet-router session.
+- `verify_x402_specialist_receipt` currently verifies the stored MCP completion boundary; the hosted specialist verifies the actual receipt during paid retry. A future improvement can add an explicit bridge-side chain reverify tool against stored challenge terms.
+- The hosted specialist endpoint is exact-allowlisted for recording stability; arbitrary marketplace endpoint execution remains intentionally out of scope.
+
+## Recommended PR title
+
+`feat: add gated devnet x402 specialist calls to RAP MCP bridge`
+
+## Recommended PR summary
+
+Adds a gated devnet x402 specialist invocation path for Claude Code MCP demos, including a consumer-side devnet USDC payer helper, MCP prepare/execute/verify tools, x402 disclosure-ledger entries, Surfpool/local E2E smoke, live hosted specialist smoke, and recording runbook.

--- a/docs/CLAUDE-CODE-MCP-X402-PR-READINESS-2026-05-09.md
+++ b/docs/CLAUDE-CODE-MCP-X402-PR-READINESS-2026-05-09.md
@@ -43,6 +43,15 @@ This slice turns the RAP MCP bridge from safe dry-run/demo scaffolding into a ga
 - `docs/CLAUDE-CODE-MCP-X402-LIVE-INVOKE-SPEC-2026-05-09.md`
 - `docs/CLAUDE-CODE-MCP-X402-PEEKABOO-DEMO-PLAN-2026-05-09.md`
 - `docs/CLAUDE-CODE-MCP-X402-RECORDING-RUNBOOK-2026-05-09.md`
+- `docs/RAP-MCP-BRIDGE-HOST-INTEGRATIONS-2026-05-08.md` — naming corrected to “Reddi Agent Protocol MCP bridge”.
+- `docs/RAP-MCP-BRIDGE-PACKAGE-PLAN-2026-05-08.md` — naming corrected to “Reddi Agent Protocol MCP bridge”.
+
+## Product naming guard
+
+- Product name: **Reddi Agent Protocol**.
+- Short form: **RAP**.
+- Do not call the product standalone “Reddi”. Literal URLs/package IDs may contain `reddi`.
+- Recording script visible line: `Starting Claude Code with Reddi Agent Protocol MCP tools...`.
 
 ## Proof artifacts
 
@@ -52,12 +61,25 @@ This slice turns the RAP MCP bridge from safe dry-run/demo scaffolding into a ga
   - `artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T214759Z-devnet-funding-preflight/SUMMARY.md`
 - Live hosted specialist smoke:
   - `artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T214912Z-live-x402-specialist-smoke/SUMMARY.md`
+- Canonical strict-naming true-live Claude Code capture:
+  - Bundle: `artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live.zip`
+  - SHA256: `b293e26fdbe8d30c5791a8e263541393b9302131961e83414ef8f164049584b0`
+  - Full video: `artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live/claude-code-mcp-x402-strict-naming-live-full.mp4`
+  - Preview: `artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live/claude-code-mcp-x402-strict-naming-live-preview.mp4`
+  - Claude output: `artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live/claude-output.txt`
 
 Live smoke receipt:
 
 - Receipt: `x402_specialist_e12428767c48f25a1e5ae5c3`
 - Devnet tx: `1g3B6EBdBcAVWQaGU3EWGLuSGYBnuFCU4MN7Vbn8SUZtEDczF5eSxRxjgZR3rUhsna5WxQjWPzbWAW6VbzfwKj9`
 - Payer USDC: `0.87 → 0.82`
+
+Canonical recording receipt:
+
+- Receipt: `x402_specialist_0460d1e4214ab0f0ddb7d667`
+- Devnet tx: `3oVM9kKqMME6J4sufvWRT5s6F1N9HcLnUGTDeLbxXQNyuAEkC7Nt4JxKs9aoxun7FVTCvzeS4Pwt2PqPMwF1oGGV`
+- Amount: `0.05 USDC` under `60000` micro-USDC cap.
+- Video: `154.9s`, `1440x810`, `1549` frames.
 
 ## Validation
 
@@ -70,6 +92,8 @@ npm run build --prefix packages/rap-mcp-bridge
 npm test --prefix packages/rap-mcp-bridge
 npm --prefix packages/rap-mcp-bridge run smoke:x402-tool-list
 npm run check:product:naming -- docs/CLAUDE-CODE-MCP-X402-RECORDING-RUNBOOK-2026-05-09.md docs/CLAUDE-CODE-MCP-X402-PEEKABOO-DEMO-PLAN-2026-05-09.md
+bash -n scripts/run-claude-code-mcp-x402-recording-demo.sh
+unzip -t artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live.zip
 ```
 
 Live smoke passed separately with explicit gate:
@@ -94,6 +118,8 @@ npm --prefix packages/rap-mcp-bridge run smoke:live-x402-specialist
 - [x] No private key material returned in tool outputs or artifacts.
 - [x] Surfpool local validator proof was run before devnet spend.
 - [x] Live smoke is devnet-only and recorded as such.
+- [x] Canonical recording uses “Reddi Agent Protocol” / “RAP” naming only.
+- [x] Earlier locked-screen/replay/pre-strict-naming captures are superseded; use the strict-naming true-live bundle for review/submission.
 
 ## Known limitations / follow-up
 
@@ -107,4 +133,4 @@ npm --prefix packages/rap-mcp-bridge run smoke:live-x402-specialist
 
 ## Recommended PR summary
 
-Adds a gated devnet x402 specialist invocation path for Claude Code MCP demos, including a consumer-side devnet USDC payer helper, MCP prepare/execute/verify tools, x402 disclosure-ledger entries, Surfpool/local E2E smoke, live hosted specialist smoke, and recording runbook.
+Adds a gated devnet x402 specialist invocation path for Claude Code MCP demos, including a consumer-side devnet USDC payer helper, MCP prepare/execute/verify tools, x402 disclosure-ledger entries, Surfpool/local E2E smoke, live hosted specialist smoke, strict Reddi Agent Protocol/RAP naming guards, and a canonical true-live Claude Code recording bundle.

--- a/docs/CLAUDE-CODE-MCP-X402-RECORDING-RUNBOOK-2026-05-09.md
+++ b/docs/CLAUDE-CODE-MCP-X402-RECORDING-RUNBOOK-2026-05-09.md
@@ -1,0 +1,150 @@
+# Claude Code MCP x402 Recording Runbook
+
+_Date: 2026-05-09 AEST_
+
+## Status
+
+Ready for repeatable recording.
+
+Proof ladder completed:
+
+1. **Dry MCP surface:** `smoke:stdio` and `smoke:x402-tool-list` passed.
+2. **Surfpool prerequisite:** local validator x402 E2E passed.
+3. **Funding preflight:** demo payer already funded; no treasury transfer required.
+4. **Live devnet smoke:** hosted specialist x402 call passed with a bounded `0.05 USDC` devnet payment.
+
+## Evidence artifacts
+
+- Surfpool/local x402 E2E proof:
+  - `artifacts/rap-mcp-bridge-x402-surfpool-local/20260508T214434Z/SUMMARY.md`
+- Devnet funding preflight:
+  - `artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T214759Z-devnet-funding-preflight/SUMMARY.md`
+- Live devnet x402 specialist smoke:
+  - `artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T214912Z-live-x402-specialist-smoke/SUMMARY.md`
+
+Live smoke result:
+
+- Payer: `3Vmcwra5tfxGwaX3jnpmYybCd7gH4fstJzi1Yci38f94`
+- Payee: `8qSuegJzQ9QGWnXZve5fKahq4rDm6K3o9wEnKLkXp3To`
+- Receipt: `x402_specialist_e12428767c48f25a1e5ae5c3`
+- Devnet tx: `1g3B6EBdBcAVWQaGU3EWGLuSGYBnuFCU4MN7Vbn8SUZtEDczF5eSxRxjgZR3rUhsna5WxQjWPzbWAW6VbzfwKj9`
+- Payer USDC: `0.87 → 0.82`
+- Ledger entries: `1`
+
+## Safety boundaries
+
+Say:
+
+- Solana **devnet** payment.
+- x402 specialist challenge → bounded devnet USDC payment → paid retry succeeds.
+- MCP receipt and disclosure ledger are exported locally.
+- Surfpool local validator proof was run before live devnet spend.
+
+Do **not** say:
+
+- Mainnet settlement.
+- Unlimited wallet delegation.
+- Arbitrary endpoint invocation.
+- Every marketplace specialist is paid-live.
+- Production custody/wallet-router is complete.
+
+## Build and smoke gates
+
+From repo root:
+
+```bash
+npm --prefix packages/rap-mcp-bridge run smoke:stdio
+npm --prefix packages/rap-mcp-bridge run smoke:x402-tool-list
+npm --prefix packages/rap-mcp-bridge run smoke:x402-surfpool-local
+RAP_MCP_LIVE_X402_SPECIALIST_SMOKE=1 \
+RAP_MCP_DEVNET_WALLET_KEYPAIR=/Users/loki/.config/solana/id.json \
+RAP_MCP_DEVNET_RPC_URL=https://api.devnet.solana.com \
+RAP_MCP_DEVNET_USDC_MINT=4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU \
+RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS=60000 \
+npm --prefix packages/rap-mcp-bridge run smoke:live-x402-specialist
+npm test --prefix packages/rap-mcp-bridge
+```
+
+The live smoke spends one capped devnet x402 payment if the hosted specialist returns a valid 402 challenge.
+
+## Claude Code MCP registration
+
+Build first:
+
+```bash
+npm --prefix packages/rap-mcp-bridge run build
+```
+
+Register MCP server:
+
+```bash
+claude mcp add reddi-rap-devnet \
+  -e REDDI_RAP_MCP_MODE=devnet \
+  -e REDDI_MCP_HOST_FRAMEWORK=claude \
+  -e REDDI_MCP_AGENT_NAME=claude-code-demo \
+  -e REDDI_MCP_STORE_DIR=/Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code/artifacts/claude-code-mcp-x402-peekaboo-demo/mcp-store \
+  -e RAP_MCP_DEVNET_PROOF_APPROVED=1 \
+  -e RAP_MCP_ALLOW_SPECIALIST_INVOKE=1 \
+  -e RAP_MCP_DEVNET_WALLET_KEYPAIR=/Users/loki/.config/solana/id.json \
+  -e RAP_MCP_DEVNET_RPC_URL=https://api.devnet.solana.com \
+  -e RAP_MCP_DEVNET_USDC_MINT=4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU \
+  -e RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS=60000 \
+  -e RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST=https://reddi-code-generation.preview.reddi.tech/v1/chat/completions \
+  -- node /Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code/packages/rap-mcp-bridge/dist/src/server.js
+```
+
+Do not open or print the keypair JSON during recording. It is acceptable to show the public wallet address and balances.
+
+Optional sanity check:
+
+```bash
+claude mcp list
+claude mcp get reddi-rap-devnet
+```
+
+## Recording prompt
+
+Use this prompt in Claude Code:
+
+```text
+Use Reddi Agent Protocol MCP tools to answer this demo question:
+
+What does a paid machine-to-machine specialist call prove for agent marketplaces?
+
+Requirements:
+- Discover or identify an available code-generation specialist.
+- Use only the allowlisted devnet x402 specialist endpoint.
+- Keep spend under the configured 60000 micro-USDC cap.
+- Execute the x402 specialist call only if the tool reports the configured devnet wallet is ready.
+- Verify the receipt before relying on the specialist output.
+- Export a disclosure ledger entry.
+- Final answer must include: chosen specialist, what it contributed, devnet payment receipt/tx boundary, and disclosure-ledger summary.
+```
+
+## Screen storyboard
+
+Target: 60–100 seconds.
+
+1. Show build/smoke proof artifacts briefly.
+2. Show Claude MCP server registration/listing.
+3. Show public demo wallet address and balances only.
+4. Paste the recording prompt.
+5. Show MCP tool calls:
+   - specialist discovery / selection
+   - x402 execute call
+   - receipt verify
+   - disclosure ledger export
+6. Show final answer with receipt tx and devnet boundary.
+7. End on artifact paths.
+
+## If live call fails during recording
+
+1. Stop recording.
+2. Re-run the live smoke script.
+3. If it fails before payment, no spend occurred; inspect endpoint/challenge readiness.
+4. If it fails after payment, use the smoke artifact and receipt/tx to debug before trying again.
+5. Do not raise cap or broaden allowlist during recording.
+
+## Next improvement after recording
+
+Add a dedicated, low-balance demo-only keypair path or wallet-router session so the recording no longer uses the default Solana CLI keypair, even though it is currently devnet-only and funded for the demo.

--- a/docs/RAP-MCP-BRIDGE-HOST-INTEGRATIONS-2026-05-08.md
+++ b/docs/RAP-MCP-BRIDGE-HOST-INTEGRATIONS-2026-05-08.md
@@ -95,7 +95,7 @@ OpenSwarm already uses an orchestrator that routes to specialists. RAP should ap
 ```md
 ## Reddi Agent Protocol paid specialists
 
-When the user requests work that would benefit from paid external specialist agents, use the Reddi MCP bridge.
+When the user requests work that would benefit from paid external specialist agents, use the Reddi Agent Protocol MCP bridge.
 
 Flow:
 1. Ask `reddi.discover_specialists` for candidates.

--- a/docs/RAP-MCP-BRIDGE-PACKAGE-PLAN-2026-05-08.md
+++ b/docs/RAP-MCP-BRIDGE-PACKAGE-PLAN-2026-05-08.md
@@ -351,7 +351,7 @@ Example after package build:
 Add to OpenSwarm agent instructions:
 
 ```md
-When you need external specialist work that may require payment, call the Reddi MCP bridge first:
+When you need external specialist work that may require payment, call the Reddi Agent Protocol MCP bridge first:
 
 1. `reddi.discover_specialists`
 2. `reddi.request_quote`

--- a/packages/rap-mcp-bridge/package-lock.json
+++ b/packages/rap-mcp-bridge/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@reddi/x402-solana": "file:../x402-solana",
         "@solana/web3.js": "^1.98.4",
         "zod": "^3.25.76"
       },
@@ -21,6 +22,21 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "../x402-solana": {
+      "name": "@reddi/x402-solana",
+      "version": "0.1.0",
+      "dependencies": {
+        "@solana/spl-token": "^0.4.14",
+        "@solana/web3.js": "^1.95.8"
+      },
+      "devDependencies": {
+        "@types/jest": "^29",
+        "@types/node": "^20",
+        "jest": "^29",
+        "ts-jest": "^29",
+        "typescript": "^5"
       }
     },
     "node_modules/@babel/runtime": {
@@ -110,6 +126,10 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@reddi/x402-solana": {
+      "resolved": "../x402-solana",
+      "link": true
     },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",

--- a/packages/rap-mcp-bridge/package.json
+++ b/packages/rap-mcp-bridge/package.json
@@ -17,15 +17,19 @@
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test dist/tests/*.test.js",
     "smoke:stdio": "npm run build && node scripts/smoke-stdio.mjs",
-    "smoke:devnet": "npm run build && node scripts/smoke-devnet-mcp.mjs"
+    "smoke:devnet": "npm run build && node scripts/smoke-devnet-mcp.mjs",
+    "smoke:x402-tool-list": "npm run build && node scripts/smoke-x402-tool-list.mjs",
+    "smoke:x402-surfpool-local": "npm run build && node scripts/smoke-x402-surfpool-local.mjs",
+    "smoke:live-x402-specialist": "npm run build && node scripts/smoke-live-x402-specialist.mjs"
   },
   "engines": {
     "node": ">=20"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "zod": "^3.25.76",
-    "@solana/web3.js": "^1.98.4"
+    "@reddi/x402-solana": "file:../x402-solana",
+    "@solana/web3.js": "^1.98.4",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/rap-mcp-bridge/scripts/smoke-live-x402-specialist.mjs
+++ b/packages/rap-mcp-bridge/scripts/smoke-live-x402-specialist.mjs
@@ -1,0 +1,138 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Connection, Keypair, PublicKey } from '@solana/web3.js';
+import { getAssociatedTokenAddressSync } from '@solana/spl-token';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+if (process.env.RAP_MCP_LIVE_X402_SPECIALIST_SMOKE !== '1') {
+  throw new Error('set RAP_MCP_LIVE_X402_SPECIALIST_SMOKE=1 to run a live devnet x402 specialist smoke');
+}
+if (!process.env.RAP_MCP_DEVNET_WALLET_KEYPAIR || !existsSync(process.env.RAP_MCP_DEVNET_WALLET_KEYPAIR)) {
+  throw new Error('set RAP_MCP_DEVNET_WALLET_KEYPAIR to an explicitly approved funded devnet demo wallet keypair path');
+}
+
+const packageDir = dirname(fileURLToPath(import.meta.url)).replace(/\/scripts$/, '');
+const repoDir = join(packageDir, '..', '..');
+const timestamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+const artifactDir = join(repoDir, 'artifacts', 'claude-code-mcp-x402-peekaboo-demo', `${timestamp}-live-x402-specialist-smoke`);
+mkdirSync(artifactDir, { recursive: true });
+
+const endpoint = process.env.RAP_MCP_LIVE_X402_SPECIALIST_ENDPOINT ?? 'https://reddi-code-generation.preview.reddi.tech/v1/chat/completions';
+const rpcUrl = process.env.RAP_MCP_DEVNET_RPC_URL ?? 'https://api.devnet.solana.com';
+const usdcMint = process.env.RAP_MCP_DEVNET_USDC_MINT ?? '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+const maxUsdcMicroUnits = Number(process.env.RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS ?? '60000');
+const storeDir = process.env.REDDI_MCP_STORE_DIR || mkdtempSync(join(tmpdir(), 'rap-mcp-live-x402-specialist-'));
+
+function loadPublicKey(path) {
+  const secret = Uint8Array.from(JSON.parse(readFileSync(path, 'utf8')));
+  return Keypair.fromSecretKey(secret).publicKey;
+}
+
+async function tokenBalance(connection, owner, mint) {
+  const ata = getAssociatedTokenAddressSync(mint, owner);
+  try {
+    const balance = await connection.getTokenAccountBalance(ata, 'confirmed');
+    return { ata: ata.toBase58(), amount: balance.value.amount, uiAmountString: balance.value.uiAmountString };
+  } catch {
+    return { ata: ata.toBase58(), amount: '0', uiAmountString: '0' };
+  }
+}
+
+const walletPublicKey = loadPublicKey(process.env.RAP_MCP_DEVNET_WALLET_KEYPAIR);
+const connection = new Connection(rpcUrl, 'confirmed');
+const mint = new PublicKey(usdcMint);
+const prePayer = await tokenBalance(connection, walletPublicKey, mint);
+
+const client = new Client({ name: 'rap-mcp-live-x402-specialist-smoke', version: '0.1.0' });
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ['dist/src/server.js'],
+  cwd: packageDir,
+  env: {
+    ...process.env,
+    REDDI_RAP_MCP_MODE: 'devnet',
+    REDDI_MCP_STORE_DIR: storeDir,
+    RAP_MCP_DEVNET_PROOF_APPROVED: '1',
+    RAP_MCP_ALLOW_SPECIALIST_INVOKE: '1',
+    RAP_MCP_DEVNET_RPC_URL: rpcUrl,
+    RAP_MCP_DEVNET_USDC_MINT: usdcMint,
+    RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS: String(maxUsdcMicroUnits),
+    RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST: endpoint,
+  },
+  stderr: 'pipe',
+});
+
+try {
+  await client.connect(transport);
+  const parseToolJson = (result, label) => {
+    const text = result.content?.[0]?.text;
+    try { return JSON.parse(text); } catch { throw new Error(`${label} returned non-JSON: ${text}`); }
+  };
+  const tools = await client.listTools();
+  const names = tools.tools.map((tool) => tool.name).sort();
+  for (const name of ['reddi.execute_x402_specialist_call', 'reddi.verify_x402_specialist_receipt', 'reddi.export_disclosure_ledger']) {
+    if (!names.includes(name)) throw new Error(`missing live x402 MCP tool: ${name}`);
+  }
+
+  const execute = parseToolJson(await client.callTool({
+    name: 'reddi.execute_x402_specialist_call',
+    arguments: {
+      endpoint,
+      body: {
+        model: 'reddi-code-generation',
+        messages: [{ role: 'user', content: 'For a demo recording, reply in one concise sentence explaining what a paid x402 specialist call proves.' }],
+        max_tokens: 80,
+      },
+      idempotencyKey: `live-x402-specialist-${timestamp}`,
+      maxUsdcMicroUnits,
+      approvalPhrase: 'EXECUTE_DEVNET_X402_SPECIALIST_CALL',
+    },
+  }), 'execute_x402_specialist_call');
+  if (execute.response?.status !== 200) throw new Error(`paid retry did not return 200: ${JSON.stringify(execute.response)}`);
+
+  const verify = parseToolJson(await client.callTool({
+    name: 'reddi.verify_x402_specialist_receipt',
+    arguments: { receiptId: execute.receiptId },
+  }), 'verify_x402_specialist_receipt');
+  if (verify.verified !== true || verify.mainnetSettlement !== 'not_applicable') throw new Error(`verification failed: ${JSON.stringify(verify)}`);
+
+  const ledger = parseToolJson(await client.callTool({
+    name: 'reddi.export_disclosure_ledger',
+    arguments: { x402ReceiptIds: [execute.receiptId] },
+  }), 'export_disclosure_ledger');
+  if (ledger.entries?.length !== 1) throw new Error(`ledger export failed: ${JSON.stringify(ledger)}`);
+
+  const payTo = execute.paymentReceipt?.payTo ? new PublicKey(String(execute.paymentReceipt.payTo)) : null;
+  const postPayer = await tokenBalance(connection, walletPublicKey, mint);
+  const postPayee = payTo ? await tokenBalance(connection, payTo, mint) : null;
+  const summary = {
+    ok: true,
+    schemaVersion: 'reddi.rap-mcp-bridge.live-x402-specialist-smoke.v1',
+    generatedAt: new Date().toISOString(),
+    boundary: 'solana-devnet-only-no-mainnet',
+    endpoint,
+    rpcUrl,
+    payer: walletPublicKey.toBase58(),
+    payTo: payTo?.toBase58() ?? null,
+    usdcMint,
+    maxUsdcMicroUnits,
+    receiptId: execute.receiptId,
+    signature: execute.paymentReceipt?.signature ?? execute.paymentReceipt?.txSignature,
+    response: execute.response,
+    verification: { mcpReceiptVerified: verify.verified, specialistHttpCompletion: execute.verification?.specialistHttpCompletion, mainnetSettlement: verify.mainnetSettlement },
+    ledgerEntryCount: ledger.entries.length,
+    balances: { payerBefore: prePayer, payerAfter: postPayer, payeeAfter: postPayee },
+    guardrails: ['devnet only', 'mainnet not applicable', 'exact endpoint allowlist', 'bounded micro-USDC cap', 'no private key material in artifact'],
+  };
+  const jsonPath = join(artifactDir, 'smoke-summary.json');
+  const mdPath = join(artifactDir, 'SUMMARY.md');
+  writeFileSync(jsonPath, `${JSON.stringify(summary, null, 2)}\n`);
+  writeFileSync(mdPath, `# Live x402 Specialist Smoke\n\n- Boundary: ${summary.boundary}\n- Endpoint: ${endpoint}\n- Payer: ${summary.payer}\n- Payee: ${summary.payTo}\n- Cap: ${maxUsdcMicroUnits} micro-USDC\n- Receipt: ${summary.receiptId}\n- Signature: ${summary.signature}\n- MCP receipt verified: ${summary.verification.mcpReceiptVerified}\n- Specialist completion: ${summary.verification.specialistHttpCompletion}\n- Ledger entries: ${summary.ledgerEntryCount}\n- Payer USDC before: ${prePayer.uiAmountString}\n- Payer USDC after: ${postPayer.uiAmountString}\n- JSON: ${jsonPath}\n`);
+  console.log(JSON.stringify({ ok: true, jsonPath, mdPath, receiptId: summary.receiptId, signature: summary.signature, payerBefore: prePayer.uiAmountString, payerAfter: postPayer.uiAmountString }, null, 2));
+} finally {
+  await client.close().catch(() => undefined);
+  if (!process.env.REDDI_MCP_STORE_DIR) rmSync(storeDir, { recursive: true, force: true });
+}

--- a/packages/rap-mcp-bridge/scripts/smoke-x402-surfpool-local.mjs
+++ b/packages/rap-mcp-bridge/scripts/smoke-x402-surfpool-local.mjs
@@ -1,0 +1,262 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Connection, Keypair, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
+import {
+  createAssociatedTokenAccountInstruction,
+  createInitializeMintInstruction,
+  createMintToInstruction,
+  getAssociatedTokenAddressSync,
+  MINT_SIZE,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import { SolanaReceiptVerifier, buildX402Challenge } from '@reddi/x402-solana';
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = dirname(fileURLToPath(import.meta.url)).replace(/\/scripts$/, '');
+const repoDir = join(packageDir, '..', '..');
+const timestamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+const artifactDir = join(repoDir, 'artifacts', 'rap-mcp-bridge-x402-surfpool-local', timestamp);
+mkdirSync(artifactDir, { recursive: true });
+
+const surfpoolPort = Number(process.env.RAP_MCP_SURFPOOL_X402_PORT ?? 19221);
+const surfpoolWsPort = Number(process.env.RAP_MCP_SURFPOOL_X402_WS_PORT ?? 19222);
+const specialistPort = Number(process.env.RAP_MCP_SURFPOOL_X402_SPECIALIST_PORT ?? 19223);
+const rpcUrl = `http://127.0.0.1:${surfpoolPort}`;
+const endpoint = `http://127.0.0.1:${specialistPort}/v1/chat/completions`;
+const amount = '0.05';
+const amountMicroUnits = 50_000n;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForRpc(connection) {
+  let lastError;
+  for (let i = 0; i < 80; i += 1) {
+    try {
+      await connection.getVersion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep(500);
+    }
+  }
+  throw new Error(`surfpool_rpc_not_ready:${lastError instanceof Error ? lastError.message : String(lastError)}`);
+}
+
+function startSurfpool() {
+  const logPath = join(artifactDir, 'surfpool.log');
+  const child = spawn('surfpool', [
+    'start', '--ci', '--legacy-anchor-compatibility', '-y', '--offline',
+    '--port', String(surfpoolPort), '--ws-port', String(surfpoolWsPort), '--no-studio', '--no-tui', '--log-level', 'info',
+  ], { stdio: ['ignore', 'pipe', 'pipe'] });
+  const chunks = [];
+  child.stdout.on('data', (chunk) => chunks.push(chunk));
+  child.stderr.on('data', (chunk) => chunks.push(chunk));
+  child.on('close', () => writeFileSync(logPath, Buffer.concat(chunks)));
+  return { child, logPath };
+}
+
+async function confirmAirdrop(connection, publicKey, lamports) {
+  const signature = await connection.requestAirdrop(publicKey, lamports);
+  const latest = await connection.getLatestBlockhash();
+  await connection.confirmTransaction({ signature, ...latest }, 'confirmed');
+  return signature;
+}
+
+async function sendTx(connection, payer, instructions, signers = []) {
+  const { Transaction, sendAndConfirmTransaction } = await import('@solana/web3.js');
+  const tx = new Transaction().add(...instructions);
+  return sendAndConfirmTransaction(connection, tx, [payer, ...signers], { commitment: 'confirmed' });
+}
+
+async function createLocalUsdcMintAndFundPayer(connection, payer, payee) {
+  const mint = Keypair.generate();
+  const rent = await connection.getMinimumBalanceForRentExemption(MINT_SIZE);
+  const payerAta = getAssociatedTokenAddressSync(mint.publicKey, payer.publicKey);
+  const payeeAta = getAssociatedTokenAddressSync(mint.publicKey, payee.publicKey);
+  await sendTx(connection, payer, [
+    (await import('@solana/web3.js')).SystemProgram.createAccount({
+      fromPubkey: payer.publicKey,
+      newAccountPubkey: mint.publicKey,
+      space: MINT_SIZE,
+      lamports: rent,
+      programId: TOKEN_PROGRAM_ID,
+    }),
+    createInitializeMintInstruction(mint.publicKey, 6, payer.publicKey, null),
+    createAssociatedTokenAccountInstruction(payer.publicKey, payerAta, payer.publicKey, mint.publicKey),
+    createAssociatedTokenAccountInstruction(payer.publicKey, payeeAta, payee.publicKey, mint.publicKey),
+    createMintToInstruction(mint.publicKey, payerAta, payer.publicKey, 100_000n),
+  ], [mint]);
+  return { mint: mint.publicKey, payerAta, payeeAta };
+}
+
+function readRequest(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+async function startLocalSpecialist({ connection, challenge, mint }) {
+  const verifier = new SolanaReceiptVerifier({ allowRealPayment: true, connection, usdcMint: mint.toBase58() });
+  const calls = [];
+  const server = createServer(async (req, res) => {
+    const body = await readRequest(req);
+    calls.push({ url: req.url, hasPayment: Boolean(req.headers['x402-payment']), bodyLength: body.length });
+    if (req.method !== 'POST' || req.url !== '/v1/chat/completions') {
+      res.writeHead(404).end('not found');
+      return;
+    }
+    const paymentHeader = req.headers['x402-payment'];
+    if (!paymentHeader) {
+      res.writeHead(402, { 'content-type': 'application/json', 'x402-request': JSON.stringify(challenge) });
+      res.end(JSON.stringify({ error: 'payment_required', x402: challenge }));
+      return;
+    }
+    const verification = await verifier.verifyReceipt(JSON.parse(String(paymentHeader)), challenge);
+    if (!verification.ok) {
+      res.writeHead(402, { 'content-type': 'application/json', 'x402-request': JSON.stringify(challenge) });
+      res.end(JSON.stringify({ error: 'invalid_payment', verification }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ answer: 'local surfpool specialist completed after verified x402 payment', verification: { ok: true, boundary: 'surfpool-local-validator' } }));
+  });
+  await new Promise((resolve) => server.listen(specialistPort, '127.0.0.1', resolve));
+  return { server, calls };
+}
+
+const tmp = mkdtempSync(join(tmpdir(), 'rap-mcp-x402-surfpool-local-'));
+const surfpool = startSurfpool();
+let specialistServer;
+const client = new Client({ name: 'rap-mcp-x402-surfpool-local-smoke', version: '0.1.0' });
+try {
+  const connection = new Connection(rpcUrl, 'confirmed');
+  await waitForRpc(connection);
+
+  const payer = Keypair.generate();
+  const payee = Keypair.generate();
+  await confirmAirdrop(connection, payer.publicKey, LAMPORTS_PER_SOL);
+  const { mint, payerAta, payeeAta } = await createLocalUsdcMintAndFundPayer(connection, payer, payee);
+  const walletPath = join(tmp, 'payer-wallet.json');
+  writeFileSync(walletPath, JSON.stringify(Array.from(payer.secretKey)), { mode: 0o600 });
+
+  const challenge = buildX402Challenge({
+    version: '1',
+    network: 'solana-devnet',
+    payTo: payee.publicKey.toBase58(),
+    amount,
+    currency: 'USDC',
+    endpoint,
+    nonce: `surfpool-local-${timestamp}`,
+    memo: 'RAP MCP x402 Surfpool local proof before devnet funding',
+  });
+  specialistServer = await startLocalSpecialist({ connection, challenge, mint });
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ['dist/src/server.js'],
+    cwd: packageDir,
+    env: {
+      ...process.env,
+      REDDI_RAP_MCP_MODE: 'devnet',
+      REDDI_MCP_STORE_DIR: join(tmp, 'store'),
+      RAP_MCP_DEVNET_PROOF_APPROVED: '1',
+      RAP_MCP_ALLOW_SPECIALIST_INVOKE: '1',
+      RAP_MCP_DEVNET_WALLET_KEYPAIR: walletPath,
+      RAP_MCP_DEVNET_RPC_URL: rpcUrl,
+      RAP_MCP_DEVNET_USDC_MINT: mint.toBase58(),
+      RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST: endpoint,
+      RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS: '60000',
+    },
+    stderr: 'pipe',
+  });
+  await client.connect(transport);
+
+  const parseToolJson = (result, label) => {
+    const text = result.content?.[0]?.text;
+    try { return JSON.parse(text); } catch { throw new Error(`${label} returned non-JSON: ${text}`); }
+  };
+
+  const tools = await client.listTools();
+  const names = tools.tools.map((tool) => tool.name).sort();
+  for (const name of ['reddi.execute_x402_specialist_call', 'reddi.verify_x402_specialist_receipt', 'reddi.export_disclosure_ledger']) {
+    if (!names.includes(name)) throw new Error(`missing MCP tool: ${name}`);
+  }
+
+  const execute = parseToolJson(await client.callTool({
+    name: 'reddi.execute_x402_specialist_call',
+    arguments: {
+      endpoint,
+      body: { messages: [{ role: 'user', content: 'Produce a one-line local Surfpool proof answer.' }] },
+      idempotencyKey: `surfpool-local-x402-${timestamp}`,
+      maxUsdcMicroUnits: 60_000,
+      approvalPhrase: 'EXECUTE_DEVNET_X402_SPECIALIST_CALL',
+    },
+  }), 'execute_x402_specialist_call');
+  if (execute.response?.status !== 200) throw new Error(`paid retry did not complete: ${JSON.stringify(execute.response)}`);
+
+  const verify = parseToolJson(await client.callTool({
+    name: 'reddi.verify_x402_specialist_receipt',
+    arguments: { receiptId: execute.receiptId },
+  }), 'verify_x402_specialist_receipt');
+  if (verify.verified !== true) throw new Error(`MCP receipt verification failed: ${JSON.stringify(verify)}`);
+
+  const ledger = parseToolJson(await client.callTool({
+    name: 'reddi.export_disclosure_ledger',
+    arguments: { x402ReceiptIds: [execute.receiptId] },
+  }), 'export_disclosure_ledger');
+  if (ledger.entries?.length !== 1) throw new Error(`ledger entry missing: ${JSON.stringify(ledger)}`);
+
+  const payerBalance = await connection.getTokenAccountBalance(payerAta, 'confirmed');
+  const payeeBalance = await connection.getTokenAccountBalance(payeeAta, 'confirmed');
+  if (BigInt(payeeBalance.value.amount) !== amountMicroUnits) throw new Error(`payee token balance mismatch:${payeeBalance.value.amount}`);
+
+  const summary = {
+    ok: true,
+    schemaVersion: 'reddi.rap-mcp-bridge.x402-surfpool-local-smoke.v1',
+    generatedAt: new Date().toISOString(),
+    boundary: 'surfpool_local_validator_only_no_devnet_no_mainnet',
+    rpcUrl,
+    endpoint,
+    tools: names.filter((name) => name.includes('x402_specialist') || name === 'reddi.export_disclosure_ledger'),
+    mint: mint.toBase58(),
+    payer: payer.publicKey.toBase58(),
+    payee: payee.publicKey.toBase58(),
+    payerTokenAccount: payerAta.toBase58(),
+    payeeTokenAccount: payeeAta.toBase58(),
+    spend: { amount, amountMicroUnits: String(amountMicroUnits), maxUsdcMicroUnits: '60000', capRespected: true },
+    receiptId: execute.receiptId,
+    signature: execute.paymentReceipt?.signature ?? execute.paymentReceipt?.txSignature,
+    specialistCalls: specialistServer.calls,
+    balances: { payerMicroUnits: payerBalance.value.amount, payeeMicroUnits: payeeBalance.value.amount },
+    verification: { mcpReceiptVerified: verify.verified, specialistHttpCompletion: execute.verification?.specialistHttpCompletion, mainnetSettlement: verify.mainnetSettlement },
+    ledgerEntryCount: ledger.entries.length,
+    nextGate: 'bounded_devnet_treasury_funding_for_demo_wallets',
+    guardrails: ['local Surfpool validator only', 'local specialist HTTP server only', 'no devnet mutation', 'no mainnet path', 'no private key material in artifact'],
+  };
+  const jsonPath = join(artifactDir, 'summary.json');
+  const mdPath = join(artifactDir, 'SUMMARY.md');
+  writeFileSync(jsonPath, `${JSON.stringify(summary, null, 2)}\n`);
+  writeFileSync(mdPath, `# RAP MCP x402 Surfpool Local Smoke\n\n- Boundary: ${summary.boundary}\n- MCP receipt verified: ${summary.verification.mcpReceiptVerified}\n- Specialist paid retry: ${summary.verification.specialistHttpCompletion}\n- Payee credited micro-USDC: ${summary.balances.payeeMicroUnits}\n- Signature: ${summary.signature}\n- Receipt: ${summary.receiptId}\n- Ledger entries: ${summary.ledgerEntryCount}\n- Next gate: ${summary.nextGate}\n- JSON: ${jsonPath}\n`);
+  console.log(JSON.stringify({ ok: true, jsonPath, mdPath, receiptId: summary.receiptId, signature: summary.signature, payeeMicroUnits: summary.balances.payeeMicroUnits }, null, 2));
+} finally {
+  await client.close().catch(() => undefined);
+  if (specialistServer) await new Promise((resolve) => specialistServer.server.close(resolve));
+  if (surfpool.child.exitCode === null) {
+    surfpool.child.kill('SIGTERM');
+    await Promise.race([
+      new Promise((resolve) => surfpool.child.once('exit', resolve)),
+      sleep(1500).then(() => { if (surfpool.child.exitCode === null) surfpool.child.kill('SIGKILL'); }),
+    ]);
+  }
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/packages/rap-mcp-bridge/scripts/smoke-x402-tool-list.mjs
+++ b/packages/rap-mcp-bridge/scripts/smoke-x402-tool-list.mjs
@@ -1,0 +1,54 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Keypair } from '@solana/web3.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const endpoint = process.env.RAP_MCP_X402_TOOL_LIST_ENDPOINT ?? 'https://reddi-code-generation.preview.reddi.tech/v1/chat/completions';
+const usdcMint = process.env.RAP_MCP_DEVNET_USDC_MINT ?? '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+const dir = mkdtempSync(join(tmpdir(), 'rap-mcp-x402-tool-list-'));
+const wallet = join(dir, 'wallet.json');
+writeFileSync(wallet, JSON.stringify(Array.from(Keypair.generate().secretKey)), { mode: 0o600 });
+
+const client = new Client({ name: 'rap-mcp-x402-tool-list-smoke', version: '0.1.0' });
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ['dist/src/server.js'],
+  cwd: new URL('..', import.meta.url).pathname,
+  env: {
+    ...process.env,
+    REDDI_RAP_MCP_MODE: 'devnet',
+    REDDI_MCP_STORE_DIR: join(dir, 'store'),
+    RAP_MCP_DEVNET_PROOF_APPROVED: '1',
+    RAP_MCP_ALLOW_SPECIALIST_INVOKE: '1',
+    RAP_MCP_DEVNET_WALLET_KEYPAIR: wallet,
+    RAP_MCP_DEVNET_USDC_MINT: usdcMint,
+    RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST: endpoint,
+    RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS: '150000',
+    // Deliberately unset: this smoke should not expose legacy synthetic devnet payment tools.
+    RAP_MCP_DEVNET_FUNDER_KEYPAIR: '',
+  },
+  stderr: 'pipe',
+});
+
+try {
+  await client.connect(transport);
+  const tools = await client.listTools();
+  const names = tools.tools.map((tool) => tool.name).sort();
+  const expected = [
+    'reddi.execute_x402_specialist_call',
+    'reddi.prepare_x402_specialist_call',
+    'reddi.verify_x402_specialist_receipt',
+  ];
+  for (const name of expected) {
+    if (!names.includes(name)) throw new Error(`missing gated x402 specialist tool: ${name}`);
+  }
+  for (const name of ['reddi.prepare_devnet_payment', 'reddi.execute_devnet_payment', 'reddi.verify_devnet_receipt']) {
+    if (names.includes(name)) throw new Error(`legacy devnet payment tool unexpectedly exposed without funder keypair: ${name}`);
+  }
+  console.log(JSON.stringify({ ok: true, x402Tools: names.filter((name) => name.includes('x402_specialist')) }, null, 2));
+} finally {
+  await client.close().catch(() => undefined);
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/packages/rap-mcp-bridge/src/config.ts
+++ b/packages/rap-mcp-bridge/src/config.ts
@@ -8,6 +8,11 @@ export type BridgeConfig = {
   devnetFunderKeypairPath?: string;
   devnetRpcUrl: string;
   devnetMaxTotalDebitLamports?: number;
+  allowSpecialistInvoke: boolean;
+  devnetWalletKeypairPath?: string;
+  devnetUsdcMint?: string;
+  devnetMaxUsdcMicroUnits: number;
+  specialistEndpointAllowlist: string[];
 };
 
 const FRAMEWORKS = new Set(["claude", "cursor", "openclaw", "openswarm", "codex", "custom"]);
@@ -86,5 +91,10 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): BridgeConfig {
     devnetFunderKeypairPath: sanitizeSmallText(env.RAP_MCP_DEVNET_FUNDER_KEYPAIR, 512),
     devnetRpcUrl: assertDevnetRpcUrl(env.RAP_MCP_DEVNET_RPC_URL ?? "https://api.devnet.solana.com"),
     devnetMaxTotalDebitLamports: parsePositiveSafeInteger(env.RAP_MCP_DEVNET_MAX_TOTAL_DEBIT_LAMPORTS, 3_200_000),
+    allowSpecialistInvoke: env.RAP_MCP_ALLOW_SPECIALIST_INVOKE === "1",
+    devnetWalletKeypairPath: sanitizeSmallText(env.RAP_MCP_DEVNET_WALLET_KEYPAIR, 512),
+    devnetUsdcMint: sanitizeSmallText(env.RAP_MCP_DEVNET_USDC_MINT, 128),
+    devnetMaxUsdcMicroUnits: parsePositiveSafeInteger(env.RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS, 150_000),
+    specialistEndpointAllowlist: (env.RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST ?? "").split(",").map((value) => value.trim()).filter(Boolean),
   };
 }

--- a/packages/rap-mcp-bridge/src/policy.ts
+++ b/packages/rap-mcp-bridge/src/policy.ts
@@ -1,13 +1,13 @@
 export type BridgePolicyState = {
   mode: "dry_run" | "devnet";
   allowPayment: boolean;
-  allowInvoke: false;
+  allowInvoke: boolean;
   allowPrivatePayloads: false;
   allowMainnet: false;
   toolNames: readonly string[];
 };
 
-export function currentPolicy(mode: "dry_run" | "devnet" = "dry_run", gatesReady = mode === "dry_run"): BridgePolicyState {
+export function currentPolicy(mode: "dry_run" | "devnet" = "dry_run", gatesReady = mode === "dry_run", invokeReady = false): BridgePolicyState {
   const effectiveMode = mode === "devnet" && gatesReady ? "devnet" : "dry_run";
   const dryRunTools = [
     "reddi.discover_specialists",
@@ -18,7 +18,7 @@ export function currentPolicy(mode: "dry_run" | "devnet" = "dry_run", gatesReady
   return {
     mode: effectiveMode,
     allowPayment: effectiveMode === "devnet",
-    allowInvoke: false,
+    allowInvoke: effectiveMode === "devnet" && invokeReady,
     allowPrivatePayloads: false,
     allowMainnet: false,
     toolNames: effectiveMode === "devnet" ? [
@@ -26,6 +26,7 @@ export function currentPolicy(mode: "dry_run" | "devnet" = "dry_run", gatesReady
       "reddi.prepare_devnet_payment",
       "reddi.execute_devnet_payment",
       "reddi.verify_devnet_receipt",
+      ...(invokeReady ? ["reddi.prepare_x402_specialist_call", "reddi.execute_x402_specialist_call", "reddi.verify_x402_specialist_receipt"] : []),
     ] : dryRunTools,
   };
 }

--- a/packages/rap-mcp-bridge/src/schemas.ts
+++ b/packages/rap-mcp-bridge/src/schemas.ts
@@ -36,6 +36,7 @@ export const verifyReceiptInputSchema = {
 
 export const exportDisclosureLedgerInputSchema = {
   quoteIds: z.array(z.string().max(160)).max(MAX_LEDGER_ENTRIES).default([]),
+  x402ReceiptIds: z.array(z.string().max(160)).max(MAX_LEDGER_ENTRIES).default([]),
 };
 
 export const prepareDevnetPaymentInputSchema = {
@@ -52,6 +53,24 @@ export const executeDevnetPaymentInputSchema = {
 
 export const verifyDevnetReceiptInputSchema = {
   quoteId: z.string().max(160),
+};
+
+export const prepareX402SpecialistCallInputSchema = {
+  x402RequestHeader: z.string().min(1).max(4096),
+  maxUsdcMicroUnits: z.number().int().positive().max(1_000_000).optional(),
+};
+
+export const executeX402SpecialistCallInputSchema = {
+  endpoint: z.string().url().max(512),
+  body: z.record(z.unknown()),
+  idempotencyKey: z.string().min(1).max(128),
+  maxUsdcMicroUnits: z.number().int().positive().max(1_000_000),
+  approvalPhrase: z.literal("EXECUTE_DEVNET_X402_SPECIALIST_CALL"),
+};
+
+export const verifyX402SpecialistReceiptInputSchema = {
+  receiptId: z.string().max(160).optional(),
+  idempotencyKey: z.string().max(128).optional(),
 };
 
 export type ReddiQuote = {

--- a/packages/rap-mcp-bridge/src/server.ts
+++ b/packages/rap-mcp-bridge/src/server.ts
@@ -9,16 +9,20 @@ import { BridgeStore } from "./store.js";
 import {
   discoverInputSchema,
   executeDevnetPaymentInputSchema,
+  executeX402SpecialistCallInputSchema,
   exportDisclosureLedgerInputSchema,
   prepareDevnetPaymentInputSchema,
+  prepareX402SpecialistCallInputSchema,
   requestQuoteInputSchema,
   verifyDevnetReceiptInputSchema,
   verifyReceiptInputSchema,
+  verifyX402SpecialistReceiptInputSchema,
 } from "./schemas.js";
 import { requestQuote } from "./tools/request-quote.js";
 import { verifyReceipt } from "./tools/verify-receipt.js";
 import { exportDisclosureLedger } from "./tools/export-disclosure-ledger.js";
 import { executeDevnetPayment, prepareDevnetPayment, verifyDevnetReceipt } from "./tools/devnet-payment.js";
+import { executeX402SpecialistCall, prepareX402SpecialistCall, verifyX402SpecialistReceipt } from "./tools/x402-specialist-call.js";
 
 function jsonContent(value: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }] };
@@ -27,7 +31,8 @@ function jsonContent(value: unknown) {
 export function createServer(env: NodeJS.ProcessEnv = process.env) {
   const config = loadConfig(env);
   const devnetToolsEnabled = config.policyMode === "devnet" && config.devnetProofApproved && Boolean(config.devnetFunderKeypairPath);
-  const policy = currentPolicy(config.policyMode, devnetToolsEnabled);
+  const specialistInvokeEnabled = config.policyMode === "devnet" && config.devnetProofApproved && config.allowSpecialistInvoke && Boolean(config.devnetWalletKeypairPath) && Boolean(config.devnetUsdcMint) && config.specialistEndpointAllowlist.length > 0;
+  const policy = currentPolicy(config.policyMode, devnetToolsEnabled, specialistInvokeEnabled);
   const client = new RapClient(config);
   const store = new BridgeStore(config.storeDir);
   const server = new McpServer({ name: "reddi-rap-mcp-bridge", version: "0.1.0" });
@@ -69,12 +74,29 @@ export function createServer(env: NodeJS.ProcessEnv = process.env) {
     }, async (args) => jsonContent(await verifyDevnetReceipt(args, store)));
   }
 
+  if (specialistInvokeEnabled) {
+    server.registerTool("reddi.prepare_x402_specialist_call", {
+      description: "Prepare a bounded devnet USDC x402 specialist call from a 402 challenge. Non-mutating readiness check; devnet only.",
+      inputSchema: prepareX402SpecialistCallInputSchema,
+    }, async (args) => jsonContent(await prepareX402SpecialistCall(args, config)));
+
+    server.registerTool("reddi.execute_x402_specialist_call", {
+      description: "Execute a bounded devnet USDC x402 specialist call. Requires approval phrase; devnet only; no mainnet.",
+      inputSchema: executeX402SpecialistCallInputSchema,
+    }, async (args) => jsonContent(await executeX402SpecialistCall(args, config, store)));
+
+    server.registerTool("reddi.verify_x402_specialist_receipt", {
+      description: "Verify a bridge-stored devnet x402 specialist receipt. Never claims mainnet settlement.",
+      inputSchema: verifyX402SpecialistReceiptInputSchema,
+    }, async (args) => jsonContent(verifyX402SpecialistReceipt(args, store)));
+  }
+
   server.registerResource("reddi-policy-current", "reddi://policy/current", {
     title: "Current RAP MCP Bridge policy",
     description: "Current policy state for the RAP MCP Bridge.",
     mimeType: "application/json",
   }, async (uri) => ({
-    contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify({ config: { rapBaseUrl: config.rapBaseUrl, hostFramework: config.hostFramework, agentName: config.agentName, policyMode: config.policyMode, devnetProofApproved: config.devnetProofApproved, devnetFunderConfigured: Boolean(config.devnetFunderKeypairPath) }, policy }, null, 2) }],
+    contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify({ config: { rapBaseUrl: config.rapBaseUrl, hostFramework: config.hostFramework, agentName: config.agentName, policyMode: config.policyMode, devnetProofApproved: config.devnetProofApproved, devnetFunderConfigured: Boolean(config.devnetFunderKeypairPath), specialistInvokeConfigured: specialistInvokeEnabled }, policy }, null, 2) }],
   }));
 
   return server;

--- a/packages/rap-mcp-bridge/src/store.ts
+++ b/packages/rap-mcp-bridge/src/store.ts
@@ -7,6 +7,8 @@ type StoreData = {
   idempotency: Record<string, { quoteId: string; requestHash: string }>;
   devnetReceipts: DevnetReceipt[];
   devnetIdempotency: Record<string, { receiptId: string; quoteId: string; requestHash: string }>;
+  x402SpecialistReceipts: X402SpecialistReceipt[];
+  x402SpecialistIdempotency: Record<string, { receiptId: string; requestHash: string }>;
 };
 
 export type DevnetReceipt = {
@@ -26,7 +28,19 @@ export type DevnetReceipt = {
   disclosureLedgerEntry: Record<string, unknown>;
 };
 
-const EMPTY: StoreData = { quotes: [], idempotency: {}, devnetReceipts: [], devnetIdempotency: {} };
+export type X402SpecialistReceipt = {
+  schemaVersion: "reddi.rap-mcp-bridge.x402-specialist-call-receipt.v1";
+  receiptId: string;
+  createdAt: string;
+  boundary: "solana-devnet-only-no-mainnet";
+  endpoint: string;
+  requestHash: string;
+  paymentReceipt: Record<string, unknown>;
+  response: { status: 200; bodyHash: string; outputPreview: string };
+  verification: { specialistHttpCompletion: "pass"; mainnetSettlement: "not_applicable" };
+};
+
+const EMPTY: StoreData = { quotes: [], idempotency: {}, devnetReceipts: [], devnetIdempotency: {}, x402SpecialistReceipts: [], x402SpecialistIdempotency: {} };
 
 export class BridgeStore {
   constructor(private readonly dir: string) {}
@@ -36,9 +50,9 @@ export class BridgeStore {
   read(): StoreData {
     try {
       const data = JSON.parse(readFileSync(this.path(), "utf8")) as Partial<StoreData>;
-      return { quotes: data.quotes ?? [], idempotency: data.idempotency ?? {}, devnetReceipts: data.devnetReceipts ?? [], devnetIdempotency: data.devnetIdempotency ?? {} };
+      return { quotes: data.quotes ?? [], idempotency: data.idempotency ?? {}, devnetReceipts: data.devnetReceipts ?? [], devnetIdempotency: data.devnetIdempotency ?? {}, x402SpecialistReceipts: data.x402SpecialistReceipts ?? [], x402SpecialistIdempotency: data.x402SpecialistIdempotency ?? {} };
     } catch {
-      return { ...EMPTY, quotes: [], idempotency: {}, devnetReceipts: [], devnetIdempotency: {} };
+      return { ...EMPTY, quotes: [], idempotency: {}, devnetReceipts: [], devnetIdempotency: {}, x402SpecialistReceipts: [], x402SpecialistIdempotency: {} };
     }
   }
 
@@ -97,5 +111,38 @@ export class BridgeStore {
 
   listDevnetReceipts(quoteId: string): DevnetReceipt[] {
     return this.read().devnetReceipts.filter((receipt) => receipt.quoteId === quoteId);
+  }
+
+  getX402SpecialistReceiptByIdempotency(idempotencyKey: string): { requestHash: string; receipt: X402SpecialistReceipt } | undefined {
+    const data = this.read();
+    const prior = data.x402SpecialistIdempotency[idempotencyKey];
+    if (!prior) return undefined;
+    const receipt = data.x402SpecialistReceipts.find((candidate) => candidate.receiptId === prior.receiptId);
+    return receipt ? { requestHash: prior.requestHash, receipt } : undefined;
+  }
+
+  getX402SpecialistReceipt(receiptId: string): X402SpecialistReceipt | undefined {
+    return this.read().x402SpecialistReceipts.find((receipt) => receipt.receiptId === receiptId);
+  }
+
+  listX402SpecialistReceipts(ids: string[]): X402SpecialistReceipt[] {
+    const data = this.read();
+    if (ids.length === 0) return data.x402SpecialistReceipts.slice(-10);
+    const wanted = new Set(ids);
+    return data.x402SpecialistReceipts.filter((receipt) => wanted.has(receipt.receiptId));
+  }
+
+  upsertX402SpecialistReceipt(idempotencyKey: string, requestHash: string, receipt: X402SpecialistReceipt): X402SpecialistReceipt {
+    const data = this.read();
+    if (data.x402SpecialistIdempotency[idempotencyKey]) {
+      const prior = data.x402SpecialistIdempotency[idempotencyKey];
+      if (prior.requestHash !== requestHash) throw new Error("idempotency_key_conflict");
+      const existing = data.x402SpecialistReceipts.find((candidate) => candidate.receiptId === prior.receiptId);
+      if (existing) return existing;
+    }
+    data.x402SpecialistReceipts.push(receipt);
+    data.x402SpecialistIdempotency[idempotencyKey] = { receiptId: receipt.receiptId, requestHash };
+    this.write(data);
+    return receipt;
   }
 }

--- a/packages/rap-mcp-bridge/src/tools/export-disclosure-ledger.ts
+++ b/packages/rap-mcp-bridge/src/tools/export-disclosure-ledger.ts
@@ -1,13 +1,15 @@
 import type { BridgeStore } from "../store.js";
 import { sha256Json } from "../hash.js";
 
-export function exportDisclosureLedger(args: { quoteIds: string[] }, store: BridgeStore) {
+export function exportDisclosureLedger(args: { quoteIds: string[]; x402ReceiptIds?: string[] }, store: BridgeStore) {
   const quotes = store.listQuotes(args.quoteIds);
+  const x402Receipts = store.listX402SpecialistReceipts(args.x402ReceiptIds ?? []);
   return {
     schemaVersion: "reddi.downstream-disclosure-ledger.v1",
     generatedAt: new Date().toISOString(),
     safePublicEvidenceOnly: true,
-    entries: quotes.map((quote) => ({
+    entries: [
+      ...quotes.map((quote) => ({
       entryId: `ledger_${quote.quoteId}`,
       runId: `planned_${quote.quoteId}`,
       quoteId: quote.quoteId,
@@ -22,5 +24,22 @@ export function exportDisclosureLedger(args: { quoteIds: string[] }, store: Brid
       verificationStatus: "planned",
       evidenceRefs: [quote.quoteId, quote.termsHash, sha256Json({ quoteId: quote.quoteId, termsHash: quote.termsHash })],
     })),
+      ...x402Receipts.map((receipt) => ({
+        entryId: `ledger_${receipt.receiptId}`,
+        runId: `paid_${receipt.receiptId}`,
+        quoteId: undefined,
+        specialistEndpoint: receipt.endpoint,
+        capability: "specialist_http_x402",
+        payloadClass: "structured_json_summary",
+        payloadHash: receipt.requestHash,
+        amount: receipt.paymentReceipt.amount,
+        currency: receipt.paymentReceipt.currency,
+        network: receipt.paymentReceipt.network,
+        paymentReceiptHash: sha256Json(JSON.parse(JSON.stringify(receipt.paymentReceipt))),
+        verificationStatus: "devnet_verified",
+        responseHash: receipt.response.bodyHash,
+        evidenceRefs: [receipt.receiptId, receipt.requestHash, String(receipt.paymentReceipt.signature ?? receipt.paymentReceipt.txSignature ?? "")].filter(Boolean),
+      })),
+    ],
   };
 }

--- a/packages/rap-mcp-bridge/src/tools/x402-specialist-call.ts
+++ b/packages/rap-mcp-bridge/src/tools/x402-specialist-call.ts
@@ -1,0 +1,106 @@
+import { Connection } from "@solana/web3.js";
+import {
+  challengeFromX402RequestHeader,
+  createSolanaDevnetUsdcPaymentClient,
+  executeDevnetUsdcPayment,
+  prepareDevnetUsdcPayment,
+  type DevnetUsdcPaymentClient,
+} from "@reddi/x402-solana";
+import type { BridgeConfig } from "../config.js";
+import { sha256Json } from "../hash.js";
+import type { BridgeStore, X402SpecialistReceipt } from "../store.js";
+
+export type PrepareX402SpecialistCallArgs = {
+  x402RequestHeader: string;
+  maxUsdcMicroUnits?: number;
+};
+
+export type ExecuteX402SpecialistCallArgs = {
+  endpoint: string;
+  body: Record<string, unknown>;
+  idempotencyKey: string;
+  maxUsdcMicroUnits: number;
+  approvalPhrase: "EXECUTE_DEVNET_X402_SPECIALIST_CALL";
+};
+
+export type FetchLike = (url: string, init: { method: "POST"; headers: Record<string, string>; body: string }) => Promise<{ status: number; headers: { get(name: string): string | null }; text(): Promise<string> }>;
+
+function assertLiveSpecialistConfig(config: BridgeConfig) {
+  if (config.policyMode !== "devnet") throw new Error("devnet_mode_not_enabled");
+  if (!config.devnetProofApproved) throw new Error("devnet_x402_requires_RAP_MCP_DEVNET_PROOF_APPROVED=1");
+  if (!config.allowSpecialistInvoke) throw new Error("specialist_invoke_requires_RAP_MCP_ALLOW_SPECIALIST_INVOKE=1");
+  if (!config.devnetWalletKeypairPath) throw new Error("devnet_x402_requires_RAP_MCP_DEVNET_WALLET_KEYPAIR");
+  if (!config.devnetUsdcMint) throw new Error("devnet_x402_requires_RAP_MCP_DEVNET_USDC_MINT");
+  if (config.specialistEndpointAllowlist.length === 0) throw new Error("specialist_endpoint_allowlist_required");
+}
+
+function paymentConfig(config: BridgeConfig, maxUsdcMicroUnits?: number) {
+  const devnetUsdcMint = config.devnetUsdcMint;
+  const devnetWalletKeypairPath = config.devnetWalletKeypairPath;
+  if (!devnetUsdcMint || !devnetWalletKeypairPath) throw new Error("devnet_x402_config_missing");
+  return {
+    rpcUrl: config.devnetRpcUrl,
+    usdcMint: devnetUsdcMint,
+    walletKeypairPath: devnetWalletKeypairPath,
+    endpointAllowlist: config.specialistEndpointAllowlist,
+    maxUsdcMicroUnits: Math.min(maxUsdcMicroUnits ?? config.devnetMaxUsdcMicroUnits, config.devnetMaxUsdcMicroUnits),
+  };
+}
+
+export async function prepareX402SpecialistCall(args: PrepareX402SpecialistCallArgs, config: BridgeConfig, client?: DevnetUsdcPaymentClient) {
+  assertLiveSpecialistConfig(config);
+  const challenge = challengeFromX402RequestHeader(args.x402RequestHeader);
+  const paymentClient = client ?? createSolanaDevnetUsdcPaymentClient(new Connection(config.devnetRpcUrl, "confirmed"));
+  return prepareDevnetUsdcPayment({ challenge, config: paymentConfig(config, args.maxUsdcMicroUnits), client: paymentClient });
+}
+
+export function verifyX402SpecialistReceipt(args: { receiptId?: string; idempotencyKey?: string }, store: BridgeStore) {
+  const receipt = args.receiptId
+    ? store.getX402SpecialistReceipt(args.receiptId)
+    : args.idempotencyKey
+      ? store.getX402SpecialistReceiptByIdempotency(args.idempotencyKey)?.receipt
+      : undefined;
+  return {
+    schemaVersion: "reddi.rap-mcp-bridge.x402-specialist-call-verification.v1",
+    verified: Boolean(receipt && receipt.verification.specialistHttpCompletion === "pass"),
+    boundary: "solana-devnet-only-no-mainnet",
+    mainnetSettlement: "not_applicable",
+    receipt: receipt ?? null,
+  };
+}
+
+export async function executeX402SpecialistCall(args: ExecuteX402SpecialistCallArgs, config: BridgeConfig, store: BridgeStore, deps?: { client?: DevnetUsdcPaymentClient; fetch?: FetchLike }): Promise<X402SpecialistReceipt> {
+  assertLiveSpecialistConfig(config);
+  const requestBodyJson = JSON.stringify(args.body);
+  const requestHash = sha256Json({ endpoint: args.endpoint, body: JSON.parse(requestBodyJson), maxUsdcMicroUnits: args.maxUsdcMicroUnits });
+  const existing = store.getX402SpecialistReceiptByIdempotency(args.idempotencyKey);
+  if (existing) {
+    if (existing.requestHash !== requestHash) throw new Error("idempotency_key_conflict");
+    return existing.receipt;
+  }
+  const fetcher = deps?.fetch ?? (globalThis.fetch as unknown as FetchLike | undefined);
+  if (!fetcher) throw new Error("fetch_unavailable");
+  const body = requestBodyJson;
+  const unpaid = await fetcher(args.endpoint, { method: "POST", headers: { "content-type": "application/json" }, body });
+  if (unpaid.status !== 402) throw new Error(`expected_x402_challenge_status_402:${unpaid.status}`);
+  const x402RequestHeader = unpaid.headers.get("x402-request");
+  if (!x402RequestHeader) throw new Error("missing_x402_request_header");
+  const challenge = challengeFromX402RequestHeader(x402RequestHeader);
+  const paymentClient = deps?.client ?? createSolanaDevnetUsdcPaymentClient(new Connection(config.devnetRpcUrl, "confirmed"));
+  const receipt = await executeDevnetUsdcPayment({ challenge, config: paymentConfig(config, args.maxUsdcMicroUnits), client: paymentClient, approvalPhrase: args.approvalPhrase });
+  const paid = await fetcher(args.endpoint, { method: "POST", headers: { "content-type": "application/json", "x402-payment": JSON.stringify(receipt) }, body });
+  if (paid.status !== 200) throw new Error(`specialist_paid_retry_failed:${paid.status}`);
+  const responseText = await paid.text();
+  const bridgeReceipt: X402SpecialistReceipt = {
+    schemaVersion: "reddi.rap-mcp-bridge.x402-specialist-call-receipt.v1",
+    receiptId: `x402_specialist_${sha256Json({ requestHash, signature: receipt.signature ?? receipt.txSignature }).slice("sha256:".length, "sha256:".length + 24)}`,
+    createdAt: new Date().toISOString(),
+    boundary: "solana-devnet-only-no-mainnet",
+    endpoint: args.endpoint,
+    requestHash,
+    paymentReceipt: receipt as unknown as Record<string, unknown>,
+    response: { status: 200, bodyHash: sha256Json({ responseText }), outputPreview: responseText.slice(0, 500) },
+    verification: { specialistHttpCompletion: "pass", mainnetSettlement: "not_applicable" },
+  };
+  return store.upsertX402SpecialistReceipt(args.idempotencyKey, requestHash, bridgeReceipt);
+}

--- a/packages/rap-mcp-bridge/tests/x402-specialist-call.test.ts
+++ b/packages/rap-mcp-bridge/tests/x402-specialist-call.test.ts
@@ -1,0 +1,173 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Keypair, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import { loadConfig } from "../src/config.js";
+import { currentPolicy } from "../src/policy.js";
+import { BridgeStore } from "../src/store.js";
+import { exportDisclosureLedger } from "../src/tools/export-disclosure-ledger.js";
+import { executeX402SpecialistCall, prepareX402SpecialistCall, verifyX402SpecialistReceipt, type FetchLike } from "../src/tools/x402-specialist-call.js";
+import type { DevnetUsdcPaymentClient } from "@reddi/x402-solana";
+
+const payTo = "3mL7kbtz3eK24vJ6wftjnLvhZrf93B71UEjB2DBDAddr";
+const usdcMint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+const endpoint = "https://reddi-code-generation.preview.reddi.tech/v1/chat/completions";
+
+function walletFile() {
+  const dir = mkdtempSync(join(tmpdir(), "rap-mcp-x402-wallet-"));
+  const kp = Keypair.generate();
+  const path = join(dir, "wallet.json");
+  writeFileSync(path, JSON.stringify(Array.from(kp.secretKey)));
+  return { dir, path, kp };
+}
+
+function header(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    version: "1",
+    network: "solana-devnet",
+    payTo,
+    amount: "0.05",
+    currency: "USDC",
+    endpoint,
+    nonce: "nonce-mcp-1",
+    ...overrides,
+  });
+}
+
+function fakeClient(options: { allowSubmit?: boolean } = {}): DevnetUsdcPaymentClient {
+  return {
+    async getSolBalanceLamports() { return LAMPORTS_PER_SOL; },
+    async getUsdcBalanceMicroUnits() { return 100_000n; },
+    async getOrCreateDestinationTokenAccount() { return "dest-token-account"; },
+    async submitUsdcTransfer() {
+      if (!options.allowSubmit) throw new Error("prepare must not submit transfer");
+      return { signature: "fake-devnet-usdc-signature", destinationTokenAccount: "dest-token-account" };
+    },
+  };
+}
+
+test("x402 specialist invoke policy is hidden unless all gates are ready", () => {
+  assert.equal(currentPolicy("devnet", true, false).allowInvoke, false);
+  assert.equal(currentPolicy("devnet", true, false).toolNames.includes("reddi.prepare_x402_specialist_call"), false);
+  const policy = currentPolicy("devnet", true, true);
+  assert.equal(policy.allowInvoke, true);
+  assert.equal(policy.toolNames.includes("reddi.prepare_x402_specialist_call"), true);
+  assert.equal(policy.toolNames.includes("reddi.execute_x402_specialist_call"), true);
+  assert.equal(policy.toolNames.includes("reddi.verify_x402_specialist_receipt"), true);
+});
+
+test("loadConfig captures specialist invoke gates without enabling them by default", () => {
+  const config = loadConfig({ HOME: tmpdir() });
+  assert.equal(config.allowSpecialistInvoke, false);
+  assert.deepEqual(config.specialistEndpointAllowlist, []);
+  assert.equal(config.devnetMaxUsdcMicroUnits, 150_000);
+});
+
+test("prepare_x402_specialist_call is non-mutating and returns readiness when gates are configured", async () => {
+  const { dir, path, kp } = walletFile();
+  try {
+    const config = loadConfig({
+      HOME: tmpdir(),
+      REDDI_RAP_MCP_MODE: "devnet",
+      RAP_MCP_DEVNET_PROOF_APPROVED: "1",
+      RAP_MCP_ALLOW_SPECIALIST_INVOKE: "1",
+      RAP_MCP_DEVNET_WALLET_KEYPAIR: path,
+      RAP_MCP_DEVNET_USDC_MINT: usdcMint,
+      RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST: endpoint,
+      RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS: "150000",
+    });
+    const result = await prepareX402SpecialistCall({ x402RequestHeader: header() }, config, fakeClient());
+    assert.equal(result.ready, true);
+    assert.equal(result.payer, kp.publicKey.toBase58());
+    assert.equal(result.spend.amountMicroUnits, "50000");
+    assert.equal(JSON.stringify(result).includes(JSON.stringify(Array.from(kp.secretKey))), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("execute_x402_specialist_call performs fake 402 to paid retry flow and stores idempotent receipt", async () => {
+  const { dir, path, kp } = walletFile();
+  const storeDir = mkdtempSync(join(tmpdir(), "rap-mcp-x402-store-"));
+  try {
+    const config = loadConfig({
+      HOME: tmpdir(),
+      REDDI_RAP_MCP_MODE: "devnet",
+      RAP_MCP_DEVNET_PROOF_APPROVED: "1",
+      RAP_MCP_ALLOW_SPECIALIST_INVOKE: "1",
+      RAP_MCP_DEVNET_WALLET_KEYPAIR: path,
+      RAP_MCP_DEVNET_USDC_MINT: usdcMint,
+      RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST: endpoint,
+      RAP_MCP_DEVNET_MAX_USDC_MICRO_UNITS: "150000",
+    });
+    const calls: Array<Record<string, unknown>> = [];
+    const fetcher: FetchLike = async (_url, init) => {
+      calls.push({ headers: init.headers, body: init.body });
+      if (!init.headers["x402-payment"]) {
+        return { status: 402, headers: { get: (name: string) => name === "x402-request" ? header() : null }, async text() { return "payment required"; } };
+      }
+      return { status: 200, headers: { get: () => null }, async text() { return JSON.stringify({ answer: "specialist output" }); } };
+    };
+    const receipt = await executeX402SpecialistCall({
+      endpoint,
+      body: { messages: [{ role: "user", content: "help" }] },
+      idempotencyKey: "idem-live-x402-1",
+      maxUsdcMicroUnits: 150_000,
+      approvalPhrase: "EXECUTE_DEVNET_X402_SPECIALIST_CALL",
+    }, config, new BridgeStore(storeDir), { client: fakeClient({ allowSubmit: true }), fetch: fetcher });
+    assert.equal(receipt.boundary, "solana-devnet-only-no-mainnet");
+    assert.equal(receipt.response.status, 200);
+    assert.equal(receipt.paymentReceipt.payer, kp.publicKey.toBase58());
+    assert.equal(calls.length, 2);
+    assert.ok((calls[1].headers as Record<string, string>)["x402-payment"]);
+
+    const again = await executeX402SpecialistCall({
+      endpoint,
+      body: { messages: [{ role: "user", content: "help" }] },
+      idempotencyKey: "idem-live-x402-1",
+      maxUsdcMicroUnits: 150_000,
+      approvalPhrase: "EXECUTE_DEVNET_X402_SPECIALIST_CALL",
+    }, config, new BridgeStore(storeDir), { client: fakeClient({ allowSubmit: true }), fetch: fetcher });
+    assert.equal(again.receiptId, receipt.receiptId);
+    assert.equal(calls.length, 2);
+
+    const verification = verifyX402SpecialistReceipt({ receiptId: receipt.receiptId }, new BridgeStore(storeDir));
+    assert.equal(verification.verified, true);
+    assert.equal(verification.mainnetSettlement, "not_applicable");
+
+    const ledger = exportDisclosureLedger({ quoteIds: [], x402ReceiptIds: [receipt.receiptId] }, new BridgeStore(storeDir));
+    assert.equal(ledger.entries.length, 1);
+    assert.equal(ledger.entries[0].verificationStatus, "devnet_verified");
+    assert.equal(ledger.entries[0].paymentReceiptHash?.startsWith("sha256:"), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(storeDir, { recursive: true, force: true });
+  }
+});
+
+test("prepare_x402_specialist_call rejects missing gates and non-allowlisted endpoints", async () => {
+  await assert.rejects(
+    prepareX402SpecialistCall({ x402RequestHeader: header() }, loadConfig({ HOME: tmpdir() }), fakeClient()),
+    /devnet_mode_not_enabled/,
+  );
+
+  const { dir, path } = walletFile();
+  try {
+    const config = loadConfig({
+      HOME: tmpdir(),
+      REDDI_RAP_MCP_MODE: "devnet",
+      RAP_MCP_DEVNET_PROOF_APPROVED: "1",
+      RAP_MCP_ALLOW_SPECIALIST_INVOKE: "1",
+      RAP_MCP_DEVNET_WALLET_KEYPAIR: path,
+      RAP_MCP_DEVNET_USDC_MINT: usdcMint,
+      RAP_MCP_SPECIALIST_ENDPOINT_ALLOWLIST: endpoint,
+    });
+    const result = await prepareX402SpecialistCall({ x402RequestHeader: header({ endpoint: "https://evil.example.test/v1/chat/completions" }) }, config, fakeClient());
+    assert.equal(result.ready, false);
+    assert.match(result.reasons.join(","), /specialist_endpoint_not_allowlisted/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/x402-solana/dist/client.d.ts
+++ b/packages/x402-solana/dist/client.d.ts
@@ -1,0 +1,71 @@
+import { Keypair, PublicKey, type Connection } from '@solana/web3.js';
+import type { X402Challenge, X402PaymentReceipt } from './types';
+declare const APPROVAL_PHRASE = "EXECUTE_DEVNET_X402_SPECIALIST_CALL";
+export type DevnetUsdcTransferResult = {
+    signature: string;
+    destinationTokenAccount: string;
+};
+export type DevnetUsdcPaymentClient = {
+    getSolBalanceLamports(publicKey: PublicKey): Promise<number>;
+    getUsdcBalanceMicroUnits(owner: PublicKey, mint: PublicKey): Promise<bigint>;
+    getOrCreateDestinationTokenAccount(payTo: PublicKey, mint: PublicKey): Promise<string>;
+    submitUsdcTransfer(input: {
+        payer: Keypair;
+        payTo: PublicKey;
+        mint: PublicKey;
+        amountMicroUnits: bigint;
+        destinationTokenAccount: string;
+        challenge: X402Challenge;
+    }): Promise<DevnetUsdcTransferResult>;
+};
+export type DevnetUsdcPaymentConfig = {
+    rpcUrl: string;
+    usdcMint: string;
+    walletKeypairPath: string;
+    endpointAllowlist: string[];
+    maxUsdcMicroUnits: bigint | number | string;
+    minFeeLamports?: number;
+};
+export type DevnetUsdcPaymentReadiness = {
+    schemaVersion: 'reddi.x402-solana.devnet-usdc-payment-readiness.v1';
+    ready: boolean;
+    boundary: 'solana-devnet-only-no-mainnet';
+    reasons: string[];
+    payer: string | null;
+    challenge: Pick<X402Challenge, 'network' | 'payTo' | 'amount' | 'currency' | 'endpoint' | 'nonce'>;
+    spend: {
+        amountMicroUnits: string;
+        maxUsdcMicroUnits: string;
+        capRespected: boolean;
+    };
+    balances: {
+        solLamports: number | null;
+        usdcMicroUnits: string | null;
+    };
+    destinationTokenAccount: string | null;
+};
+export type ExecuteDevnetUsdcPaymentInput = {
+    challenge: X402Challenge;
+    config: DevnetUsdcPaymentConfig;
+    client: DevnetUsdcPaymentClient;
+    approvalPhrase: typeof APPROVAL_PHRASE;
+};
+export declare function loadDevnetKeypair(path: string): Keypair;
+export declare function assertDevnetRpcUrl(rpcUrl: string): void;
+export declare function assertEndpointAllowed(endpoint: string, allowlist: string[]): void;
+export declare function usdcAmountToMicroUnits(amount: string | number): bigint;
+export declare function validateDevnetUsdcChallenge(challenge: X402Challenge, config: DevnetUsdcPaymentConfig): {
+    payTo: PublicKey;
+    mint: PublicKey;
+    amountMicroUnits: bigint;
+    maxUsdcMicroUnits: bigint;
+};
+export declare function prepareDevnetUsdcPayment(input: {
+    challenge: X402Challenge;
+    config: DevnetUsdcPaymentConfig;
+    client: Pick<DevnetUsdcPaymentClient, 'getSolBalanceLamports' | 'getUsdcBalanceMicroUnits' | 'getOrCreateDestinationTokenAccount'>;
+}): Promise<DevnetUsdcPaymentReadiness>;
+export declare function executeDevnetUsdcPayment(input: ExecuteDevnetUsdcPaymentInput): Promise<X402PaymentReceipt>;
+export declare function createSolanaDevnetUsdcPaymentClient(connection: Connection): DevnetUsdcPaymentClient;
+export declare function challengeFromX402RequestHeader(header: string): X402Challenge;
+export {};

--- a/packages/x402-solana/dist/client.js
+++ b/packages/x402-solana/dist/client.js
@@ -1,0 +1,210 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.loadDevnetKeypair = loadDevnetKeypair;
+exports.assertDevnetRpcUrl = assertDevnetRpcUrl;
+exports.assertEndpointAllowed = assertEndpointAllowed;
+exports.usdcAmountToMicroUnits = usdcAmountToMicroUnits;
+exports.validateDevnetUsdcChallenge = validateDevnetUsdcChallenge;
+exports.prepareDevnetUsdcPayment = prepareDevnetUsdcPayment;
+exports.executeDevnetUsdcPayment = executeDevnetUsdcPayment;
+exports.createSolanaDevnetUsdcPaymentClient = createSolanaDevnetUsdcPaymentClient;
+exports.challengeFromX402RequestHeader = challengeFromX402RequestHeader;
+const node_fs_1 = require("node:fs");
+const web3_js_1 = require("@solana/web3.js");
+const spl_token_1 = require("@solana/spl-token");
+const payment_1 = require("./payment");
+const DEVNET_NETWORK = 'solana-devnet';
+const DEFAULT_MIN_FEE_LAMPORTS = 5000;
+const APPROVAL_PHRASE = 'EXECUTE_DEVNET_X402_SPECIALIST_CALL';
+function loadDevnetKeypair(path) {
+    if (!path || !(0, node_fs_1.existsSync)(path))
+        throw new Error('devnet_wallet_keypair_unavailable');
+    const secret = JSON.parse((0, node_fs_1.readFileSync)(path, 'utf8'));
+    if (!Array.isArray(secret))
+        throw new Error('devnet_wallet_keypair_invalid');
+    return web3_js_1.Keypair.fromSecretKey(Uint8Array.from(secret));
+}
+function assertDevnetRpcUrl(rpcUrl) {
+    let parsed;
+    try {
+        parsed = new URL(rpcUrl);
+    }
+    catch {
+        throw new Error('invalid_devnet_rpc_url');
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol))
+        throw new Error('unsupported_devnet_rpc_url_protocol');
+    const host = parsed.hostname.toLowerCase();
+    if (host.includes('mainnet'))
+        throw new Error('mainnet_rpc_url_forbidden');
+    const allowed = host === 'api.devnet.solana.com' || host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.includes('devnet');
+    if (!allowed)
+        throw new Error(`unsupported_devnet_rpc_url_host:${parsed.hostname}`);
+}
+function assertEndpointAllowed(endpoint, allowlist) {
+    if (!allowlist.length)
+        throw new Error('specialist_endpoint_allowlist_required');
+    let parsed;
+    try {
+        parsed = new URL(endpoint);
+    }
+    catch {
+        throw new Error('invalid_specialist_endpoint_url');
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol))
+        throw new Error('unsupported_specialist_endpoint_protocol');
+    if (!allowlist.includes(endpoint))
+        throw new Error('specialist_endpoint_not_allowlisted');
+}
+function usdcAmountToMicroUnits(amount) {
+    const text = String(amount);
+    if (!/^\d+(\.\d{1,6})?$/.test(text))
+        throw new Error('invalid_usdc_amount');
+    const [wholeRaw, fracRaw = ''] = text.split('.');
+    const whole = BigInt(wholeRaw || '0');
+    const frac = BigInt((fracRaw + '000000').slice(0, 6));
+    const microUnits = whole * 1000000n + frac;
+    if (microUnits <= 0n)
+        throw new Error('invalid_usdc_amount');
+    return microUnits;
+}
+function normalizeCap(value) {
+    const cap = BigInt(value);
+    if (cap <= 0n)
+        throw new Error('invalid_devnet_usdc_spend_cap');
+    return cap;
+}
+function validateDevnetUsdcChallenge(challenge, config) {
+    assertDevnetRpcUrl(config.rpcUrl);
+    assertEndpointAllowed(challenge.endpoint, config.endpointAllowlist);
+    if (challenge.network !== DEVNET_NETWORK)
+        throw new Error('x402_challenge_not_solana_devnet');
+    if (String(challenge.currency).toUpperCase() !== 'USDC')
+        throw new Error('x402_challenge_currency_must_be_USDC');
+    if (!challenge.nonce)
+        throw new Error('x402_challenge_nonce_required');
+    if (!(0, payment_1.isValidSolanaPublicKey)(challenge.payTo))
+        throw new Error('x402_challenge_payee_invalid');
+    if (!(0, payment_1.isValidSolanaPublicKey)(config.usdcMint))
+        throw new Error('devnet_usdc_mint_invalid');
+    const amountMicroUnits = usdcAmountToMicroUnits(challenge.amount);
+    const maxUsdcMicroUnits = normalizeCap(config.maxUsdcMicroUnits);
+    if (amountMicroUnits > maxUsdcMicroUnits)
+        throw new Error(`devnet_usdc_spend_cap_exceeded:${amountMicroUnits}>${maxUsdcMicroUnits}`);
+    return {
+        payTo: new web3_js_1.PublicKey(challenge.payTo),
+        mint: new web3_js_1.PublicKey(config.usdcMint),
+        amountMicroUnits,
+        maxUsdcMicroUnits,
+    };
+}
+async function prepareDevnetUsdcPayment(input) {
+    const reasons = [];
+    let payer = null;
+    let payTo;
+    let mint;
+    let amountMicroUnits;
+    let maxUsdcMicroUnits;
+    try {
+        ({ payTo, mint, amountMicroUnits, maxUsdcMicroUnits } = validateDevnetUsdcChallenge(input.challenge, input.config));
+        payer = loadDevnetKeypair(input.config.walletKeypairPath);
+    }
+    catch (error) {
+        return readiness(input.challenge, null, '0', String(input.config.maxUsdcMicroUnits), false, reasons.concat(error instanceof Error ? error.message : String(error)), null, null, null);
+    }
+    const solLamports = await input.client.getSolBalanceLamports(payer.publicKey);
+    const usdcMicroUnits = await input.client.getUsdcBalanceMicroUnits(payer.publicKey, mint);
+    const destinationTokenAccount = await input.client.getOrCreateDestinationTokenAccount(payTo, mint);
+    const minFeeLamports = input.config.minFeeLamports ?? DEFAULT_MIN_FEE_LAMPORTS;
+    if (solLamports < minFeeLamports)
+        reasons.push(`insufficient_sol_for_fees:${solLamports}<${minFeeLamports}`);
+    if (usdcMicroUnits < amountMicroUnits)
+        reasons.push(`insufficient_usdc:${usdcMicroUnits}<${amountMicroUnits}`);
+    return readiness(input.challenge, payer.publicKey.toBase58(), String(amountMicroUnits), String(maxUsdcMicroUnits), amountMicroUnits <= maxUsdcMicroUnits, reasons, solLamports, String(usdcMicroUnits), destinationTokenAccount);
+}
+function readiness(challenge, payer, amountMicroUnits, maxUsdcMicroUnits, capRespected, reasons, solLamports, usdcMicroUnits, destinationTokenAccount) {
+    return {
+        schemaVersion: 'reddi.x402-solana.devnet-usdc-payment-readiness.v1',
+        ready: reasons.length === 0,
+        boundary: 'solana-devnet-only-no-mainnet',
+        reasons,
+        payer,
+        challenge: {
+            network: challenge.network,
+            payTo: challenge.payTo,
+            amount: challenge.amount,
+            currency: challenge.currency,
+            endpoint: challenge.endpoint,
+            nonce: challenge.nonce,
+        },
+        spend: { amountMicroUnits, maxUsdcMicroUnits, capRespected },
+        balances: { solLamports, usdcMicroUnits },
+        destinationTokenAccount,
+    };
+}
+async function executeDevnetUsdcPayment(input) {
+    if (input.approvalPhrase !== APPROVAL_PHRASE)
+        throw new Error('missing_devnet_x402_specialist_call_approval_phrase');
+    const { payTo, mint, amountMicroUnits } = validateDevnetUsdcChallenge(input.challenge, input.config);
+    const payer = loadDevnetKeypair(input.config.walletKeypairPath);
+    const readiness = await prepareDevnetUsdcPayment({ challenge: input.challenge, config: input.config, client: input.client });
+    if (!readiness.ready)
+        throw new Error(`devnet_usdc_payment_not_ready:${readiness.reasons.join(',')}`);
+    const destinationTokenAccount = readiness.destinationTokenAccount ?? await input.client.getOrCreateDestinationTokenAccount(payTo, mint);
+    const result = await input.client.submitUsdcTransfer({ payer, payTo, mint, amountMicroUnits, destinationTokenAccount, challenge: input.challenge });
+    return {
+        network: DEVNET_NETWORK,
+        payTo: input.challenge.payTo,
+        amount: input.challenge.amount,
+        currency: 'USDC',
+        nonce: input.challenge.nonce,
+        signature: result.signature,
+        txSignature: result.signature,
+        payer: payer.publicKey.toBase58(),
+        mint: mint.toBase58(),
+        destinationTokenAccount: result.destinationTokenAccount,
+    };
+}
+function createSolanaDevnetUsdcPaymentClient(connection) {
+    return {
+        async getSolBalanceLamports(publicKey) {
+            return connection.getBalance(publicKey, 'confirmed');
+        },
+        async getUsdcBalanceMicroUnits(owner, mint) {
+            const tokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(mint, owner, false, spl_token_1.TOKEN_PROGRAM_ID, spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID);
+            const accountInfo = await connection.getAccountInfo(tokenAccount, 'confirmed');
+            if (!accountInfo)
+                return 0n;
+            const balance = await connection.getTokenAccountBalance(tokenAccount, 'confirmed');
+            return BigInt(balance.value.amount);
+        },
+        async getOrCreateDestinationTokenAccount(payTo, mint) {
+            return (0, spl_token_1.getAssociatedTokenAddressSync)(mint, payTo, false, spl_token_1.TOKEN_PROGRAM_ID, spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID).toBase58();
+        },
+        async submitUsdcTransfer(input) {
+            const sourceTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(input.mint, input.payer.publicKey, false, spl_token_1.TOKEN_PROGRAM_ID, spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID);
+            const destinationTokenAccount = new web3_js_1.PublicKey(input.destinationTokenAccount);
+            const tx = new web3_js_1.Transaction();
+            const destinationInfo = await connection.getAccountInfo(destinationTokenAccount, 'confirmed');
+            if (!destinationInfo) {
+                tx.add((0, spl_token_1.createAssociatedTokenAccountInstruction)(input.payer.publicKey, destinationTokenAccount, input.payTo, input.mint, spl_token_1.TOKEN_PROGRAM_ID, spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID));
+            }
+            tx.add((0, spl_token_1.createTransferCheckedInstruction)(sourceTokenAccount, input.mint, destinationTokenAccount, input.payer.publicKey, input.amountMicroUnits, 6, [], spl_token_1.TOKEN_PROGRAM_ID));
+            const signature = await (0, web3_js_1.sendAndConfirmTransaction)(connection, tx, [input.payer], { commitment: 'confirmed' });
+            return { signature, destinationTokenAccount: destinationTokenAccount.toBase58() };
+        },
+    };
+}
+function challengeFromX402RequestHeader(header) {
+    const parsed = JSON.parse(header);
+    return (0, payment_1.buildX402Challenge)({
+        version: typeof parsed.version === 'string' ? parsed.version : '1',
+        network: parsed.network,
+        payTo: typeof parsed.payTo === 'string' ? parsed.payTo : parsed.paymentAddress,
+        amount: parsed.amount,
+        currency: parsed.currency,
+        endpoint: parsed.endpoint,
+        nonce: parsed.nonce,
+        memo: typeof parsed.memo === 'string' ? parsed.memo : undefined,
+    });
+}

--- a/packages/x402-solana/dist/index.d.ts
+++ b/packages/x402-solana/dist/index.d.ts
@@ -9,3 +9,4 @@ export * from './nonce';
 export * from './payment';
 export * from './middleware';
 export * from './jupiter';
+export * from './client';

--- a/packages/x402-solana/dist/index.js
+++ b/packages/x402-solana/dist/index.js
@@ -25,3 +25,4 @@ __exportStar(require("./nonce"), exports);
 __exportStar(require("./payment"), exports);
 __exportStar(require("./middleware"), exports);
 __exportStar(require("./jupiter"), exports);
+__exportStar(require("./client"), exports);

--- a/packages/x402-solana/package.json
+++ b/packages/x402-solana/package.json
@@ -9,6 +9,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.95.8"
   },
   "devDependencies": {

--- a/packages/x402-solana/src/client.ts
+++ b/packages/x402-solana/src/client.ts
@@ -1,0 +1,287 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { Keypair, LAMPORTS_PER_SOL, PublicKey, sendAndConfirmTransaction, Transaction, type Connection } from '@solana/web3.js';
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  createAssociatedTokenAccountInstruction,
+  createTransferCheckedInstruction,
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import { buildX402Challenge, isValidSolanaPublicKey } from './payment';
+import type { SolanaPaymentNetwork, X402Challenge, X402PaymentReceipt } from './types';
+
+const DEVNET_NETWORK: SolanaPaymentNetwork = 'solana-devnet';
+const DEFAULT_MIN_FEE_LAMPORTS = 5_000;
+const APPROVAL_PHRASE = 'EXECUTE_DEVNET_X402_SPECIALIST_CALL';
+
+export type DevnetUsdcTransferResult = {
+  signature: string;
+  destinationTokenAccount: string;
+};
+
+export type DevnetUsdcPaymentClient = {
+  getSolBalanceLamports(publicKey: PublicKey): Promise<number>;
+  getUsdcBalanceMicroUnits(owner: PublicKey, mint: PublicKey): Promise<bigint>;
+  getOrCreateDestinationTokenAccount(payTo: PublicKey, mint: PublicKey): Promise<string>;
+  submitUsdcTransfer(input: {
+    payer: Keypair;
+    payTo: PublicKey;
+    mint: PublicKey;
+    amountMicroUnits: bigint;
+    destinationTokenAccount: string;
+    challenge: X402Challenge;
+  }): Promise<DevnetUsdcTransferResult>;
+};
+
+export type DevnetUsdcPaymentConfig = {
+  rpcUrl: string;
+  usdcMint: string;
+  walletKeypairPath: string;
+  endpointAllowlist: string[];
+  maxUsdcMicroUnits: bigint | number | string;
+  minFeeLamports?: number;
+};
+
+export type DevnetUsdcPaymentReadiness = {
+  schemaVersion: 'reddi.x402-solana.devnet-usdc-payment-readiness.v1';
+  ready: boolean;
+  boundary: 'solana-devnet-only-no-mainnet';
+  reasons: string[];
+  payer: string | null;
+  challenge: Pick<X402Challenge, 'network' | 'payTo' | 'amount' | 'currency' | 'endpoint' | 'nonce'>;
+  spend: {
+    amountMicroUnits: string;
+    maxUsdcMicroUnits: string;
+    capRespected: boolean;
+  };
+  balances: {
+    solLamports: number | null;
+    usdcMicroUnits: string | null;
+  };
+  destinationTokenAccount: string | null;
+};
+
+export type ExecuteDevnetUsdcPaymentInput = {
+  challenge: X402Challenge;
+  config: DevnetUsdcPaymentConfig;
+  client: DevnetUsdcPaymentClient;
+  approvalPhrase: typeof APPROVAL_PHRASE;
+};
+
+export function loadDevnetKeypair(path: string): Keypair {
+  if (!path || !existsSync(path)) throw new Error('devnet_wallet_keypair_unavailable');
+  const secret = JSON.parse(readFileSync(path, 'utf8'));
+  if (!Array.isArray(secret)) throw new Error('devnet_wallet_keypair_invalid');
+  return Keypair.fromSecretKey(Uint8Array.from(secret));
+}
+
+export function assertDevnetRpcUrl(rpcUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(rpcUrl);
+  } catch {
+    throw new Error('invalid_devnet_rpc_url');
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) throw new Error('unsupported_devnet_rpc_url_protocol');
+  const host = parsed.hostname.toLowerCase();
+  if (host.includes('mainnet')) throw new Error('mainnet_rpc_url_forbidden');
+  const allowed = host === 'api.devnet.solana.com' || host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.includes('devnet');
+  if (!allowed) throw new Error(`unsupported_devnet_rpc_url_host:${parsed.hostname}`);
+}
+
+export function assertEndpointAllowed(endpoint: string, allowlist: string[]): void {
+  if (!allowlist.length) throw new Error('specialist_endpoint_allowlist_required');
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    throw new Error('invalid_specialist_endpoint_url');
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) throw new Error('unsupported_specialist_endpoint_protocol');
+  if (!allowlist.includes(endpoint)) throw new Error('specialist_endpoint_not_allowlisted');
+}
+
+export function usdcAmountToMicroUnits(amount: string | number): bigint {
+  const text = String(amount);
+  if (!/^\d+(\.\d{1,6})?$/.test(text)) throw new Error('invalid_usdc_amount');
+  const [wholeRaw, fracRaw = ''] = text.split('.');
+  const whole = BigInt(wholeRaw || '0');
+  const frac = BigInt((fracRaw + '000000').slice(0, 6));
+  const microUnits = whole * 1_000_000n + frac;
+  if (microUnits <= 0n) throw new Error('invalid_usdc_amount');
+  return microUnits;
+}
+
+function normalizeCap(value: bigint | number | string): bigint {
+  const cap = BigInt(value);
+  if (cap <= 0n) throw new Error('invalid_devnet_usdc_spend_cap');
+  return cap;
+}
+
+export function validateDevnetUsdcChallenge(challenge: X402Challenge, config: DevnetUsdcPaymentConfig): {
+  payTo: PublicKey;
+  mint: PublicKey;
+  amountMicroUnits: bigint;
+  maxUsdcMicroUnits: bigint;
+} {
+  assertDevnetRpcUrl(config.rpcUrl);
+  assertEndpointAllowed(challenge.endpoint, config.endpointAllowlist);
+  if (challenge.network !== DEVNET_NETWORK) throw new Error('x402_challenge_not_solana_devnet');
+  if (String(challenge.currency).toUpperCase() !== 'USDC') throw new Error('x402_challenge_currency_must_be_USDC');
+  if (!challenge.nonce) throw new Error('x402_challenge_nonce_required');
+  if (!isValidSolanaPublicKey(challenge.payTo)) throw new Error('x402_challenge_payee_invalid');
+  if (!isValidSolanaPublicKey(config.usdcMint)) throw new Error('devnet_usdc_mint_invalid');
+  const amountMicroUnits = usdcAmountToMicroUnits(challenge.amount);
+  const maxUsdcMicroUnits = normalizeCap(config.maxUsdcMicroUnits);
+  if (amountMicroUnits > maxUsdcMicroUnits) throw new Error(`devnet_usdc_spend_cap_exceeded:${amountMicroUnits}>${maxUsdcMicroUnits}`);
+  return {
+    payTo: new PublicKey(challenge.payTo),
+    mint: new PublicKey(config.usdcMint),
+    amountMicroUnits,
+    maxUsdcMicroUnits,
+  };
+}
+
+export async function prepareDevnetUsdcPayment(input: {
+  challenge: X402Challenge;
+  config: DevnetUsdcPaymentConfig;
+  client: Pick<DevnetUsdcPaymentClient, 'getSolBalanceLamports' | 'getUsdcBalanceMicroUnits' | 'getOrCreateDestinationTokenAccount'>;
+}): Promise<DevnetUsdcPaymentReadiness> {
+  const reasons: string[] = [];
+  let payer: Keypair | null = null;
+  let payTo: PublicKey;
+  let mint: PublicKey;
+  let amountMicroUnits: bigint;
+  let maxUsdcMicroUnits: bigint;
+  try {
+    ({ payTo, mint, amountMicroUnits, maxUsdcMicroUnits } = validateDevnetUsdcChallenge(input.challenge, input.config));
+    payer = loadDevnetKeypair(input.config.walletKeypairPath);
+  } catch (error) {
+    return readiness(input.challenge, null, '0', String(input.config.maxUsdcMicroUnits), false, reasons.concat(error instanceof Error ? error.message : String(error)), null, null, null);
+  }
+
+  const solLamports = await input.client.getSolBalanceLamports(payer.publicKey);
+  const usdcMicroUnits = await input.client.getUsdcBalanceMicroUnits(payer.publicKey, mint);
+  const destinationTokenAccount = await input.client.getOrCreateDestinationTokenAccount(payTo, mint);
+  const minFeeLamports = input.config.minFeeLamports ?? DEFAULT_MIN_FEE_LAMPORTS;
+  if (solLamports < minFeeLamports) reasons.push(`insufficient_sol_for_fees:${solLamports}<${minFeeLamports}`);
+  if (usdcMicroUnits < amountMicroUnits) reasons.push(`insufficient_usdc:${usdcMicroUnits}<${amountMicroUnits}`);
+
+  return readiness(input.challenge, payer.publicKey.toBase58(), String(amountMicroUnits), String(maxUsdcMicroUnits), amountMicroUnits <= maxUsdcMicroUnits, reasons, solLamports, String(usdcMicroUnits), destinationTokenAccount);
+}
+
+function readiness(
+  challenge: X402Challenge,
+  payer: string | null,
+  amountMicroUnits: string,
+  maxUsdcMicroUnits: string,
+  capRespected: boolean,
+  reasons: string[],
+  solLamports: number | null,
+  usdcMicroUnits: string | null,
+  destinationTokenAccount: string | null,
+): DevnetUsdcPaymentReadiness {
+  return {
+    schemaVersion: 'reddi.x402-solana.devnet-usdc-payment-readiness.v1',
+    ready: reasons.length === 0,
+    boundary: 'solana-devnet-only-no-mainnet',
+    reasons,
+    payer,
+    challenge: {
+      network: challenge.network,
+      payTo: challenge.payTo,
+      amount: challenge.amount,
+      currency: challenge.currency,
+      endpoint: challenge.endpoint,
+      nonce: challenge.nonce,
+    },
+    spend: { amountMicroUnits, maxUsdcMicroUnits, capRespected },
+    balances: { solLamports, usdcMicroUnits },
+    destinationTokenAccount,
+  };
+}
+
+export async function executeDevnetUsdcPayment(input: ExecuteDevnetUsdcPaymentInput): Promise<X402PaymentReceipt> {
+  if (input.approvalPhrase !== APPROVAL_PHRASE) throw new Error('missing_devnet_x402_specialist_call_approval_phrase');
+  const { payTo, mint, amountMicroUnits } = validateDevnetUsdcChallenge(input.challenge, input.config);
+  const payer = loadDevnetKeypair(input.config.walletKeypairPath);
+  const readiness = await prepareDevnetUsdcPayment({ challenge: input.challenge, config: input.config, client: input.client });
+  if (!readiness.ready) throw new Error(`devnet_usdc_payment_not_ready:${readiness.reasons.join(',')}`);
+  const destinationTokenAccount = readiness.destinationTokenAccount ?? await input.client.getOrCreateDestinationTokenAccount(payTo, mint);
+  const result = await input.client.submitUsdcTransfer({ payer, payTo, mint, amountMicroUnits, destinationTokenAccount, challenge: input.challenge });
+  return {
+    network: DEVNET_NETWORK,
+    payTo: input.challenge.payTo,
+    amount: input.challenge.amount,
+    currency: 'USDC',
+    nonce: input.challenge.nonce,
+    signature: result.signature,
+    txSignature: result.signature,
+    payer: payer.publicKey.toBase58(),
+    mint: mint.toBase58(),
+    destinationTokenAccount: result.destinationTokenAccount,
+  };
+}
+
+export function createSolanaDevnetUsdcPaymentClient(connection: Connection): DevnetUsdcPaymentClient {
+  return {
+    async getSolBalanceLamports(publicKey: PublicKey): Promise<number> {
+      return connection.getBalance(publicKey, 'confirmed');
+    },
+
+    async getUsdcBalanceMicroUnits(owner: PublicKey, mint: PublicKey): Promise<bigint> {
+      const tokenAccount = getAssociatedTokenAddressSync(mint, owner, false, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+      const accountInfo = await connection.getAccountInfo(tokenAccount, 'confirmed');
+      if (!accountInfo) return 0n;
+      const balance = await connection.getTokenAccountBalance(tokenAccount, 'confirmed');
+      return BigInt(balance.value.amount);
+    },
+
+    async getOrCreateDestinationTokenAccount(payTo: PublicKey, mint: PublicKey): Promise<string> {
+      return getAssociatedTokenAddressSync(mint, payTo, false, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID).toBase58();
+    },
+
+    async submitUsdcTransfer(input): Promise<DevnetUsdcTransferResult> {
+      const sourceTokenAccount = getAssociatedTokenAddressSync(input.mint, input.payer.publicKey, false, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+      const destinationTokenAccount = new PublicKey(input.destinationTokenAccount);
+      const tx = new Transaction();
+      const destinationInfo = await connection.getAccountInfo(destinationTokenAccount, 'confirmed');
+      if (!destinationInfo) {
+        tx.add(createAssociatedTokenAccountInstruction(
+          input.payer.publicKey,
+          destinationTokenAccount,
+          input.payTo,
+          input.mint,
+          TOKEN_PROGRAM_ID,
+          ASSOCIATED_TOKEN_PROGRAM_ID,
+        ));
+      }
+      tx.add(createTransferCheckedInstruction(
+        sourceTokenAccount,
+        input.mint,
+        destinationTokenAccount,
+        input.payer.publicKey,
+        input.amountMicroUnits,
+        6,
+        [],
+        TOKEN_PROGRAM_ID,
+      ));
+      const signature = await sendAndConfirmTransaction(connection, tx, [input.payer], { commitment: 'confirmed' });
+      return { signature, destinationTokenAccount: destinationTokenAccount.toBase58() };
+    },
+  };
+}
+
+export function challengeFromX402RequestHeader(header: string): X402Challenge {
+  const parsed = JSON.parse(header);
+  return buildX402Challenge({
+    version: typeof parsed.version === 'string' ? parsed.version : '1',
+    network: parsed.network,
+    payTo: typeof parsed.payTo === 'string' ? parsed.payTo : parsed.paymentAddress,
+    amount: parsed.amount,
+    currency: parsed.currency,
+    endpoint: parsed.endpoint,
+    nonce: parsed.nonce,
+    memo: typeof parsed.memo === 'string' ? parsed.memo : undefined,
+  });
+}

--- a/packages/x402-solana/src/index.ts
+++ b/packages/x402-solana/src/index.ts
@@ -10,3 +10,4 @@ export * from './nonce';
 export * from './payment';
 export * from './middleware';
 export * from './jupiter';
+export * from './client';

--- a/packages/x402-solana/tests/client.test.ts
+++ b/packages/x402-solana/tests/client.test.ts
@@ -87,7 +87,9 @@ describe('devnet USDC x402 payer client', () => {
     expect(result.ready).toBe(true);
     expect(result.payer).toBe(keypair.publicKey.toBase58());
     expect(result.spend.amountMicroUnits).toBe('50000');
-    expect(JSON.stringify(result)).not.toContain(String(keypair.secretKey[0]));
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(JSON.stringify(Array.from(keypair.secretKey)));
+    expect(serialized).not.toContain(Buffer.from(keypair.secretKey).toString('base64'));
   });
 
   it('reports insufficient balances without submitting transfer', async () => {

--- a/packages/x402-solana/tests/client.test.ts
+++ b/packages/x402-solana/tests/client.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Keypair, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
+import {
+  assertDevnetRpcUrl,
+  challengeFromX402RequestHeader,
+  createSolanaDevnetUsdcPaymentClient,
+  executeDevnetUsdcPayment,
+  prepareDevnetUsdcPayment,
+  usdcAmountToMicroUnits,
+  validateDevnetUsdcChallenge,
+  type DevnetUsdcPaymentClient,
+} from '../src/client';
+import { buildX402Challenge } from '../src/payment';
+
+const payTo = '3mL7kbtz3eK24vJ6wftjnLvhZrf93B71UEjB2DBDAddr';
+const usdcMint = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+const endpoint = 'https://reddi-code-generation.preview.reddi.tech/v1/chat/completions';
+
+function tempKeypairPath(): { path: string; keypair: Keypair } {
+  const keypair = Keypair.generate();
+  const dir = mkdtempSync(join(tmpdir(), 'reddi-x402-devnet-wallet-'));
+  const path = join(dir, 'wallet.json');
+  writeFileSync(path, JSON.stringify(Array.from(keypair.secretKey)));
+  return { path, keypair };
+}
+
+function challenge(overrides: Partial<Parameters<typeof buildX402Challenge>[0]> = {}) {
+  return buildX402Challenge({
+    network: 'solana-devnet',
+    payTo,
+    amount: '0.05',
+    currency: 'USDC',
+    endpoint,
+    nonce: 'nonce-123',
+    ...overrides,
+  });
+}
+
+function config(walletKeypairPath: string, overrides = {}) {
+  return {
+    rpcUrl: 'https://api.devnet.solana.com',
+    usdcMint,
+    walletKeypairPath,
+    endpointAllowlist: [endpoint],
+    maxUsdcMicroUnits: 150_000,
+    ...overrides,
+  };
+}
+
+function fakeClient(overrides: Partial<DevnetUsdcPaymentClient> = {}): DevnetUsdcPaymentClient {
+  return {
+    async getSolBalanceLamports() { return LAMPORTS_PER_SOL; },
+    async getUsdcBalanceMicroUnits() { return 100_000n; },
+    async getOrCreateDestinationTokenAccount() { return 'dest-token-account'; },
+    async submitUsdcTransfer() { return { signature: 'devnet-usdc-signature', destinationTokenAccount: 'dest-token-account' }; },
+    ...overrides,
+  };
+}
+
+describe('devnet USDC x402 payer client', () => {
+  it('converts decimal USDC amounts to micro-units exactly', () => {
+    expect(usdcAmountToMicroUnits('0.05')).toBe(50_000n);
+    expect(usdcAmountToMicroUnits('1')).toBe(1_000_000n);
+    expect(usdcAmountToMicroUnits('1.000001')).toBe(1_000_001n);
+    expect(() => usdcAmountToMicroUnits('0.0000001')).toThrow('invalid_usdc_amount');
+  });
+
+  it('rejects mainnet RPC URLs', () => {
+    expect(() => assertDevnetRpcUrl('https://api.mainnet-beta.solana.com')).toThrow('mainnet_rpc_url_forbidden');
+  });
+
+  it('validates devnet USDC challenges and spend caps', () => {
+    const { path } = tempKeypairPath();
+    const validated = validateDevnetUsdcChallenge(challenge(), config(path));
+    expect(validated.amountMicroUnits).toBe(50_000n);
+    expect(validated.maxUsdcMicroUnits).toBe(150_000n);
+    expect(() => validateDevnetUsdcChallenge(challenge({ amount: '0.20' }), config(path))).toThrow('devnet_usdc_spend_cap_exceeded');
+    expect(() => validateDevnetUsdcChallenge(challenge({ network: 'solana-mainnet-beta' }), config(path))).toThrow('x402_challenge_not_solana_devnet');
+    expect(() => validateDevnetUsdcChallenge(challenge({ endpoint: 'https://evil.example.test/pay' }), config(path))).toThrow('specialist_endpoint_not_allowlisted');
+  });
+
+  it('prepares a non-mutating readiness response without exposing secret key material', async () => {
+    const { path, keypair } = tempKeypairPath();
+    const result = await prepareDevnetUsdcPayment({ challenge: challenge(), config: config(path), client: fakeClient() });
+    expect(result.ready).toBe(true);
+    expect(result.payer).toBe(keypair.publicKey.toBase58());
+    expect(result.spend.amountMicroUnits).toBe('50000');
+    expect(JSON.stringify(result)).not.toContain(String(keypair.secretKey[0]));
+  });
+
+  it('reports insufficient balances without submitting transfer', async () => {
+    const { path } = tempKeypairPath();
+    const submitUsdcTransfer = jest.fn();
+    const result = await prepareDevnetUsdcPayment({
+      challenge: challenge(),
+      config: config(path),
+      client: fakeClient({
+        async getSolBalanceLamports() { return 1; },
+        async getUsdcBalanceMicroUnits() { return 1n; },
+        submitUsdcTransfer,
+      }),
+    });
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toContain('insufficient_sol_for_fees:1<5000');
+    expect(result.reasons).toContain('insufficient_usdc:1<50000');
+    expect(submitUsdcTransfer).not.toHaveBeenCalled();
+  });
+
+  it('executes only with the approval phrase and returns an x402 payment receipt', async () => {
+    const { path, keypair } = tempKeypairPath();
+    await expect(executeDevnetUsdcPayment({
+      challenge: challenge(),
+      config: config(path),
+      client: fakeClient(),
+      // @ts-expect-error exercising runtime guard
+      approvalPhrase: 'NOPE',
+    })).rejects.toThrow('missing_devnet_x402_specialist_call_approval_phrase');
+
+    const receipt = await executeDevnetUsdcPayment({
+      challenge: challenge(),
+      config: config(path),
+      client: fakeClient(),
+      approvalPhrase: 'EXECUTE_DEVNET_X402_SPECIALIST_CALL',
+    });
+    expect(receipt.network).toBe('solana-devnet');
+    expect(receipt.currency).toBe('USDC');
+    expect(receipt.signature).toBe('devnet-usdc-signature');
+    expect(receipt.payer).toBe(keypair.publicKey.toBase58());
+    expect(receipt.mint).toBe(new PublicKey(usdcMint).toBase58());
+  });
+
+  it('creates a Solana adapter that reads balances and computes the destination token account without submitting', async () => {
+    const owner = Keypair.generate().publicKey;
+    const mint = new PublicKey(usdcMint);
+    const connection = {
+      async getBalance(publicKey: PublicKey) {
+        expect(publicKey.toBase58()).toBe(owner.toBase58());
+        return 12345;
+      },
+      async getAccountInfo() { return null; },
+      async getTokenAccountBalance() { throw new Error('should not read token balance for missing ATA'); },
+    } as any;
+    const client = createSolanaDevnetUsdcPaymentClient(connection);
+    await expect(client.getSolBalanceLamports(owner)).resolves.toBe(12345);
+    await expect(client.getUsdcBalanceMicroUnits(owner, mint)).resolves.toBe(0n);
+    await expect(client.getOrCreateDestinationTokenAccount(new PublicKey(payTo), mint)).resolves.toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/);
+  });
+
+  it('parses hosted x402 request headers into strict challenges', () => {
+    const parsed = challengeFromX402RequestHeader(JSON.stringify({
+      version: '1',
+      network: 'solana-devnet',
+      payTo,
+      amount: '0.05',
+      currency: 'USDC',
+      endpoint,
+      nonce: 'nonce-456',
+    }));
+    expect(parsed.network).toBe('solana-devnet');
+    expect(parsed.payTo).toBe(payTo);
+    expect(parsed.nonce).toBe('nonce-456');
+  });
+});

--- a/scripts/run-claude-code-mcp-x402-recording-demo.sh
+++ b/scripts/run-claude-code-mcp-x402-recording-demo.sh
@@ -32,10 +32,12 @@ Requirements:
 - Verify the receipt before relying on the specialist output.
 - Export a disclosure ledger entry.
 - Final answer must include: chosen specialist endpoint, what it contributed, devnet payment receipt/tx boundary, and disclosure-ledger summary.
+- Product naming: call it "Reddi Agent Protocol" or "RAP" only; do not shorten the product name to "Reddi".
+- If describing the hosted code-generation endpoint, call it the "Reddi Agent Protocol code-generation specialist endpoint" or "RAP code-generation specialist endpoint".
 EOF
 )
 
-printf 'Starting Claude Code with Reddi MCP tools...\n\n'
+printf 'Starting Claude Code with Reddi Agent Protocol MCP tools...\n\n'
 claude -p \
   --permission-mode acceptEdits \
   --allowedTools "mcp__reddi-rap-devnet__reddi_discover_specialists,mcp__reddi-rap-devnet__reddi_prepare_x402_specialist_call,mcp__reddi-rap-devnet__reddi_execute_x402_specialist_call,mcp__reddi-rap-devnet__reddi_verify_x402_specialist_receipt,mcp__reddi-rap-devnet__reddi_export_disclosure_ledger" \

--- a/scripts/run-claude-code-mcp-x402-recording-demo.sh
+++ b/scripts/run-claude-code-mcp-x402-recording-demo.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="/Users/loki/.openclaw/workspace/projects/reddi-agent-protocol-code"
+cd "$ROOT"
+
+TS="${1:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT_DIR="$ROOT/artifacts/claude-code-mcp-x402-peekaboo-demo/${TS}-claude-code-recording-run"
+mkdir -p "$OUT_DIR"
+
+cat <<'BANNER'
+Reddi Agent Protocol + Claude Code MCP x402 demo
+Boundary: Solana devnet only · exact endpoint allowlist · 60000 micro-USDC cap
+BANNER
+
+printf '\nProof ladder:\n'
+printf '  Surfpool local proof: artifacts/rap-mcp-bridge-x402-surfpool-local/20260508T214434Z/SUMMARY.md\n'
+printf '  Live smoke proof:    artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T214912Z-live-x402-specialist-smoke/SUMMARY.md\n'
+printf '  Rehearsal proof:     artifacts/claude-code-mcp-x402-peekaboo-demo/20260508T220315Z-claude-print-rehearsal/SUMMARY.md\n\n'
+
+PROMPT=$(cat <<'EOF'
+Use Reddi Agent Protocol MCP tools to answer this demo question:
+
+What does a paid machine-to-machine specialist call prove for agent marketplaces?
+
+Requirements:
+- First call discovery to show the marketplace exists.
+- For the paid call, use only this exact allowlisted devnet x402 endpoint: https://reddi-code-generation.preview.reddi.tech/v1/chat/completions
+- Do not use example.com endpoints.
+- Keep spend under the configured 60000 micro-USDC cap.
+- Execute the x402 specialist call only if the configured devnet wallet is ready or if execute captures a valid 402 challenge and enforces readiness internally.
+- Verify the receipt before relying on the specialist output.
+- Export a disclosure ledger entry.
+- Final answer must include: chosen specialist endpoint, what it contributed, devnet payment receipt/tx boundary, and disclosure-ledger summary.
+EOF
+)
+
+printf 'Starting Claude Code with Reddi MCP tools...\n\n'
+claude -p \
+  --permission-mode acceptEdits \
+  --allowedTools "mcp__reddi-rap-devnet__reddi_discover_specialists,mcp__reddi-rap-devnet__reddi_prepare_x402_specialist_call,mcp__reddi-rap-devnet__reddi_execute_x402_specialist_call,mcp__reddi-rap-devnet__reddi_verify_x402_specialist_receipt,mcp__reddi-rap-devnet__reddi_export_disclosure_ledger" \
+  --max-budget-usd 1 \
+  --output-format text \
+  "$PROMPT" | tee "$OUT_DIR/claude-output.txt"
+
+printf '\nSaved Claude output: %s\n' "$OUT_DIR/claude-output.txt"
+printf 'MCP store: artifacts/claude-code-mcp-x402-peekaboo-demo/mcp-store/store.json\n'
+printf 'Done.\n'


### PR DESCRIPTION
## Summary

Adds a gated devnet x402 specialist invocation path for Claude Code MCP demos.

This includes:

- consumer-side devnet USDC x402 payer helper in `@reddi/x402-solana`
- gated Reddi Agent Protocol MCP tools for prepare/execute/verify specialist calls
- x402 receipt storage and disclosure-ledger export support
- Surfpool/local x402 end-to-end smoke
- gated live devnet specialist smoke
- Claude Code recording script/runbooks
- strict Reddi Agent Protocol/RAP naming guards
- canonical true-live Claude Code demo bundle

## Product naming

Product name is **Reddi Agent Protocol**. Short form is **RAP**. Avoid standalone “Reddi” as the product name except inside literal URLs/package identifiers.

The canonical recording start line is:

> Starting Claude Code with Reddi Agent Protocol MCP tools...

## Canonical demo artifact

Use this bundle for review:

`artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live.zip`

SHA256:

`b293e26fdbe8d30c5791a8e263541393b9302131961e83414ef8f164049584b0`

Supersedes older locked-screen, replay, and pre-strict-naming captures.

## Canonical recording proof

- Receipt: `x402_specialist_0460d1e4214ab0f0ddb7d667`
- Devnet tx: `3oVM9kKqMME6J4sufvWRT5s6F1N9HcLnUGTDeLbxXQNyuAEkC7Nt4JxKs9aoxun7FVTCvzeS4Pwt2PqPMwF1oGGV`
- Amount: `0.05 USDC`
- Cap: `60000` micro-USDC
- Boundary: `solana-devnet-only-no-mainnet`
- Video: `154.9s`, `1440x810`, `1549` frames

## Safety

- Default bridge remains dry-run only.
- x402 specialist tools are hidden unless devnet mode + proof approval + invoke gate are configured.
- Execute requires exact approval phrase `EXECUTE_DEVNET_X402_SPECIALIST_CALL`.
- Mainnet RPC URLs are rejected.
- Specialist endpoint must exactly match allowlist.
- Per-call cap is enforced in micro-USDC.
- No private key material is returned in tool outputs or artifacts.
- Surfpool local validator proof was run before devnet spend.
- Live smoke and canonical recording are devnet-only.

## Validation

Passed locally in Loop 43:

```bash
npm run build --prefix packages/x402-solana
npm test --prefix packages/x402-solana -- --runInBand
npm run build --prefix packages/rap-mcp-bridge
npm test --prefix packages/rap-mcp-bridge
npm --prefix packages/rap-mcp-bridge run smoke:x402-tool-list
bash -n scripts/run-claude-code-mcp-x402-recording-demo.sh
unzip -t artifacts/claude-code-mcp-x402-peekaboo-demo/final-bundle-20260508T231415Z-strict-naming-live.zip
```

Results:

- x402-solana tests: 34/34 pass
- RAP MCP bridge tests: 26/26 pass
- x402 tool-list smoke: pass
- forbidden shorthand naming scan: pass

## Notes for reviewer

This PR intentionally does not enable arbitrary paid marketplace endpoint execution. The demo path is exact-allowlisted, devnet-only, explicitly gated, capped, and receipt/disclosure-ledger backed.

The final local branch currently has these commits over `main`:

1. `6045db55 feat: add gated devnet x402 MCP specialist demo`
2. `8b5b75e7 docs: enforce Reddi Agent Protocol naming in MCP demo`
3. `95db7b14 docs: point PR readiness at strict naming capture`
4. `09775348 test: harden x402 secret leakage assertion`
