### PR TITLE
feat: add Pay.sh source adapter preview

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,28 @@
 # Reddi Agent Protocol — Status
 
+## Latest Update — Pay.sh Solana source adapter implementation PR opened (2026-05-13 AEST)
+
+Implemented the first Solana-first Pay.sh integration slice for Issue #317. Scope is metadata/dry-run only: no `pay setup`, no `pay topup`, no wallet creation, no paid Pay.sh call, no external service invocation, and no secrets stored.
+
+Delivered:
+- Pay.sh source profile and provider-to-RAP-candidate mapping: `lib/integrations/source-adapter/profiles/pay-sh.ts`
+- Pay.sh catalog loader: `lib/integrations/source-adapter/pay-sh-catalog.ts`
+- Pay.sh quote preview helper: `lib/integrations/source-adapter/pay-sh-quote-preview.ts`
+- Dry-run APIs: `/api/source-adapters/pay-sh` and `/api/source-adapters/pay-sh/quote-preview`
+- Live metadata ingest script: `scripts/ingest-pay-sh-catalog.mjs` / `npm run ingest:pay-sh`
+- BDD/source-conformance coverage for `pay-sh`
+- Retrospective: `docs/PAY-SH-SOURCE-ADAPTER-IMPLEMENTATION-RETROSPECTIVE-2026-05-13.md`
+
+Validation:
+- `npm run test:bdd:index` PASS
+- `npm run check:rap:naming` PASS
+- Pay.sh focused Jest PASS (8/8)
+- Routing policy/planner resolve Jest PASS (9/9)
+- `npm run ingest:pay-sh` PASS; wrote 72 provider metadata entries to local artifact
+- `./scripts/run-source-conformance.sh --source pay-sh --mode smoke` PASS including build; artifact `artifacts/source-conformance/20260513-084938-pay-sh-smoke/SUMMARY.md`
+
+RESUME FROM HERE: Review/merge the Pay.sh source adapter PR, then next slice should test Pay CLI sandbox/MCP behavior locally without top-up or paid calls.
+
 ## Latest Update — Agent wallet/account abstraction POC research drafted (2026-05-13 AEST)
 
 Drafted `docs/ACCOUNT-ABSTRACTION-AGENT-WALLET-POC-2026-05-13.md` for the RAP MCP consumer onboarding problem: a Pi/dev-style agent user should be able to install the RAP MCP client, log in by email/passkey, top up by card, delegate bounded spend to their agent, and consume specialist agents without managing raw crypto wallet details.

--- a/app/api/source-adapters/pay-sh/quote-preview/route.ts
+++ b/app/api/source-adapters/pay-sh/quote-preview/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { buildPayShQuotePreview } from "@/lib/integrations/source-adapter/pay-sh-quote-preview";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const candidateId = url.searchParams.get("candidateId") ?? "";
+  const task = url.searchParams.get("task") ?? undefined;
+
+  if (!candidateId) {
+    return NextResponse.json(
+      {
+        ok: false,
+        mode: "dry-run-quote-preview",
+        error: "candidateId is required",
+      },
+      { status: 400 }
+    );
+  }
+
+  const preview = buildPayShQuotePreview({ candidateId, task });
+  return NextResponse.json(preview, { status: preview.ok ? 200 : 404 });
+}

--- a/app/api/source-adapters/pay-sh/route.ts
+++ b/app/api/source-adapters/pay-sh/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+import { loadPayShCatalog } from "@/lib/integrations/source-adapter/pay-sh-catalog";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limitParam = url.searchParams.get("limit");
+  const category = url.searchParams.get("category") ?? undefined;
+  const q = url.searchParams.get("q") ?? undefined;
+  const limit = limitParam ? Number(limitParam) : undefined;
+
+  const catalog = loadPayShCatalog({
+    limit: Number.isFinite(limit) ? limit : undefined,
+    category,
+    q,
+  });
+
+  const body = {
+    ...catalog,
+    mode: "dry-run-catalog",
+    boundary:
+      "Metadata-only Pay.sh catalog preview: RAP never creates a wallet, tops up, pays, or invokes Pay.sh services from this endpoint.",
+  };
+
+  if (!catalog.ok) {
+    return NextResponse.json(body, { status: 404 });
+  }
+
+  return NextResponse.json(body);
+}

