### PR TITLE
test: make integration validator RPC configurable

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,11 +4,31 @@
 
 Onboarding/judge UX is locally shippable and validated. Public proof path now has a stable in-product `/judge-replication` route (temporary `here.now` guide links removed from source CTAs). `/start` has overview + 3 proof videos; homepage shows 3 proof videos; contextual proof videos are embedded on setup/agents/register/economic-demo; `/register` is readable before wallet connect; `/economic-demo` defaults to safe recorded-proof verification with fresh devnet actions under an advanced warning.
 
-Latest validation: third 10-loop review/PR-readiness pass completed after Nissan approved PR operations and bounded devnet spend. Additional loops 21–30 PASS: branch packaging review, origin/main freshness, product naming, submission claim boundaries, submission prep check, overclaim scan, BDD index/status 15/15, changed UI Playwright, targeted Jest, bounded devnet/safety smoke including Quasar PER devnet, integration lane, and PR creation/review. Evidence logs: `artifacts/validation-loops-20260509-third-pass/`.
+Latest validation: fourth progress/validation pass completed after PR #301/#302. Loops 31–40 found and patched one real improvement: legacy `e2e/integration.spec.ts` / `scripts/run-integration-lane.sh` now support configurable `INTEGRATION_VALIDATOR_RPC_URL` and report the exact validator RPC/status. Validation PASS: default integration lane, override integration lane, product naming, submission claim boundaries, BDD index/status 15/15, targeted Playwright, targeted Jest, `git diff --check`. Evidence logs: `artifacts/validation-loops-20260509-fourth-pass/`.
 
 Agent validation: Belle P0/P1 resolved (mobile overflow fixed, start copy clarified, agents CTA accessibility cleaned). Oli P0/P1 resolved for stale tests and submission-prep gate; no fresh devnet signing/spend required in the final 10-loop retry. Surfpool/mock-Jupiter artifact exists locally; submission prep now includes Surfpool rehearsal, A→B→C critical, and Quasar critical evidence paths. Public Jupiter devnet execution remains a boundary, not a claim.
 
-Next: PR #301 (`test: harden BDD e2e validation evidence`) was opened, locally reviewed, passed GitHub/Vercel checks, and merged to `main` at `ac1eb528`. Nissan has approved PR operations and bounded devnet spend when needed. If Playwright `e2e/integration.spec.ts` should be counted as active rather than skipped in the ordinary suite, wire its validator preflight to the isolated Surfpool launcher; current full suite, targeted Playwright, build, dedicated Surfpool lanes, and bounded devnet smoke are green.
+Next: Open/review/merge the small integration-RPC configurability PR if GitHub/Vercel checks pass. Nissan has approved PR operations and bounded devnet spend when needed. The ordinary integration lane can now point at an explicit validator RPC; full Surfpool orchestration remains covered by the dedicated Surfpool scripts.
+
+## Latest Update — Fourth 10-loop progress pass (2026-05-09 23:58 AEST)
+
+Nissan asked for up to 10 more similar loops and to approve/merge PRs once confirmed working. Completed loops 31–40, with retrospectives logged at `artifacts/validation-loops-20260509-fourth-pass/README.md`.
+
+Loop outcomes:
+- Loop 31 confirmed post-merge baseline: clean `main`, no open PRs.
+- Loop 32 inspected the remaining integration skip gap: `e2e/integration.spec.ts` was hard-coded to `localhost:8899`.
+- Loop 33 inspected Surfpool wrapper ports and chose a focused patch instead of churn.
+- Loop 34 patched `INTEGRATION_VALIDATOR_RPC_URL` support into the integration spec and runner summary.
+- Loop 35 ran the default integration lane: PASS/exit 0.
+- Loop 36 ran the integration lane with `INTEGRATION_VALIDATOR_RPC_URL=http://127.0.0.1:18999`: PASS/exit 0 and summary reported the override.
+- Loop 37 reran product naming, submission claim boundaries, BDD index, and BDD status: PASS.
+- Loop 38 ran targeted Playwright (`integration`, `economic-demo`, `judge-replication-onboarding`): PASS.
+- Loop 39 ran targeted Jest and diff hygiene: PASS.
+- Loop 40 updates status/memory, opens a PR, waits for checks, and merges if green.
+
+Retrospective: this pass made concrete progress on the known validator-preflight limitation without overclaiming full automatic Surfpool orchestration. The ordinary integration lane is now configurable and more honest; dedicated Surfpool scripts remain the runtime proof path.
+
+RESUME FROM HERE: Review/merge the integration-RPC configurability PR once checks are green.
 
 ## Latest Update — Third 10-loop PR/readiness pass (2026-05-09 23:45 AEST)
 

--- a/e2e/integration.spec.ts
+++ b/e2e/integration.spec.ts
@@ -3,7 +3,7 @@
  *
  * Requires:
  *   - Ollama running at localhost:11434 with at least one model
