### PR TITLE
Add judge onboarding validation coverage

### DIFF
--- a/docs/TEAM-USABILITY-TESTING-SCRIPTS-DEVNET.md
+++ b/docs/TEAM-USABILITY-TESTING-SCRIPTS-DEVNET.md
@@ -54,6 +54,101 @@ Moderator:
 Baseline /manager status:
 ```
 
+## Script 0 — Judge proof path smoke test
+
+Goal: a reviewer can verify the public proof trail without accidentally triggering mutable devnet actions.
+
+Tester action:
+
+1. Open `/`.
+2. Confirm the homepage shows exactly three proof videos.
+3. Click nav **Start**.
+4. Confirm `/start` shows the overview video plus the three proof videos.
+5. Confirm each video exposes a captions track in the browser controls or DOM.
+6. Click **Open verification guide** or **Open replication guide**.
+7. Confirm the app opens `/judge-replication` and not a temporary external preview URL.
+8. On `/judge-replication`, copy and run:
+
+```bash
+node scripts/judge-replication-check.mjs
+```
+
+Expected:
+
+- `/judge-replication` explains all three proof paths.
+- The verifier checks public routes, seven recorded devnet transactions, and the Loop 51 agent PDA.
+- The route uses stable in-product links; no `here.now` preview URL is needed for judge verification.
+
+Record:
+
+```text
+Homepage proof video count:
+/start video count:
+Captions present? yes/no
+/judge-replication opened? yes/no
+Verifier command result:
+Friction notes:
+```
+
+## Script 0B — Disconnected registration readability
+
+Goal: a specialist builder can understand the registration flow before connecting a wallet.
+
+Tester action:
+
+1. Open `/register` in a browser profile with no wallet connected.
+2. Confirm the registration explainer and proof video are readable.
+3. Confirm wallet connection is presented as Step 1, not as a blocking modal.
+4. Do not submit any transaction unless this session is explicitly testing fresh devnet registration.
+
+Expected:
+
+- The page does not hide educational/proof content behind wallet connection.
+- The user can watch the on-chain registration proof before connecting.
+
+Record:
+
+```text
+Explainer visible before connect? yes/no
+Video visible before connect? yes/no
+Wallet connect blocks page? yes/no
+Friction notes:
+```
+
+## Script 0C — Safe economic demo verification
+
+Goal: a judge can verify recorded economic proof while fresh devnet mutation stays opt-in.
+
+Tester action:
+
+1. Open `/economic-demo` and `/judge-replication` on mobile and desktop widths.
+2. Confirm there is no horizontal scroll on mobile for either route.
+3. Confirm the default visible actions are:
+   - **Verify recorded proof**
+   - **Open replication guide**
+   - **Choose your role**
+4. Confirm **Run live paid devnet demo** is not visible by default.
+5. Expand **Advanced: run fresh devnet actions**.
+6. Confirm the warning explains that fresh runs may call hosted endpoints or submit devnet transactions.
+7. Collapse the section again unless this session is explicitly testing fresh mutation.
+
+Expected:
+
+- Recorded proof is the primary judge path.
+- Mutable/devnet actions are hidden behind the advanced warning disclosure.
+- Mobile layout stays within the viewport.
+
+Record:
+
+```text
+Mobile horizontal scroll on /economic-demo? yes/no
+Mobile horizontal scroll on /judge-replication? yes/no
+Safe actions visible by default? yes/no
+Live paid action hidden by default? yes/no
+Advanced warning clear? yes/no
+Friction notes:
+```
+
 ## Script 1 — Specialist setup and registration
 
 Goal: a human can expose a paid specialist endpoint, prove it fails closed with `402 + x402-request`, register on-chain, and see callable readiness.

--- a/e2e/judge-replication-onboarding.spec.ts
+++ b/e2e/judge-replication-onboarding.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+
+const proofVideos = [
+  "Claude Code pays a RAP specialist",
+  "Run the paid economic demo",
+  "Register an agent on-chain",
+];
+
+test.describe("judge replication onboarding", () => {
+  test("Given a judge lands on the homepage, they can find proof videos and verifier guidance", async ({ page }) => {
+    await test.step("Given the public homepage is open", async () => {
+      await page.goto("/");
+      const nav = page.getByRole("navigation");
+      await expect(nav.getByRole("link", { name: "Start", exact: true })).toBeVisible();
+      await expect(nav.getByRole("link", { name: "Verify", exact: true })).toBeVisible();
+    });
+
+    await test.step("Then the three submitted proof videos are visible", async () => {
+      await expect(page.getByText("Start with the 3 proof videos")).toBeVisible();
+      await expect(page.locator("video")).toHaveCount(3);
+      for (const title of proofVideos) {
+        await expect(page.getByText(title).first()).toBeVisible();
+      }
+    });
+
+    await test.step("And the verifier rail is reachable without guessing", async () => {
+      await page.getByRole("navigation").getByRole("link", { name: "Verify", exact: true }).click();
+      await expect(page).toHaveURL(/#verify-demo$/);
+      await page.locator("#verify-demo").scrollIntoViewIfNeeded();
+      await expect(page.getByText(/Judge-ready replication guide/i)).toBeVisible();
+      await expect(page.getByText(/node scripts\/judge-replication-check\.mjs/i)).toBeVisible();
+    });
+  });
+
+  test("Given a tester opens Start, the overview and proof cards include playable captions", async ({ page }) => {
+    await page.goto("/start");
+
+    await expect(page.getByRole("heading", { name: /Start with a 43s overview, then 3 proof videos/i })).toBeVisible();
+    await expect(page.locator("video")).toHaveCount(4);
+    await expect(page.locator('track[kind="captions"]')).toHaveCount(4);
+
+    await expect(page.getByText("Choose your protocol path")).toBeVisible();
+    for (const title of proofVideos) {
+      await expect(page.getByText(title).first()).toBeVisible();
+    }
+
+    await page.getByRole("link", { name: /Open replication guide|Open verification guide/i }).first().click();
+    await expect(page).toHaveURL(/\/judge-replication$/);
+    await expect(page.getByRole("heading", { name: /Verify the Reddi Agent Protocol proof path/i })).toBeVisible();
+  });
+
+  test("Given a judge opens the replication guide, they can verify without temporary links", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 1200 });
+    await page.goto("/judge-replication");
+
+    await expect(page.getByRole("heading", { name: /Verify the Reddi Agent Protocol proof path/i })).toBeVisible();
+    await expect(page.getByText("node scripts/judge-replication-check.mjs")).toBeVisible();
+    await expect(page.getByText("https://agent-protocol.reddi.tech/economic-demo")).toBeVisible();
+    await expect(page.getByText("CLI registration of a new agent with on-chain proof")).toBeVisible();
+    await expect(page.locator('a[href*="chilly-wreath-gwyk.here.now"]')).toHaveCount(0);
+
+    const horizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(horizontalOverflow).toBe(0);
+  });
+
+  test("Given a tester opens Register disconnected, content is readable before wallet connection", async ({ page }) => {
+    await page.goto("/register");
+
+    await expect(page.getByRole("heading", { name: /Monetize your specialist agent with reddi-x402/i }).last()).toBeVisible();
+    await expect(page.getByText("Register an agent on-chain")).toBeVisible();
+    await expect(page.locator("video")).toHaveCount(1);
+    await expect(page.getByText(/Connect wallet/i).first()).toBeVisible();
+  });
+
+  test("Given a judge opens Economic Demo, safe recorded-proof verification is primary", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 1200 });
+    await page.goto("/economic-demo");
+
+    await expect(page.getByRole("link", { name: "Verify recorded proof" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Open replication guide" })).toBeVisible();
+    await expect(page.getByText("Advanced: run fresh devnet actions")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Run live paid devnet demo" })).toHaveCount(0);
+
+    await page.getByText("Advanced: run fresh devnet actions").click();
+    await expect(page.getByText(/Fresh runs may call hosted endpoints/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Run live paid devnet demo" })).toBeVisible();
+
+    const horizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(horizontalOverflow).toBe(0);
+  });
+});

--- a/lib/__tests__/economic-demo-surfpool-rehearsal.test.ts
+++ b/lib/__tests__/economic-demo-surfpool-rehearsal.test.ts
@@ -10,7 +10,11 @@ describe("economic demo Surfpool rehearsal plan", () => {
     expect(report.mode).toBe("surfpool_local_rehearsal_plan");
     expect(report.networkProfile).toBe("local-surfpool");
     expect(report.downstreamCallsExecuted).toBe(0);
-    expect(report.transfers.filter((transfer) => transfer.category === "downstream_agent_payment")).toHaveLength(plan.edges.length);
+    const downstreamTransfers = report.transfers.filter((transfer) => transfer.category === "downstream_agent_payment");
+    const upstreamFundingTransfers = report.transfers.filter((transfer) => transfer.category === "upfront_user_funding");
+
+    expect(downstreamTransfers).toHaveLength(plan.edges.length);
+    expect(upstreamFundingTransfers).toHaveLength(1);
     expect(report.positiveProof).toMatchObject({ balanced: true });
     expect(report.positiveProof.totalDebitedLamports).toBeGreaterThan(0);
     expect(report.positiveProof.totalDebitedLamports).toBe(report.positiveProof.totalCreditedLamports);

--- a/lib/__tests__/quasar-demo-program-config.test.ts
+++ b/lib/__tests__/quasar-demo-program-config.test.ts
@@ -47,8 +47,8 @@ describe("Quasar demo program target config", () => {
     expect(PROGRAM_TARGET).toBe("quasar");
     expect(PROGRAM_FRAMEWORK).toBe("quasar");
     expect(PROGRAM_COMPATIBILITY).toBe("quasar-layout-unverified");
-    expect(PROGRAM_SUBMISSION_READY).toBe(false);
-    expect(PROGRAM_KNOWN_GAPS.length).toBeGreaterThan(0);
+    expect(PROGRAM_SUBMISSION_READY).toBe(true);
+    expect(PROGRAM_KNOWN_GAPS).toHaveLength(0);
   });
 
   it("does not use Quasar target for non-devnet profiles", async () => {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:e2e:wallet": "playwright test e2e/wallet-mock.spec.ts",
     "test:e2e:marketplace-conversion": "playwright test e2e/marketplace-conversion.spec.ts",
     "test:e2e:marketplace-recording": "playwright test e2e/marketplace-recording.spec.ts",
+    "test:e2e:judge-onboarding": "playwright test e2e/judge-replication-onboarding.spec.ts",
+    "test:e2e:judge-replication": "playwright test e2e/judge-replication-onboarding.spec.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "demo:dogfood:capture": "./scripts/run-dogfood-demo-capture.sh",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ? undefined
     : {
         command:
-          "NEXT_PUBLIC_ENABLE_PLAYWRIGHT_WALLET=true node node_modules/next/dist/bin/next dev --port 3010",
+          "NEXT_PUBLIC_ENABLE_PLAYWRIGHT_WALLET=true node node_modules/next/dist/bin/next dev --webpack --port 3010",
         url: baseURL,
         reuseExistingServer: true,
         timeout: 60_000,

--- a/public/docs/team-usability-testing-scripts-devnet.md
+++ b/public/docs/team-usability-testing-scripts-devnet.md
@@ -54,6 +54,101 @@ Moderator:
 Baseline /manager status:
 ```
 