--- a/docs/PAY-SH-SOURCE-ADAPTER-IMPLEMENTATION-RETROSPECTIVE-2026-05-13.md
+++ b/docs/PAY-SH-SOURCE-ADAPTER-IMPLEMENTATION-RETROSPECTIVE-2026-05-13.md
@@ -1,0 +1,53 @@
+# Pay.sh Source Adapter — 10-loop Retrospective
+
+Issue: #317
+Branch: feature/pay-sh-source-adapter
+
+## Loop log
+
+### Loop 1 — profile contract
+- Added Pay.sh source profile and provider→candidate mapping.
+- Registered `pay-sh` in source profile registry.
+- Guardrail: metadata-only; no wallet setup/top-up/payment surfaces.
+
+### Loop 2 — profile tests
+- Added profile tests for registry discovery, category mapping, manifest validation, and candidate conversion.
+- This pins Pay.sh candidates as externally listed and not RAP-attested.
+
+### Loop 3 — deterministic ID hygiene
+- First profile test exposed over-normalized Pay.sh FQNs.
+- Fixed candidate IDs to preserve provider slug hyphens while converting namespace separators to colons.
+
+### Loop 4 — catalog loader and API
+- Added Pay.sh catalog artifact loader with category/search/limit filters.
+- Added `/api/source-adapters/pay-sh` dry-run catalog endpoint.
+- Boundary explicitly forbids wallet creation, top-up, payment, or external invocation.
+
+### Loop 5 — catalog route tests
+- Added mocked API route tests for dry-run catalog success and missing-artifact guidance.
+- Confirmed route forwards limit/category/search filters to loader.
+
+### Loop 6 — quote preview
+- Added Pay.sh quote-preview helper and route.
+- Added required gates for top-up verification, tiny spend caps, receipt capture, attestation, and preventing arbitrary agent sends.
+- Added route tests for success and missing candidate validation.
+
+### Loop 7 — ingest and conformance wiring
+- Added `scripts/ingest-pay-sh-catalog.mjs` and `npm run ingest:pay-sh`.
+- Added `pay-sh` to source-conformance and matrix scripts.
+- Added BDD scenarios for Pay.sh provider import and dry-run quote-preview gates.
+
+### Loop 8 — source-aware surfaces
+- Added `pay-sh` to MCP preferredSource/sourceRouting type surfaces.
+- Fixed source-conformance help text after adding the new source.
+- Updated BDD feature-index validation command notes to include Pay.sh tests and conformance lane.
+
+### Loop 9 — live metadata ingest rehearsal
+- Ran `npm run ingest:pay-sh` against the public Pay.sh catalog.
+- Produced local metadata artifact only; no wallet setup, top-up, payment, or API invocation.
+
+### Loop 10 — final gate and PR packaging
+- Ran live metadata ingest only: 72 providers captured from public Pay.sh catalog.
+- Ran Pay.sh source-conformance smoke including build: PASS.
+- Added STATUS update and committed retrospective as durable repo evidence.
+- Remaining boundary: next slice may inspect Pay CLI sandbox/MCP, but must not run top-up or paid calls without explicit approval.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -50,11 +50,12 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Feature: `docs/bdd/features/bucket-s-source-adapters.feature`
 - Verify:
   - `npm run check:rap:naming`
-  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts lib/__tests__/source-adapter-circle-x402-profile.test.ts lib/__tests__/circle-x402-catalog-route.test.ts lib/__tests__/circle-x402-quote-preview-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
+  - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts lib/__tests__/source-adapter-circle-x402-profile.test.ts lib/__tests__/circle-x402-catalog-route.test.ts lib/__tests__/circle-x402-quote-preview-route.test.ts lib/__tests__/source-adapter-pay-sh-profile.test.ts lib/__tests__/pay-sh-catalog-route.test.ts lib/__tests__/pay-sh-quote-preview-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
   - `npm run test:source:conformance`
   - `./scripts/run-source-conformance.sh --source hermes --mode smoke`
   - `./scripts/run-source-conformance.sh --source pi --mode smoke`
   - `./scripts/run-source-conformance.sh --source circle-x402 --mode smoke`
+  - `./scripts/run-source-conformance.sh --source pay-sh --mode smoke`
   - `npm run test:source:matrix`
 
 ### Bucket I — Agent Manager Operations

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -88,3 +88,17 @@ Feature: Bucket S Source Adapter Onboarding
     Then Reddi returns source-aware route policy metadata
     And live payment is disabled in the preview policy
     And required approval attestation and receipt gates are listed before any paid invocation
+
+  @S5.7 @conformance @pay-sh @cross-source-parity
+  Scenario: Pay.sh catalog providers import as Solana-first unattested specialist candidates
+    When a Pay.sh catalog provider is converted into a RAP candidate
+    Then the candidate includes a valid source-adapter specialist manifest
+    And the candidate is marked externally listed and not RAP-attested
+    And pricing preserves Solana USDC minimum maximum metering and free-tier fields
+
+  @S5.8 @conformance @pay-sh @settlement-safety
+  Scenario: Pay.sh quote preview remains dry-run until explicit wallet and spend approval
+    When a Pay.sh candidate is selected for route preview
+    Then Reddi returns Solana-first source-aware route policy metadata
+    And live payment is disabled in the preview policy
+    And required top-up spend-cap receipt and attestation gates are listed before any paid invocation

