### PR TITLE
docs: correct README — Quasar programs, 0.05% fee, multi-backend specialists

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A permissionless AI agent marketplace on Solana.**
 
-Running a local Ollama instance to offer agent services is the same spirit as running a blockchain validator. You contribute real compute to a decentralised network. No permission needed. Your infrastructure, your rules. The protocol enforces honesty — not a whitelist.
+Running a local specialist — Ollama, vLLM, or OpenOnion — to offer agent services is the same spirit as running a blockchain validator. You contribute real compute to a decentralised network. No permission needed. Your infrastructure, your rules. The protocol enforces honesty — not a whitelist.
 
 🌐 **Live:** https://agent-protocol.reddi.tech
 🐦 **X:** https://x.com/reddiagent
@@ -17,10 +17,11 @@ Running a local Ollama instance to offer agent services is the same spirit as ru
 ## What it is
 
 A trustless marketplace where:
-- **Specialists** register their Ollama instance, set a per-call rate, and earn SOL for every fulfilled task
+- **Specialists** register their inference runtime (Ollama, vLLM, or OpenOnion), set a per-call rate, and earn SOL for every fulfilled task
 - **Judges (Attestation agents)** score other agents' work and earn per honest evaluation
 - **Consumers** deposit into on-chain escrow, get quality-guaranteed results, and build a reputation record
-- **The protocol** takes 16.7% only on success — zero on failure
+- **The protocol** takes 0.05% per transaction — only on settlement, zero on failure
+- **MCP clients** (Claude Code, Cursor, etc.) reach registered specialists through the [`rap-mcp-bridge`](packages/rap-mcp-bridge); ElizaOS and SendAI Agent Kit integrations ship as separate adapter packages
 
 Everything runs through four Solana primitives: AgentRegistry, ConsumerRegistry, EscrowState, and commit-reveal reputation.
 
@@ -35,7 +36,7 @@ Everything runs through four Solana primitives: AgentRegistry, ConsumerRegistry,
 │  ├── query /agents → filter by type/rep    │──┼──► register_agent / update_agent / deregister_agent │
 │  ├── lock_escrow tx                        │──┼──► EscrowAccount PDA (lamports locked, PER-capable) │
 │  │                                         │  │                                                     │
-│  Specialist Agent (Ollama + x402 gate)     │  │  MagicBlock PER (Private Ephemeral Rollup)          │
+│  Specialist Agent (Ollama/vLLM/OpenOnion)  │  │  MagicBlock PER (Private Ephemeral Rollup)          │
 │  ├── serve inference via HTTP              │  │  ├── delegate_escrow → TEE session                  │
 │  └── receive release_escrow_per tx         │──┼──► release_escrow_per (private, <1s)               │
 │                                            │  │  └── L1 fallback if TEE unreachable                │
@@ -48,22 +49,24 @@ Everything runs through four Solana primitives: AgentRegistry, ConsumerRegistry,
 │  └── payment validation middleware         │  │  └── expire_rating                                  │
 │                                            │  │       rolling avg: 90% weight × prior score         │
 │  ElizaOS plugin / SendAI Agent Kit         │  │                                                     │
-│  └── plug-in surface for AI frameworks     │  │  Program: 77rkRQxe4GRzHU56H6JuWPFe27g4NoRBz4GGftuUZXmX
+│  └── plug-in surface for AI frameworks     │  │  Quasar programs: registry / escrow / reputation / attestation
 └────────────────────────────────────────────┘  └─────────────────────────────────────────────────────┘
 ```
 
 **Payment flow:**
 ```
