### PR TITLE
feat: gate Pay.sh endpoints by environment

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,26 @@
 # Reddi Agent Protocol — Status
 
+## Latest Update — Pay.sh endpoint/environment compatibility gate implemented (2026-05-13 AEST)
+
+Implemented Issue #329 on branch `feature/pay-sh-endpoint-environment-gate`. Scope remains dry-run/policy only: no `pay setup`, no `pay topup`, no wallet creation, no `pay mcp`, no paid Pay.sh call, no provider invocation, and no secrets stored.
+
+Delivered:
+- Pay.sh policy-plan `endpointCompatibility` output
+- New block reason `endpoint_environment_mismatch`
+- Sandbox plans prefer provider `sandbox_service_url` when present and block mismatches
+- Sandbox plans without provider sandbox URL remain allowlist-only for debugger/demo/mock planning
+- Devnet plans require devnet-like endpoints in addition to declared/detected devnet support
+- Mainnet/future-live plans require endpoint compatibility with candidate `serviceUrl` plus existing allowlist gates
+- BDD scenario S5.12 for endpoint/environment mismatch rejection
+
+Validation:
+- `npm run test:bdd:index` PASS
+- `npm run check:rap:naming` PASS
+- Focused Pay.sh Jest PASS: 21/21
+- `./scripts/run-source-conformance.sh --source pay-sh --mode smoke` PASS including build; artifact `artifacts/source-conformance/20260513-151809-pay-sh-smoke/SUMMARY.md`
+
+RESUME FROM HERE: Open PR for Issue #329, review/merge if CI stays green, then next slice can add a sandbox UI/CLI demo that composes catalog → quote-preview → policy-plan without executing Pay.sh.
+
 ## Latest Update — Pay.sh environment capability metadata implemented (2026-05-13 AEST)
 
 Merged PR #327 for Issue #326. Scope remains dry-run/metadata only: no `pay setup`, no `pay topup`, no wallet creation, no `pay mcp`, no paid Pay.sh call, no provider invocation, and no secrets stored.

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -123,3 +123,10 @@ Feature: Bucket S Source Adapter Onboarding
     Then sandbox localnet is represented as the primary no-real-funds pre-go-live environment
     And devnet support is unknown unless provider metadata or payment challenge evidence declares it
     And mainnet remains explicitly gated with live payment disabled by default
+
+  @S5.12 @conformance @pay-sh @environment-capabilities @settlement-safety
+  Scenario: Pay.sh policy plans reject endpoint and environment mismatches
+    When a Pay.sh endpoint is planned for sandbox devnet or mainnet execution
+    Then sandbox plans prefer provider sandbox service URLs when declared
+    And devnet plans require declared or challenge-detected devnet support
+    And mainnet plans require candidate service URL compatibility plus explicit allowlisting