- *   - Local Solana validator running at localhost:8899
+ *   - Local Solana validator running at INTEGRATION_VALIDATOR_RPC_URL (default: http://localhost:8899)
  *
  * All 4 tests auto-skip if infrastructure is not available.
  */
@@ -40,10 +40,12 @@ async function checkOllama(): Promise<{ ok: boolean; model: string }> {
   }
 }
 
+const validatorRpcUrl = process.env.INTEGRATION_VALIDATOR_RPC_URL || 'http://localhost:8899'
+
 async function checkValidator(): Promise<boolean> {
   try {
     const { stdout } = await execCmd(
-      'curl -s -X POST http://localhost:8899 ' +
+      `curl -s -X POST ${JSON.stringify(validatorRpcUrl)} ` +
       '-H "Content-Type: application/json" ' +
       "-d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getHealth\"}'"
     )
@@ -69,9 +71,11 @@ test.describe('Integration — real Ollama + local validator', () => {
     ollamaModel = ollama.model
 
     if (!infraAvailable) {
-      console.log(`⚠️  Integration tests skipped — Ollama: ${ollama.ok}, Validator: ${validatorOk}`)
+      console.log(
+        `⚠️  Integration tests skipped — Ollama: ${ollama.ok}, Validator: ${validatorOk}, Validator RPC: ${validatorRpcUrl}`
+      )
     } else {
-      console.log(`✅ Infra ready — Ollama model: ${ollamaModel}, validator: ok`)
+      console.log(`✅ Infra ready — Ollama model: ${ollamaModel}, validator: ok, validator RPC: ${validatorRpcUrl}`)
     }
   })
 

--- a/scripts/run-integration-lane.sh
+++ b/scripts/run-integration-lane.sh
@@ -39,9 +39,11 @@ PY
   fi
 }
 
+VALIDATOR_RPC_URL="${INTEGRATION_VALIDATOR_RPC_URL:-http://localhost:8899}"
+
 probe_validator() {
   local health
-  health="$(curl -s --max-time 4 -X POST http://localhost:8899 \
+  health="$(curl -s --max-time 4 -X POST "$VALIDATOR_RPC_URL" \
     -H 'Content-Type: application/json' \
     -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' || true)"
 
@@ -122,7 +124,8 @@ cat > "$OUT_DIR/SUMMARY.md" <<EOF
 - Ollama model (effective summary): ${FINAL_MODEL}
 - Model source: ${MODEL_SOURCE_NOTE}
 - Model probe/selection mismatch: ${MODEL_MISMATCH}
-- Local validator (8899): ${VALIDATOR_STATUS}
+- Local validator RPC: ${VALIDATOR_RPC_URL}
+- Local validator status: ${VALIDATOR_STATUS}
 - Playwright infra hint: ${INFRA_HINT:-n/a}
 
 ## Surfpool Runtime Evidence Snapshot
@@ -137,7 +140,7 @@ cat > "$OUT_DIR/SUMMARY.md" <<EOF
   - ${OUT_DIR}/report.json
 
 ## Interpretation
-- This Playwright lane is a legacy live-infra probe for Ollama + a validator on localhost:8899.
+- This Playwright lane is a legacy live-infra probe for Ollama + a validator at the configured RPC URL.
 - If all tests are skipped, those exact prerequisites were unavailable or not ready.
 - Dedicated Surfpool runtime evidence is tracked separately above because the active local-validator proof path uses isolated Surfpool ports instead of localhost:8899.
 - If tests pass, this lane provides additional runtime-backed evidence beyond route/unit contracts.


### PR DESCRIPTION
## Summary
- Make the legacy Playwright integration lane validator preflight configurable via `INTEGRATION_VALIDATOR_RPC_URL`.
- Report the configured validator RPC/status in integration-lane summaries.
- Preserve the dedicated Surfpool scripts as the full runtime proof path; this patch makes the ordinary integration lane more honest and reusable.

## Validation
- `npm run lint -- e2e/integration.spec.ts scripts/run-integration-lane.sh` PASS (shell script ignored by eslint config warning only)
- `bash -n scripts/run-integration-lane.sh` PASS
- `npm run test:e2e:integration-lane` PASS/exit 0
- `INTEGRATION_VALIDATOR_RPC_URL=http://127.0.0.1:18999 npm run test:e2e:integration-lane` PASS/exit 0 and summary reports override
- `npm run check:product:naming` PASS
- `npm run check:submission:claim-boundaries` PASS
- `npm run test:bdd:index` PASS
- `npm run test:bdd:status` PASS 15/15
- `npx playwright test e2e/integration.spec.ts e2e/economic-demo.spec.ts e2e/judge-replication-onboarding.spec.ts --workers=1` PASS
- `npx jest lib/__tests__/economic-demo-live-paid-devnet-run.test.ts lib/__tests__/economic-demo-surfpool-rehearsal.test.ts --runInBand` PASS
- `git diff --check` PASS