--- a/lib/__tests__/pay-sh-catalog-route.test.ts
+++ b/lib/__tests__/pay-sh-catalog-route.test.ts
@@ -1,0 +1,53 @@
+jest.mock("@/lib/integrations/source-adapter/pay-sh-catalog", () => ({
+  loadPayShCatalog: jest.fn(),
+}));
+
+describe("Pay.sh catalog route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("returns a dry-run catalog and forwards filters", async () => {
+    const { loadPayShCatalog } = await import("@/lib/integrations/source-adapter/pay-sh-catalog");
+    (loadPayShCatalog as jest.Mock).mockReturnValue({
+      ok: true,
+      sourcePath: "artifacts/pay-sh-catalog/20260513-initial/catalog.json",
+      summary: { provider_count: 72 },
+      candidates: [{ candidateId: "pay-sh:merit-systems:stablecrypto:market-data" }],
+      total: 12,
+      returned: 1,
+    });
+
+    const { GET } = await import("@/app/api/source-adapters/pay-sh/route");
+    const res = await GET(new Request("http://localhost/api/source-adapters/pay-sh?limit=1&category=finance&q=market"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(loadPayShCatalog).toHaveBeenCalledWith({ limit: 1, category: "finance", q: "market" });
+    expect(data.mode).toBe("dry-run-catalog");
+    expect(data.boundary).toContain("never creates a wallet");
+    expect(data.candidates).toHaveLength(1);
+  });
+
+  it("returns 404 with setup guidance when the catalog artifact is missing", async () => {
+    const { loadPayShCatalog } = await import("@/lib/integrations/source-adapter/pay-sh-catalog");
+    (loadPayShCatalog as jest.Mock).mockReturnValue({
+      ok: false,
+      sourcePath: "missing/catalog.json",
+      summary: null,
+      candidates: [],
+      total: 0,
+      returned: 0,
+      error: "Pay.sh catalog artifact not found at missing/catalog.json. Run npm run ingest:pay-sh first.",
+    });
+
+    const { GET } = await import("@/app/api/source-adapters/pay-sh/route");
+    const res = await GET(new Request("http://localhost/api/source-adapters/pay-sh"));
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.ok).toBe(false);
+    expect(data.error).toContain("ingest:pay-sh");
+  });
+});

--- a/lib/__tests__/pay-sh-quote-preview-route.test.ts
+++ b/lib/__tests__/pay-sh-quote-preview-route.test.ts
@@ -1,0 +1,59 @@
+jest.mock("@/lib/integrations/source-adapter/pay-sh-catalog", () => ({
+  loadPayShCandidate: jest.fn(),
+}));
+
+describe("Pay.sh quote preview route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("builds a dry-run route preview for a Pay.sh candidate", async () => {
+    const { loadPayShCandidate } = await import("@/lib/integrations/source-adapter/pay-sh-catalog");
+    (loadPayShCandidate as jest.Mock).mockReturnValue({
+      ok: true,
+      sourcePath: "artifacts/pay-sh-catalog/20260513-initial/catalog.json",
+      candidate: {
+        candidateId: "pay-sh:agentmail:email",
+        source: "pay-sh",
+        providerFqn: "agentmail/email",
+        providerName: "AgentMail",
+        category: "messaging",
+        taskTypes: ["communications"],
+        endpointCount: 83,
+        pricing: {
+          currency: "USDC",
+          network: "solana",
+          minUsd: 0,
+          maxUsd: 10,
+          hasFreeTier: true,
+          hasMetering: true,
+        },
+        trustNotes: ["Imported from Pay.sh catalog as external Solana x402/MPP metadata."],
+      },
+    });
+
+    const { GET } = await import("@/app/api/source-adapters/pay-sh/quote-preview/route");
+    const res = await GET(new Request("http://localhost/api/source-adapters/pay-sh/quote-preview?candidateId=pay-sh:agentmail:email&task=send%20email"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(loadPayShCandidate).toHaveBeenCalledWith("pay-sh:agentmail:email");
+    expect(data.routePreview.plannerPolicy).toMatchObject({
+      preferredSource: "pay-sh",
+      livePaymentAllowed: false,
+      solanaFirst: true,
+    });
+    expect(data.quotePreview).toMatchObject({ currency: "USDC", network: "solana", maxUsd: 10 });
+    expect(data.requiredGates.join(" ")).toContain("top-up");
+  });
+
+  it("rejects missing candidateId", async () => {
+    const { GET } = await import("@/app/api/source-adapters/pay-sh/quote-preview/route");
+    const res = await GET(new Request("http://localhost/api/source-adapters/pay-sh/quote-preview"));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toContain("candidateId");
+  });
+});

