### PR TITLE
feat: add Pay.sh environment capabilities

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,24 @@
 # Reddi Agent Protocol — Status
 
+## Latest Update — Pay.sh environment capability metadata implemented (2026-05-13 AEST)
+
+Implemented Issue #326 on branch `feature/pay-sh-environment-capabilities`. Scope remains dry-run/metadata only: no `pay setup`, no `pay topup`, no wallet creation, no `pay mcp`, no paid Pay.sh call, no provider invocation, and no secrets stored.
+
+Delivered:
+- Pay.sh candidate `environmentCapabilities` separating Solana rail from `sandbox/localnet`, `devnet`, and `mainnet` states
+- `sandbox_service_url` preservation in Pay.sh catalog provider typing and candidate mapping
+- Devnet support state: `provider_declared | challenge_detected | unknown`; current mapping only declares devnet from provider metadata
+- Policy-plan `environment` input/output with sandbox default, devnet unknown blocking, and explicit mainnet gating while `livePaymentAllowed=false`
+- BDD scenario S5.11 for Pay.sh environment capabilities
+
+Validation:
+- `npm run test:bdd:index` PASS
+- `npm run check:rap:naming` PASS
+- Focused Pay.sh Jest PASS: 19/19
+- `./scripts/run-source-conformance.sh --source pay-sh --mode smoke` PASS including build; artifact `artifacts/source-conformance/20260513-141024-pay-sh-smoke/SUMMARY.md`
+
+RESUME FROM HERE: Open PR for Issue #326, review/merge if CI stays green, then next slice can add endpoint-to-environment URL matching or a sandbox UI demo.
+
 ## Latest Update — Pay.sh sandbox/devnet research drafted (2026-05-13 AEST)
 
 Researched whether Pay.sh supports no-real-funds environments for Reddi Agent Protocol pre-go-live work. Drafted `docs/PAY-SH-DEVNET-SANDBOX-RESEARCH-2026-05-13.md`.

