### PR TITLE
fix: make Z picture executable demo production safe

### DIFF
--- a/app/api/economic-demo/z-picture-run/route.ts
+++ b/app/api/economic-demo/z-picture-run/route.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
 import { generateEconomicDemoImage } from "@/lib/economic-demo/image-adapter";
+import { Z_PICTURE_STATIC_IMAGE_URL, Z_PICTURE_STATIC_PROOF } from "@/lib/economic-demo/z-picture-static-proof";
 import { runEconomicDemoLivePaidDevnet } from "@/lib/economic-demo/live-paid-devnet-run";
 import { emitTorqueEvent, getLeaderboard } from "@/lib/torque/client";
 import { TORQUE_EVENTS } from "@/lib/torque/events";
@@ -30,16 +31,10 @@ function stripDataUrl(dataUrl: string) {
   return idx >= 0 ? dataUrl.slice(idx + marker.length) : null;
 }
 
-export async function POST(req: Request) {
-  const body = (await req.json().catch(() => ({}))) as { prompt?: string; walletAuthorization?: { wallet?: string; signature?: string; message?: string } };
-  const prompt = body.prompt?.trim() || "Generate a clean high-contrast square image showing one large capital letter Z, centered, bold, unmistakable, on a simple futuristic dark background.";
-  const runId = `z-picture-${new Date().toISOString().replace(/[:.]/g, "")}-${randomUUID().slice(0, 8)}`;
+type ZPictureBody = { prompt?: string; walletAuthorization?: { wallet?: string; signature?: string; message?: string } };
 
-  const leaderboardBefore = await getLeaderboard();
-  const paidRun = await runEconomicDemoLivePaidDevnet({ scenarioId: "picture", prompt });
-  const image = await generateEconomicDemoImage({ prompt, provider: "openai" });
-
-  const walletAuthorization = body.walletAuthorization?.wallet && body.walletAuthorization?.signature && body.walletAuthorization?.message
+function walletAuthorizationFromBody(body: ZPictureBody) {
+  return body.walletAuthorization?.wallet && body.walletAuthorization?.signature && body.walletAuthorization?.message
     ? {
         wallet: String(body.walletAuthorization.wallet),
         signature: String(body.walletAuthorization.signature),
@@ -47,6 +42,34 @@ export async function POST(req: Request) {
         boundary: "Client Phantom signature authorizes this browser demo run; x402 transfer signer is reported separately in paidRun.orchestratorWallet.",
       }
     : null;
+}
+
+function staticReplayResult(body: ZPictureBody, prompt: string, reason: string) {
+  const walletAuthorization = walletAuthorizationFromBody(body) ?? Z_PICTURE_STATIC_PROOF.walletAuthorization;
+  return {
+    ...Z_PICTURE_STATIC_PROOF,
+    ok: true,
+    replay: true,
+    source: "static-production-replay",
+    fallbackReason: reason,
+    prompt,
+    image: { ...Z_PICTURE_STATIC_PROOF.image, imageUrl: Z_PICTURE_STATIC_IMAGE_URL },
+    walletAuthorization,
+  };
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as ZPictureBody;
+  const prompt = body.prompt?.trim() || "Generate a clean high-contrast square image showing one large capital letter Z, centered, bold, unmistakable, on a simple futuristic dark background.";
+
+  try {
+    const runId = `z-picture-${new Date().toISOString().replace(/[:.]/g, "")}-${randomUUID().slice(0, 8)}`;
+
+    const leaderboardBefore = await getLeaderboard();
+    const paidRun = await runEconomicDemoLivePaidDevnet({ scenarioId: "picture", prompt });
+    const image = await generateEconomicDemoImage({ prompt, provider: "openai" });
+
+    const walletAuthorization = walletAuthorizationFromBody(body);
 
   const consumer = walletAuthorization?.wallet ?? paidRun.orchestratorWallet ?? PER_PROOF.payer;
   const agent = paidRun.timeline.find((step) => step.status === "payment_submitted")?.payTo ?? PER_PROOF.payee;
@@ -84,6 +107,10 @@ export async function POST(req: Request) {
     torque: { leaderboardBefore, leaderboardAfter, score: torqueScore },
     artifacts: { directory: outDir, image: b64 ? join(outDir, "z-image.png") : null, summary: join(outDir, "summary.json") },
   };
-  await writeFile(join(outDir, "summary.json"), JSON.stringify({ ...result, image: { ...image, imageUrl: b64 ? "[saved-to-z-image.png]" : image.imageUrl } }, null, 2));
-  return Response.json(result);
+    await writeFile(join(outDir, "summary.json"), JSON.stringify({ ...result, image: { ...image, imageUrl: b64 ? "[saved-to-z-image.png]" : image.imageUrl } }, null, 2));
+    return Response.json(result);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return Response.json(staticReplayResult(body, prompt, reason));
+  }
 }

--- a/app/economic-demo/z-picture-demo/page.tsx
+++ b/app/economic-demo/z-picture-demo/page.tsx
@@ -11,6 +11,9 @@ const WalletMultiButton = dynamic(
 
 type PaymentTx = { profileId: string; signature: string; solscan: string };
 type RunResult = {
+  replay?: boolean;
+  source?: string;
+  fallbackReason?: string;
   image: { imageUrl: string; provider: string; model: string; receipt: string };
   walletAuthorization?: { wallet: string; signature: string; message: string; boundary: string } | null;
   paidRun: { status: string; spentUsdc: string; orchestratorWallet: string | null };
@@ -62,8 +65,9 @@ export default function ZPictureDemoPage() {
     }
     try {
       const res = await fetch("/api/economic-demo/z-picture-run", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ prompt, walletAuthorization: { wallet: publicKey.toBase58(), signature, message: authorizationMessage } }) });
-      const data = await res.json();
-      if (!res.ok || !data.ok) throw new Error(data.error || "z_picture_run_failed");
+      const text = await res.text();
+      const data = text ? JSON.parse(text) : null;
+      if (!res.ok || !data?.ok) throw new Error(data?.error || data?.fallbackReason || `z_picture_run_failed_${res.status}`);
       setResult(data);
       setStatus("done");
     } catch (err) {
@@ -93,6 +97,7 @@ export default function ZPictureDemoPage() {
 
         {result && (
           <div className="mt-8 grid gap-6 lg:grid-cols-2">
+            {result.replay && <section className="rounded-2xl border border-yellow-400/25 bg-yellow-400/10 p-5 lg:col-span-2"><p className="section-label">Production replay mode</p><h2 className="mt-2 text-2xl font-semibold">Signed interaction captured; replaying the completed devnet proof</h2><p className="mt-3 text-sm leading-6 text-yellow-50/90">The browser wallet signature was captured, but this deployment is replaying the frozen completed proof because the live image/payment runner is not guaranteed inside Vercel serverless runtime. Fallback reason: <span className="font-mono">{result.fallbackReason}</span></p></section>}
             <section className="rounded-2xl border border-white/10 bg-card/80 p-5">
               <p className="section-label">Returned image proof</p>
               <h2 className="mt-2 text-2xl font-semibold">The generated image contains “Z”</h2>


### PR DESCRIPTION
## Summary
- make `/api/economic-demo/z-picture-run` catch production runtime failures and always return JSON
- reuse the completed static Z-picture proof as a signed production replay when live serverless execution fails
- preserve the browser wallet authorization from the current interaction in replay mode
- make `/economic-demo/z-picture-demo` robust to empty/non-JSON responses and show a clear replay-mode banner

## Why
The executable demo page exists, but production POSTs to the run endpoint returned HTTP 500 with an empty body. The browser then tried `res.json()` and showed `Unexpected end of JSON input`.

## Test
- `npm run build`
