### PR TITLE
feat: add Circle x402 source adapter preview

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,22 +1,74 @@
 # Reddi Agent Protocol — Status
 
-## Latest Update — Legacy RAP naming audit branch (2026-05-13 AEST)
+## Latest Update — Circle x402 source adapter packaged after RAP naming merge (2026-05-13 AEST)
 
-Branch: `fix/rap-legacy-naming-audit`. The Circle x402 feature work was stashed first as `wip-circle-x402-feature-before-rap-legacy-naming-audit` so this branch stays focused on naming.
+PR #312 (`docs: enforce RAP naming in legacy collateral`) was merged into `main` at `93702861`. The Circle x402 feature work was restored onto branch `feature/circle-x402-source-adapter` after updating from main.
 
-Nissan clarified the product name: **Reddi Agent Protocol**, short form **RAP**. The standalone shorthand should not be used as the protocol/product name; package identifiers like `reddi-x402` remain valid.
+Delivered in this feature branch:
+- Circle x402 source profile and Discovery-resource conversion helpers
+- Metadata-only ingest script: `scripts/ingest-circle-x402-discovery.mjs`
+- Dry-run catalog API/page: `/api/source-adapters/circle-x402` and `/circle-x402`
+- Dry-run route/quote preview API: `/api/source-adapters/circle-x402/quote-preview`
+- Tests for Circle profile, catalog route, and quote-preview route
+- BDD/source conformance wiring for `circle-x402`
 
-Delivered:
-- Added `scripts/check-rap-naming.mjs`
-- Added npm script `check:rap:naming`
-- Patched legacy docs/scripts/package text caught by the guard, including app, x402, marketplace, agent-manifest, and pitch phrasing that used standalone protocol shorthand.
+Boundary remains clean: no Circle login, wallet setup, funding, terms acceptance, x402 payment header creation, external service invocation, or live spend. Imported Circle resources remain externally listed and not RAP-attested until RAP attestors verify receipts/evidence.
 
-Validation:
+RESUME FROM HERE: Resolve/validate feature branch, commit, push, and open the Circle x402 source-adapter PR.
+
+## Previous Update — Legacy RAP naming audit branch (2026-05-13 AEST)
+
+PR #312 merged. Product naming rule is now guarded: use **Reddi Agent Protocol** or **RAP**, not standalone shorthand as the protocol/product name. Package identifiers such as `reddi-x402` remain valid.
+
+Validation before merge:
 - `npm run check:product:naming` PASS
 - `npm run check:rap:naming` PASS
 - `npm test` inside `packages/openrouter-specialists` PASS (54/54)
 
-RESUME FROM HERE: Commit this branch, then push/open PR if desired. After this naming PR is handled, restore stash `wip-circle-x402-feature-before-rap-legacy-naming-audit` and package the Circle x402 feature PR on top of the cleaned naming baseline.
+## Previous Update — Circle x402 dry-run catalog + quote preview (2026-05-13 AEST)
+
+Completed an autonomous completion pass from the Circle x402 adapter slice through local dry-run catalog, route/quote preview, BDD/docs sync, and validation. Everything remains metadata/local-preview only; there is no live Circle payment or invocation path.
+
+Delivered:
+- API: `app/api/source-adapters/circle-x402/route.ts`
+- Catalog loader: `lib/integrations/source-adapter/circle-x402-catalog.ts`
+- UI: `/circle-x402` at `app/circle-x402/page.tsx`
+- Marketplace CTA from `/agents` to `/circle-x402`
+- Route tests: `lib/__tests__/circle-x402-catalog-route.test.ts`
+- Quote preview helper: `lib/integrations/source-adapter/circle-x402-quote-preview.ts`
+- Quote preview API: `app/api/source-adapters/circle-x402/quote-preview/route.ts`
+- Quote preview tests: `lib/__tests__/circle-x402-quote-preview-route.test.ts`
+- `/circle-x402` UI can preview a selected candidate's RAP route with `livePaymentAllowed: false`, estimated USDC metadata, and required gates.
+
+Validation:
+- `npx jest lib/__tests__/circle-x402-catalog-route.test.ts lib/__tests__/circle-x402-quote-preview-route.test.ts lib/__tests__/source-adapter-circle-x402-profile.test.ts --runInBand` PASS (9/9)
+- `npm run test:bdd:index` PASS
+- `./scripts/run-source-conformance.sh --source circle-x402 --mode smoke` PASS including build; latest summary: `artifacts/source-conformance/20260513-054116-circle-x402-smoke/SUMMARY.md`
+- `pnpm build` PASS; new routes present: `/circle-x402`, `/api/source-adapters/circle-x402`, and `/api/source-adapters/circle-x402/quote-preview`
+
+## Previous Update — Circle x402 source adapter Iteration 1 (2026-05-13 AEST)
+
+Planned and implemented the first Circle for Agents / Circle x402 integration slice after the alignment crawl. This is metadata-only and does not perform Circle CLI login, wallet setup, funding, terms acceptance, or live paid calls.
+
+Delivered:
+- Spec: `docs/CIRCLE-X402-SOURCE-ADAPTER-SPEC-2026-05-13.md`
+- Source profile + conversion helpers: `lib/integrations/source-adapter/profiles/circle-x402.ts`
+- Registry support for `circle-x402`: `lib/integrations/source-adapter/profiles/index.ts`
+- MCP preferred-source enum updated to include `circle-x402`: `lib/mcp/tools.ts`
+- Tests: `lib/__tests__/source-adapter-circle-x402-profile.test.ts`
+- Live metadata ingest script: `scripts/ingest-circle-x402-discovery.mjs` and npm script `ingest:circle-x402`
+- BDD/source conformance hooks updated for `circle-x402`
+
+## Latest Update — Public cohort readiness matrix created (2026-05-12 AEST)
+
+Created `docs/RAP-SHARED-CONTEXT-PACK-2026-05-12.md` as the current working baseline for Reddi Agent Protocol roadmap discussions. It synthesizes the status files, payment architecture, `reddi-x402` scope, reputation design, verifiable protocol index, whitepaper candidate/plan, RAP MCP bridge design, agent-framework onboarding guide, OpenRouter 30-specialist readiness boundary, and final recording packet claim boundaries.
+
+Created `docs/PUBLIC-AGENT-COHORT-READINESS-MATRIX-2026-05-12.md` to turn the baseline into launch gates for the first public Specialist, Attestor, and Consumer cohorts. Recommended default: Phase 1 dry-run public market first; then bounded devnet paid invocation only after readiness gates pass. Proposed first batch: specialists = codegen, research/citation, content, QA, proof artifact; attestors = schema, factuality/citation, code/test, receipt/disclosure; consumers = RAP MCP Bridge + OpenClaw skill/playbook.
+
+Key roadmap framing captured: Reddi Agent Protocol is the protocol/marketplace/control-plane layer; `reddi-x402` is the installable payment/privacy rail; first public cohort should be organized across Specialist, Attestor, and Consumer readiness matrices. Boundary reminders remain explicit: no mainnet settlement claim, no successful public Jupiter devnet swap claim, no production-paid claim for all 30 OpenRouter specialists without refreshed funding/deployment/live paid-call readiness.
+
+RESUME FROM HERE: Use `docs/RAP-SHARED-CONTEXT-PACK-2026-05-12.md` and `docs/PUBLIC-AGENT-COHORT-READINESS-MATRIX-2026-05-12.md` as the shared group-chat baseline. Next useful implementation artifact is a machine-checkable `data/public-cohort/` seed plus a readiness validator/page.
+
 
 ## Current Resume — 2026-05-09
 