--- a/lib/__tests__/source-adapter-pay-sh-profile.test.ts
+++ b/lib/__tests__/source-adapter-pay-sh-profile.test.ts
@@ -1,0 +1,70 @@
+import {
+  buildPayShSourceManifest,
+  mapPayShCategoryToTaskTypes,
+  payShCatalogProviderToCandidate,
+  PAY_SH_SOURCE_PROFILE,
+  type PayShCatalogProvider,
+} from "@/lib/integrations/source-adapter/profiles/pay-sh";
+import { getSourceProfile } from "@/lib/integrations/source-adapter/profiles";
+import { validateSourceAdapterManifest } from "@/lib/integrations/source-adapter/schema";
+
+describe("source adapter pay-sh profile", () => {
+  it("is discoverable via source registry", () => {
+    const profile = getSourceProfile("pay-sh");
+    expect(profile).toBeTruthy();
+    expect(profile?.source).toBe("pay-sh");
+    expect(profile?.roles).toContain("specialist");
+    expect(profile?.roles).toContain("consumer");
+  });
+
+  it("maps Pay.sh categories into RAP task types", () => {
+    expect(mapPayShCategoryToTaskTypes("finance")).toEqual(["market-data", "financial-analysis"]);
+    expect(mapPayShCategoryToTaskTypes("messaging")).toEqual(["communications", "email", "workflow-automation"]);
+    expect(mapPayShCategoryToTaskTypes("UNKNOWN_VENDOR_CATEGORY")).toEqual(["external-api"]);
+  });
+
+  it("builds a valid Pay.sh specialist manifest", () => {
+    const manifest = buildPayShSourceManifest({
+      role: "specialist",
+      runtime: "mcp",
+      taskTypes: ["market-data"],
+    });
+
+    const validation = validateSourceAdapterManifest(manifest);
+    expect(validation.ok).toBe(true);
+    expect(manifest.source).toBe(PAY_SH_SOURCE_PROFILE.source);
+    expect(manifest.paymentPolicy).toBe("x402_required");
+  });
+
+  it("converts a Pay.sh catalog provider into an unattested RAP specialist candidate", () => {
+    const provider: PayShCatalogProvider = {
+      fqn: "merit-systems/stablecrypto/market-data",
+      title: "StableCrypto",
+      description: "Market data APIs",
+      category: "finance",
+      service_url: "https://stablecrypto.dev",
+      endpoint_count: 105,
+      has_metering: true,
+      has_free_tier: false,
+      min_price_usd: 0.01,
+      max_price_usd: 0.01,
+      sha: "2858c649a49c995a",
+    };
+
+    const candidate = payShCatalogProviderToCandidate(provider);
+
+    expect(candidate.candidateId).toBe("pay-sh:merit-systems:stablecrypto:market-data");
+    expect(candidate.providerName).toBe("StableCrypto");
+    expect(candidate.taskTypes).toEqual(["market-data", "financial-analysis"]);
+    expect(candidate.pricing).toMatchObject({
+      currency: "USDC",
+      network: "solana",
+      minUsd: 0.01,
+      maxUsd: 0.01,
+      hasMetering: true,
+    });
+    expect(candidate.attestationState).toBe("externally_listed_unattested");
+    expect(validateSourceAdapterManifest(candidate.sourceAdapter).ok).toBe(true);
+    expect(candidate.trustNotes.join(" ")).toContain("Not RAP-attested");
+  });
+});

--- a/lib/integrations/source-adapter/pay-sh-catalog.ts
+++ b/lib/integrations/source-adapter/pay-sh-catalog.ts
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  payShCatalogProviderToCandidate,
+  type PayShCatalogProvider,
+  type ReddiPayShCandidate,
+} from "@/lib/integrations/source-adapter/profiles/pay-sh";
+
+export const DEFAULT_PAY_SH_CATALOG_PATH = "artifacts/pay-sh-catalog/20260513-initial/catalog.json";
+const DEFAULT_PAY_SH_CATALOG_ABSOLUTE_PATH = join(
+  process.cwd(),
+  "artifacts",
+  "pay-sh-catalog",
+  "20260513-initial",
+  "catalog.json"
+);
+
+export type PayShCatalogSummary = {
+  generated_at?: string;
+  provider_count?: number;
+  base_url?: string;
+  categories?: Record<string, number>;
+  pricesUsd?: {
+    min?: number | null;
+    max?: number | null;
+  };
+  boundary?: string;
+};
+
+export type PayShCatalog = {
+  ok: boolean;
+  sourcePath: string;
+  summary: PayShCatalogSummary | null;
+  candidates: ReddiPayShCandidate[];
+  total: number;
+  returned: number;
+  error?: string;
+};
+
+export type PayShCandidateLookup = Pick<PayShCatalog, "ok" | "sourcePath" | "error"> & {
+  candidate: ReddiPayShCandidate | null;
+};
+
+function readPayShProviders():
+  | { ok: true; sourcePath: string; summary: PayShCatalogSummary | null; providers: PayShCatalogProvider[] }
+  | { ok: false; sourcePath: string; error: string } {
+  const sourcePath = DEFAULT_PAY_SH_CATALOG_PATH;
+  const absolutePath = DEFAULT_PAY_SH_CATALOG_ABSOLUTE_PATH;
+
+  if (!existsSync(absolutePath)) {
+    return {
+      ok: false,
+      sourcePath,
+      error: `Pay.sh catalog artifact not found at ${sourcePath}. Run npm run ingest:pay-sh first.`,
+    };
+  }
+
+  const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as {
+    summary?: PayShCatalogSummary;
+    providers?: PayShCatalogProvider[];
+  };
+
+  return {
+    ok: true,
+    sourcePath,
+    summary: parsed.summary ?? null,
+    providers: parsed.providers ?? [],
+  };
+}
+
+export function loadPayShCatalog(options: { limit?: number; category?: string; q?: string } = {}): PayShCatalog {
+  const loaded = readPayShProviders();
+  if (!loaded.ok) {
+    return {
+      ok: false,
+      sourcePath: loaded.sourcePath,
+      summary: null,
+      candidates: [],
+      total: 0,
+      returned: 0,
+      error: loaded.error,
+    };
+  }
+
+  const limit = Math.max(1, Math.min(options.limit ?? 50, 200));
+  let providers = loaded.providers;
+  if (options.category) {
+    providers = providers.filter((provider) => provider.category === options.category);
+  }
+  if (options.q) {
+    const q = options.q.toLowerCase();
+    providers = providers.filter((provider) =>
+      [provider.fqn, provider.title, provider.description, provider.use_case, provider.category]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(q))
+    );
+  }
+
+  const candidates = providers.slice(0, limit).map(payShCatalogProviderToCandidate);
+
+  return {
+    ok: true,
+    sourcePath: loaded.sourcePath,
+    summary: loaded.summary,
+    candidates,
+    total: providers.length,
+    returned: candidates.length,
+  };
+}
+
+export function loadPayShCandidate(candidateId: string): PayShCandidateLookup {
+  const loaded = readPayShProviders();
+  if (!loaded.ok) {
+    return {
+      ok: false,
+      sourcePath: loaded.sourcePath,
+      candidate: null,
+      error: loaded.error,
+    };
+  }
+
+  const candidate = loaded.providers
+    .map(payShCatalogProviderToCandidate)
+    .find((item) => item.candidateId === candidateId) ?? null;
+
+  return {
+    ok: candidate !== null,
+    sourcePath: loaded.sourcePath,
+    candidate,
+    error: candidate ? undefined : `Pay.sh candidate not found: ${candidateId}`,
+  };
+}

