### PR TITLE
Add open source governance boundary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Reddi Agent Protocol
+
+Reddi Agent Protocol is open-source-first protocol infrastructure for paid agent work. Contributions should improve the local protocol, SDKs, conformance checks, adapters, documentation, or governance without making the OSS core depend on a hosted Reddi service.
+
+## Project Boundary
+
+The OSS core includes:
+
+- Protocol schemas for quote, policy, receipt, attestation, disclosure, settlement, and reputation flows.
+- Local SDKs, middleware, MCP bridge packages, and framework adapters.
+- Conformance tests, BDD scenarios, example specialists, and local evidence archives.
+- Solana/devnet/localnet reference implementations and optional settlement/source adapters.
+- Documentation needed to run, test, inspect, and extend the core locally.
+
+Optional hosted Reddi services may exist later for convenience, operations, or monetization. They are not required to use the OSS core. Do not add a core dependency on private dashboards, hosted registries, managed relays, proprietary marketplaces, private deployment URLs, or paid provider credentials.
+
+## How to Contribute
+
+1. Open or pick a GitHub issue before making a material change.
+2. Keep PRs scoped to one issue or one coherent slice.
+3. Include acceptance criteria in the PR description and link the issue it closes or advances.
+4. Add or update tests/docs that match the risk of the change.
+5. Run the narrowest meaningful validation locally and list the exact commands/results in the PR.
+6. After merge, maintainers review roadmap/dependency follow-ups through issue #340.
+
+Docs-only changes normally need `git diff --check`. Code, package, protocol, or BDD changes need the relevant package scripts listed in `package.json`.
+
+## Roadmap and Labels
+
+Public roadmap issues are organized as epics, features, tasks, and process items:
+
+- Epics: broad product areas such as protocol core, SDK/middleware, trust primitives, reputation, and adoption.
+- Features: user- or developer-visible capabilities that may span multiple PRs.
+- Tasks: bounded implementation, documentation, validation, or governance work.
+- Process: maintainer workflow and roadmap hygiene, including the post-merge review loop in #340.
+
+Current epic anchors:
+
+- [#334 Product core: reddi-x402 policy, payment, and receipts](https://github.com/nissan/reddi-agent-protocol/issues/334)
+- [#335 Product workflow UX: paid agent workflows and ledger](https://github.com/nissan/reddi-agent-protocol/issues/335)
+- [#336 Source and trust integrations: adapters, conformance, auth](https://github.com/nissan/reddi-agent-protocol/issues/336)
+- [#337 Evidence, attestation, and reputation loop](https://github.com/nissan/reddi-agent-protocol/issues/337)
+- [#338 Payment rail neutrality and adapter strategy](https://github.com/nissan/reddi-agent-protocol/issues/338)
+- [#339 Deployment, operations, and marketplace readiness](https://github.com/nissan/reddi-agent-protocol/issues/339)
+- [#355 OSS developer release and conformance readiness](https://github.com/nissan/reddi-agent-protocol/issues/355)
+
+Common labels:
+
+- `product-roadmap`: part of the standalone Reddi Agent Protocol roadmap.
+- `oss-core`: belongs in the open protocol, SDK, docs, tests, or conformance surface.
+- `v0.1`: targeted for the first public adoption milestone.
+- `dependency-map`: issue declares dependencies, blockers, or reverse dependencies.
+- `task`, `feature`, `epic`: issue type.
+- `status: blocked`, `status: in review`, `status: done`: maintainer state.
+
+When a PR changes dependencies, sequence, or scope, update the issue thread so #340 can drive a roadmap review after merge.
+
+## Security and Secrets
+
+Never commit private keys, API keys, paid-provider credentials, production wallet material, unredacted auth headers, raw payment headers, or private prompts/logs. Use `.env.example` placeholders and local environment variables for configuration. Generated evidence should be safe to publish by default; redact secrets and private payloads before adding artifacts to a PR.
+
+Security reports should follow `SECURITY.md`. Do not file public issues for exploitable vulnerabilities.
+
+## License
+
+Unless a file says otherwise, original contributions are accepted under the MIT License in `LICENSE`.
+
+The repository may also contain copied, vendored, generated, or externally sourced material under `ingests/`, `third_party/`, `artifacts/`, public assets, and research/evidence folders. Those materials keep their original ownership and license terms unless explicitly relicensed. See `NOTICE.md` before adding or reusing third-party material.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Redditech Pty Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,14 @@
+# Notice and License Scope
+
+Unless a file says otherwise, original Reddi Agent Protocol source code and documentation in this repository are licensed under the MIT License in `LICENSE`.
+
+That repository-level license does not override third-party rights or upstream terms for copied, vendored, generated, or externally sourced material. In particular:
+
+- `third_party/` may contain upstream projects or vendored reference material governed by their own licenses.
+- `ingests/` may contain copied or transformed external documentation, catalogs, research inputs, or source snapshots governed by the original source terms.
+- `artifacts/` may contain generated evidence, screenshots, recordings, research outputs, or externally derived materials; these should not be treated as reusable MIT-licensed source unless an artifact explicitly says so.
+- Public assets, generated media, benchmark inputs, and externally sourced docs retain their original ownership and usage restrictions unless explicitly relicensed by the rights holder.
+
+Contributors should preserve upstream notices when adding third-party material and should prefer links or small quoted excerpts over copying external docs into the repo. If an external source must be checked in for reproducibility, document its origin, retrieval date, and license/usage boundary near the artifact.
+
+Before publishing an npm package or other release artifact, inspect the packaged file list and exclude `ingests/`, `third_party/`, generated evidence, private logs, local artifacts, and unrelated app output unless that material is intentionally included with a compatible license.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Running a local specialist — Ollama, vLLM, or OpenOnion — to offer agent ser
 🧪 **Judge replication guide:** [`docs/JUDGE-REPLICATION-GUIDE.md`](docs/JUDGE-REPLICATION-GUIDE.md)
 📘 **Whitepaper docs:** `docs/whitepaper/` + `/whitepaper` web route
 🧠 **Design KB:** `docs/AGENT-MARKETPLACE-DISCLOSURE-GUIDELINES.md` (agent composition disclosure + zk-attestable checkpoint pattern)
+🤝 **Contributing:** [`CONTRIBUTING.md`](CONTRIBUTING.md)
+🏛️ **Open-source governance:** [`docs/OPEN-SOURCE-GOVERNANCE.md`](docs/OPEN-SOURCE-GOVERNANCE.md)
+🔐 **Security:** [`SECURITY.md`](SECURITY.md)
+📄 **License scope:** [`NOTICE.md`](NOTICE.md)
 🔗 **Solana program (devnet):** see below
 
 ---
@@ -24,6 +28,14 @@ A trustless marketplace where:
 - **MCP clients** (Claude Code, Cursor, etc.) reach registered specialists through the [`rap-mcp-bridge`](packages/rap-mcp-bridge); ElizaOS and SendAI Agent Kit integrations ship as separate adapter packages
 
 Everything runs through four Solana primitives: AgentRegistry, ConsumerRegistry, EscrowState, and commit-reveal reputation.
+
+## Open-source core and hosted boundary
+
+Reddi Agent Protocol is open-source-first. The core protocol, SDKs, middleware, MCP bridge, conformance tests, local/devnet examples, and documentation should remain usable without a hosted Reddi account, private deployment URL, paid-provider credential, or Redditech-operated service.
+
+Optional hosted Reddi services may later provide convenience layers such as managed relays, hosted marketplace listings, reputation/attestation indexes, audit-log retention, dashboards, support, or SLA-backed registries. Those services must stay replaceable adapters around the OSS core, not prerequisites for running or validating the protocol.
+
+See [`docs/OPEN-SOURCE-GOVERNANCE.md`](docs/OPEN-SOURCE-GOVERNANCE.md) for the open-core boundary, roadmap labels, contribution rules, and post-merge roadmap review workflow.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,7 +102,23 @@ Adevar Labs audit credits will be used to fund a pre-mainnet security review cov
 If you identify a security issue:
 
 1. Do not publish exploit details publicly before coordinated remediation.
-2. Report privately to the maintainers with reproduction steps, scope, and impact.
-3. Allow reasonable remediation time before disclosure.
+2. Use GitHub's private vulnerability reporting flow for this repository when the **Security** tab offers **Report a vulnerability**.
+3. If private vulnerability reporting is unavailable, open a public GitHub issue titled `Security contact request` and include only that you need a private channel. Do not include exploit details, private keys, payloads, logs, screenshots, or reproduction steps in the public issue.
+4. Allow reasonable remediation time before disclosure.
 
 We will acknowledge valid reports, prioritize fixes by severity, and coordinate transparent postmortems once patched.
+
+Do not open a public GitHub issue with details for exploitable vulnerabilities, private-key exposure, credential leakage, bypassable payment gates, escrow-release flaws, attestation manipulation, replay attacks, or unauthenticated access to private data.
+
+## Secret Handling
+
+The OSS core must not require private operational secrets to run or validate. Keep production values outside the repository and use local environment variables or a secret manager.
+
+Never commit:
+
+- Wallet private keys, seed phrases, signer keypair arrays, or funded key material.
+- API keys, bearer tokens, x402 payment headers, auth headers, paid-provider credentials, or raw payment payloads.
+- Private deployment URLs when they are required for protocol correctness.
+- Private prompts, private user data, raw logs, or unredacted generated evidence.
+
+Examples and fixtures should use placeholders. Generated artifacts must be redacted before publication. If a credential is committed or appears in a public artifact, assume it is compromised, rotate it, and disclose the rotation in the relevant security follow-up without repeating the secret value.

--- a/docs/OPEN-SOURCE-GOVERNANCE.md
+++ b/docs/OPEN-SOURCE-GOVERNANCE.md
@@ -1,0 +1,102 @@
+# Open Source Governance
+
+Reddi Agent Protocol is governed as an open-source-first protocol and SDK project. The core must remain usable without Redditech-operated infrastructure, private credentials, or hosted services.
+
+## Open-Core Boundary
+
+### OSS Core
+
+The open-source core is the part contributors and adopters can run, inspect, fork, and validate locally:
+
+- Protocol schemas for quotes, policies, receipts, attestations, disclosure ledgers, settlement adapters, and reputation signals.
+- SDKs, middleware, MCP bridge packages, and framework adapters that enforce local policy and receipt capture.
+- Conformance suites, BDD scenarios, local fixtures, example specialists, and reference source/settlement adapters.
+- Documentation for local setup, devnet/localnet operation, security boundaries, and contribution workflows.
+- Safe public evidence formats that exclude secrets, private prompts, raw auth headers, and wallet key material.
+
+The MIT license in the repository root applies to original Reddi Agent Protocol source and docs unless a file says otherwise. It does not override third-party rights for copied, vendored, generated, or externally sourced material. See `NOTICE.md` for carve-outs covering `ingests/`, `third_party/`, generated artifacts, public assets, and externally sourced docs.
+
+### Optional Hosted Product
+
+Redditech may later provide hosted services around the protocol, such as:
+
+- Managed facilitator or relay infrastructure.
+- Hosted marketplace listings, source/trust registries, or reputation/attestation indexes.
+- Team policy dashboards, audit-log retention, compliance exports, or support/private integrations.
+- Managed specialist hosting, uptime monitoring, SLA-backed registries, or workflow billing.
+
+These services can improve convenience and fund ongoing work, but they must not become a requirement for using the OSS core. Public protocol behavior should remain specified, testable, and replaceable by community-run infrastructure.
+
+## No Hosted-Service Requirement
+
+Core PRs must preserve these guarantees:
+
+- A developer can clone the repo, install dependencies, and run the relevant local/devnet path without a hosted Reddi account.
+- Protocol, SDK, and conformance behavior can be tested with local fixtures, localnet, devnet, sandbox, or dry-run modes.
+- Private Redditech URLs, Coolify/Vercel deployment state, paid-provider accounts, and production secrets are not required for OSS validation.
+- Hosted endpoints used in examples are clearly labelled as examples or demos, not protocol requirements.
+- Any managed-service integration has an adapter boundary and a documented local or third-party replacement path.
+
+If a change appears to require hosted infrastructure, split the hosted convenience layer from the OSS protocol/API surface before merging.
+
+## Roadmap Model
+
+The public roadmap uses GitHub issues as the coordination source:
+
+- Product epics describe large roadmap areas.
+- Feature issues describe user-visible or developer-visible capabilities.
+- Task issues describe bounded implementation, documentation, governance, validation, or release work.
+- Process issues describe maintainer workflow. Issue #340 tracks post-PR roadmap review.
+
+Current public epics:
+
+- [#334 Product core: reddi-x402 policy, payment, and receipts](https://github.com/nissan/reddi-agent-protocol/issues/334)
+- [#335 Product workflow UX: paid agent workflows and ledger](https://github.com/nissan/reddi-agent-protocol/issues/335)
+- [#336 Source and trust integrations: adapters, conformance, auth](https://github.com/nissan/reddi-agent-protocol/issues/336)
+- [#337 Evidence, attestation, and reputation loop](https://github.com/nissan/reddi-agent-protocol/issues/337)
+- [#338 Payment rail neutrality and adapter strategy](https://github.com/nissan/reddi-agent-protocol/issues/338)
+- [#339 Deployment, operations, and marketplace readiness](https://github.com/nissan/reddi-agent-protocol/issues/339)
+- [#355 OSS developer release and conformance readiness](https://github.com/nissan/reddi-agent-protocol/issues/355)
+
+Labels explain where an issue sits:
+
+- `product-roadmap`: public standalone RAP roadmap work.
+- `oss-core`: open protocol, SDK, docs, tests, or conformance work.
+- `v0.1`: first public adoption milestone.
+- `dependency-map`: issue includes dependency and reverse-dependency context.
+- `epic`, `feature`, `task`: issue type.
+- `status: blocked`, `status: in review`, `status: done`: maintainer state.
+
+After each merged PR, maintainers review the linked issue and #340 for dependency changes, newly discovered blockers, stale acceptance criteria, and follow-up roadmap issues.
+
+## Contribution Boundaries
+
+Preferred contributions:
+
+- Tighten protocol specifications, schemas, validation, and conformance behavior.
+- Improve local developer setup, examples, fixture quality, or reproducible evidence.
+- Add adapters with dry-run/sandbox/localnet defaults and clear live-spend gates.
+- Improve security posture, secret handling, and disclosure hygiene.
+- Clarify roadmap sequencing and dependency maps.
+
+Out-of-scope for OSS core:
+
+- Requiring proprietary hosted services for protocol correctness.
+- Committing private operational URLs as mandatory defaults.
+- Storing API keys, wallet private keys, auth headers, raw payment headers, or private prompts/logs.
+- Treating hosted Reddi marketplace data as the only source of truth.
+- Adding live spend, mainnet execution, or paid provider calls without explicit approval gates and safe defaults.
+
+## Security Disclosure and Secret Handling
+
+Use `SECURITY.md` for responsible disclosure. Security-sensitive details should be shared privately, not in public issues.
+
+Secret-handling rules:
+
+- Keep secrets in local environment variables or a secret manager, never in source.
+- Use placeholders in examples.
+- Redact generated artifacts before publishing or committing them.
+- Do not persist raw prompts, outputs, x402 headers, auth headers, payment payloads, private keys, or paid-provider credentials unless a document explicitly defines a safe redacted format.
+- Rotate any credential that is accidentally committed, even if it is later removed from git.
+
+These rules apply to contributors, maintainers, examples, test fixtures, and generated evidence.


### PR DESCRIPTION
## Summary

Closes #352.

Adds the OSS readiness/governance layer for Reddi Agent Protocol:

- MIT `LICENSE` for original Reddi Agent Protocol source/docs.
- `NOTICE.md` with explicit carve-outs for `ingests/`, `third_party/`, generated artifacts, public assets, and externally sourced docs/material.
- `CONTRIBUTING.md` with contribution workflow, roadmap labels, #340 post-merge review loop, OSS core boundary, and secret/license guidance.
- `docs/OPEN-SOURCE-GOVERNANCE.md` defining the open-core vs hosted-product boundary and no-hosted-service requirement.
- README links and summary for contribution/governance/security/license-scope docs.
- `SECURITY.md` clarification for private vulnerability reporting, public fallback without exploit details, and secret handling.

## Validation

- `git diff --check`

## UI evidence

No UI changes. Docs/governance only.

## Guardrails

- No app/package code changed.
- No secrets, hosted-service requirements, live payment paths, deploy changes, or paid calls.
- Root MIT license is scoped by `NOTICE.md`; third-party/vendor/ingested/generated material keeps its original terms unless explicitly relicensed.
