### PR TITLE
Show Torque leaderboard fallback data

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -9,11 +9,11 @@ export default async function LeaderboardPage() {
     <main className="container mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-6">Specialist Leaderboard</h1>
       <p className="text-muted-foreground mb-8">
-        Top specialists ranked by completed jobs. Powered by{" "}
+        Top specialists ranked by completed jobs and quality signals. Powered by{" "}
         <a href="https://torque.so" target="_blank" rel="noopener noreferrer" className="underline">
           Torque Protocol
-        </a>
-        .
+        </a>{" "}
+        event plumbing with protocol-simulation fallback data when the external campaign leaderboard is empty or lagging.
       </p>
 
       {entries.length === 0 ? (
@@ -29,6 +29,7 @@ export default async function LeaderboardPage() {
                 <th className="text-left py-3 px-4 font-semibold">Rank</th>
                 <th className="text-left py-3 px-4 font-semibold">Specialist</th>
                 <th className="text-right py-3 px-4 font-semibold">Jobs Completed</th>
+                <th className="text-right py-3 px-4 font-semibold">Avg Rating</th>
                 <th className="text-right py-3 px-4 font-semibold">Rewards Earned</th>
               </tr>
             </thead>
@@ -46,8 +47,9 @@ export default async function LeaderboardPage() {
                       {entry.userPubkey.slice(0, 8)}...{entry.userPubkey.slice(-8)}
                     </a>
                   </td>
-                  <td className="py-3 px-4 text-right">{entry.value}</td>
-                  <td className="py-3 px-4 text-right">{entry.rewards ?? "—"}</td>
+                  <td className="py-3 px-4 text-right">{entry.components?.completedJobs ?? entry.value}</td>
+                  <td className="py-3 px-4 text-right">{entry.components?.averageRating ? `★ ${entry.components.averageRating.toFixed(1)}` : "—"}</td>
+                  <td className="py-3 px-4 text-right">{entry.rewards && entry.rewards > 0 ? entry.rewards : "—"}</td>
                 </tr>
               ))}
             </tbody>
@@ -56,7 +58,7 @@ export default async function LeaderboardPage() {
       )}
 
       <p className="text-xs text-muted-foreground mt-8">
-        Rankings update each epoch. Powered by on-chain data from the Reddi Agent Protocol escrow program at{" "}
+        Rankings update each epoch when the Torque campaign is active. If Torque has not indexed entries yet, this page shows protocol-simulation activity from Reddi Agent Protocol planner feedback and reputation signals. Escrow program:{" "}
         <span className="font-mono">{ESCROW_PROGRAM_ID.toBase58()}</span>.
       </p>
     </main>

--- a/lib/__tests__/torque-client.test.ts
+++ b/lib/__tests__/torque-client.test.ts
@@ -84,28 +84,31 @@ describe("Torque client", () => {
   });
 
   describe("getLeaderboard", () => {
-    it("returns empty array when TORQUE_API_TOKEN is not set", async () => {
+    it("returns protocol-simulation fallback when TORQUE_API_TOKEN is not set", async () => {
       delete process.env.TORQUE_API_TOKEN;
       const { getLeaderboard } = await import("../torque/client");
       const result = await getLeaderboard();
-      expect(result).toEqual([]);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toMatchObject({ source: "protocol-simulation" });
     });
 
-    it("returns empty array when no campaign ID configured", async () => {
+    it("returns protocol-simulation fallback when no campaign ID configured", async () => {
       process.env.TORQUE_API_TOKEN = "test-token";
       delete process.env.TORQUE_LEADERBOARD_CAMPAIGN_ID;
       const { getLeaderboard } = await import("../torque/client");
       const result = await getLeaderboard();
-      expect(result).toEqual([]);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toMatchObject({ source: "protocol-simulation" });
     });
 
-    it("returns empty array on fetch failure", async () => {
+    it("returns protocol-simulation fallback on fetch failure", async () => {
       process.env.TORQUE_API_TOKEN = "test-token";
       process.env.TORQUE_LEADERBOARD_CAMPAIGN_ID = "camp-123";
       global.fetch = jest.fn().mockRejectedValue(new Error("network error"));
       const { getLeaderboard } = await import("../torque/client");
       const result = await getLeaderboard();
-      expect(result).toEqual([]);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toMatchObject({ source: "protocol-simulation" });
     });
 
     it("returns leaderboard entries on success", async () => {

--- a/lib/torque/client.ts
+++ b/lib/torque/client.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { getTorqueConfig, isTorqueEnabled } from "./config";
 import type { TorqueEventPayload } from "./events";
 
@@ -6,6 +8,49 @@ export interface LeaderboardEntry {
   rank: number;
   value: number;
   rewards?: number;
+  source?: "torque" | "protocol-simulation";
+  components?: {
+    completedJobs: number;
+    averageRating: number;
+    attestationAgreements: number;
+  };
+}
+
+type SpecialistIndexRecord = {
+  walletAddress?: string;
+  routingSignals?: {
+    feedbackCount?: number;
+    avgFeedbackScore?: number;
+    attestationAgreements?: number;
+  };
+};
+
+function getProtocolSimulationLeaderboard(): LeaderboardEntry[] {
+  const path = join(process.cwd(), "data", "onboarding", "specialist-index.json");
+  if (!existsSync(path)) return [];
+
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as SpecialistIndexRecord[];
+    return raw
+      .filter((entry) => entry.walletAddress && (entry.routingSignals?.feedbackCount ?? 0) > 0)
+      .map((entry) => {
+        const completedJobs = entry.routingSignals?.feedbackCount ?? 0;
+        const averageRating = entry.routingSignals?.avgFeedbackScore ?? 0;
+        const attestationAgreements = entry.routingSignals?.attestationAgreements ?? 0;
+        return {
+          userPubkey: entry.walletAddress!,
+          rank: 0,
+          value: completedJobs,
+          rewards: 0,
+          source: "protocol-simulation" as const,
+          components: { completedJobs, averageRating, attestationAgreements },
+        };
+      })
+      .sort((a, b) => b.value - a.value || (b.components?.averageRating ?? 0) - (a.components?.averageRating ?? 0))
+      .map((entry, index) => ({ ...entry, rank: index + 1 }));
+  } catch {
+    return [];
+  }
 }
 
 export async function emitTorqueEvent(payload: TorqueEventPayload): Promise<void> {
@@ -33,22 +78,24 @@ export async function emitTorqueEvent(payload: TorqueEventPayload): Promise<void
 }
 
 export async function getLeaderboard(campaignId?: string): Promise<LeaderboardEntry[]> {
-  if (!isTorqueEnabled()) return [];
+  if (!isTorqueEnabled()) return getProtocolSimulationLeaderboard();
 
   const config = getTorqueConfig();
   const id = campaignId ?? config.leaderboardCampaignId;
-  if (!id) return [];
+  if (!id) return getProtocolSimulationLeaderboard();
 
   try {
     const res = await fetch(`${config.apiBase}/v1/campaigns/${id}/leaderboard`, {
       headers: { Authorization: `Bearer ${config.apiToken}` },
       signal: AbortSignal.timeout(3000),
     });
-    if (!res.ok) return [];
+    if (!res.ok) return getProtocolSimulationLeaderboard();
     const data = await res.json();
-    return data.entries ?? [];
+    const entries = data.entries ?? [];
+    if (entries.length === 0) return getProtocolSimulationLeaderboard();
+    return entries.map((entry: LeaderboardEntry) => ({ ...entry, source: entry.source ?? "torque" }));
   } catch {
-    return [];
+    return getProtocolSimulationLeaderboard();
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds protocol-simulation fallback entries for /leaderboard when Torque campaign data is empty/lagging
- Shows avg rating alongside completed jobs
- Keeps claim boundary explicit: rewards remain blank unless live Torque rewards exist

## Validation
- npx jest lib/__tests__/torque-client.test.ts lib/__tests__/torque-leaderboard-route.test.ts --runInBand
- npm run build