--- a/lib/integrations/source-adapter/pay-sh-quote-preview.ts
+++ b/lib/integrations/source-adapter/pay-sh-quote-preview.ts
@@ -1,0 +1,96 @@
+import { loadPayShCandidate } from "@/lib/integrations/source-adapter/pay-sh-catalog";
+import type { ReddiPayShCandidate } from "@/lib/integrations/source-adapter/profiles/pay-sh";
+
+export type PayShQuotePreview = {
+  ok: boolean;
+  mode: "dry-run-quote-preview";
+  candidate: ReddiPayShCandidate | null;
+  task: string;
+  routePreview: {
+    requestedSource: "pay-sh";
+    candidateSource: "pay-sh";
+    strictSourceMatch: true;
+    routeState: "external_unattested_candidate";
+    plannerPolicy: {
+      preferredSource: "pay-sh";
+      strictSourceMatch: true;
+      requireAttestationBeforeTrust: true;
+      livePaymentAllowed: false;
+      solanaFirst: true;
+    };
+  } | null;
+  quotePreview: {
+    currency: "USDC";
+    network: "solana";
+    rail: "pay_sh_x402_or_mpp";
+    minUsd: number;
+    maxUsd: number;
+    metered: boolean;
+    hasFreeTier: boolean;
+  } | null;
+  requiredGates: string[];
+  trustNotes: string[];
+  error?: string;
+};
+
+export function buildPayShQuotePreview(input: { candidateId: string; task?: string }): PayShQuotePreview {
+  const candidateResult = loadPayShCandidate(input.candidateId);
+  const task = input.task?.trim() || "Preview Pay.sh Solana API route";
+
+  if (!candidateResult.ok || !candidateResult.candidate) {
+    return {
+      ok: false,
+      mode: "dry-run-quote-preview",
+      candidate: null,
+      task,
+      routePreview: null,
+      quotePreview: null,
+      requiredGates: [],
+      trustNotes: [],
+      error: candidateResult.error ?? `Pay.sh candidate not found: ${input.candidateId}`,
+    };
+  }
+
+  const candidate = candidateResult.candidate;
+
+  return {
+    ok: true,
+    mode: "dry-run-quote-preview",
+    candidate,
+    task,
+    routePreview: {
+      requestedSource: "pay-sh",
+      candidateSource: "pay-sh",
+      strictSourceMatch: true,
+      routeState: "external_unattested_candidate",
+      plannerPolicy: {
+        preferredSource: "pay-sh",
+        strictSourceMatch: true,
+        requireAttestationBeforeTrust: true,
+        livePaymentAllowed: false,
+        solanaFirst: true,
+      },
+    },
+    quotePreview: {
+      currency: "USDC",
+      network: "solana",
+      rail: "pay_sh_x402_or_mpp",
+      minUsd: candidate.pricing.minUsd,
+      maxUsd: candidate.pricing.maxUsd,
+      metered: candidate.pricing.hasMetering,
+      hasFreeTier: candidate.pricing.hasFreeTier,
+    },
+    requiredGates: [
+      "User explicitly approves live Pay.sh payment experiment.",
+      "Pay.sh wallet/top-up path is verified for the user's geography before live payment.",
+      "Tiny spend cap is configured before payment.",
+      "Pay.sh receipt/x402/MPP payment proof is captured and attached to a RAP evidence pack.",
+      "RAP attestor verifies output, receipt, and disclosure before trust/reputation credit.",
+      "Agent cannot change wallet limits, top up funds, or call arbitrary non-allowlisted services.",
+    ],
+    trustNotes: [
+      ...candidate.trustNotes,
+      "Preview only: no Pay.sh wallet is created, no top-up is initiated, and no paid API request is sent.",
+    ],
+  };
+}