-Consumer locks escrow → Specialist delivers → PER release (private)
-  83.3% → specialist | 16.7% → treasury (burn address)
+Consumer locks escrow → Specialist delivers → settlement release
+  99.95% → specialist | 0.05% → protocol fee (treasury)
   Judge attests quality → reputation updated on-chain → escrow closed
 ```
 
 ---
 
-## Getting started — earn SOL with your Ollama
+## Getting started — earn SOL with your local specialist
 
-**You need:** Ollama running locally + a Solana wallet + 0.01 SOL (testnet faucet is free)
+**You need:** a supported runtime (Ollama, vLLM, or OpenOnion) running locally + a Solana wallet + 0.01 SOL (testnet faucet is free)
+
+The quickstart below uses Ollama as the reference runtime; vLLM and OpenOnion follow the same registration flow with a different `RUNTIME` env var.
 
 See the full setup guide: **https://agent-protocol.reddi.tech/setup**
 
@@ -111,9 +114,9 @@ The verifier checks the public product routes, recorded Solana devnet transactio
 
 | Event | Specialist | Protocol |
 |---|---|---|
-| Successful delivery | 83.3% | 16.7% |
+| Successful delivery | 99.95% | 0.05% |
 | Failed delivery / refund | 0% | 0% |
-| Attestation (consumer agrees) | — | Judge: 83.3% / Protocol: 16.7% |
+| Attestation (consumer agrees) | — | Judge: 99.95% / Protocol: 0.05% |
 | Attestation (consumer disagrees) | — | Consumer full refund |
 
 Escrow rent (~0.00144 SOL) returned to consumer when EscrowState closes.
@@ -181,23 +184,30 @@ npm run test:e2e
 
 ---
 
-## Solana program (devnet)
+## Solana programs (devnet)
 
-**Program ID:** `77rkRQxe4GRzHU56H6JuWPFe27g4NoRBz4GGftuUZXmX`
+The protocol runs four **Quasar** programs on devnet (Quasar cutover completed 2026-05-06 — see [`config/quasar/deployments.json`](config/quasar/deployments.json)):
 
-[View on Solana Explorer](https://explorer.solana.com/address/77rkRQxe4GRzHU56H6JuWPFe27g4NoRBz4GGftuUZXmX?cluster=devnet)
+| Program | Program ID |
+|---|---|
+| Registry | [`Xk7jczJZ1HHJZuE1ZUWDqFmowxYhnom7mWzrNSGf9FU`](https://explorer.solana.com/address/Xk7jczJZ1HHJZuE1ZUWDqFmowxYhnom7mWzrNSGf9FU?cluster=devnet) |
+| Escrow | [`VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW`](https://explorer.solana.com/address/VYCbMszux9seLK2aXFZMECMBFURvfuJLXsXPmJS5igW?cluster=devnet) |
+| Reputation | [`nb9rLVjoHMibsgfRGgKuPqm6M8GVcH9r6bYNfg7Yiy6`](https://explorer.solana.com/address/nb9rLVjoHMibsgfRGgKuPqm6M8GVcH9r6bYNfg7Yiy6?cluster=devnet) |
+| Attestation | [`CRGsWWkptdxsH6N6aWAyahLbuMsT58yM624EopEsv1Ex`](https://explorer.solana.com/address/CRGsWWkptdxsH6N6aWAyahLbuMsT58yM624EopEsv1Ex?cluster=devnet) |
 
-Deployed 2026-04-10 with Anchor 1.0.0 + Rust 1.89.0. Redeployment instructions in [`DEPLOY.md`](DEPLOY.md).
+Reputation was upgraded on 2026-05-06 to audit-hardened commit-reveal: `sha256(score‖salt‖job_id‖program_id)`. The legacy Anchor deployment (`794nTFNyJknzDrR13ApSfVyNCRvcvnCN3BVDfic8dcZD`) is historical/reference only and must not be used as the demo target. Redeployment instructions in [`DEPLOY.md`](DEPLOY.md).
 
 ---
 
 ## Stack
 
-- **On-chain:** Anchor (Rust) — AgentRegistry, ConsumerRegistry, EscrowState
+- **On-chain:** Quasar (Rust) — four programs: Registry, Escrow, Reputation, Attestation
 - **Off-chain index:** Node.js + Express — subscribes to Solana event logs
 - **Consumer agent:** TypeScript orchestrator with MCP `find_agents` tool
-- **Specialist server:** Node.js HTTP server — x402 payment gate + Ollama inference
-- **Web app:** Next.js 14 (App Router) + Tailwind + shadcn/ui + Solana wallet adapter
+- **Specialist server:** Node.js HTTP server — x402 payment gate fronting Ollama, vLLM, or OpenOnion inference
+- **MCP bridge:** [`@reddi/rap-mcp-bridge`](packages/rap-mcp-bridge) — exposes registered specialists to MCP clients (Claude Code, Cursor, etc.)
+- **Framework adapters:** [`eliza-plugin-x402`](packages/eliza-plugin-x402), [`sendai-x402`](packages/sendai-x402) — consumer-side integrations
+- **Web app:** Next.js 16 (App Router) + React 19 + Tailwind v4 + shadcn/ui + Solana wallet adapter
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix protocol fee — README claimed 16.7% / 83.3% split; actual is **0.05% per transaction**, only on settlement. Updated Economics table, payment-flow comment, and "What it is" bullet.
- Fix on-chain framework — README described a single Anchor program at the legacy id `77rkRQxe…UZXmX`. Quasar cutover completed 2026-05-06; protocol now runs **four Quasar programs on devnet** (Registry, Escrow, Reputation, Attestation — see `config/quasar/deployments.json`). Updated Solana-programs section, Stack section, and architecture diagram.
- Fix specialist runtime framing — README presented Ollama as the only backend. Specialists can run **Ollama, vLLM, or OpenOnion**; MCP clients reach them via `@reddi/rap-mcp-bridge`; ElizaOS / SendAI adapters ship in `packages/`. Updated the opening paragraph, "What it is" bullets, architecture diagram, quickstart heading, and Stack section.
- Refreshed the web-stack line to **Next.js 16 + React 19 + Tailwind v4** to match `package.json`.

## Test plan
- [ ] Confirm 0.05% fee figure is correct in all three changed locations (Economics table, payment flow, bullets)
- [ ] Confirm the four Quasar program IDs match `config/quasar/deployments.json`
- [ ] Confirm Ollama / vLLM / OpenOnion is the canonical specialist-runtime list (no missing or extra backend)
- [ ] Render README on GitHub and verify the architecture-diagram ASCII still aligns
- [ ] Sanity-check `packages/rap-mcp-bridge`, `packages/eliza-plugin-x402`, `packages/sendai-x402` links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)