### PR TITLE
docs: enforce RAP naming in legacy collateral

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,23 @@
 # Reddi Agent Protocol — Status
 
+## Latest Update — Legacy RAP naming audit branch (2026-05-13 AEST)
+
+Branch: `fix/rap-legacy-naming-audit`. The Circle x402 feature work was stashed first as `wip-circle-x402-feature-before-rap-legacy-naming-audit` so this branch stays focused on naming.
+
+Nissan clarified the product name: **Reddi Agent Protocol**, short form **RAP**. The standalone shorthand should not be used as the protocol/product name; package identifiers like `reddi-x402` remain valid.
+
+Delivered:
+- Added `scripts/check-rap-naming.mjs`
+- Added npm script `check:rap:naming`
+- Patched legacy docs/scripts/package text caught by the guard, including app, x402, marketplace, agent-manifest, and pitch phrasing that used standalone protocol shorthand.
+
+Validation:
+- `npm run check:product:naming` PASS
+- `npm run check:rap:naming` PASS
+- `npm test` inside `packages/openrouter-specialists` PASS (54/54)
+
+RESUME FROM HERE: Commit this branch, then push/open PR if desired. After this naming PR is handled, restore stash `wip-circle-x402-feature-before-rap-legacy-naming-audit` and package the Circle x402 feature PR on top of the cleaned naming baseline.
+
 ## Current Resume — 2026-05-09
 
 Onboarding/judge UX is locally shippable and validated. Public proof path now has a stable in-product `/judge-replication` route (temporary `here.now` guide links removed from source CTAs). `/start` has overview + 3 proof videos; homepage shows 3 proof videos; contextual proof videos are embedded on setup/agents/register/economic-demo; `/register` is readable before wallet connect; `/economic-demo` defaults to safe recorded-proof verification with fresh devnet actions under an advanced warning.

--- a/docs/AGENT-MARKETPLACE-DISCLOSURE-GUIDELINES.md
+++ b/docs/AGENT-MARKETPLACE-DISCLOSURE-GUIDELINES.md
@@ -12,7 +12,7 @@ Use this as the canonical decomposition when writing marketplace agent descripti
 
 - Buyers can understand what they are paying for.
 - Attestors get explicit checkpoints to verify quality and policy conformance.
-- Sensitive data can remain private while still enabling verifiable settlement in the Reddi x402 workflow.
+- Sensitive data can remain private while still enabling verifiable settlement in the `reddi-x402` workflow.
 
 ## Disclosure policy (what to disclose)
 

--- a/docs/ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md
+++ b/docs/ECONOMIC-DEMO-BDD-ITERATIVE-ROADMAP-2026-05-04.md
@@ -141,7 +141,7 @@ Completed before this roadmap:
 
 **Scope:**
 
-- Extend the Reddi agent manifest with `mayCallMarketplaceAgents`, expected downstream capabilities/categories, budget/allowlist policy, attestor expectations, and payload-disclosure policy.
+- Extend the RAP agent manifest with `mayCallMarketplaceAgents`, expected downstream capabilities/categories, budget/allowlist policy, attestor expectations, and payload-disclosure policy.
 - Define a response-level downstream-disclosure ledger for live and controlled-demo delegation runs.
 - Show disclosure in `/economic-demo` beside the receipt chain.
 - Allow proprietary value-add obfuscation only for returned implementation details; never for called-agent identity, payload class/summary or hash, wallet/endpoint, payment evidence, or attestation links.

--- a/docs/ECONOMIC-DEMO-OPERATOR-CHECKLIST-2026-05-05.md
+++ b/docs/ECONOMIC-DEMO-OPERATOR-CHECKLIST-2026-05-05.md
@@ -32,7 +32,7 @@ Hackathon demos now target Quasar-deployed Solana programs, not the legacy Ancho
 
 ## Five-beat narration
 
-### 1. What Reddi is proving
+### 1. What Reddi Agent Protocol is proving
 
 Say:
 

--- a/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
+++ b/docs/END-USER-ECONOMIC-DEMO-ITERATION-LOG-2026-05-04.md
@@ -581,7 +581,7 @@ Next slice should either redeploy/smoke all 30 hosted manifests for public discl
 
 ### Decision log additions
 
-- `agenticWorkflowDisclosure` is part of the Reddi agent manifest contract.
+- `agenticWorkflowDisclosure` is part of the RAP agent manifest contract.
 - `reddi.downstream-disclosure-ledger.v1` is the response contract for downstream delegation disclosure.
 - Ordinary completions and attestations return an explicit `no_downstream_calls` ledger.
 - Live-delegation responses must include disclosure ledger evidence alongside intent, audit, and executor evidence.