--- a/lib/integrations/source-adapter/profiles/index.ts
+++ b/lib/integrations/source-adapter/profiles/index.ts
@@ -2,12 +2,14 @@ import { CIRCLE_X402_SOURCE_ID, CIRCLE_X402_SOURCE_PROFILE } from "@/lib/integra
 import { HERMES_SOURCE_ID, HERMES_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/hermes";
 import { OPENCLAW_SOURCE_ID, OPENCLAW_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/openclaw";
 import { PI_SOURCE_ID, PI_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/pi";
+import { PAY_SH_SOURCE_ID, PAY_SH_SOURCE_PROFILE } from "@/lib/integrations/source-adapter/profiles/pay-sh";
 
 export const SOURCE_PROFILE_REGISTRY = {
   [OPENCLAW_SOURCE_ID]: OPENCLAW_SOURCE_PROFILE,
   [HERMES_SOURCE_ID]: HERMES_SOURCE_PROFILE,
   [PI_SOURCE_ID]: PI_SOURCE_PROFILE,
   [CIRCLE_X402_SOURCE_ID]: CIRCLE_X402_SOURCE_PROFILE,
+  [PAY_SH_SOURCE_ID]: PAY_SH_SOURCE_PROFILE,
 } as const;
 
 export type SourceProfileId = keyof typeof SOURCE_PROFILE_REGISTRY;

--- a/lib/integrations/source-adapter/profiles/pay-sh.ts
+++ b/lib/integrations/source-adapter/profiles/pay-sh.ts
@@ -1,0 +1,145 @@
+import { SOURCE_ADAPTER_VERSION, type SourceAdapterManifest, type SourceAdapterRole } from "@/lib/integrations/source-adapter/schema";
+
+export const PAY_SH_SOURCE_ID = "pay-sh" as const;
+
+export type PayShProviderCategory =
+  | "ai_ml"
+  | "compute"
+  | "data"
+  | "finance"
+  | "messaging"
+  | "media"
+  | "shopping"
+  | "solana_infrastructure"
+  | string;
+
+export type PayShCatalogProvider = {
+  fqn: string;
+  title: string;
+  description?: string;
+  use_case?: string;
+  category?: PayShProviderCategory;
+  service_url?: string;
+  endpoint_count?: number;
+  has_metering?: boolean;
+  has_free_tier?: boolean;
+  min_price_usd?: number;
+  max_price_usd?: number;
+  sha?: string;
+};
+
+export type ReddiPayShCandidate = {
+  candidateId: string;
+  source: typeof PAY_SH_SOURCE_ID;
+  providerFqn: string;
+  providerName: string;
+  serviceUrl?: string;
+  category: string;
+  taskTypes: string[];
+  endpointCount: number;
+  pricing: {
+    currency: "USDC";
+    network: "solana";
+    minUsd: number;
+    maxUsd: number;
+    hasFreeTier: boolean;
+    hasMetering: boolean;
+  };
+  sourceAdapter: SourceAdapterManifest;
+  attestationState: "externally_listed_unattested";
+  trustNotes: string[];
+};
+
+export const PAY_SH_SOURCE_PROFILE = {
+  source: PAY_SH_SOURCE_ID,
+  roles: ["specialist", "consumer"] as SourceAdapterRole[],
+  runtimes: ["http", "mcp", "pay-cli", "x402", "mpp", "solana-usdc"],
+  defaultPaymentPolicy: "x402_required" as const,
+  defaultAttestationState: "externally_listed_unattested" as const,
+  capabilityHints: {
+    specialist: ["pay-sh", "x402", "mpp", "paid-api", "solana-usdc", "external-service"],
+    consumer: ["discover", "quote", "pay", "verify-receipt", "mcp"],
+  },
+};
+
+const CATEGORY_TASK_TYPES: Record<string, string[]> = {
+  ai_ml: ["ai-inference", "model-api", "media-generation"],
+  compute: ["developer-tooling", "infrastructure", "rpc"],
+  data: ["research", "data-enrichment"],
+  finance: ["market-data", "financial-analysis"],
+  messaging: ["communications", "email", "workflow-automation"],
+  media: ["media-generation", "creative-generation"],
+  shopping: ["shopping", "ecommerce-intelligence"],
+  solana_infrastructure: ["solana-infrastructure", "rpc", "onchain-data"],
+};
+
+export function mapPayShCategoryToTaskTypes(category: PayShProviderCategory | undefined) {
+  if (!category) return ["external-api"];
+  return CATEGORY_TASK_TYPES[category] ?? ["external-api"];
+}
+
+function stableCandidateId(fqn: string) {
+  return `${PAY_SH_SOURCE_ID}:${fqn.replace(/\//g, ":").replace(/[^a-zA-Z0-9:-]+/g, "-").replace(/^[:\-]+|[:\-]+$/g, "").toLowerCase()}`;
+}
+
+export function buildPayShSourceManifest(input: {
+  role: Extract<SourceAdapterRole, "specialist" | "consumer">;
+  runtime?: "http" | "mcp" | "pay-cli";
+  taskTypes: string[];
+  inputModes?: string[];
+  outputModes?: string[];
+}): SourceAdapterManifest {
+  return {
+    version: SOURCE_ADAPTER_VERSION,
+    source: PAY_SH_SOURCE_ID,
+    role: input.role,
+    runtime: input.runtime ?? "http",
+    capabilities: {
+      taskTypes: input.taskTypes,
+      inputModes: input.inputModes ?? ["json", "text"],
+      outputModes: input.outputModes ?? ["json"],
+    },
+    paymentPolicy: PAY_SH_SOURCE_PROFILE.defaultPaymentPolicy,
+    failurePolicy: {
+      maxRetries: 0,
+      refundOnFailure: false,
+    },
+  };
+}
+
+export function payShCatalogProviderToCandidate(provider: PayShCatalogProvider): ReddiPayShCandidate {
+  const category = provider.category ?? "unknown";
+  const taskTypes = mapPayShCategoryToTaskTypes(category);
+  const minUsd = Math.max(0, provider.min_price_usd ?? 0);
+  const maxUsd = Math.max(minUsd, provider.max_price_usd ?? minUsd);
+
+  return {
+    candidateId: stableCandidateId(provider.fqn),
+    source: PAY_SH_SOURCE_ID,
+    providerFqn: provider.fqn,
+    providerName: provider.title,
+    serviceUrl: provider.service_url,
+    category,
+    taskTypes,
+    endpointCount: provider.endpoint_count ?? 0,
+    pricing: {
+      currency: "USDC",
+      network: "solana",
+      minUsd,
+      maxUsd,
+      hasFreeTier: provider.has_free_tier === true || minUsd === 0,
+      hasMetering: provider.has_metering === true,
+    },
+    sourceAdapter: buildPayShSourceManifest({
+      role: "specialist",
+      runtime: "http",
+      taskTypes,
+    }),
+    attestationState: PAY_SH_SOURCE_PROFILE.defaultAttestationState,
+    trustNotes: [
+      "Imported from Pay.sh catalog as external Solana x402/MPP metadata.",
+      "Not RAP-attested until a RAP attestor verifies output, receipt, and evidence.",
+      "Preview only: RAP has not created a Pay.sh wallet, top-up, or paid API call for this candidate.",
+    ],
+  };
+}

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -49,7 +49,7 @@ export type ResolveInput = {
     requireAttestation?: boolean;
     preferredPrivacyMode?: "public" | "per" | "vanish";
     minReputation?: number;
-    preferredSource?: "openclaw" | "hermes" | "pi" | "circle-x402";
+    preferredSource?: "openclaw" | "hermes" | "pi" | "circle-x402" | "pay-sh";
     strictSourceMatch?: boolean;
   };
 };
@@ -68,8 +68,8 @@ export type ResolveOutput = {
     avgFeedbackScore: number;
     selectionReasons: string[];
     sourceRouting?: {
-      requestedSource: "openclaw" | "hermes" | "pi" | "circle-x402" | null;
-      candidateSource: "openclaw" | "hermes" | "pi" | "circle-x402" | null;
+      requestedSource: "openclaw" | "hermes" | "pi" | "circle-x402" | "pay-sh" | null;
+      candidateSource: "openclaw" | "hermes" | "pi" | "circle-x402" | "pay-sh" | null;
       strictSourceMatch: boolean;
       scoreDelta: number;
       decisionTrace: string[];
@@ -82,8 +82,8 @@ export type ResolveOutput = {
     score: number;
     selectionReasons: string[];
     sourceRouting?: {
-      requestedSource: "openclaw" | "hermes" | "pi" | "circle-x402" | null;
-      candidateSource: "openclaw" | "hermes" | "pi" | "circle-x402" | null;
+      requestedSource: "openclaw" | "hermes" | "pi" | "circle-x402" | "pay-sh" | null;
+      candidateSource: "openclaw" | "hermes" | "pi" | "circle-x402" | "pay-sh" | null;
       strictSourceMatch: boolean;
       scoreDelta: number;
       decisionTrace: string[];
@@ -288,7 +288,7 @@ export const MCP_TOOL_SCHEMAS = [
             minReputation: { type: "number", description: "Minimum on-chain reputation score." },
             preferredSource: {
               type: "string",
-              enum: ["openclaw", "hermes", "pi", "circle-x402"],
+              enum: ["openclaw", "hermes", "pi", "circle-x402", "pay-sh"],
               description: "Optional source-ecosystem preference for candidate routing.",
             },
             strictSourceMatch: {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "evidence:torque:reputation-ranking": "node ./scripts/generate-torque-reputation-ranking-evidence.mjs",
     "smoke:umbra:devnet:receiver-claimable-utxo": "node ./scripts/run-umbra-devnet-receiver-claimable-utxo-smoke.mjs",
     "ingest:circle-x402": "node ./scripts/ingest-circle-x402-discovery.mjs",
+    "ingest:pay-sh": "node ./scripts/ingest-pay-sh-catalog.mjs",
     "check:rap:naming": "node ./scripts/check-rap-naming.mjs"
   },
   "dependencies": {

--- a/scripts/ingest-pay-sh-catalog.mjs
+++ b/scripts/ingest-pay-sh-catalog.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+const CATALOG_URL = process.env.PAY_SH_CATALOG_URL ?? "https://pay.sh/api/catalog";
+const OUT_PATH = process.env.PAY_SH_CATALOG_OUT ?? join("artifacts", "pay-sh-catalog", "20260513-initial", "catalog.json");
+
+function summarize(providers, raw) {
+  const categories = {};
+  let min = null;
+  let max = null;
+  for (const provider of providers) {
+    const category = provider.category ?? "unknown";
+    categories[category] = (categories[category] ?? 0) + 1;
+    for (const value of [provider.min_price_usd, provider.max_price_usd]) {
+      if (typeof value !== "number") continue;
+      min = min === null ? value : Math.min(min, value);
+      max = max === null ? value : Math.max(max, value);
+    }
+  }
+  return {
+    generated_at: raw.generated_at,
+    provider_count: raw.provider_count ?? providers.length,
+    base_url: raw.base_url,
+    categories,
+    pricesUsd: { min, max },
+    boundary: "Metadata-only Pay.sh catalog ingest; does not create wallets, top up funds, pay, or invoke APIs.",
+  };
+}
+
+async function main() {
+  const res = await fetch(CATALOG_URL, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`Pay.sh catalog fetch failed: ${res.status} ${res.statusText}`);
+  const raw = await res.json();
+  const providers = Array.isArray(raw.providers) ? raw.providers : [];
+  const payload = {
+    summary: summarize(providers, raw),
+    providers,
+  };
+  await mkdir(dirname(OUT_PATH), { recursive: true });
+  await writeFile(OUT_PATH, JSON.stringify(payload, null, 2));
+  console.log(`wrote ${providers.length} Pay.sh providers to ${OUT_PATH}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/run-source-conformance-matrix.sh
+++ b/scripts/run-source-conformance-matrix.sh
@@ -10,7 +10,7 @@ LOG_FILE="$OUT_DIR/matrix.log"
 SUMMARY="$OUT_DIR/SUMMARY.md"
 mkdir -p "$OUT_DIR"
 
-SOURCES=(openclaw hermes pi circle-x402)
+SOURCES=(openclaw hermes pi circle-x402 pay-sh)
 
 run_source() {
   local src="$1"
@@ -46,7 +46,7 @@ TOTAL_COUNT=$((PASS_COUNT + FAIL_COUNT))
   echo "# Source Conformance Matrix"
   echo ""
   echo "- Timestamp: $TS"
-  echo "- Sources: openclaw, hermes, pi, circle-x402"
+  echo "- Sources: openclaw, hermes, pi, circle-x402, pay-sh"
   echo "- Rows passed: $PASS_COUNT"
   echo "- Rows failed: $FAIL_COUNT"
   echo "- Rows total: $TOTAL_COUNT"

--- a/scripts/run-source-conformance.sh
+++ b/scripts/run-source-conformance.sh
@@ -25,10 +25,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$SOURCE" in
-  openclaw|hermes|pi|circle-x402)
+  openclaw|hermes|pi|circle-x402|pay-sh)
     ;;
   *)
-    echo "Unsupported source: $SOURCE (allowed: openclaw|hermes|pi|circle-x402)"
+    echo "Unsupported source: $SOURCE (allowed: openclaw|hermes|pi|circle-x402|pay-sh)"
     exit 1
     ;;
 esac
@@ -99,6 +99,10 @@ case "$SOURCE" in
   circle-x402)
     run_step "Circle x402 profile + discovery mapping contracts" \
       npx jest lib/__tests__/source-adapter-circle-x402-profile.test.ts --runInBand
+    ;;
+  pay-sh)
+    run_step "Pay.sh profile + catalog mapping contracts" \
+      npx jest lib/__tests__/source-adapter-pay-sh-profile.test.ts --runInBand
     ;;
 esac
 


### PR DESCRIPTION
Closes #317.

## Summary
- add `pay-sh` as a Solana-first RAP source adapter profile
- convert Pay.sh catalog providers into externally listed / not RAP-attested specialist candidates
- add metadata-only ingest: `npm run ingest:pay-sh`
- add dry-run catalog API: `/api/source-adapters/pay-sh`
- add dry-run quote preview API: `/api/source-adapters/pay-sh/quote-preview`
- wire `pay-sh` into source conformance, matrix, BDD feature index, and MCP preferred source typings
- add 10-loop retrospective: `docs/PAY-SH-SOURCE-ADAPTER-IMPLEMENTATION-RETROSPECTIVE-2026-05-13.md`

## Safety / boundaries
- metadata and dry-run preview only
- no `pay setup`
- no `pay topup`
- no wallet creation
- no paid Pay.sh calls
- no external API invocation
- no wallet secrets or payment credentials stored

## Validation
- `npm run test:bdd:index`
- `npm run check:rap:naming`
- `npx jest lib/__tests__/source-adapter-pay-sh-profile.test.ts lib/__tests__/pay-sh-catalog-route.test.ts lib/__tests__/pay-sh-quote-preview-route.test.ts --runInBand`
- `npx jest lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
- `npm run ingest:pay-sh` (metadata-only public catalog ingest; 72 providers)
- `./scripts/run-source-conformance.sh --source pay-sh --mode smoke`

Latest source-conformance artifact: `artifacts/source-conformance/20260513-084938-pay-sh-smoke/SUMMARY.md`