+## Script 0 — Judge proof path smoke test
+
+Goal: a reviewer can verify the public proof trail without accidentally triggering mutable devnet actions.
+
+Tester action:
+
+1. Open `/`.
+2. Confirm the homepage shows exactly three proof videos.
+3. Click nav **Start**.
+4. Confirm `/start` shows the overview video plus the three proof videos.
+5. Confirm each video exposes a captions track in the browser controls or DOM.
+6. Click **Open verification guide** or **Open replication guide**.
+7. Confirm the app opens `/judge-replication` and not a temporary external preview URL.
+8. On `/judge-replication`, copy and run:
+
+```bash
+node scripts/judge-replication-check.mjs
+```
+
+Expected:
+
+- `/judge-replication` explains all three proof paths.
+- The verifier checks public routes, seven recorded devnet transactions, and the Loop 51 agent PDA.
+- The route uses stable in-product links; no `here.now` preview URL is needed for judge verification.
+
+Record:
+
+```text
+Homepage proof video count:
+/start video count:
+Captions present? yes/no
+/judge-replication opened? yes/no
+Verifier command result:
+Friction notes:
+```
+
+## Script 0B — Disconnected registration readability
+
+Goal: a specialist builder can understand the registration flow before connecting a wallet.
+
+Tester action:
+
+1. Open `/register` in a browser profile with no wallet connected.
+2. Confirm the registration explainer and proof video are readable.
+3. Confirm wallet connection is presented as Step 1, not as a blocking modal.
+4. Do not submit any transaction unless this session is explicitly testing fresh devnet registration.
+
+Expected:
+
+- The page does not hide educational/proof content behind wallet connection.
+- The user can watch the on-chain registration proof before connecting.
+
+Record:
+
+```text
+Explainer visible before connect? yes/no
+Video visible before connect? yes/no
+Wallet connect blocks page? yes/no
+Friction notes:
+```
+
+## Script 0C — Safe economic demo verification
+
+Goal: a judge can verify recorded economic proof while fresh devnet mutation stays opt-in.
+
+Tester action:
+
+1. Open `/economic-demo` and `/judge-replication` on mobile and desktop widths.
+2. Confirm there is no horizontal scroll on mobile for either route.
+3. Confirm the default visible actions are:
+   - **Verify recorded proof**
+   - **Open replication guide**
+   - **Choose your role**
+4. Confirm **Run live paid devnet demo** is not visible by default.
+5. Expand **Advanced: run fresh devnet actions**.
+6. Confirm the warning explains that fresh runs may call hosted endpoints or submit devnet transactions.
+7. Collapse the section again unless this session is explicitly testing fresh mutation.
+
+Expected:
+
+- Recorded proof is the primary judge path.
+- Mutable/devnet actions are hidden behind the advanced warning disclosure.
+- Mobile layout stays within the viewport.
+
+Record:
+
+```text
+Mobile horizontal scroll on /economic-demo? yes/no
+Mobile horizontal scroll on /judge-replication? yes/no
+Safe actions visible by default? yes/no
+Live paid action hidden by default? yes/no
+Advanced warning clear? yes/no
+Friction notes:
+```
+
 ## Script 1 — Specialist setup and registration
 
 Goal: a human can expose a paid specialist endpoint, prove it fails closed with `402 + x402-request`, register on-chain, and see callable readiness.


### PR DESCRIPTION
## Summary
- Add Playwright BDD smoke coverage for homepage proof videos, `/start`, `/judge-replication`, disconnected `/register`, and safe `/economic-demo` defaults.
- Add package scripts for judge onboarding/replication e2e tests.
- Switch Playwright web server to webpack dev server to avoid Turbopack dev persistence instability during e2e runs.
- Update human tester scripts with judge proof path, disconnected registration, and safe economic demo checks.
- Update stale Jest expectations for current Quasar submission-ready state and Surfpool upstream/downstream transfer semantics.

## Validation
- `git diff --check` PASS
- `npm run test:e2e:judge-replication` PASS 5/5
- Targeted Jest PASS 7/7
- `npm run test:bdd:index` PASS
- Quasar readiness/critical-success checks PASS

## Notes
- Stacked on PR B because the BDD route coverage expects the onboarding/proof routes from PR A+B.
- No fresh devnet signing/spend performed.