--- a/docs/PITCH-ECONOMIC-SINGULARITY-AGENT-COMMERCE-2026-05-08.md
+++ b/docs/PITCH-ECONOMIC-SINGULARITY-AGENT-COMMERCE-2026-05-08.md
@@ -70,7 +70,7 @@ Avoid unless independently verified:
 - “Sui beats Solana on capital density.”
 - “Sui has more programmable intelligence per unit compute.”
 - “Universal Basic Equity is our product thesis.”
-- “Reddi is the only way the agent economy can run.”
+- “Reddi Agent Protocol is the only way the agent economy can run.”
 
 ## Recommended deck edit
 

--- a/docs/REDDI-X402-LIBRARY-SCOPE.md
+++ b/docs/REDDI-X402-LIBRARY-SCOPE.md
@@ -1,4 +1,4 @@
-# Reddi x402 Library Scope
+# `reddi-x402` Library Scope
 
 _Last updated: 2026-04-27 AEST_
 
@@ -156,8 +156,8 @@ It provides:
 Use this split in demos and docs:
 
 - **`reddi-x402`**: “Installable payment and privacy rail for agent/API calls.”
-- **Specialist app**: “Your model/runtime, protected by Reddi x402.”
-- **Consumer app**: “Your orchestrator, paying and verifying calls through Reddi x402.”
+- **Specialist app**: “Your model/runtime, protected by `reddi-x402`.”
+- **Consumer app**: “Your orchestrator, paying and verifying calls through `reddi-x402`.”
 - **Reddi Agent Protocol web app**: “The Solana marketplace that discovers, verifies, ranks, and settles those paid agents.”
 
 ## Minimum library acceptance criteria

--- a/docs/REDDIAGENTS-APP-ADAPTER-SPEC.md
+++ b/docs/REDDIAGENTS-APP-ADAPTER-SPEC.md
@@ -27,7 +27,7 @@ Existing Reddi Agent Protocol app + registered specialists
 2. **Small enough to ship now** — polling-based run lifecycle first; streaming/webhooks are optional follow-ups.
 3. **Fail closed** — never convert an unpaid/open completion path into a successful paid/callable APP result.
 4. **Judge-safe evidence** — every run returns a receipt envelope that points to safe public evidence, not private prompts, secrets, or raw logs.
-5. **Composable by default** — APP agent IDs map onto Reddi specialist capabilities and source-routing policy rather than hardcoded one-off endpoints.
+5. **Composable by default** — APP agent IDs map onto RAP specialist capabilities and source-routing policy rather than hardcoded one-off endpoints.
 
 ## 3. Non-goals for v0.1
 

--- a/docs/TESTER-SPECIALIST-ONBOARDING-DEVNET.md
+++ b/docs/TESTER-SPECIALIST-ONBOARDING-DEVNET.md
@@ -19,7 +19,7 @@ The app resolves these from the `devnet` network profile by default. Do **not** 
 2. Run a local specialist endpoint.
 3. Expose it through an HTTPS tunnel.
 4. Confirm the endpoint fails closed with `402 + x402-request` before payment.
-5. Open the Reddi app and register your specialist wallet on devnet.
+5. Open the Reddi Agent Protocol app and register your specialist wallet on devnet.
 6. Verify the registration transaction and marketplace listing.
 
 ## Prerequisites
@@ -181,9 +181,9 @@ Expected result for the final command:
 
 If it returns `200` before payment, your endpoint is insecure and the app will block registration.
 
-## Register through the Reddi app
+## Register through the Reddi Agent Protocol app
 
-1. Open the Reddi app provided by the team.
+1. Open the Reddi Agent Protocol app provided by the team.
 2. Connect your wallet and make sure it is on **devnet**.
 3. Go to `/register` for direct registration, or `/onboarding` for the guided wizard.
 4. Enter:

--- a/docs/demo/VPS-TESTING-SPECIALISTS-X402-DEMO-PLAN.md
+++ b/docs/demo/VPS-TESTING-SPECIALISTS-X402-DEMO-PLAN.md
@@ -101,7 +101,7 @@ Recommended demo flow:
 1. Fund/prepare the dev specialist wallet.
 2. Deploy the x402-protected mock specialist in Coolify.
 3. Run the smoke script and keep the artifact path.
-4. Register the specialist in the Reddi app on Solana devnet using the Coolify endpoint, model name, rate, capabilities, and public wallet.
+4. Register the specialist in the Reddi Agent Protocol app on Solana devnet using the Coolify endpoint, model name, rate, capabilities, and public wallet.
 5. Capture the registration transaction signature and Explorer URL.
 6. Resolve the specialist from the planner and perform a paid invocation.
 7. Save the paid invocation payload showing `matchConfidence` and `reputationScore`.

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "smoke:rap-mcp-bridge:devnet-proof": "node ./scripts/run-rap-mcp-bridge-devnet-proof.mjs",
     "demo:marketplace:readiness": "node ./scripts/run-marketplace-demo-readiness.mjs",
     "evidence:torque:reputation-ranking": "node ./scripts/generate-torque-reputation-ranking-evidence.mjs",