--- a/app/api/source-adapters/pay-sh/policy-plan/route.ts
+++ b/app/api/source-adapters/pay-sh/policy-plan/route.ts
@@ -27,6 +27,7 @@ export async function POST(req: Request) {
   const plan = buildPayShPolicyPlan({
     candidateId: body.candidateId,
     task: body.task,
+    environment: body.environment,
     endpointUrl: body.endpointUrl,
     toolName: body.toolName,
     estimatedUsd: body.estimatedUsd,

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -116,3 +116,10 @@ Feature: Bucket S Source Adapter Onboarding
     Then Reddi requires explicit user approval endpoint allowlisting tiny spend cap receipt capture and attestation
     And live payment remains disabled in the policy plan
     And non-curl MCP tools are blocked from future paid invocation
+
+  @S5.11 @conformance @pay-sh @environment-capabilities
+  Scenario: Pay.sh environment capabilities separate sandbox devnet and mainnet
+    When a Pay.sh catalog provider is converted into a RAP candidate
+    Then sandbox localnet is represented as the primary no-real-funds pre-go-live environment
+    And devnet support is unknown unless provider metadata or payment challenge evidence declares it
+    And mainnet remains explicitly gated with live payment disabled by default

--- a/lib/__tests__/pay-sh-policy-plan-route.test.ts
+++ b/lib/__tests__/pay-sh-policy-plan-route.test.ts
@@ -24,6 +24,7 @@ describe("Pay.sh policy-plan route", () => {
         body: JSON.stringify({
           candidateId: "pay-sh:agentmail:email",
           task: "Send email",
+          environment: "sandbox",
           endpointUrl: "https://agentmail.to/api/send",
           allowlistedEndpoints: ["https://agentmail.to/api/"],
           estimatedUsd: 0.05,
@@ -39,6 +40,7 @@ describe("Pay.sh policy-plan route", () => {
       expect.objectContaining({
         candidateId: "pay-sh:agentmail:email",
         task: "Send email",
+        environment: "sandbox",
         endpointUrl: "https://agentmail.to/api/send",
         allowlistedEndpoints: ["https://agentmail.to/api/"],
       })

--- a/lib/__tests__/pay-sh-policy-plan.test.ts
+++ b/lib/__tests__/pay-sh-policy-plan.test.ts
@@ -18,6 +18,11 @@ describe("Pay.sh dry-run paid-call policy plan", () => {
               candidateId: "pay-sh:agentmail:email",
               providerName: "AgentMail",
               pricing: { currency: "USDC", network: "solana", minUsd: 0.01, maxUsd: 0.25 },
+              environmentCapabilities: {
+                sandbox: { supported: true, network: "localnet" },
+                devnet: { support: "unknown", network: "devnet" },
+                mainnet: { supported: true, network: "mainnet", livePaymentAllowed: false },
+              },
             },
           }
         : { ok: false, candidate: null, error: "not found" }
@@ -41,6 +46,13 @@ describe("Pay.sh dry-run paid-call policy plan", () => {
     expect(plan.ok).toBe(true);
     expect(plan.mode).toBe("dry-run-paid-call-policy-plan");
     expect(plan.policy.livePaymentAllowed).toBe(false);
+    expect(plan.environment).toMatchObject({
+      requested: "sandbox",
+      executionNetwork: "localnet",
+      sandboxAvailable: true,
+      devnetSupport: "unknown",
+      mainnetGated: true,
+    });
     expect(plan.policy.eligibleForFutureLivePayment).toBe(true);
     expect(plan.blockReasons).toEqual([]);
     expect(plan.executionBoundary).toContain("Dry-run policy planning only");
@@ -104,5 +116,88 @@ describe("Pay.sh dry-run paid-call policy plan", () => {
 
     expect(plan.ok).toBe(false);
     expect(plan.blockReasons).toContain("candidate_not_found");
+  });
+
+  it("blocks devnet unless provider metadata or challenge support is detected", async () => {
+    await mockCandidate(true);
+    const { buildPayShPolicyPlan } = await import("@/lib/integrations/source-adapter/pay-sh-policy-plan");
+
+    const plan = buildPayShPolicyPlan({
+      candidateId: "pay-sh:agentmail:email",
+      task: "Call a devnet endpoint",
+      environment: "devnet",
+      endpointUrl: "https://agentmail.to/api/send",
+      allowlistedEndpoints: ["https://agentmail.to/api/"],
+      estimatedUsd: 0.01,
+      spendCapUsd: 0.1,
+      userApprovedLivePayment: true,
+    });
+
+    expect(plan.environment).toMatchObject({
+      requested: "devnet",
+      executionNetwork: "devnet",
+      devnetSupport: "unknown",
+    });
+    expect(plan.blockReasons).toContain("devnet_support_unknown");
+    expect(plan.policy.livePaymentAllowed).toBe(false);
+  });
+
+  it("allows the devnet environment gate when provider metadata declares devnet", async () => {
+    const { buildPayShQuotePreview } = await import("@/lib/integrations/source-adapter/pay-sh-quote-preview");
+    (buildPayShQuotePreview as jest.Mock).mockReturnValue({
+      ok: true,
+      candidate: {
+        candidateId: "pay-sh:quicknode:rpc",
+        providerName: "QuickNode",
+        pricing: { currency: "USDC", network: "solana", minUsd: 0.001, maxUsd: 0.001 },
+        environmentCapabilities: {
+          sandbox: { supported: true, network: "localnet" },
+          devnet: { support: "provider_declared", network: "devnet" },
+          mainnet: { supported: true, network: "mainnet", livePaymentAllowed: false },
+        },
+      },
+    });
+    const { buildPayShPolicyPlan } = await import("@/lib/integrations/source-adapter/pay-sh-policy-plan");
+
+    const plan = buildPayShPolicyPlan({
+      candidateId: "pay-sh:quicknode:rpc",
+      task: "Call a devnet RPC endpoint",
+      environment: "devnet",
+      endpointUrl: "https://x402.quicknode.com/solana-devnet",
+      allowlistedEndpoints: ["https://x402.quicknode.com/"],
+      estimatedUsd: 0.001,
+      spendCapUsd: 0.1,
+      userApprovedLivePayment: true,
+    });
+
+    expect(plan.environment.devnetSupport).toBe("provider_declared");
+    expect(plan.blockReasons).not.toContain("devnet_support_unknown");
+    expect(plan.policy.livePaymentAllowed).toBe(false);
+  });
+
+  it("keeps mainnet explicit and gated even when planning gates pass", async () => {
+    await mockCandidate(true);
+    const { buildPayShPolicyPlan } = await import("@/lib/integrations/source-adapter/pay-sh-policy-plan");
+
+    const plan = buildPayShPolicyPlan({
+      candidateId: "pay-sh:agentmail:email",
+      task: "Plan a mainnet call",
+      environment: "mainnet",
+      endpointUrl: "https://agentmail.to/api/send",
+      allowlistedEndpoints: ["https://agentmail.to/api/"],
+      estimatedUsd: 0.01,
+      spendCapUsd: 0.1,
+      userApprovedLivePayment: true,
+    });
+
+    expect(plan.environment).toMatchObject({
+      requested: "mainnet",
+      executionNetwork: "mainnet",
+      livePaymentExperiment: true,
+      mainnetGated: true,
+    });
+    expect(plan.blockReasons).toEqual([]);
+    expect(plan.policy.eligibleForFutureLivePayment).toBe(true);
+    expect(plan.policy.livePaymentAllowed).toBe(false);
   });
 });

--- a/lib/__tests__/source-adapter-pay-sh-profile.test.ts
+++ b/lib/__tests__/source-adapter-pay-sh-profile.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildPayShEnvironmentCapabilities,
   buildPayShSourceManifest,
   mapPayShCategoryToTaskTypes,
   payShCatalogProviderToCandidate,
@@ -63,8 +64,52 @@ describe("source adapter pay-sh profile", () => {
       maxUsd: 0.01,
       hasMetering: true,
     });
+    expect(candidate.environmentCapabilities.sandbox).toMatchObject({
+      supported: true,
+      network: "localnet",
+      defaultRpcUrl: "https://402.surfnet.dev:8899",
+      localRpcUrl: "http://localhost:8899",
+      funding: "surfpool_fake_sol_usdc",
+    });
+    expect(candidate.environmentCapabilities.devnet.support).toBe("unknown");
+    expect(candidate.environmentCapabilities.mainnet).toMatchObject({
+      supported: true,
+      network: "mainnet",
+      livePaymentAllowed: false,
+    });
     expect(candidate.attestationState).toBe("externally_listed_unattested");
     expect(validateSourceAdapterManifest(candidate.sourceAdapter).ok).toBe(true);
     expect(candidate.trustNotes.join(" ")).toContain("Not RAP-attested");
+  });
+
+  it("preserves provider sandbox URLs for Pay.sh sandbox/localnet testing", () => {
+    const capabilities = buildPayShEnvironmentCapabilities({
+      fqn: "example/provider",
+      title: "Example Provider",
+      category: "data",
+      service_url: "https://api.example.com",
+      sandbox_service_url: "https://sandbox.example.com",
+    });
+
+    expect(capabilities.sandbox.providerSandboxServiceUrl).toBe("https://sandbox.example.com");
+    expect(capabilities.sandbox.notes.join(" ")).toContain("sandbox_service_url");
+    expect(capabilities.sandbox.notes.join(" ")).toContain("localnet/Surfpool");
+  });
+
+  it("marks devnet as provider-declared only when metadata says so", () => {
+    const capabilities = buildPayShEnvironmentCapabilities({
+      fqn: "quicknode/rpc",
+      title: "QuickNode",
+      description: "Pay-per-request RPC with Solana devnet support.",
+      category: "compute",
+      service_url: "https://x402.quicknode.com",
+    });
+
+    expect(capabilities.devnet).toMatchObject({
+      support: "provider_declared",
+      network: "devnet",
+      detection: "provider_metadata",
+    });
+    expect(capabilities.devnet.notes.join(" ")).toContain("challenge");
   });
 });

--- a/lib/integrations/source-adapter/pay-sh-policy-plan.ts
+++ b/lib/integrations/source-adapter/pay-sh-policy-plan.ts
@@ -3,6 +3,7 @@ import { buildPayShQuotePreview } from "@/lib/integrations/source-adapter/pay-sh
 export type PayShPolicyPlanInput = {
   candidateId: string;
   task: string;
+  environment?: "sandbox" | "devnet" | "mainnet";
   endpointUrl?: string;
   toolName?: string;
   estimatedUsd?: number;
@@ -18,6 +19,7 @@ export type PayShPolicyBlockReason =
   | "tool_not_allowed_for_live_payment"
   | "endpoint_missing"
   | "endpoint_not_allowlisted"
+  | "devnet_support_unknown"
   | "user_approval_missing"
   | "spend_cap_missing"
   | "estimated_cost_exceeds_spend_cap"
@@ -35,6 +37,14 @@ export type PayShPolicyPlan = {
     endpointUrl: string | null;
     estimatedUsd: number | null;
     spendCapUsd: number | null;
+  };
+  environment: {
+    requested: "sandbox" | "devnet" | "mainnet";
+    executionNetwork: "localnet" | "devnet" | "mainnet";
+    livePaymentExperiment: boolean;
+    sandboxAvailable: boolean;
+    devnetSupport: "provider_declared" | "challenge_detected" | "unknown";
+    mainnetGated: true;
   };
   policy: {
     source: "pay-sh";
@@ -80,6 +90,9 @@ function endpointIsAllowlisted(endpointUrl: string | undefined, allowlistedEndpo
 
 export function buildPayShPolicyPlan(input: PayShPolicyPlanInput): PayShPolicyPlan {
   const quote = buildPayShQuotePreview({ candidateId: input.candidateId, task: input.task });
+  const requestedEnvironment = input.environment ?? "sandbox";
+  const candidateEnv = quote.candidate?.environmentCapabilities;
+  const executionNetwork = requestedEnvironment === "sandbox" ? "localnet" : requestedEnvironment;
   const toolName = input.toolName ?? "curl";
   const endpointUrl = input.endpointUrl?.trim() || null;
   const estimatedUsd = typeof input.estimatedUsd === "number" ? Math.max(0, input.estimatedUsd) : null;
@@ -115,6 +128,23 @@ export function buildPayShPolicyPlan(input: PayShPolicyPlanInput): PayShPolicyPl
       detail: endpointUrl
         ? "Endpoint must match an explicit allowlist entry before future live payment."
         : "Cannot evaluate allowlist until endpoint is supplied.",
+    },
+    {
+      id: "environment_supported",
+      passed:
+        requestedEnvironment === "sandbox" ||
+        requestedEnvironment === "mainnet" ||
+        candidateEnv?.devnet.support === "provider_declared" ||
+        candidateEnv?.devnet.support === "challenge_detected",
+      required: true,
+      detail:
+        requestedEnvironment === "sandbox"
+          ? "Pay.sh sandbox/localnet is the default no-real-funds pre-go-live lane."
+          : requestedEnvironment === "devnet"
+            ? candidateEnv?.devnet.support === "provider_declared" || candidateEnv?.devnet.support === "challenge_detected"
+              ? "Devnet support is detected for this candidate, but must still be verified against the payment challenge."
+              : "Devnet support is unknown for this candidate; use sandbox/localnet or provider mocks until a devnet challenge is detected."
+            : "Mainnet is structurally supported but remains gated and disabled by default.",
     },
     {
       id: "user_approval",
@@ -153,6 +183,7 @@ export function buildPayShPolicyPlan(input: PayShPolicyPlanInput): PayShPolicyPl
   if (!gates.find((gate) => gate.id === "tool_allowed")?.passed) blockReasons.push("tool_not_allowed_for_live_payment");
   if (!gates.find((gate) => gate.id === "endpoint_present")?.passed) blockReasons.push("endpoint_missing");
   if (!gates.find((gate) => gate.id === "endpoint_allowlisted")?.passed) blockReasons.push("endpoint_not_allowlisted");
+  if (!gates.find((gate) => gate.id === "environment_supported")?.passed) blockReasons.push("devnet_support_unknown");
   if (!gates.find((gate) => gate.id === "user_approval")?.passed) blockReasons.push("user_approval_missing");
   if (!gates.find((gate) => gate.id === "spend_cap_present")?.passed) blockReasons.push("spend_cap_missing");
   if (!gates.find((gate) => gate.id === "estimated_cost_within_cap")?.passed) blockReasons.push("estimated_cost_exceeds_spend_cap");
@@ -172,6 +203,14 @@ export function buildPayShPolicyPlan(input: PayShPolicyPlanInput): PayShPolicyPl
       endpointUrl,
       estimatedUsd,
       spendCapUsd,
+    },
+    environment: {
+      requested: requestedEnvironment,
+      executionNetwork,
+      livePaymentExperiment: requestedEnvironment === "mainnet",
+      sandboxAvailable: candidateEnv?.sandbox.supported === true,
+      devnetSupport: candidateEnv?.devnet.support ?? "unknown",
+      mainnetGated: true,
     },
     policy: {
       source: "pay-sh",

--- a/lib/integrations/source-adapter/profiles/pay-sh.ts
+++ b/lib/integrations/source-adapter/profiles/pay-sh.ts
@@ -20,12 +20,40 @@ export type PayShCatalogProvider = {
   use_case?: string;
   category?: PayShProviderCategory;
   service_url?: string;
+  sandbox_service_url?: string;
   endpoint_count?: number;
   has_metering?: boolean;
   has_free_tier?: boolean;
   min_price_usd?: number;
   max_price_usd?: number;
   sha?: string;
+};
+
+export type PayShDevnetSupportState = "provider_declared" | "challenge_detected" | "unknown";
+
+export type PayShEnvironmentCapabilities = {
+  sandbox: {
+    supported: true;
+    network: "localnet";
+    defaultRpcUrl: "https://402.surfnet.dev:8899";
+    localRpcUrl: "http://localhost:8899";
+    command: "pay --sandbox curl <sandbox endpoint>";
+    funding: "surfpool_fake_sol_usdc";
+    providerSandboxServiceUrl?: string;
+    notes: string[];
+  };
+  devnet: {
+    support: PayShDevnetSupportState;
+    network: "devnet";
+    detection: "provider_metadata" | "payment_challenge" | "not_detected";
+    notes: string[];
+  };
+  mainnet: {
+    supported: true;
+    network: "mainnet";
+    livePaymentAllowed: false;
+    requirements: string[];
+  };
 };
 
 export type ReddiPayShCandidate = {
@@ -45,6 +73,7 @@ export type ReddiPayShCandidate = {
     hasFreeTier: boolean;
     hasMetering: boolean;
   };
+  environmentCapabilities: PayShEnvironmentCapabilities;
   sourceAdapter: SourceAdapterManifest;
   attestationState: "externally_listed_unattested";
   trustNotes: string[];
@@ -80,6 +109,62 @@ export function mapPayShCategoryToTaskTypes(category: PayShProviderCategory | un
 
 function stableCandidateId(fqn: string) {
   return `${PAY_SH_SOURCE_ID}:${fqn.replace(/\//g, ":").replace(/[^a-zA-Z0-9:-]+/g, "-").replace(/^[:\-]+|[:\-]+$/g, "").toLowerCase()}`;
+}
+
+function providerMentionsDevnet(provider: PayShCatalogProvider) {
+  return [provider.fqn, provider.title, provider.description, provider.use_case, provider.category, provider.service_url]
+    .filter(Boolean)
+    .some((value) => String(value).toLowerCase().includes("devnet"));
+}
+
+export function buildPayShEnvironmentCapabilities(provider: PayShCatalogProvider): PayShEnvironmentCapabilities {
+  const sandboxServiceUrl = provider.sandbox_service_url?.trim() || undefined;
+  const devnetDeclared = providerMentionsDevnet(provider);
+
+  return {
+    sandbox: {
+      supported: true,
+      network: "localnet",
+      defaultRpcUrl: "https://402.surfnet.dev:8899",
+      localRpcUrl: "http://localhost:8899",
+      command: "pay --sandbox curl <sandbox endpoint>",
+      funding: "surfpool_fake_sol_usdc",
+      providerSandboxServiceUrl: sandboxServiceUrl,
+      notes: [
+        sandboxServiceUrl
+          ? "Provider metadata includes a sandbox_service_url; use it for no-real-funds pre-go-live tests."
+          : "No provider sandbox_service_url is declared; use Pay.sh debugger/demo flows or RAP mocks for provider payloads.",
+        "Sandbox maps to Pay.sh localnet/Surfpool, not Solana devnet.",
+        "Sandbox tests must not create mainnet wallets, top up funds, or invoke real paid provider calls.",
+      ],
+    },
+    devnet: {
+      support: devnetDeclared ? "provider_declared" : "unknown",
+      network: "devnet",
+      detection: devnetDeclared ? "provider_metadata" : "not_detected",
+      notes: devnetDeclared
+        ? [
+            "Provider metadata mentions devnet; verify the actual x402/MPP challenge before treating devnet as supported.",
+            "Devnet support is provider/challenge-dependent and is not implied for all Pay.sh providers.",
+          ]
+        : [
+            "No devnet support detected in provider metadata.",
+            "Only enable devnet if a provider declares it or a payment challenge identifies Solana devnet.",
+          ],
+    },
+    mainnet: {
+      supported: true,
+      network: "mainnet",
+      livePaymentAllowed: false,
+      requirements: [
+        "explicit_user_approval_per_experiment",
+        "endpoint_allowlist",
+        "tiny_spend_cap",
+        "receipt_capture",
+        "rap_attestation_before_trust_credit",
+      ],
+    },
+  };
 }
 
 export function buildPayShSourceManifest(input: {
@@ -130,6 +215,7 @@ export function payShCatalogProviderToCandidate(provider: PayShCatalogProvider):
       hasFreeTier: provider.has_free_tier === true || minUsd === 0,
       hasMetering: provider.has_metering === true,
     },
+    environmentCapabilities: buildPayShEnvironmentCapabilities(provider),
     sourceAdapter: buildPayShSourceManifest({
       role: "specialist",
       runtime: "http",


### PR DESCRIPTION
Closes #326.

## Summary
- adds Pay.sh candidate environment capability metadata for sandbox/localnet, devnet, and mainnet
- preserves provider `sandbox_service_url` when present
- defaults policy planning to sandbox/localnet, blocks unknown devnet, and keeps mainnet explicitly gated with live payment disabled
- adds BDD S5.11 coverage for the environment capability matrix

## Guardrails
No `pay setup`, no `pay topup`, no wallet creation, no `pay mcp`, no paid Pay.sh call, no provider invocation, no secrets stored.

## Validation
- `npm run test:bdd:index`
- `npm run check:rap:naming`
- `npx jest lib/__tests__/source-adapter-pay-sh-profile.test.ts lib/__tests__/pay-sh-catalog-route.test.ts lib/__tests__/pay-sh-quote-preview-route.test.ts lib/__tests__/pay-sh-policy-plan.test.ts lib/__tests__/pay-sh-policy-plan-route.test.ts --runInBand`
- `./scripts/run-source-conformance.sh --source pay-sh --mode smoke`

Artifact: `artifacts/source-conformance/20260513-141024-pay-sh-smoke/SUMMARY.md`