--- a/lib/__tests__/pay-sh-policy-plan.test.ts
+++ b/lib/__tests__/pay-sh-policy-plan.test.ts
@@ -17,6 +17,7 @@ describe("Pay.sh dry-run paid-call policy plan", () => {
             candidate: {
               candidateId: "pay-sh:agentmail:email",
               providerName: "AgentMail",
+              serviceUrl: "https://agentmail.to",
               pricing: { currency: "USDC", network: "solana", minUsd: 0.01, maxUsd: 0.25 },
               environmentCapabilities: {
                 sandbox: { supported: true, network: "localnet" },
@@ -52,6 +53,10 @@ describe("Pay.sh dry-run paid-call policy plan", () => {
       sandboxAvailable: true,
       devnetSupport: "unknown",
       mainnetGated: true,
+    });
+    expect(plan.endpointCompatibility).toMatchObject({
+      compatible: true,
+      rule: "sandbox_allowlist_only",
     });
     expect(plan.policy.eligibleForFutureLivePayment).toBe(true);
     expect(plan.blockReasons).toEqual([]);
@@ -149,6 +154,7 @@ describe("Pay.sh dry-run paid-call policy plan", () => {
       candidate: {
         candidateId: "pay-sh:quicknode:rpc",
         providerName: "QuickNode",
+        serviceUrl: "https://x402.quicknode.com",
         pricing: { currency: "USDC", network: "solana", minUsd: 0.001, maxUsd: 0.001 },
         environmentCapabilities: {
           sandbox: { supported: true, network: "localnet" },
@@ -171,6 +177,10 @@ describe("Pay.sh dry-run paid-call policy plan", () => {
     });
 
     expect(plan.environment.devnetSupport).toBe("provider_declared");
+    expect(plan.endpointCompatibility).toMatchObject({
+      compatible: true,
+      rule: "devnet_declared_endpoint",
+    });
     expect(plan.blockReasons).not.toContain("devnet_support_unknown");
     expect(plan.policy.livePaymentAllowed).toBe(false);
   });
@@ -198,6 +208,72 @@ describe("Pay.sh dry-run paid-call policy plan", () => {
     });
     expect(plan.blockReasons).toEqual([]);
     expect(plan.policy.eligibleForFutureLivePayment).toBe(true);
+    expect(plan.policy.livePaymentAllowed).toBe(false);
+  });
+
+  it("blocks sandbox endpoints that do not match declared sandbox_service_url", async () => {
+    const { buildPayShQuotePreview } = await import("@/lib/integrations/source-adapter/pay-sh-quote-preview");
+    (buildPayShQuotePreview as jest.Mock).mockReturnValue({
+      ok: true,
+      candidate: {
+        candidateId: "pay-sh:example:provider",
+        providerName: "Example Provider",
+        serviceUrl: "https://api.example.com",
+        pricing: { currency: "USDC", network: "solana", minUsd: 0.01, maxUsd: 0.01 },
+        environmentCapabilities: {
+          sandbox: {
+            supported: true,
+            network: "localnet",
+            providerSandboxServiceUrl: "https://sandbox.example.com",
+          },
+          devnet: { support: "unknown", network: "devnet" },
+          mainnet: { supported: true, network: "mainnet", livePaymentAllowed: false },
+        },
+      },
+    });
+    const { buildPayShPolicyPlan } = await import("@/lib/integrations/source-adapter/pay-sh-policy-plan");
+
+    const plan = buildPayShPolicyPlan({
+      candidateId: "pay-sh:example:provider",
+      task: "Plan sandbox call",
+      environment: "sandbox",
+      endpointUrl: "https://api.example.com/v1/search",
+      allowlistedEndpoints: ["https://api.example.com/"],
+      estimatedUsd: 0.01,
+      spendCapUsd: 0.1,
+      userApprovedLivePayment: true,
+    });
+
+    expect(plan.endpointCompatibility).toMatchObject({
+      compatible: false,
+      rule: "sandbox_service_url",
+      expectedBaseUrl: "https://sandbox.example.com",
+    });
+    expect(plan.blockReasons).toContain("endpoint_environment_mismatch");
+    expect(plan.policy.livePaymentAllowed).toBe(false);
+  });
+
+  it("requires mainnet/future-live endpoints to match candidate serviceUrl", async () => {
+    await mockCandidate(true);
+    const { buildPayShPolicyPlan } = await import("@/lib/integrations/source-adapter/pay-sh-policy-plan");
+
+    const plan = buildPayShPolicyPlan({
+      candidateId: "pay-sh:agentmail:email",
+      task: "Plan wrong host mainnet call",
+      environment: "mainnet",
+      endpointUrl: "https://evil.example/api/send",
+      allowlistedEndpoints: ["https://evil.example/"],
+      estimatedUsd: 0.01,
+      spendCapUsd: 0.1,
+      userApprovedLivePayment: true,
+    });
+
+    expect(plan.endpointCompatibility).toMatchObject({
+      compatible: false,
+      rule: "mainnet_service_url",
+      expectedBaseUrl: "https://agentmail.to",
+    });
+    expect(plan.blockReasons).toContain("endpoint_environment_mismatch");
     expect(plan.policy.livePaymentAllowed).toBe(false);
   });
 });

--- a/lib/integrations/source-adapter/pay-sh-policy-plan.ts
+++ b/lib/integrations/source-adapter/pay-sh-policy-plan.ts
@@ -19,6 +19,7 @@ export type PayShPolicyBlockReason =
   | "tool_not_allowed_for_live_payment"
   | "endpoint_missing"
   | "endpoint_not_allowlisted"
+  | "endpoint_environment_mismatch"
   | "devnet_support_unknown"
   | "user_approval_missing"
   | "spend_cap_missing"
@@ -45,6 +46,12 @@ export type PayShPolicyPlan = {
     sandboxAvailable: boolean;
     devnetSupport: "provider_declared" | "challenge_detected" | "unknown";
     mainnetGated: true;
+  };
+  endpointCompatibility: {
+    compatible: boolean;
+    rule: "sandbox_service_url" | "sandbox_allowlist_only" | "devnet_declared_endpoint" | "mainnet_service_url" | "candidate_missing" | "endpoint_missing";
+    expectedBaseUrl: string | null;
+    detail: string;
   };
   policy: {
     source: "pay-sh";
@@ -88,6 +95,82 @@ function endpointIsAllowlisted(endpointUrl: string | undefined, allowlistedEndpo
   return allowlistedEndpoints.some((allowed) => normalizedEndpoint.startsWith(normalizeUrl(allowed)));
 }
 
+function endpointStartsWithBase(endpointUrl: string | null, baseUrl: string | undefined) {
+  if (!endpointUrl || !baseUrl) return false;
+  return normalizeUrl(endpointUrl).startsWith(normalizeUrl(baseUrl));
+}
+
+function endpointLooksDevnet(endpointUrl: string | null) {
+  return endpointUrl !== null && /devnet/i.test(endpointUrl);
+}
+
+function buildEndpointCompatibility(input: {
+  endpointUrl: string | null;
+  requestedEnvironment: "sandbox" | "devnet" | "mainnet";
+  candidate: ReturnType<typeof buildPayShQuotePreview>["candidate"];
+}): PayShPolicyPlan["endpointCompatibility"] {
+  const { endpointUrl, requestedEnvironment, candidate } = input;
+  if (!candidate) {
+    return {
+      compatible: false,
+      rule: "candidate_missing",
+      expectedBaseUrl: null,
+      detail: "Cannot evaluate endpoint/environment compatibility until Pay.sh candidate metadata is found.",
+    };
+  }
+  if (!endpointUrl) {
+    return {
+      compatible: false,
+      rule: "endpoint_missing",
+      expectedBaseUrl: null,
+      detail: "Cannot evaluate endpoint/environment compatibility until endpointUrl is supplied.",
+    };
+  }
+
+  const sandboxServiceUrl = candidate.environmentCapabilities.sandbox.providerSandboxServiceUrl;
+  if (requestedEnvironment === "sandbox") {
+    if (!sandboxServiceUrl) {
+      return {
+        compatible: true,
+        rule: "sandbox_allowlist_only",
+        expectedBaseUrl: null,
+        detail: "No provider sandbox_service_url is declared; sandbox planning relies on explicit endpoint allowlisting/debugger/demo URLs only.",
+      };
+    }
+    const compatible = endpointStartsWithBase(endpointUrl, sandboxServiceUrl);
+    return {
+      compatible,
+      rule: "sandbox_service_url",
+      expectedBaseUrl: sandboxServiceUrl,
+      detail: compatible
+        ? "Sandbox endpoint matches the provider sandbox_service_url."
+        : "Sandbox endpoint must match the provider sandbox_service_url when one is declared.",
+    };
+  }
+
+  if (requestedEnvironment === "devnet") {
+    const compatible = endpointLooksDevnet(endpointUrl);
+    return {
+      compatible,
+      rule: "devnet_declared_endpoint",
+      expectedBaseUrl: null,
+      detail: compatible
+        ? "Devnet endpoint appears environment-specific; provider/challenge devnet support is still required."
+        : "Devnet plans must use an explicitly devnet-like endpoint until challenge-level network evidence is captured.",
+    };
+  }
+
+  const compatible = endpointStartsWithBase(endpointUrl, candidate.serviceUrl);
+  return {
+    compatible,
+    rule: "mainnet_service_url",
+    expectedBaseUrl: candidate.serviceUrl ?? null,
+    detail: compatible
+      ? "Mainnet endpoint matches the candidate serviceUrl."
+      : "Mainnet/future-live endpoint must match the candidate serviceUrl in addition to the explicit allowlist.",
+  };
+}
+
 export function buildPayShPolicyPlan(input: PayShPolicyPlanInput): PayShPolicyPlan {
   const quote = buildPayShQuotePreview({ candidateId: input.candidateId, task: input.task });
   const requestedEnvironment = input.environment ?? "sandbox";
@@ -99,6 +182,11 @@ export function buildPayShPolicyPlan(input: PayShPolicyPlanInput): PayShPolicyPl
   const spendCapUsd = typeof input.spendCapUsd === "number" ? Math.max(0, input.spendCapUsd) : null;
   const receiptCaptureRequired = input.requireReceiptCapture !== false;
   const attestationRequired = input.requireAttestation !== false;
+  const endpointCompatibility = buildEndpointCompatibility({
+    endpointUrl,
+    requestedEnvironment,
+    candidate: quote.candidate,
+  });
 
   const gates = [
     {
@@ -128,6 +216,12 @@ export function buildPayShPolicyPlan(input: PayShPolicyPlanInput): PayShPolicyPl
       detail: endpointUrl
         ? "Endpoint must match an explicit allowlist entry before future live payment."
         : "Cannot evaluate allowlist until endpoint is supplied.",
+    },
+    {
+      id: "endpoint_environment_compatible",
+      passed: endpointCompatibility.compatible,
+      required: true,
+      detail: endpointCompatibility.detail,
     },
     {
       id: "environment_supported",
@@ -183,6 +277,7 @@ export function buildPayShPolicyPlan(input: PayShPolicyPlanInput): PayShPolicyPl
   if (!gates.find((gate) => gate.id === "tool_allowed")?.passed) blockReasons.push("tool_not_allowed_for_live_payment");
   if (!gates.find((gate) => gate.id === "endpoint_present")?.passed) blockReasons.push("endpoint_missing");
   if (!gates.find((gate) => gate.id === "endpoint_allowlisted")?.passed) blockReasons.push("endpoint_not_allowlisted");
+  if (!gates.find((gate) => gate.id === "endpoint_environment_compatible")?.passed) blockReasons.push("endpoint_environment_mismatch");
   if (!gates.find((gate) => gate.id === "environment_supported")?.passed) blockReasons.push("devnet_support_unknown");
   if (!gates.find((gate) => gate.id === "user_approval")?.passed) blockReasons.push("user_approval_missing");
   if (!gates.find((gate) => gate.id === "spend_cap_present")?.passed) blockReasons.push("spend_cap_missing");
@@ -212,6 +307,7 @@ export function buildPayShPolicyPlan(input: PayShPolicyPlanInput): PayShPolicyPl
       devnetSupport: candidateEnv?.devnet.support ?? "unknown",
       mainnetGated: true,
     },
+    endpointCompatibility,
     policy: {
       source: "pay-sh",
       network: "solana",


### PR DESCRIPTION
Closes #329.

## Summary
- adds Pay.sh policy-plan endpoint/environment compatibility metadata
- blocks sandbox endpoints that mismatch declared `sandbox_service_url`
- keeps sandbox providers without sandbox URLs on explicit allowlist-only debugger/demo/mock planning
- requires devnet-like endpoints for devnet plans and candidate `serviceUrl` compatibility for mainnet/future-live plans
- adds BDD S5.12 coverage

## Guardrails
No `pay setup`, no `pay topup`, no wallet creation, no `pay mcp`, no paid Pay.sh call, no provider invocation, no secrets stored.

## Validation
- `npm run test:bdd:index`
- `npm run check:rap:naming`
- `npx jest lib/__tests__/source-adapter-pay-sh-profile.test.ts lib/__tests__/pay-sh-catalog-route.test.ts lib/__tests__/pay-sh-quote-preview-route.test.ts lib/__tests__/pay-sh-policy-plan.test.ts lib/__tests__/pay-sh-policy-plan-route.test.ts --runInBand`
- `./scripts/run-source-conformance.sh --source pay-sh --mode smoke`

Artifact: `artifacts/source-conformance/20260513-151809-pay-sh-smoke/SUMMARY.md`