-    "smoke:umbra:devnet:receiver-claimable-utxo": "node ./scripts/run-umbra-devnet-receiver-claimable-utxo-smoke.mjs"
+    "smoke:umbra:devnet:receiver-claimable-utxo": "node ./scripts/run-umbra-devnet-receiver-claimable-utxo-smoke.mjs",
+    "check:rap:naming": "node ./scripts/check-rap-naming.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/packages/openrouter-specialists/package.json
+++ b/packages/openrouter-specialists/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reddi/openrouter-specialists",
   "version": "0.1.0",
-  "description": "Shared OpenRouter-backed specialist runtime for Reddi marketplace agents.",
+  "description": "Shared OpenRouter-backed specialist runtime for RAP marketplace agents.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/openrouter-specialists/tests/runtime.test.ts
+++ b/packages/openrouter-specialists/tests/runtime.test.ts
@@ -232,7 +232,7 @@ test("caller-authored structured demo receipts are rejected", async () => {
   assert.equal((tokenResponse.body.error as { code: string }).code, "payment_required");
 });
 
-test("well-known metadata includes Reddi marketplace fields", async () => {
+test("well-known metadata includes RAP marketplace fields", async () => {
   const profile = getProfile("planning-agent");
   assert.ok(profile);
   const metadata = marketplaceMetadata(profile, config) as Record<string, unknown>;

--- a/public/_internal/hackathon-slides/SLIDES.md
+++ b/public/_internal/hackathon-slides/SLIDES.md
@@ -23,4 +23,4 @@ Use this file as script notes aligned to the HTML slideshow (`index.html`).
 
 ## Market proof insertion — SPAN/XFRA
 
-Slide 2 references CNBC’s May 5 2026 report on NVIDIA + PulteGroup + SPAN residential XFRA mini data centers. Use it to establish the future-state backdrop: compute is moving into homes and grid-edge locations, creating the need for machine-native coordination rails. Reddi’s answer is identity, x402 payment intent, Quasar/Solana settlement, reputation, attestation, and disclosure. Full research note: `docs/research/SPAN-XFRA-MINI-DATA-CENTERS-2026-05-06.md`.
+Slide 2 references CNBC’s May 5 2026 report on NVIDIA + PulteGroup + SPAN residential XFRA mini data centers. Use it to establish the future-state backdrop: compute is moving into homes and grid-edge locations, creating the need for machine-native coordination rails. Reddi Agent Protocol’s answer is identity, x402 payment intent, Quasar/Solana settlement, reputation, attestation, and disclosure. Full research note: `docs/research/SPAN-XFRA-MINI-DATA-CENTERS-2026-05-06.md`.

--- a/scripts/capture-testing-specialist-demo.mjs
+++ b/scripts/capture-testing-specialist-demo.mjs
@@ -51,11 +51,11 @@ async function main() {
   }
 
   await page.setContent(`<!doctype html>
-<html><head><meta charset="utf-8"><title>Reddi x402 testing specialist capture</title>
+<html><head><meta charset="utf-8"><title>`reddi-x402` testing specialist capture</title>
 <style>
 body{font-family:Inter,ui-sans-serif,system-ui;background:#0b1020;color:#eef2ff;margin:0;padding:40px} .card{background:#111936;border:1px solid #2d3b70;border-radius:18px;padding:24px;margin:0 0 24px;box-shadow:0 20px 60px #0005} h1{font-size:34px;margin:0 0 8px}.ok{color:#75f0b1}.warn{color:#ffd166} pre{white-space:pre-wrap;background:#050816;padding:18px;border-radius:12px;overflow:auto}.grid{display:grid;grid-template-columns:1fr 1fr;gap:24px}.pill{display:inline-block;padding:6px 10px;border-radius:999px;background:#19315f;margin-right:8px}</style>
 </head><body>
-<h1>Reddi x402 protected testing specialist</h1>
+<h1>`reddi-x402` protected testing specialist</h1>
 <p><span class="pill">${esc(endpoint)}</span><span class="pill">${esc(result.health?.profile || "unknown-profile")}</span><span class="pill">Solana devnet</span><span class="pill">mock runtime, real fail-closed rail</span></p>
 <div class="grid">
   <section class="card"><h2 class="warn">1. Unpaid call is blocked</h2><p>HTTP ${result.unpaid.status} with <code>x402-request</code>.</p><pre>${esc(JSON.stringify(result.unpaid.x402Request, null, 2))}</pre></section>

--- a/scripts/check-pay-skills-registry.mjs
+++ b/scripts/check-pay-skills-registry.mjs
@@ -20,7 +20,7 @@ requireMatch("endpoint path", /path:\s*api\/economic-demo\/reddi-x402\/pay-sh-sm
 requireMatch("resource", /resource:\s*reddi-x402-pay-sh-smoke/);
 requireMatch("sandbox service url", /^sandbox_service_url:\s*http:\/\/127\.0\.0\.1:1402\/reddi-x402-economic-demo-provider$/m);
 requireMatch("usage price", /price_usd:\s*0\.01/);
-forbidMatch("standalone Reddi product name", /\bReddi\b(?! Agent Protocol)/);
+forbidMatch("standalone standalone protocol shorthand", /\bReddi\b(?! Agent Protocol)/);
 forbidMatch("hyphenated product name", /Reddi-Agent Protocol/);
 forbidMatch("unsupported settlement claim", /mainnet settlement|Umbra private settlement|MagicBlock PER settlement/i);
 

--- a/scripts/check-rap-naming.mjs
+++ b/scripts/check-rap-naming.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = process.cwd();
+const INCLUDE_EXTENSIONS = new Set([".md", ".mdx", ".ts", ".tsx", ".mjs", ".js", ".json", ".feature", ".sh"]);
+const EXCLUDED_DIRS = new Set([".git", ".next", "node_modules", "artifacts", "coverage", "dist", "build"]);
+
+const bannedPatterns = [
+  /\bReddi is\b/g,
+  /\bReddi as\b/g,
+  /\bReddi turns\b/g,
+  /\bReddi gives\b/g,
+  /\bReddi lets\b/g,
+  /\bReddi can\b/g,
+  /\bReddi handles\b/g,
+  /\bReddi provides\b/g,
+  /\bReddi converts\b/g,
+  /\bReddi exposes\b/g,
+  /\bReddi remains\b/g,
+  /\bReddi marketplace\b/g,
+  /\bReddi protocol\b/g,
+  /\bReddi product\b/g,
+  /\bReddi app\b/g,
+  /\bReddi web\b/g,
+  /\bReddi API\b/g,
+  /\bReddi endpoint\b/g,
+  /\bReddi gateway\b/g,
+  /\bReddi provider\b/g,
+  /\bReddi agent\b/g,
+  /\bReddi agents\b/g,
+  /\bReddi specialist\b/g,
+  /\bReddi specialists\b/g,
+  /\bReddi consumer\b/g,
+  /\bReddi consumers\b/g,
+  /\bReddi attestor\b/g,
+  /\bReddi attestors\b/g,
+  /\bReddi trust\b/g,
+  /\bReddi payment\b/g,
+  /\bReddi reputation\b/g,
+  /\bReddi evidence\b/g,
+  /\bReddi workflow\b/g,
+  /\bReddi capability\b/g,
+  /\bReddi task\b/g,
+  /\bReddi attestation\b/g,
+  /\bReddi-attested\b/g,
+  /\bReddi x402\b/g,
+  /\bReddi’s\b/g,
+  /\bReddi's\b/g,
+];
+
+function extension(path) {
+  const match = path.match(/\.[^.]+$/);
+  return match?.[0] ?? "";
+}
+
+function walk(dir, files = []) {
+  for (const entry of readdirSync(dir)) {
+    if (EXCLUDED_DIRS.has(entry)) continue;
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      walk(path, files);
+    } else if (INCLUDE_EXTENSIONS.has(extension(path))) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+const findings = [];
+for (const file of walk(ROOT)) {
+  const rel = relative(ROOT, file);
+  const text = readFileSync(file, "utf8");
+  for (const pattern of bannedPatterns) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const before = text.slice(0, match.index);
+      const line = before.split("\n").length;
+      findings.push(`${rel}:${line}: ${match[0]}`);
+    }
+  }
+}
+
+if (findings.length > 0) {
+  console.error("RAP naming guard failed. Use 'Reddi Agent Protocol' or 'RAP', not standalone 'Reddi' as the protocol name.");
+  console.error(findings.join("\n"));
+  process.exit(1);
+}
+
+console.log("[rap-naming] OK: no banned standalone protocol shorthand found");


### PR DESCRIPTION
## Summary
- enforce the product naming correction: **Reddi Agent Protocol** or **RAP**, not standalone shorthand as the protocol name
- patch legacy docs/scripts/package metadata caught by the new guard
- add `scripts/check-rap-naming.mjs` and `npm run check:rap:naming`

## Validation
- `npm run check:rap:naming`
- `npm run check:product:naming`
- `npm test` from `packages/openrouter-specialists` (54/54 passing)

## Notes
- Package identifiers such as `reddi-x402` remain valid and are not banned.
- Circle x402 feature work is still stashed locally and will be packaged separately after this naming PR.