--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -47,9 +47,14 @@ export default function AgentsPage() {
           title="Available Specialists"
           subtitle="Discover and hire AI specialists for your agent workflows"
           actions={
-            <Link href="/register" className={buttonVariants({ size: "sm" })}>
-              + Register yours
-            </Link>
+            <div className="flex flex-wrap gap-2">
+              <Link href="/circle-x402" className={buttonVariants({ variant: "outline", size: "sm" })}>
+                Circle x402 dry-run
+              </Link>
+              <Link href="/register" className={buttonVariants({ size: "sm" })}>
+                + Register yours
+              </Link>
+            </div>
           }
         />
 

--- a/app/api/source-adapters/circle-x402/quote-preview/route.ts
+++ b/app/api/source-adapters/circle-x402/quote-preview/route.ts
@@ -1,0 +1,31 @@
+import { buildCircleX402QuotePreview } from "@/lib/integrations/source-adapter/circle-x402-quote-preview";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as { candidateId?: string; task?: string };
+    const candidateId = body.candidateId?.trim();
+
+    if (!candidateId) {
+      return Response.json(
+        { ok: false, mode: "dry-run-quote-preview", error: "candidateId is required" },
+        { status: 400 }
+      );
+    }
+
+    const preview = buildCircleX402QuotePreview({ candidateId, task: body.task });
+    return Response.json(preview, { status: preview.ok ? 200 : 404 });
+  } catch (error) {
+    return Response.json(
+      {
+        ok: false,
+        mode: "dry-run-quote-preview",
+        error: error instanceof Error ? error.message : "Circle x402 quote preview failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/source-adapters/circle-x402/route.ts
+++ b/app/api/source-adapters/circle-x402/route.ts
@@ -1,0 +1,22 @@
+import { loadCircleX402Catalog } from "@/lib/integrations/source-adapter/circle-x402-catalog";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const limit = Number(searchParams.get("limit") ?? 50);
+  const category = searchParams.get("category") ?? undefined;
+  const catalog = loadCircleX402Catalog({ limit, category });
+
+  const status = catalog.ok ? 200 : 404;
+  return Response.json(
+    {
+      ...catalog,
+      mode: "dry-run-catalog",
+      boundary: "Circle x402 resources are externally listed and not RAP-attested until RAP verifies receipts/evidence through attestors. This endpoint never pays or invokes services.",
+    },
+    { status }
+  );
+}

--- a/app/circle-x402/page.tsx
+++ b/app/circle-x402/page.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+import { buttonVariants } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
+import type { ReddiCircleX402Candidate } from "@/lib/integrations/source-adapter/profiles/circle-x402";
+
+type QuotePreviewResponse = {
+  ok: boolean;
+  mode: "dry-run-quote-preview";
+  task: string;
+  candidate: ReddiCircleX402Candidate | null;
+  routePreview: {
+    routeState: string;
+    plannerPolicy: {
+      preferredSource: "circle-x402";
+      strictSourceMatch: boolean;
+      requireAttestationBeforeTrust: boolean;
+      livePaymentAllowed: boolean;
+    };
+  } | null;
+  quotePreview: {
+    currency: "USDC";
+    network: string;
+    rail: "circle_gateway" | "vanilla_x402";
+    estimatedUsd?: number;
+    maxAmountRequired?: string;
+  } | null;
+  requiredGates: string[];
+  trustNotes: string[];
+  error?: string;
+};
+
+type CatalogResponse = {
+  ok: boolean;
+  summary: {
+    totalResources?: number;
+    pricesUsdc?: { median?: number | null; p90?: number | null; max?: number | null };
+    categories?: Record<string, number>;
+  } | null;
+  candidates: ReddiCircleX402Candidate[];
+  total: number;
+  returned: number;
+  boundary: string;
+  error?: string;
+};
+
+function money(value: number | null | undefined) {
+  if (value === null || value === undefined) return "unknown";
+  if (value === 0) return "$0";
+  if (value < 0.01) return `$${value.toFixed(6)}`;
+  return `$${value.toFixed(3)}`;
+}
+
+export default function CircleX402Page() {
+  const [catalog, setCatalog] = useState<CatalogResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [category, setCategory] = useState("All");
+  const [quotePreview, setQuotePreview] = useState<QuotePreviewResponse | null>(null);
+  const [quoteLoading, setQuoteLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      const qs = new URLSearchParams({ limit: "36" });
+      if (category !== "All") qs.set("category", category);
+      const response = await fetch(`/api/source-adapters/circle-x402?${qs.toString()}`);
+      const data = (await response.json()) as CatalogResponse;
+      if (!cancelled) {
+        setCatalog(data);
+        setLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [category]);
+
+  async function previewQuote(candidate: ReddiCircleX402Candidate) {
+    setQuoteLoading(true);
+    try {
+      const response = await fetch("/api/source-adapters/circle-x402/quote-preview", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          candidateId: candidate.candidateId,
+          task: `Preview RAP route for ${candidate.providerName}`,
+        }),
+      });
+      const data = (await response.json()) as QuotePreviewResponse;
+      setQuotePreview(data);
+    } finally {
+      setQuoteLoading(false);
+    }
+  }
+
+  const categories = useMemo(() => {
+    const entries = Object.entries(catalog?.summary?.categories ?? {});
+    return ["All", ...entries.sort((a, b) => b[1] - a[1]).map(([name]) => name)];
+  }, [catalog?.summary?.categories]);
+
+  return (
+    <div className="min-h-screen bg-page">
+      <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+        <PageHeader
+          label="Circle x402 source adapter"
+          title="Circle-listed paid APIs, ready for RAP trust wrapping"
+          subtitle="Dry-run catalog and quote preview. RAP can import Circle x402 resources as external specialist candidates, then add routing, receipt verification, attestation, reputation, and disclosure before any explicitly approved live spend."
+          actions={
+            <Link href="/agents" className={buttonVariants({ variant: "outline", size: "sm" })}>
+              Back to marketplace
+            </Link>
+          }
+        />
+
+        <section className="mb-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 p-5 text-sm text-amber-100">
+          <div className="font-semibold text-amber-50">Boundary: dry-run only</div>
+          <p className="mt-2 text-amber-100/80">
+            This page never logs into Circle, accepts terms, funds wallets, creates payment headers, pays, or invokes services. Imported resources are marked externally listed and not RAP-attested until RAP attestors verify receipts and evidence.
+          </p>
+        </section>
+
+        <section className="mb-8 grid gap-4 md:grid-cols-4">
+          <div className="rounded-xl bg-surface p-4 glow-border">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Ingested resources</div>
+            <div className="mt-2 text-2xl font-semibold text-white">{catalog?.summary?.totalResources ?? catalog?.total ?? "—"}</div>
+          </div>
+          <div className="rounded-xl bg-surface p-4 glow-border">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Median price</div>
+            <div className="mt-2 text-2xl font-semibold text-white">{money(catalog?.summary?.pricesUsdc?.median)}</div>
+          </div>
+          <div className="rounded-xl bg-surface p-4 glow-border">
+            <div className="text-xs uppercase tracking-wide text-gray-500">P90 price</div>
+            <div className="mt-2 text-2xl font-semibold text-white">{money(catalog?.summary?.pricesUsdc?.p90)}</div>
+          </div>
+          <div className="rounded-xl bg-surface p-4 glow-border">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Returned now</div>
+            <div className="mt-2 text-2xl font-semibold text-white">{catalog?.returned ?? "—"}</div>
+          </div>
+        </section>
+
+        {quotePreview ? (
+          <section className="mb-8 rounded-2xl bg-surface p-5 glow-border">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <div className="text-xs uppercase tracking-wide text-indigo-300">Dry-run route preview</div>
+                <h2 className="mt-2 text-xl font-semibold text-white">{quotePreview.candidate?.providerName ?? "Candidate unavailable"}</h2>
+                <p className="mt-2 text-sm text-gray-400">{quotePreview.task}</p>
+              </div>
+              <span className="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-xs text-amber-100">
+                {quotePreview.routePreview?.routeState.replaceAll("_", " ") ?? "not routable"}
+              </span>
+            </div>
+            {quotePreview.ok ? (
+              <div className="mt-5 grid gap-4 md:grid-cols-3">
+                <div className="rounded-lg border border-gray-800 bg-black/20 p-3 text-sm text-gray-300">
+                  <div className="text-gray-500">Source policy</div>
+                  <div>preferredSource: circle-x402</div>
+                  <div>strictSourceMatch: true</div>
+                  <div>livePaymentAllowed: false</div>
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-black/20 p-3 text-sm text-gray-300">
+                  <div className="text-gray-500">Quote preview</div>
+                  <div>Rail: {quotePreview.quotePreview?.rail ?? "unknown"}</div>
+                  <div>Network: {quotePreview.quotePreview?.network ?? "unknown"}</div>
+                  <div>Estimated: {money(quotePreview.quotePreview?.estimatedUsd)}</div>
+                </div>
+                <div className="rounded-lg border border-amber-400/20 bg-amber-400/5 p-3 text-sm text-amber-100">
+                  <div className="font-medium">Required before live payment</div>
+                  <ul className="mt-2 list-disc space-y-1 pl-4 text-xs text-amber-100/80">
+                    {quotePreview.requiredGates.map((gate) => (
+                      <li key={gate}>{gate}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-red-200">{quotePreview.error}</p>
+            )}
+          </section>
+        ) : null}
+
+        <div className="mb-8 flex flex-wrap gap-3">
+          {categories.map((name) => (
+            <button
+              key={name}
+              onClick={() => setCategory(name)}
+              className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                category === name ? "bg-indigo-500 text-white" : "bg-surface text-gray-400 glow-border hover:text-white"
+              }`}
+            >
+              {name.replaceAll("_", " ")}
+            </button>
+          ))}
+        </div>
+
+        {loading ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-48 animate-pulse rounded-xl bg-surface/70 glow-border" />
+            ))}
+          </div>
+        ) : catalog?.ok ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            {catalog.candidates.map((candidate) => (
+              <article key={candidate.candidateId} className="rounded-xl bg-surface p-5 glow-border">
+                <div className="text-xs uppercase tracking-wide text-indigo-300">{candidate.category.replaceAll("_", " ")}</div>
+                <h2 className="mt-2 line-clamp-2 text-lg font-semibold text-white">{candidate.providerName}</h2>
+                <p className="mt-2 break-all text-xs text-gray-500">{candidate.resource}</p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {candidate.taskTypes.map((task) => (
+                    <span key={task} className="rounded-full bg-indigo-500/10 px-2 py-1 text-xs text-indigo-200">
+                      {task}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-4 rounded-lg border border-gray-800 bg-black/20 p-3 text-xs text-gray-300">
+                  <div>Rail: {candidate.payment[0]?.rail ?? "unknown"}</div>
+                  <div>Network: {candidate.payment[0]?.network ?? "unknown"}</div>
+                  <div>Price: {money(candidate.payment[0]?.priceUsdc)}</div>
+                </div>
+                <div className="mt-4 rounded-lg border border-amber-400/20 bg-amber-400/5 p-3 text-xs text-amber-100">
+                  {candidate.attestationState.replaceAll("_", " ")}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void previewQuote(candidate)}
+                  disabled={quoteLoading}
+                  className="mt-4 w-full rounded-lg bg-indigo-500 px-3 py-2 text-sm font-medium text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {quoteLoading ? "Previewing…" : "Preview RAP route — no spend"}
+                </button>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-xl border border-red-400/30 bg-red-400/10 p-5 text-red-100">
+            {catalog?.error ?? "Circle catalog unavailable."}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
+++ b/docs/BDD-ITERATION-LOG-2026-04-22-source-adapters.md
@@ -148,3 +148,44 @@ This log follows `playbooks/bdd-gap-closure-loop/PLAYBOOK.md` and is updated eve
   - Source-aware routing defaults are now wired with strict guardrails and deterministic reasons.
   - Matrix regressions are CI-gated with retained artifacts for fast diagnosis.
   - Next iteration should add source-aware ranking explainability in API output metadata (per-candidate source match summary) for external supervisor debugging.
+
+## Iteration 7
+- Focus: Circle for Agents / Circle x402 Discovery source adapter baseline.
+- Delivered:
+  - Added implementation spec: `docs/CIRCLE-X402-SOURCE-ADAPTER-SPEC-2026-05-13.md`.
+  - Added Circle x402 source profile + deterministic Discovery resource conversion:
+    - `lib/integrations/source-adapter/profiles/circle-x402.ts`
+    - registered in `lib/integrations/source-adapter/profiles/index.ts`.
+  - Extended MCP source preference enum to include `circle-x402`.
+  - Added tests:
+    - `lib/__tests__/source-adapter-circle-x402-profile.test.ts`.
+  - Added metadata-only live ingest script:
+    - `scripts/ingest-circle-x402-discovery.mjs`
+    - npm script `ingest:circle-x402`.
+  - Extended Bucket-S BDD/conformance docs and harnesses for Circle x402.
+- Verified:
+  - `npx jest lib/__tests__/source-adapter-circle-x402-profile.test.ts --runInBand` -> PASS, 1 suite, 4/4 tests.
+  - `npm run test:bdd:index` -> PASS.
+  - `./scripts/run-source-conformance.sh --source circle-x402 --mode smoke` -> PASS, including build gate.
+  - Artifact evidence: `artifacts/source-conformance/20260513-044642-circle-x402-smoke/SUMMARY.md`.
+  - `npm run ingest:circle-x402 -- --out-dir artifacts/circle-x402-discovery/20260513-iteration1` -> PASS, 509 resources ingested, median price $0.005 USDC.
+- Retrospective:
+  - Circle x402 should be treated as an external paid-service source, not as RAP trust evidence. Candidates default to `externally_listed_unattested` until RAP verifies receipts/evidence through attestors.
+  - Next iteration should expose the Circle ingest artifact through a dry-run UI/API demo before any live pay/invoke path.
+
+## Iteration 8
+- Focus: Circle x402 dry-run catalog UI/API.
+- Delivered:
+  - Added catalog loader: `lib/integrations/source-adapter/circle-x402-catalog.ts`.
+  - Added dry-run API: `app/api/source-adapters/circle-x402/route.ts`.
+  - Added UI route: `/circle-x402` via `app/circle-x402/page.tsx`.
+  - Linked marketplace `/agents` to the Circle x402 dry-run surface.
+  - Added route tests: `lib/__tests__/circle-x402-catalog-route.test.ts`.
+- Verified:
+  - `npx jest lib/__tests__/circle-x402-catalog-route.test.ts lib/__tests__/source-adapter-circle-x402-profile.test.ts --runInBand` -> PASS, 2 suites, 6/6 tests.
+  - `pnpm build` -> PASS; routes include `/circle-x402` and `/api/source-adapters/circle-x402`.
+- Boundary:
+  - Still metadata/dry-run only. No live Circle payment, login, funding, terms acceptance, or service invocation.
+  - UI repeats that Circle resources are externally listed and not RAP-attested until RAP verifies receipts/evidence.
+- Retrospective:
+  - The first product-visible integration should stay at catalog + quote-preview level. Live x402 payment should be a separate explicit experiment with tiny caps and approval controls.

--- a/docs/CIRCLE-X402-SOURCE-ADAPTER-SPEC-2026-05-13.md
+++ b/docs/CIRCLE-X402-SOURCE-ADAPTER-SPEC-2026-05-13.md
@@ -1,0 +1,124 @@
+# Circle x402 Source Adapter Spec
+
+_Date: 2026-05-13 AEST_  
+_Status: Iteration 1 implementation target_
+
+## Intent
+
+Use Circle for Agents / Circle x402 Discovery as a Reddi Agent Protocol source ecosystem, without confusing Circle's payment rails with RAP's trust layer.
+
+Circle supplies wallet/payment/catalog primitives. RAP wraps those primitives with specialist manifests, capability routing, attestation state, receipts/evidence, and reputation policy.
+
+## Non-goals
+
+- No live paid Circle calls in this slice.
+- No Circle CLI login, wallet creation, funding, terms acceptance, or private-key handling.
+- No claim that Circle Gateway Nanopayments support Solana. Current Circle docs list Solana Gateway support but Nanopayments = No.
+- No claim that Circle-listed resources are RAP-attested before RAP attestors have run.
+
+## Source identity
+
+- Source id: `circle-x402`
+- Roles: `specialist`, `consumer`
+- Runtimes: `http`, `circle-gateway`, `vanilla-x402`
+- Default payment policy: `x402_required`
+- Default attestation state: `externally_listed_unattested`
+
+## Input
+
+Circle Discovery API resource shape, minimally:
+
+```json
+{
+  "resource": "https://api.example.com/path",
+  "type": "http",
+  "x402Version": 1,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "maxAmountRequired": "5000",
+      "asset": "0x...",
+      "payTo": "0x..."
+    }
+  ],
+  "metadata": {
+    "provider": {
+      "name": "Provider",
+      "description": "Provider description",
+      "category": "WEB_SEARCH_RESEARCH",
+      "tags": ["research"]
+    },
+    "description": "Endpoint description",
+    "supportsCircleGateway": true,
+    "supportsVanillax402": true
+  }
+}
+```
+
+## RAP candidate mapping
+
+Each Circle resource becomes a RAP specialist candidate:
+
+- `candidateId`: stable `circle-x402:<host>:<path>` slug
+- `source`: `circle-x402`
+- `providerName`: `metadata.provider.name`
+- `resource`: Circle resource URL
+- `category`: Circle provider category
+- `taskTypes`: mapped RAP capability taxonomy
+- `sourceAdapter`: valid `source-adapter.v1` specialist manifest
+- `payment`: accepted payment options normalized to price/network/rail fields
+- `attestationState`: `externally_listed_unattested`
+- `trustNotes`: explicit boundary that listing is external until RAP attestation runs
+
+## Category mapping
+
+| Circle category | RAP task types |
+|---|---|
+| `FINANCIAL_ANALYSIS` | `financial-analysis`, `market-data` |
+| `SOCIAL_INTELLIGENCE` | `social-intelligence`, `profile-analysis` |
+| `WEB_SEARCH_RESEARCH` | `research`, `web-search` |
+| `PREDICTION_MARKETS` | `prediction-market-analysis`, `forecasting` |
+| `CREATIVE` | `creative-generation` |
+| `INFRASTRUCTURE` | `infrastructure`, `developer-tooling` |
+| unknown | `external-api` |
+
+## Payment rail mapping
+
+- `supportsCircleGateway=true` + Gateway-compatible payment option → `circle_gateway`
+- otherwise x402-compatible payment option → `vanilla_x402`
+- preserve original network CAIP id and atomic amount
+- convert USDC subunits to decimal price when `maxAmountRequired` is numeric
+
+## Safety gates
+
+- Import is metadata-only by default.
+- Live pay/invoke remains behind explicit approval and tiny caps.
+- Wrong payee/amount/network/resource must fail closed in future paid client work.
+- Circle resources imported from Discovery API must display as `externally listed, not RAP-attested yet` until RAP attestation evidence exists.
+
+## Acceptance criteria for Iteration 1
+
+- `circle-x402` source profile resolves from source registry.
+- Circle category mapping is deterministic and tested.
+- Circle discovery resource converts into a valid `source-adapter.v1` specialist candidate.
+- Candidate keeps external-listing/unattested boundary metadata.
+- Source conformance harness accepts `circle-x402` and runs Circle-specific tests.
+
+## Iteration 2 — dry-run route / quote preview
+
+Implemented a product-visible dry-run route preview on top of the metadata catalog:
+
+- API: `POST /api/source-adapters/circle-x402/quote-preview`
+- UI: `/circle-x402` candidate cards expose `Preview RAP route`
+- Helper: `lib/integrations/source-adapter/circle-x402-quote-preview.ts`
+
+The preview returns:
+
+- `mode: dry-run-quote-preview`
+- source-aware route policy with `preferredSource: circle-x402`, `strictSourceMatch: true`
+- `livePaymentAllowed: false`
+- rail/network/estimated USDC amount from Circle Discovery metadata
+- required gates before paid invocation: explicit user approval, tiny spend cap, runtime-only Circle credentials, receipt capture, and RAP attestor verification
+
+This is still not a payment or invocation path. It creates no x402 payment headers and makes no external service request.

--- a/docs/PUBLIC-AGENT-COHORT-READINESS-MATRIX-2026-05-12.md
+++ b/docs/PUBLIC-AGENT-COHORT-READINESS-MATRIX-2026-05-12.md
@@ -1,0 +1,340 @@
+# Reddi Agent Protocol — Public Agent Cohort Readiness Matrix
+
+_Date: 2026-05-12 AEST_  
+_Source baseline: `docs/RAP-SHARED-CONTEXT-PACK-2026-05-12.md`_
+
+Purpose: convert the shared Reddi Agent Protocol context into an actionable launch matrix for the first public batch of **specialist**, **attestor**, and **consumer** agents.
+
+## North star
+
+Launch a small, honest, verifiable devnet-first public agent market where:
+
+1. consumer agents discover and quote specialists,
+2. specialists expose useful paid endpoints protected by `reddi-x402`,
+3. attestors independently evaluate outputs and receipts,
+4. Reddi Agent Protocol records payment, settlement, reputation, and disclosure evidence.
+
+Initial launch should optimize for repeatable evidence and trust, not raw breadth.
+
+## Product boundaries
+
+- **Reddi Agent Protocol** = marketplace/control-plane/protocol layer.
+- **`reddi-x402`** = installable payment/privacy rail for paid agent/API calls.
+- **Devnet-first** until production preflight proves funding, deployment, secrets, and live paid-call readiness.
+- No mainnet settlement, public Jupiter devnet swap success, or production-paid-all-30-specialists claims yet.
+
+## Launch phases
+
+### Phase 0 — Internal freeze
+
+Goal: freeze truth and avoid roadmap drift.
+
+Exit gates:
+
+- Shared context pack accepted as baseline.
+- This readiness matrix accepted as launch checklist.
+- Current claim boundaries embedded in public docs, demo scripts, and operator runbooks.
+- One canonical launch dashboard/page chosen for public cohort status.
+
+### Phase 1 — Dry-run public market
+
+Goal: public users can inspect agents, manifests, quotes, policies, and expected payment flows without spend.
+
+Exit gates:
+
+- Specialist manifests visible and probeable.
+- Consumer flow can discover/request quote in dry-run mode.
+- Attestor profiles and verdict schemas are visible.
+- Disclosure ledger preview can be exported without private payloads.
+- No payment/invocation tools exposed by default.
+
+### Phase 2 — Bounded devnet paid market
+
+Goal: selected consumers can perform tiny capped devnet paid invocations with receipt/evidence logging.
+
+Exit gates:
+
+- Explicit spend cap, network allowlist, endpoint allowlist, and approval policy active.
+- Paid specialist retry returns output plus receipt metadata.
+- Attestor verdict updates settlement/reputation evidence path.
+- Replay, wrong amount, wrong payee, wrong network, and expired quote tests fail closed.
+- Evidence bundle generated per run.
+
+### Phase 3 — Public devnet cohort
+
+Goal: first external/public operators onboard and self-verify with guided docs.
+
+Exit gates:
+
+- “Become a specialist” guide.
+- “Run an attestor” guide.
+- “Hire a specialist from your agent” guide.
+- Public readiness checklist visible per agent.
+- Support/incident path defined.
+- Cohort participants pass all launch gates below.
+
+### Phase 4 — Production readiness preflight
+
+Goal: only after devnet cohort is reliable, decide which parts graduate toward production-paid claims.
+
+Exit gates:
+
+- Funding/deployment/env readiness preflight passes.
+- Secret handling audited.
+- Mainnet/legal/compliance boundaries reviewed.
+- Production payment risks and dispute path documented.
+- Public claims updated only after evidence exists.
+
+## Cohort A — Specialist agents
+
+### Recommended first batch
+
+Start with 5 specialists because it demonstrates marketplace diversity without making readiness unmanageable:
+
+1. **Code Generation Specialist** — bounded code patch/diff generation.
+2. **Research + Citation Specialist** — sourced brief with citations.
+3. **Content Drafting Specialist** — short-form/product copy drafts.
+4. **QA / Verification Specialist** — test-plan or claim-boundary review.
+5. **Proof Artifact Specialist** — screenshot/video/evidence-pack assistance.
+
+### Specialist readiness gates
+
+Required before public listing:
+
+- Public manifest at `/.well-known/reddi-agent.json`.
+- Manifest includes id, display name, capabilities, endpoint, wallet/payee, network, price, privacy mode, health endpoint, evidence policy, and operator contact/disclosure field.
+- Protected endpoint returns unpaid `402 + x402-request` before any useful output.
+- Paid retry returns output plus receipt metadata.
+- Nonce/replay prevention works.
+- Wrong amount, wrong payee, wrong network, expired quote, and duplicate receipt all reject closed.
+- Endpoint does not log raw prompts by default.
+- Request isolation enabled by default; no hidden model/session context reuse unless explicitly negotiated.
+- Devnet receipt artifact captured.
+- Disclosure ledger artifact captured.
+- Registration and marketplace profile are visible in Reddi Agent Protocol.
+- Health/probe endpoint passes current marketplace probe.
+
+### Specialist nice-to-have gates
+
+- Example prompt and expected output.
+- Published model/provider/runtime disclosure.
+- SLA or latency expectation.
+- Rate limit policy.
+- Refund/dispute handling description.
+- Attestor compatibility declaration.
+
+### Specialist readiness status template
+
+```text
+Specialist: <name>
+Role: code | research | content | qa | proof
+Endpoint: <url>
+Manifest: pass/fail
+Unpaid x402 challenge: pass/fail
+Paid devnet retry: pass/fail
+Receipt verification: pass/fail
+Fail-closed negative tests: pass/fail
+Privacy-safe logs: pass/fail
+Marketplace registration: pass/fail
+Attestor coverage: pass/fail
+Disclosure ledger: pass/fail
+Launch status: blocked | dry-run-ready | devnet-paid-ready | public-cohort-ready
+Blockers: ...
+```
+
+## Cohort B — Attestor agents
+
+### Recommended first batch
+
+Start with 4 attestors:
+
+1. **Schema / Format Attestor** — checks structured output contract.
+2. **Citation / Factuality Attestor** — checks citations and factual claims.
+3. **Code/Test Attestor** — checks code patch validity, tests, or repo hygiene.
+4. **Receipt / Disclosure Attestor** — verifies x402 receipt, quote match, endpoint identity, and disclosure ledger completeness.
+
+### Attestor readiness gates
+
+Required before public listing:
+
+- Public attestor manifest with domain, rubric, version, endpoint, operator, and supported evidence types.
+- Deterministic verdict schema documented.
+- Verdict includes pass/fail, confidence, reasons, evidence hash references, and limitations.
+- Prompt/output/verdict hash binding supported.
+- Attestor can evaluate at least one specialist cohort role.
+- Attestor never receives private payloads unless privacy policy explicitly allows it.
+- Attestor reliability/reputation is tracked separately from specialist quality.
+- Settlement-compatible fields are present.
+- Negative case tested: malformed output should fail.
+- Positive case tested: valid output should pass.
+- Disagreement/appeal policy documented, even if manual for v1.
+
+### Attestor nice-to-have gates
+
+- Rubric examples.
+- Calibration set.
+- Self-disclosure of model/runtime.
+- Blind evaluation mode.
+- Commit-reveal or delayed reveal support for sensitive scoring.
+
+### Attestor readiness status template
+
+```text
+Attestor: <name>
+Domain: schema | factuality | code | receipt
+Rubric version: <version>
+Verdict schema: pass/fail
+Evidence hash binding: pass/fail
+Positive fixture: pass/fail
+Negative fixture: pass/fail
+Settlement fields: pass/fail
+Reputation tracking: pass/fail
+Privacy boundary: pass/fail
+Launch status: blocked | dry-run-ready | devnet-ready | public-cohort-ready
+Blockers: ...
+```
+
+## Cohort C — Consumer agents
+
+### Recommended first batch
+
+Start with 2 consumer runtimes and one thin SDK path:
+
+1. **RAP MCP Bridge** for Claude/Cursor/OpenClaw/OpenSwarm-style agents.
+2. **OpenClaw project skill/playbook** for native OpenClaw usage.
+3. **HTTP/SDK example consumer** for custom agents and OpenAI/Codex-style wrappers.
+
+### Consumer readiness gates
+
+Required before public listing:
+
+- Discovery works in dry-run mode.
+- Quote-first flow works without spend.
+- No pay/invoke tools exposed unless explicitly enabled.
+- Spend cap configured.
+- Network allowlist configured.
+- Endpoint/specialist allowlist configured for live devnet mode.
+- Human approval or bounded session authority required before spend.
+- Private payload sharing disabled by default.
+- Receipt verification required before using paid output.
+- Disclosure ledger exported when specialist output influences final answer/artifact.
+- Payment receipt, quote, specialist output metadata, and attestation verdict are logged to local artifacts.
+- Failure mode is safe: if payment, verification, or attestation fails, do not silently use the output as trusted.
+
+### Consumer nice-to-have gates
+
+- Per-task budget policy.
+- Automatic candidate ranking explanation.
+- Multi-specialist planning with total budget cap.
+- Policy simulation preview.
+- “Why this specialist?” UI/trace.
+
+### Consumer readiness status template
+
+```text
+Consumer: <runtime/name>
+Mode: MCP | OpenClaw skill | HTTP SDK
+Dry-run discovery: pass/fail
+Quote-first: pass/fail
+Payment disabled by default: pass/fail
+Spend cap: pass/fail
+Network allowlist: pass/fail
+Endpoint allowlist: pass/fail
+Approval policy: pass/fail
+Receipt verification: pass/fail
+Disclosure ledger: pass/fail
+Private payload guard: pass/fail
+Launch status: blocked | dry-run-ready | devnet-paid-ready | public-cohort-ready
+Blockers: ...
+```
+
+## Cross-cohort launch gates
+
+A cohort participant is **public-cohort-ready** only when all applicable gates pass and the following shared gates are true:
+
+- Product naming follows Reddi Agent Protocol / `reddi-x402` boundary.
+- Claim boundary scan passes.
+- No secrets or private keys in repo/artifacts.
+- No raw private prompts in public evidence.
+- Devnet receipts are reproducible or recorded with enough metadata.
+- Health/probe route works.
+- Docs include setup, test, and rollback/disable steps.
+- Operator knows whether the agent is dry-run, devnet-paid, or production-paid.
+- Status page/dashboard accurately labels the readiness tier.
+
+## Evidence bundle per public paid run
+
+Each devnet paid run should produce a small artifact folder:
+
+```text
+run-id/
+  README.md                       # human summary and claim boundary
+  quote.json                      # quote terms and expiry
+  payment-receipt.json            # tx/signature/receipt metadata
+  specialist-response.json        # output metadata; redact private payloads
+  attestor-verdict.json           # rubric verdict and evidence hashes
+  disclosure-ledger.json          # downstream use disclosure
+  reputation-update.json          # score delta or no-op reason
+  screenshots/                    # optional proof visuals
+```
+
+## Immediate work plan
+
+### Workstream 1 — Public cohort dashboard
+
+Create or adapt a route/page that lists candidate specialists, attestors, and consumers with readiness tier:
+
+- blocked
+- dry-run-ready
+- devnet-paid-ready
+- public-cohort-ready
+- production-preflight-only
+
+### Workstream 2 — `reddi-x402` cleanup
+
+- Converge TS package naming under public `reddi-x402` brand.
+- Ensure all protected specialist examples emit proper `x402-request` challenges.
+- Add minimal TS specialist and TS consumer examples.
+- Scaffold Python specialist and consumer examples.
+
+### Workstream 3 — RAP MCP bridge hardening
+
+- Default policy: dry-run only.
+- Expose discovery, quote, verify, and disclosure export first.
+- Hide pay/invoke until devnet approval policy and cap checks are configured.
+- Add one end-to-end dry-run demo and one bounded devnet demo.
+
+### Workstream 4 — Attestor schemas
+
+- Finalize common verdict schema.
+- Add fixtures for positive/negative cases.
+- Connect verdict fields to settlement/reputation update path.
+- Add attestor reliability tracking docs.
+
+### Workstream 5 — Public onboarding docs
+
+Publish three guides:
+
+1. Become a specialist agent.
+2. Run an attestor agent.
+3. Hire specialists from your agent runtime.
+
+## Proposed first sprint backlog
+
+1. Add `data/public-cohort/` seed files for candidate specialists, attestors, and consumers.
+2. Add a `scripts/check-public-cohort-readiness.*` validator.
+3. Add a `/public-cohort` or `/agents/public-cohort` readiness page.
+4. Convert this matrix into machine-checkable JSON schema.
+5. Pick the first 5 specialist profiles from the 30 OpenRouter set and mark them `dry-run-ready` or blocked with explicit reasons.
+6. Pick 4 attestor roles and create rubric/verdict schema stubs.
+7. Mark RAP MCP Bridge as first consumer and validate dry-run discovery/quote/verify.
+
+## Decision needed from Nissan
+
+Recommended default: start Phase 1 with **dry-run public market** and choose the first batch as:
+
+- Specialists: codegen, research/citation, content, QA, proof artifact.
+- Attestors: schema, factuality/citation, code/test, receipt/disclosure.
+- Consumers: RAP MCP Bridge + OpenClaw skill/playbook.
+
+Only move to bounded devnet paid invocation after the dry-run cohort passes this matrix.

--- a/docs/RAP-SHARED-CONTEXT-PACK-2026-05-12.md
+++ b/docs/RAP-SHARED-CONTEXT-PACK-2026-05-12.md
@@ -1,0 +1,195 @@
+# Reddi Agent Protocol — Shared Context Pack
+
+_Date: 2026-05-12 AEST_
+
+Purpose: shared working context for assessing current status, roadmap, and onboarding the first public specialist, attestor, and consumer agents.
+
+## 1. Product truth
+
+**Product name:** Reddi Agent Protocol.  
+**Key library/package boundary:** `reddi-x402`.  
+**Core positioning:** the economic/trust layer for autonomous agent markets: discovery, x402 quote/payment, escrow/settlement, attestation, reputation, receipt/evidence export.
+
+Do not position `reddi-x402` as the whole marketplace. It is the installable rail that protects paid agent/API endpoints and lets consumers pay/verify calls. Reddi Agent Protocol is the marketplace/control-plane layer above it.
+
+## 2. Current technical baseline
+
+The repo is effectively green for the latest validation wave.
+
+- Public app proof routes exist: `/start`, `/judge-replication`, `/economic-demo`, `/register`, `/agents`, `/setup`.
+- Onboarding/judge UX is locally shippable and validated.
+- Latest ordinary gates in status are green: BDD index/sweep/status, Playwright, Surfpool critical lanes, Quasar/PER smoke, source matrix, build/lint with only known non-blocking warnings.
+- PR #303 is merged to `main`; current repo state had no open PRs in the latest status note.
+- Default `/economic-demo` is safe recorded-proof verification; fresh devnet actions are explicitly advanced/mutable.
+
+## 3. Protocol model
+
+Participants:
+
+- **Consumer agent:** discovers/selects specialists, requests quotes, pays/invokes, verifies receipts, records disclosure.
+- **Specialist agent:** runs useful work behind an x402/payment gate and returns output plus evidence/receipt metadata.
+- **Attestor/judge agent:** evaluates outputs and feeds settlement/reputation signals.
+- **Protocol layer:** registry, escrow/payment state, attestation state, reputation state, evidence traceability.
+
+Lifecycle:
+
+1. Discover eligible specialists by capability, price, health, reputation, attestation/privacy constraints.
+2. Request quote / receive x402 challenge.
+3. Enforce budget, privacy, allowlist, and human/session approval policy.
+4. Pay/invoke through `reddi-x402`/bridge.
+5. Verify payment receipt, endpoint identity, quote terms, output/evidence.
+6. Route attestation verdict into settlement and reputation.
+7. Export disclosure ledger for downstream transparency.
+
+## 4. Evidence-backed claims we can safely make
+
+- Reddi Agent Protocol has devnet/on-chain proof for registry, payment, reputation, attestation, and Quasar/PER-adjacent flows.
+- Quasar devnet is the strongest final protocol proof lane.
+- Surfpool/mock-Jupiter is the successful local swap-shaped visual/proof lane.
+- Public Jupiter devnet execution remains quote/build/sign boundary evidence only, not a successful public Jupiter swap claim.
+- Pay.sh / `reddi-x402` evidence proves sandbox HTTP 402 → payment → HTTP 200 receipt compatibility for single-recipient charge flow.
+- MagicBlock PER evidence supports bounded delegated-vault settlement claims, not arbitrary-wallet/private-payee settlement.
+- Umbra evidence supports devnet private-payment adapter lanes, not mainnet/live production private settlement.
+- Torque evidence supports reputation-ranking/retention compatibility, not a live production rewards campaign.
+- 30 OpenRouter specialist profiles are configured, manifest-valid, package-tested, devnet-registered, and hosted endpoint evidence exists for manifests and unpaid x402 challenges.
+
+## 5. Claim boundaries / do not say yet
+
+Do not claim:
+
+- mainnet settlement support is live;
+- successful public Jupiter devnet swap;
+- judge wallet was charged;
+- all 30 OpenRouter specialists are production-paid settlement endpoints with freshly confirmed funding/secrets/live paid calls;
+- Pay.sh capped-session or split-payment settlement is complete;
+- Umbra mainnet/private production settlement is complete;
+- MagicBlock PER proves arbitrary-wallet/private payee settlement;
+- Torque live rewards have been distributed.
+
+## 6. `reddi-x402` boundary
+
+`reddi-x402` should promise:
+
+- fail-closed middleware for protected endpoints;
+- x402 challenge generation;
+- receipt verification;
+- nonce/replay prevention;
+- request isolation;
+- privacy-safe logging defaults;
+- consumer fetch/client wrapper;
+- policy helpers and receipt trace object.
+
+Open gaps:
+
+- Python package surface still needs scaffold/implementation.
+- TS package naming needs convergence under public `reddi-x402` naming.
+- Specialist wrappers must consistently emit proper `x402-request` challenges on probed protected paths.
+- Minimal TS and Python specialist/consumer examples are needed.
+
+## 7. Reputation / attestation model
+
+Current canonical trust primitive is on-chain `reputation_score` stored on agent account state.
+
+- Registration establishes identity baseline.
+- Job completion creates reputation update opportunity.
+- Commit/reveal reduces front-running and tactical rating manipulation.
+- Rolling score model is 90% previous score + 10% new valid rating.
+- Attestor/judge accuracy becomes second-order trust.
+- Future SPL reputation token is a portability layer, not current canonical truth.
+
+## 8. First public cohort roadmap
+
+### A. Specialist agents
+
+Goal: onboard useful paid endpoints that can be discovered, quoted, paid, verified, and ranked.
+
+Minimum public readiness:
+
+- public manifest at `/.well-known/reddi-agent.json`;
+- protected endpoint returns unpaid `402 + x402-request`;
+- paid retry returns useful output plus receipt metadata;
+- wallet/payee, price, capability, privacy, and health metadata are registered;
+- endpoint logs avoid raw prompts by default;
+- replay/wrong amount/wrong payee/wrong network paths fail closed;
+- devnet receipt and disclosure ledger artifact captured.
+
+Near-term cohort candidates:
+
+- code-generation specialist;
+- research/citation specialist;
+- content specialist;
+- verifier/QA specialist;
+- image/proof artifact specialist.
+
+### B. Attestor agents
+
+Goal: make quality validation independent and machine-readable.
+
+Minimum public readiness:
+
+- attestor manifest with evaluation domain and scoring rubric;
+- deterministic verdict schema;
+- evidence hash binding for prompt/output/verdict;
+- settlement-compatible pass/fail/confidence fields;
+- reputation impact rules documented;
+- attestor reliability tracked separately from specialist quality.
+
+Initial attestor types:
+
+- format/schema attestor;
+- factuality/citation attestor;
+- code/test attestor;
+- payment/receipt verifier;
+- disclosure-ledger verifier.
+
+### C. Consumer agents
+
+Goal: let real orchestrators hire specialists without receiving unlimited wallet authority.
+
+Minimum public readiness:
+
+- discovery + quote-first flow;
+- dry-run mode by default;
+- explicit spend caps and network allowlist;
+- bounded delegate/session authority for live devnet;
+- receipt/evidence logging;
+- disclosure ledger export;
+- no private payload sharing by default.
+
+Priority consumer integrations:
+
+- RAP MCP bridge for Claude/Cursor/OpenClaw/OpenSwarm-like agents;
+- OpenClaw skill/playbook integration;
+- OpenAI/Codex-style HTTP wrapper;
+- custom framework SDK example.
+
+## 9. Recommended next roadmap sequence
+
+1. **Context freeze:** keep this context pack as the working baseline for strategy discussions.
+2. **Readiness matrix:** create one checklist each for Specialist, Attestor, Consumer public launch.
+3. **Public cohort selection:** pick 3–5 specialist roles, 2–3 attestor roles, and 1–2 consumer runtimes for the first batch.
+4. **MCP bridge demo hardening:** publish dry-run discovery/quote/verify flow first; only enable devnet pay/invoke behind explicit approval and small caps.
+5. **`reddi-x402` package cleanup:** converge TS naming, scaffold Python, add minimal examples.
+6. **Registry/reputation UX:** show why each specialist was selected, what was paid, who attested, and how reputation changed.
+7. **External onboarding docs:** build “Become a specialist,” “Run an attestor,” and “Hire a specialist from your agent” docs.
+8. **Production-readiness preflight:** funding/deployment/env checks for any claim that endpoints are live paid production settlement endpoints.
+
+## 10. Source map crawled for this pack
+
+Primary status/docs:
+
+- `projects/reddi-agent-protocol/STATUS.md`
+- `projects/reddi-agent-protocol-code/STATUS.md`
+- `projects/reddi-agent-protocol-code/README.md`
+- `projects/reddi-agent-protocol-code/docs/PAYMENT-FLOW-ARCHITECTURE.md`
+- `projects/reddi-agent-protocol-code/docs/REDDI-X402-LIBRARY-SCOPE.md`
+- `projects/reddi-agent-protocol-code/docs/REPUTATION-TOKEN-DESIGN.md`
+- `projects/reddi-agent-protocol-code/docs/verifiable-agent-protocol/README.md`
+- `projects/reddi-agent-protocol-code/docs/whitepaper/WHITEPAPER-v1.md`
+- `projects/reddi-agent-protocol-code/docs/whitepaper/PHASED-PLAN.md`
+- `projects/reddi-agent-protocol-code/docs/RAP-MCP-BRIDGE-DESIGN-2026-05-08.md`
+- `projects/reddi-agent-protocol-code/docs/AGENT-FRAMEWORK-MCP-X402-ONBOARDING-2026-05-08.md`
+- `projects/reddi-agent-protocol-code/docs/OPENROUTER-30-SPECIALIST-READINESS-2026-05-08.md`
+- `projects/reddi-agent-protocol-code/artifacts/final-recording-packet-20260507.md`
+
+Repository inventory crawl excluded heavy/generated folders like `.git`, `node_modules`, `.next`, `.vercel`, `target`, coverage and Playwright reports. Observed source/evidence scale included ~640 markdown docs, ~424 TypeScript files, ~60 TSX files, ~232 Rust files, plus substantial proof artifacts/images/videos/logs.

--- a/docs/REDDIAGENTS-APP-ADAPTER-SPEC.md
+++ b/docs/REDDIAGENTS-APP-ADAPTER-SPEC.md
@@ -276,7 +276,7 @@ Recommended bridge order:
 
 1. Resolve `agent_id` from `lib/app-adapter/registry.ts`.
 2. Validate input against the agent schema.
-3. Apply Reddi source policy, e.g. `preferredSource: "openclaw"` for ReddiAgents demo specialists.
+3. Apply RAP source policy, e.g. `preferredSource: "openclaw"` for ReddiAgents demo specialists.
 4. Call existing planner/specialist route or shared function.
 5. Preserve x402 challenge/payment status.
 6. Normalize final result into APP output + Reddi receipt envelope.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -1,6 +1,6 @@
 # BDD Feature Index
 
-_Last updated: 2026-05-09 AEST_
+_Last updated: 2026-05-13 AEST_
 
 Purpose: single lookup from BDD feature file -> bucket -> executable verification command(s).
 
@@ -49,10 +49,12 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket S — Source Adapter Onboarding
 - Feature: `docs/bdd/features/bucket-s-source-adapters.feature`
 - Verify:
-  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
+  - `npm run check:rap:naming`
+  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts lib/__tests__/source-adapter-circle-x402-profile.test.ts lib/__tests__/circle-x402-catalog-route.test.ts lib/__tests__/circle-x402-quote-preview-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
   - `npm run test:source:conformance`
   - `./scripts/run-source-conformance.sh --source hermes --mode smoke`
   - `./scripts/run-source-conformance.sh --source pi --mode smoke`
+  - `./scripts/run-source-conformance.sh --source circle-x402 --mode smoke`
   - `npm run test:source:matrix`
 
 ### Bucket I — Agent Manager Operations

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -74,3 +74,17 @@ Feature: Bucket S Source Adapter Onboarding
     When source-conformance-matrix workflow runs on source adapter changes
     Then matrix execution must pass before merge
     And source and matrix artifact directories are uploaded for inspection
+
+  @S5.5 @conformance @circle-x402 @cross-source-parity
+  Scenario: Circle x402 Discovery resources import as unattested specialist candidates
+    When a Circle x402 Discovery resource is converted into a RAP candidate
+    Then the candidate includes a valid source-adapter specialist manifest
+    And the candidate is marked externally listed and not RAP-attested
+    And payment options preserve rail network amount and payee fields
+
+  @S5.6 @conformance @circle-x402 @settlement-safety
+  Scenario: Circle x402 quote preview remains dry-run until explicit approval
+    When a Circle x402 candidate is selected for route preview
+    Then Reddi returns source-aware route policy metadata
+    And live payment is disabled in the preview policy
+    And required approval attestation and receipt gates are listed before any paid invocation

--- a/lib/__tests__/circle-x402-catalog-route.test.ts
+++ b/lib/__tests__/circle-x402-catalog-route.test.ts
@@ -1,0 +1,53 @@
+jest.mock("@/lib/integrations/source-adapter/circle-x402-catalog", () => ({
+  loadCircleX402Catalog: jest.fn(),
+}));
+
+describe("Circle x402 catalog route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("returns a dry-run catalog and forwards category/limit filters", async () => {
+    const { loadCircleX402Catalog } = await import("@/lib/integrations/source-adapter/circle-x402-catalog");
+    (loadCircleX402Catalog as jest.Mock).mockReturnValue({
+      ok: true,
+      sourcePath: "artifacts/circle-x402-discovery/20260513-iteration1/resources.json",
+      summary: { totalResources: 509 },
+      candidates: [{ candidateId: "circle-x402:example:resource" }],
+      total: 12,
+      returned: 1,
+    });
+
+    const { GET } = await import("@/app/api/source-adapters/circle-x402/route");
+    const res = await GET(new Request("http://localhost/api/source-adapters/circle-x402?limit=1&category=FINANCIAL_ANALYSIS"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(loadCircleX402Catalog).toHaveBeenCalledWith({ limit: 1, category: "FINANCIAL_ANALYSIS" });
+    expect(data.mode).toBe("dry-run-catalog");
+    expect(data.boundary).toContain("never pays or invokes");
+    expect(data.candidates).toHaveLength(1);
+  });
+
+  it("returns 404 with setup guidance when the ingest artifact is missing", async () => {
+    const { loadCircleX402Catalog } = await import("@/lib/integrations/source-adapter/circle-x402-catalog");
+    (loadCircleX402Catalog as jest.Mock).mockReturnValue({
+      ok: false,
+      sourcePath: "missing/resources.json",
+      summary: null,
+      candidates: [],
+      total: 0,
+      returned: 0,
+      error: "Circle x402 ingest artifact not found at missing/resources.json. Run npm run ingest:circle-x402 first.",
+    });
+
+    const { GET } = await import("@/app/api/source-adapters/circle-x402/route");
+    const res = await GET(new Request("http://localhost/api/source-adapters/circle-x402"));
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.ok).toBe(false);
+    expect(data.error).toContain("ingest:circle-x402");
+  });
+});

--- a/lib/__tests__/circle-x402-quote-preview-route.test.ts
+++ b/lib/__tests__/circle-x402-quote-preview-route.test.ts
@@ -1,0 +1,104 @@
+jest.mock("@/lib/integrations/source-adapter/circle-x402-quote-preview", () => ({
+  buildCircleX402QuotePreview: jest.fn(),
+}));
+
+describe("Circle x402 quote preview route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("requires candidateId", async () => {
+    const { POST } = await import("@/app/api/source-adapters/circle-x402/quote-preview/route");
+    const res = await POST(
+      new Request("http://localhost/api/source-adapters/circle-x402/quote-preview", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ task: "preview" }),
+      })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBe("candidateId is required");
+    expect(data.mode).toBe("dry-run-quote-preview");
+  });
+
+  it("returns a dry-run quote preview without allowing live payment", async () => {
+    const { buildCircleX402QuotePreview } = await import("@/lib/integrations/source-adapter/circle-x402-quote-preview");
+    (buildCircleX402QuotePreview as jest.Mock).mockReturnValue({
+      ok: true,
+      mode: "dry-run-quote-preview",
+      candidate: { candidateId: "circle-x402:provider:path", providerName: "Provider" },
+      task: "Preview Provider",
+      routePreview: {
+        requestedSource: "circle-x402",
+        candidateSource: "circle-x402",
+        strictSourceMatch: true,
+        routeState: "external_unattested_candidate",
+        plannerPolicy: {
+          preferredSource: "circle-x402",
+          strictSourceMatch: true,
+          requireAttestationBeforeTrust: true,
+          livePaymentAllowed: false,
+        },
+      },
+      quotePreview: {
+        currency: "USDC",
+        network: "eip155:8453",
+        rail: "circle_gateway",
+        estimatedUsd: 0.005,
+      },
+      requiredGates: ["User explicitly approves live x402 payment experiment."],
+      trustNotes: ["Preview only: no x402 payment header is created and no external endpoint is invoked."],
+    });
+
+    const { POST } = await import("@/app/api/source-adapters/circle-x402/quote-preview/route");
+    const res = await POST(
+      new Request("http://localhost/api/source-adapters/circle-x402/quote-preview", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ candidateId: "circle-x402:provider:path", task: "Preview Provider" }),
+      })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(buildCircleX402QuotePreview).toHaveBeenCalledWith({
+      candidateId: "circle-x402:provider:path",
+      task: "Preview Provider",
+    });
+    expect(data.mode).toBe("dry-run-quote-preview");
+    expect(data.routePreview.plannerPolicy.livePaymentAllowed).toBe(false);
+    expect(data.requiredGates[0]).toContain("approves");
+  });
+
+  it("returns 404 when a candidate cannot be found", async () => {
+    const { buildCircleX402QuotePreview } = await import("@/lib/integrations/source-adapter/circle-x402-quote-preview");
+    (buildCircleX402QuotePreview as jest.Mock).mockReturnValue({
+      ok: false,
+      mode: "dry-run-quote-preview",
+      candidate: null,
+      task: "Preview",
+      routePreview: null,
+      quotePreview: null,
+      requiredGates: [],
+      trustNotes: [],
+      error: "Circle x402 candidate not found: missing",
+    });
+
+    const { POST } = await import("@/app/api/source-adapters/circle-x402/quote-preview/route");
+    const res = await POST(
+      new Request("http://localhost/api/source-adapters/circle-x402/quote-preview", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ candidateId: "missing" }),
+      })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.ok).toBe(false);
+    expect(data.error).toContain("not found");
+  });
+});

--- a/lib/__tests__/source-adapter-circle-x402-profile.test.ts
+++ b/lib/__tests__/source-adapter-circle-x402-profile.test.ts
@@ -1,0 +1,79 @@
+import {
+  buildCircleX402SourceManifest,
+  circleX402DiscoveryResourceToCandidate,
+  CIRCLE_X402_SOURCE_PROFILE,
+  mapCircleX402CategoryToTaskTypes,
+  type CircleX402DiscoveryResource,
+} from "@/lib/integrations/source-adapter/profiles/circle-x402";
+import { getSourceProfile } from "@/lib/integrations/source-adapter/profiles";
+import { validateSourceAdapterManifest } from "@/lib/integrations/source-adapter/schema";
+
+describe("source adapter circle-x402 profile", () => {
+  it("is discoverable via source registry", () => {
+    const profile = getSourceProfile("circle-x402");
+    expect(profile).toBeTruthy();
+    expect(profile?.source).toBe("circle-x402");
+    expect(profile?.roles).toContain("specialist");
+    expect(profile?.roles).toContain("consumer");
+  });
+
+  it("maps Circle discovery categories into RAP task types", () => {
+    expect(mapCircleX402CategoryToTaskTypes("WEB_SEARCH_RESEARCH")).toEqual(["research", "web-search"]);
+    expect(mapCircleX402CategoryToTaskTypes("FINANCIAL_ANALYSIS")).toEqual(["financial-analysis", "market-data"]);
+    expect(mapCircleX402CategoryToTaskTypes("UNKNOWN_VENDOR_CATEGORY")).toEqual(["external-api"]);
+  });
+
+  it("builds a valid Circle x402 specialist manifest", () => {
+    const manifest = buildCircleX402SourceManifest({
+      role: "specialist",
+      runtime: "circle-gateway",
+      taskTypes: ["research", "web-search"],
+    });
+
+    const validation = validateSourceAdapterManifest(manifest);
+    expect(validation.ok).toBe(true);
+    expect(manifest.source).toBe(CIRCLE_X402_SOURCE_PROFILE.source);
+    expect(manifest.paymentPolicy).toBe("x402_required");
+  });
+
+  it("converts a Circle Discovery resource into an unattested RAP specialist candidate", () => {
+    const resource: CircleX402DiscoveryResource = {
+      resource: "https://api.example.com/v1/search/research",
+      type: "http",
+      x402Version: 1,
+      accepts: [
+        {
+          scheme: "exact",
+          network: "eip155:8453",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          maxAmountRequired: "5000",
+          payTo: "0x1234567890123456789012345678901234567890",
+        },
+      ],
+      metadata: {
+        provider: {
+          name: "Example Research API",
+          category: "WEB_SEARCH_RESEARCH",
+          tags: ["research", "web"],
+        },
+        description: "Paid research endpoint",
+        supportsCircleGateway: true,
+        supportsVanillax402: true,
+      },
+    };
+
+    const candidate = circleX402DiscoveryResourceToCandidate(resource);
+
+    expect(candidate.candidateId).toBe("circle-x402:api.example.com:v1-search-research");
+    expect(candidate.providerName).toBe("Example Research API");
+    expect(candidate.taskTypes).toEqual(["research", "web-search"]);
+    expect(candidate.attestationState).toBe("externally_listed_unattested");
+    expect(candidate.payment[0]).toMatchObject({
+      rail: "circle_gateway",
+      network: "eip155:8453",
+      priceUsdc: 0.005,
+    });
+    expect(validateSourceAdapterManifest(candidate.sourceAdapter).ok).toBe(true);
+    expect(candidate.trustNotes.join(" ")).toContain("Not RAP-attested");
+  });
+});

--- a/lib/integrations/source-adapter/circle-x402-catalog.ts
+++ b/lib/integrations/source-adapter/circle-x402-catalog.ts
@@ -1,0 +1,131 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  circleX402DiscoveryResourceToCandidate,
+  type CircleX402DiscoveryResource,
+  type ReddiCircleX402Candidate,
+} from "@/lib/integrations/source-adapter/profiles/circle-x402";
+
+export const DEFAULT_CIRCLE_X402_INGEST_PATH = "artifacts/circle-x402-discovery/20260513-iteration1/resources.json";
+const DEFAULT_CIRCLE_X402_INGEST_ABSOLUTE_PATH = join(
+  process.cwd(),
+  "artifacts",
+  "circle-x402-discovery",
+  "20260513-iteration1",
+  "resources.json"
+);
+
+export type CircleX402IngestSummary = {
+  crawledAt?: string;
+  source?: string;
+  totalResources?: number;
+  categories?: Record<string, number>;
+  providers?: Record<string, number>;
+  networks?: Record<string, number>;
+  pricesUsdc?: {
+    count?: number;
+    min?: number | null;
+    median?: number | null;
+    p90?: number | null;
+    max?: number | null;
+    mean?: number | null;
+  };
+  boundary?: string;
+};
+
+export type CircleX402Catalog = {
+  ok: boolean;
+  sourcePath: string;
+  summary: CircleX402IngestSummary | null;
+  candidates: ReddiCircleX402Candidate[];
+  total: number;
+  returned: number;
+  error?: string;
+};
+
+export type CircleX402CandidateLookup = Pick<CircleX402Catalog, "ok" | "sourcePath" | "error"> & {
+  candidate: ReddiCircleX402Candidate | null;
+};
+
+function readCircleX402Resources():
+  | { ok: true; sourcePath: string; summary: CircleX402IngestSummary | null; resources: CircleX402DiscoveryResource[] }
+  | { ok: false; sourcePath: string; error: string } {
+  const sourcePath = DEFAULT_CIRCLE_X402_INGEST_PATH;
+  const absolutePath = DEFAULT_CIRCLE_X402_INGEST_ABSOLUTE_PATH;
+
+  if (!existsSync(absolutePath)) {
+    return {
+      ok: false,
+      sourcePath,
+      error: `Circle x402 ingest artifact not found at ${sourcePath}. Run npm run ingest:circle-x402 first.`,
+    };
+  }
+
+  const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as {
+    summary?: CircleX402IngestSummary;
+    items?: CircleX402DiscoveryResource[];
+  };
+
+  return {
+    ok: true,
+    sourcePath,
+    summary: parsed.summary ?? null,
+    resources: parsed.items ?? [],
+  };
+}
+
+export function loadCircleX402Catalog(options: { limit?: number; category?: string } = {}): CircleX402Catalog {
+  const loaded = readCircleX402Resources();
+  if (!loaded.ok) {
+    return {
+      ok: false,
+      sourcePath: loaded.sourcePath,
+      summary: null,
+      candidates: [],
+      total: 0,
+      returned: 0,
+      error: loaded.error,
+    };
+  }
+
+  const limit = Math.max(1, Math.min(options.limit ?? 50, 200));
+  let resources = loaded.resources;
+  if (options.category) {
+    resources = resources.filter((resource) => resource.metadata?.provider?.category === options.category);
+  }
+
+  const candidates = resources.slice(0, limit).map(circleX402DiscoveryResourceToCandidate);
+
+  return {
+    ok: true,
+    sourcePath: loaded.sourcePath,
+    summary: loaded.summary,
+    candidates,
+    total: resources.length,
+    returned: candidates.length,
+  };
+}
+
+export function loadCircleX402Candidate(candidateId: string): CircleX402CandidateLookup {
+  const loaded = readCircleX402Resources();
+  if (!loaded.ok) {
+    return {
+      ok: false,
+      sourcePath: loaded.sourcePath,
+      candidate: null,
+      error: loaded.error,
+    };
+  }
+
+  const candidate = loaded.resources
+    .map(circleX402DiscoveryResourceToCandidate)
+    .find((item) => item.candidateId === candidateId) ?? null;
+
+  return {
+    ok: candidate !== null,
+    sourcePath: loaded.sourcePath,
+    candidate,
+    error: candidate ? undefined : `Circle x402 candidate not found: ${candidateId}`,
+  };
+}

--- a/lib/integrations/source-adapter/circle-x402-quote-preview.ts
+++ b/lib/integrations/source-adapter/circle-x402-quote-preview.ts
@@ -1,0 +1,111 @@
+import {
+  loadCircleX402Candidate,
+  type CircleX402Catalog,
+} from "@/lib/integrations/source-adapter/circle-x402-catalog";
+import type { ReddiCircleX402Candidate } from "@/lib/integrations/source-adapter/profiles/circle-x402";
+
+export type CircleX402QuotePreview = {
+  ok: boolean;
+  mode: "dry-run-quote-preview";
+  candidate: ReddiCircleX402Candidate | null;
+  task: string;
+  routePreview: {
+    requestedSource: "circle-x402";
+    candidateSource: "circle-x402";
+    strictSourceMatch: true;
+    routeState: "external_unattested_candidate";
+    plannerPolicy: {
+      preferredSource: "circle-x402";
+      strictSourceMatch: true;
+      requireAttestationBeforeTrust: true;
+      livePaymentAllowed: false;
+    };
+  } | null;
+  quotePreview: {
+    currency: "USDC";
+    network: string;
+    rail: "circle_gateway" | "vanilla_x402";
+    maxAmountRequired?: string;
+    estimatedUsd?: number;
+    payTo?: string;
+  } | null;
+  requiredGates: string[];
+  trustNotes: string[];
+  error?: string;
+};
+
+function lowestPricedPayment(candidate: ReddiCircleX402Candidate) {
+  const priced = candidate.payment
+    .filter((payment) => typeof payment.priceUsdc === "number")
+    .sort((a, b) => (a.priceUsdc ?? Number.POSITIVE_INFINITY) - (b.priceUsdc ?? Number.POSITIVE_INFINITY));
+  return priced[0] ?? candidate.payment[0] ?? null;
+}
+
+export function buildCircleX402QuotePreview(input: {
+  candidateId: string;
+  task?: string;
+}): CircleX402QuotePreview {
+  const candidateResult = loadCircleX402Candidate(input.candidateId);
+  const task = input.task?.trim() || "Preview external x402 specialist route";
+
+  if (!candidateResult.ok || !candidateResult.candidate) {
+    return {
+      ok: false,
+      mode: "dry-run-quote-preview",
+      candidate: null,
+      task,
+      routePreview: null,
+      quotePreview: null,
+      requiredGates: [],
+      trustNotes: [],
+      error: candidateResult.error ?? `Circle x402 candidate not found: ${input.candidateId}`,
+    };
+  }
+
+  const candidate = candidateResult.candidate;
+  const payment = lowestPricedPayment(candidate);
+
+  return {
+    ok: true,
+    mode: "dry-run-quote-preview",
+    candidate,
+    task,
+    routePreview: {
+      requestedSource: "circle-x402",
+      candidateSource: "circle-x402",
+      strictSourceMatch: true,
+      routeState: "external_unattested_candidate",
+      plannerPolicy: {
+        preferredSource: "circle-x402",
+        strictSourceMatch: true,
+        requireAttestationBeforeTrust: true,
+        livePaymentAllowed: false,
+      },
+    },
+    quotePreview: payment
+      ? {
+          currency: "USDC",
+          network: payment.network,
+          rail: payment.rail,
+          maxAmountRequired: payment.maxAmountRequired,
+          estimatedUsd: payment.priceUsdc,
+          payTo: payment.payTo,
+        }
+      : null,
+    requiredGates: [
+      "User explicitly approves live x402 payment experiment.",
+      "Tiny spend cap is configured before payment.",
+      "Circle wallet/session/payment credentials are present only at runtime.",
+      "Receipt is captured and attached to a RAP evidence pack.",
+      "RAP attestor verifies output, receipt, and disclosure before trust/reputation credit.",
+    ],
+    trustNotes: [
+      ...candidate.trustNotes,
+      "Preview only: no x402 payment header is created and no external endpoint is invoked.",
+    ],
+  };
+}
+
+export type CircleX402CandidateLookup = Pick<CircleX402Catalog, "ok" | "sourcePath" | "error"> & {
+  candidate: ReddiCircleX402Candidate | null;
+};

--- a/lib/integrations/source-adapter/profiles/circle-x402.ts
+++ b/lib/integrations/source-adapter/profiles/circle-x402.ts
@@ -1,0 +1,161 @@
+import { SOURCE_ADAPTER_VERSION, type SourceAdapterManifest, type SourceAdapterRole } from "@/lib/integrations/source-adapter/schema";
+
+export const CIRCLE_X402_SOURCE_ID = "circle-x402" as const;
+
+export type CircleX402Category =
+  | "FINANCIAL_ANALYSIS"
+  | "SOCIAL_INTELLIGENCE"
+  | "WEB_SEARCH_RESEARCH"
+  | "PREDICTION_MARKETS"
+  | "CREATIVE"
+  | "INFRASTRUCTURE"
+  | string;
+
+export type CircleX402PaymentRequirement = {
+  scheme?: string;
+  network?: string;
+  asset?: string;
+  maxAmountRequired?: string;
+  payTo?: string;
+};
+
+export type CircleX402DiscoveryResource = {
+  resource: string;
+  type?: "http" | "mcp" | string;
+  x402Version?: number;
+  accepts?: CircleX402PaymentRequirement[];
+  metadata?: {
+    provider?: {
+      name?: string;
+      description?: string;
+      category?: CircleX402Category;
+      tags?: string[];
+      website?: string;
+      docsUrl?: string;
+      openApiUrl?: string;
+    };
+    description?: string;
+    supportsCircleGateway?: boolean;
+    supportsVanillax402?: boolean;
+  };
+};
+
+export type ReddiCircleX402Candidate = {
+  candidateId: string;
+  source: typeof CIRCLE_X402_SOURCE_ID;
+  providerName: string;
+  resource: string;
+  category: string;
+  taskTypes: string[];
+  sourceAdapter: SourceAdapterManifest;
+  payment: Array<{
+    rail: "circle_gateway" | "vanilla_x402";
+    scheme: string;
+    network: string;
+    asset?: string;
+    payTo?: string;
+    maxAmountRequired?: string;
+    priceUsdc?: number;
+  }>;
+  attestationState: "externally_listed_unattested";
+  trustNotes: string[];
+};
+
+export const CIRCLE_X402_SOURCE_PROFILE = {
+  source: CIRCLE_X402_SOURCE_ID,
+  roles: ["specialist", "consumer"] as SourceAdapterRole[],
+  runtimes: ["http", "circle-gateway", "vanilla-x402"],
+  defaultPaymentPolicy: "x402_required" as const,
+  defaultAttestationState: "externally_listed_unattested" as const,
+  capabilityHints: {
+    specialist: ["x402", "paid-api", "external-service", "circle-discovery"],
+    consumer: ["discover", "quote", "pay", "verify-receipt"],
+  },
+};
+
+const CATEGORY_TASK_TYPES: Record<string, string[]> = {
+  FINANCIAL_ANALYSIS: ["financial-analysis", "market-data"],
+  SOCIAL_INTELLIGENCE: ["social-intelligence", "profile-analysis"],
+  WEB_SEARCH_RESEARCH: ["research", "web-search"],
+  PREDICTION_MARKETS: ["prediction-market-analysis", "forecasting"],
+  CREATIVE: ["creative-generation"],
+  INFRASTRUCTURE: ["infrastructure", "developer-tooling"],
+};
+
+export function mapCircleX402CategoryToTaskTypes(category: CircleX402Category | undefined) {
+  if (!category) return ["external-api"];
+  return CATEGORY_TASK_TYPES[category] ?? ["external-api"];
+}
+
+function parseUsdcSubunits(value: string | undefined) {
+  if (!value || !/^\d+$/.test(value)) return undefined;
+  return Number(value) / 1_000_000;
+}
+
+function stableCandidateId(resource: string) {
+  const url = new URL(resource);
+  const pathSlug = url.pathname
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+  return `${CIRCLE_X402_SOURCE_ID}:${url.hostname}:${pathSlug || "root"}`;
+}
+
+export function buildCircleX402SourceManifest(input: {
+  role: Extract<SourceAdapterRole, "specialist" | "consumer">;
+  runtime?: "http" | "circle-gateway" | "vanilla-x402";
+  taskTypes: string[];
+  inputModes?: string[];
+  outputModes?: string[];
+}): SourceAdapterManifest {
+  return {
+    version: SOURCE_ADAPTER_VERSION,
+    source: CIRCLE_X402_SOURCE_ID,
+    role: input.role,
+    runtime: input.runtime ?? "http",
+    capabilities: {
+      taskTypes: input.taskTypes,
+      inputModes: input.inputModes ?? ["json", "text"],
+      outputModes: input.outputModes ?? ["json"],
+    },
+    paymentPolicy: CIRCLE_X402_SOURCE_PROFILE.defaultPaymentPolicy,
+    failurePolicy: {
+      maxRetries: 0,
+      refundOnFailure: false,
+    },
+  };
+}
+
+export function circleX402DiscoveryResourceToCandidate(resource: CircleX402DiscoveryResource): ReddiCircleX402Candidate {
+  const category = resource.metadata?.provider?.category ?? "UNKNOWN";
+  const taskTypes = mapCircleX402CategoryToTaskTypes(category);
+  const supportsCircleGateway = resource.metadata?.supportsCircleGateway === true;
+
+  return {
+    candidateId: stableCandidateId(resource.resource),
+    source: CIRCLE_X402_SOURCE_ID,
+    providerName: resource.metadata?.provider?.name ?? "Unknown Circle x402 provider",
+    resource: resource.resource,
+    category,
+    taskTypes,
+    sourceAdapter: buildCircleX402SourceManifest({
+      role: "specialist",
+      runtime: supportsCircleGateway ? "circle-gateway" : "vanilla-x402",
+      taskTypes,
+    }),
+    payment: (resource.accepts ?? []).map((accept) => ({
+      rail: supportsCircleGateway ? "circle_gateway" : "vanilla_x402",
+      scheme: accept.scheme ?? "exact",
+      network: accept.network ?? "unknown",
+      asset: accept.asset,
+      payTo: accept.payTo,
+      maxAmountRequired: accept.maxAmountRequired,
+      priceUsdc: parseUsdcSubunits(accept.maxAmountRequired),
+    })),
+    attestationState: CIRCLE_X402_SOURCE_PROFILE.defaultAttestationState,
+    trustNotes: [
+      "Imported from Circle x402 Discovery as external catalog metadata.",
+      "Not RAP-attested until a RAP attestor verifies output, receipt, and evidence.",
+    ],
+  };
+}

--- a/lib/integrations/source-adapter/profiles/index.ts
+++ b/lib/integrations/source-adapter/profiles/index.ts
@@ -1,3 +1,4 @@
+import { CIRCLE_X402_SOURCE_ID, CIRCLE_X402_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/circle-x402";
 import { HERMES_SOURCE_ID, HERMES_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/hermes";
 import { OPENCLAW_SOURCE_ID, OPENCLAW_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/openclaw";
 import { PI_SOURCE_ID, PI_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/pi";
@@ -6,6 +7,7 @@ export const SOURCE_PROFILE_REGISTRY = {
   [OPENCLAW_SOURCE_ID]: OPENCLAW_SOURCE_PROFILE,
   [HERMES_SOURCE_ID]: HERMES_SOURCE_PROFILE,
   [PI_SOURCE_ID]: PI_SOURCE_PROFILE,
+  [CIRCLE_X402_SOURCE_ID]: CIRCLE_X402_SOURCE_PROFILE,
 } as const;
 
 export type SourceProfileId = keyof typeof SOURCE_PROFILE_REGISTRY;

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -49,7 +49,7 @@ export type ResolveInput = {
     requireAttestation?: boolean;
     preferredPrivacyMode?: "public" | "per" | "vanish";
     minReputation?: number;
-    preferredSource?: "openclaw" | "hermes" | "pi";
+    preferredSource?: "openclaw" | "hermes" | "pi" | "circle-x402";
     strictSourceMatch?: boolean;
   };
 };
@@ -68,8 +68,8 @@ export type ResolveOutput = {
     avgFeedbackScore: number;
     selectionReasons: string[];
     sourceRouting?: {
-      requestedSource: "openclaw" | "hermes" | "pi" | null;
-      candidateSource: "openclaw" | "hermes" | "pi" | null;
+      requestedSource: "openclaw" | "hermes" | "pi" | "circle-x402" | null;
+      candidateSource: "openclaw" | "hermes" | "pi" | "circle-x402" | null;
       strictSourceMatch: boolean;
       scoreDelta: number;
       decisionTrace: string[];
@@ -82,8 +82,8 @@ export type ResolveOutput = {
     score: number;
     selectionReasons: string[];
     sourceRouting?: {
-      requestedSource: "openclaw" | "hermes" | "pi" | null;
-      candidateSource: "openclaw" | "hermes" | "pi" | null;
+      requestedSource: "openclaw" | "hermes" | "pi" | "circle-x402" | null;
+      candidateSource: "openclaw" | "hermes" | "pi" | "circle-x402" | null;
       strictSourceMatch: boolean;
       scoreDelta: number;
       decisionTrace: string[];
@@ -288,7 +288,7 @@ export const MCP_TOOL_SCHEMAS = [
             minReputation: { type: "number", description: "Minimum on-chain reputation score." },
             preferredSource: {
               type: "string",
-              enum: ["openclaw", "hermes", "pi"],
+              enum: ["openclaw", "hermes", "pi", "circle-x402"],
               description: "Optional source-ecosystem preference for candidate routing.",
             },
             strictSourceMatch: {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "demo:marketplace:readiness": "node ./scripts/run-marketplace-demo-readiness.mjs",
     "evidence:torque:reputation-ranking": "node ./scripts/generate-torque-reputation-ranking-evidence.mjs",
     "smoke:umbra:devnet:receiver-claimable-utxo": "node ./scripts/run-umbra-devnet-receiver-claimable-utxo-smoke.mjs",
+    "ingest:circle-x402": "node ./scripts/ingest-circle-x402-discovery.mjs",
     "check:rap:naming": "node ./scripts/check-rap-naming.mjs"
   },
   "dependencies": {

--- a/scripts/ingest-circle-x402-discovery.mjs
+++ b/scripts/ingest-circle-x402-discovery.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+
+const API = "https://api.circle.com/v1/x402/discovery/resources";
+const limit = Number(process.env.CIRCLE_X402_DISCOVERY_LIMIT ?? 200);
+const outDir = process.argv.includes("--out-dir")
+  ? process.argv[process.argv.indexOf("--out-dir") + 1]
+  : path.join("artifacts", "circle-x402-discovery", new Date().toISOString().replace(/[:.]/g, "-"));
+
+async function fetchJson(url) {
+  const response = await fetch(url, { headers: { accept: "application/json", "user-agent": "reddi-agent-protocol-ingest/1.0" } });
+  if (!response.ok) {
+    throw new Error(`Circle Discovery fetch failed: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+function minPriceUsdc(item) {
+  const prices = (item.accepts ?? [])
+    .map((accept) => accept.maxAmountRequired)
+    .filter((value) => typeof value === "string" && /^\d+$/.test(value))
+    .map((value) => Number(value) / 1_000_000);
+  if (!prices.length) return undefined;
+  return Math.min(...prices);
+}
+
+function increment(counter, key) {
+  counter[key || "unknown"] = (counter[key || "unknown"] ?? 0) + 1;
+}
+
+const items = [];
+let total = Infinity;
+let offset = 0;
+
+while (offset < total) {
+  const url = `${API}?limit=${limit}&offset=${offset}`;
+  const page = await fetchJson(url);
+  items.push(...(page.items ?? []));
+  total = page.pagination?.total ?? items.length;
+  offset += limit;
+}
+
+const categories = {};
+const providers = {};
+const networks = {};
+const prices = [];
+
+for (const item of items) {
+  increment(categories, item.metadata?.provider?.category);
+  increment(providers, item.metadata?.provider?.name);
+  for (const accept of item.accepts ?? []) increment(networks, accept.network);
+  const price = minPriceUsdc(item);
+  if (price !== undefined) prices.push(price);
+}
+
+prices.sort((a, b) => a - b);
+const percentile = (p) => (prices.length ? prices[Math.min(prices.length - 1, Math.floor((prices.length - 1) * p))] : null);
+const mean = prices.length ? prices.reduce((sum, price) => sum + price, 0) / prices.length : null;
+
+const summary = {
+  crawledAt: new Date().toISOString(),
+  source: API,
+  totalResources: items.length,
+  categories,
+  providers,
+  networks,
+  pricesUsdc: {
+    count: prices.length,
+    min: prices[0] ?? null,
+    median: percentile(0.5),
+    p90: percentile(0.9),
+    max: prices[prices.length - 1] ?? null,
+    mean,
+  },
+  boundary: "Metadata-only ingest. Live pay/invoke requires explicit approval and spend caps.",
+};
+
+await mkdir(outDir, { recursive: true });
+await writeFile(path.join(outDir, "resources.json"), JSON.stringify({ summary, items }, null, 2));
+await writeFile(path.join(outDir, "SUMMARY.md"), `# Circle x402 Discovery Ingest\n\n- Source: ${API}\n- Crawled at: ${summary.crawledAt}\n- Total resources: ${summary.totalResources}\n- Priced resources: ${summary.pricesUsdc.count}\n- Median price USDC: ${summary.pricesUsdc.median}\n- Boundary: ${summary.boundary}\n\n## Categories\n\n${Object.entries(categories).map(([k, v]) => `- ${k}: ${v}`).join("\n")}\n`);
+
+console.log(JSON.stringify({ ok: true, outDir, totalResources: items.length, pricesUsdc: summary.pricesUsdc }, null, 2));

--- a/scripts/run-source-conformance-matrix.sh
+++ b/scripts/run-source-conformance-matrix.sh
@@ -10,7 +10,7 @@ LOG_FILE="$OUT_DIR/matrix.log"
 SUMMARY="$OUT_DIR/SUMMARY.md"
 mkdir -p "$OUT_DIR"
 
-SOURCES=(openclaw hermes pi)
+SOURCES=(openclaw hermes pi circle-x402)
 
 run_source() {
   local src="$1"
@@ -46,7 +46,7 @@ TOTAL_COUNT=$((PASS_COUNT + FAIL_COUNT))
   echo "# Source Conformance Matrix"
   echo ""
   echo "- Timestamp: $TS"
-  echo "- Sources: openclaw, hermes, pi"
+  echo "- Sources: openclaw, hermes, pi, circle-x402"
   echo "- Rows passed: $PASS_COUNT"
   echo "- Rows failed: $FAIL_COUNT"
   echo "- Rows total: $TOTAL_COUNT"

--- a/scripts/run-source-conformance.sh
+++ b/scripts/run-source-conformance.sh
@@ -25,10 +25,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$SOURCE" in
-  openclaw|hermes|pi)
+  openclaw|hermes|pi|circle-x402)
     ;;
   *)
-    echo "Unsupported source: $SOURCE (allowed: openclaw|hermes|pi)"
+    echo "Unsupported source: $SOURCE (allowed: openclaw|hermes|pi|circle-x402)"
     exit 1
     ;;
 esac
@@ -77,6 +77,9 @@ echo "[source-conformance] artifacts=$OUT_DIR"
 run_step "BDD feature index integrity" \
   ./scripts/check-bdd-feature-index.sh
 
+run_step "RAP naming guard" \
+  npm run check:rap:naming
+
 run_step "Source adapter schema + probe contracts" \
   npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts --runInBand
 
@@ -92,6 +95,10 @@ case "$SOURCE" in
   pi)
     run_step "pi profile + extension-bundle compatibility" \
       npx jest lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts --runInBand
+    ;;
+  circle-x402)
+    run_step "Circle x402 profile + discovery mapping contracts" \
+      npx jest lib/__tests__/source-adapter-circle-x402-profile.test.ts --runInBand
     ;;
 esac
 


### PR DESCRIPTION
## Summary
- add `circle-x402` as a Reddi Agent Protocol source adapter profile
- add Circle Discovery metadata ingest and deterministic conversion into externally listed / not RAP-attested specialist candidates
- add dry-run catalog API/page at `/api/source-adapters/circle-x402` and `/circle-x402`
- add dry-run quote/route preview API at `/api/source-adapters/circle-x402/quote-preview`
- wire Circle x402 into Bucket S BDD/source-conformance flows
- include the RAP shared context/public cohort docs created during the planning pass

## Safety / boundaries
- metadata and dry-run preview only
- no Circle login, terms acceptance, wallet setup, funding, x402 payment header creation, external service invocation, or live spend
- imported resources remain externally listed and not RAP-attested until RAP attestors verify receipts/evidence

## Validation
- `npm run check:rap:naming`
- `npx jest lib/__tests__/circle-x402-catalog-route.test.ts lib/__tests__/circle-x402-quote-preview-route.test.ts lib/__tests__/source-adapter-circle-x402-profile.test.ts --runInBand`
- `./scripts/run-source-conformance.sh --source circle-x402 --mode smoke`

Latest source-conformance artifact: `artifacts/source-conformance/20260513-060649-circle-x402-smoke/SUMMARY.md`
