### PR TITLE
Add local RAP budget policy evaluator

### DIFF
--- a/packages/x402-solana/README.md
+++ b/packages/x402-solana/README.md
@@ -10,6 +10,7 @@ HTTP 402 Payment Middleware for Solana. Enables trustless micropayment flows bet
 
 - **Nonce-based replay protection** — prevents duplicate payment attempts
 - **x402 standard compliance** — parses/validates x402-request headers
+- **Local buyer budget preflight** — evaluates spend/call limits before payment authorization
 - **Modular design** — nonce store, payment logic, and middleware are separately testable
 - **Mock-friendly** — tests don't require Solana devnet access
 
@@ -102,6 +103,50 @@ Sends the payment and returns a receipt.
 const receipt = await sendPayment(request);
 // { txSignature: '...', slot: 12345, lamports: 1000, nonce: '...' }
 ```
+
+### `evaluateBudgetPolicy({ policy, quote, usage }): BudgetPolicyDecision`
+
+Runs a pure local buyer preflight check before any signer, hosted facilitator, or downstream x402/OpenRouter call is used. Amounts are represented in the payment asset's smallest unit.
+
+```typescript
+import { assetNetworkKey, evaluateBudgetPolicy } from '@reddi/x402-solana';
+
+const decision = evaluateBudgetPolicy({
+  policy: {
+    schemaVersion: 'reddi.budget-policy.v1',
+    limits: {
+      perRequest: { maxAmount: '100000' },
+      perSession: { maxAmount: '500000' },
+      perSource: { 'source:planning': { maxAmount: '250000' } },
+      perSpecialist: { 'specialist:coder': { maxAmount: '300000' } },
+      perAssetNetwork: [
+        { asset: 'USDC', network: 'solana-devnet', maxAmount: '400000' },
+      ],
+      callCount: { maxCalls: 5 },
+    },
+  },
+  quote: {
+    amount: '50000',
+    asset: 'USDC',
+    network: 'solana-devnet',
+    source: 'source:planning',
+    specialist: 'specialist:coder',
+  },
+  usage: {
+    sessionSpent: '100000',
+    sourceSpent: { 'source:planning': '25000' },
+    specialistSpent: { 'specialist:coder': '50000' },
+    assetNetworkSpent: { [assetNetworkKey('USDC', 'solana-devnet')]: '100000' },
+    callCount: 2,
+  },
+});
+
+if (!decision.allowed) {
+  throw new Error(`budget_preflight_denied:${decision.reasonCodes.join(',')}`);
+}
+```
+
+Buyer-client integration for #342: parse the x402 quote/challenge, call `evaluateBudgetPolicy` with the operator's local policy and current local usage ledger, persist the returned audit notes with the receipt attempt, and only then continue to payment preparation. Hosted/live delegation paths should stay fail-closed until they combine this local decision with explicit operator approval.
 
 ## Testing
 

--- a/packages/x402-solana/dist/budget-policy.d.ts
+++ b/packages/x402-solana/dist/budget-policy.d.ts
@@ -1,0 +1,68 @@
+export type BudgetPolicyAmount = bigint | number | string;
+export type BudgetPolicyReasonCode = 'allowed' | 'budget_policy_missing' | 'invalid_quote' | 'malformed_limit' | 'request_amount_exceeds_limit' | 'session_budget_exceeded' | 'source_budget_exceeded' | 'specialist_budget_exceeded' | 'asset_network_budget_exceeded' | 'call_count_exceeded' | 'unsupported_asset_network';
+export type BudgetPolicyAssetNetwork = {
+    asset: string;
+    network: string;
+};
+export type BudgetAmountLimit = {
+    /** Maximum spend in the asset's smallest unit. */
+    maxAmount: BudgetPolicyAmount;
+    note?: string;
+};
+export type BudgetAssetNetworkLimit = BudgetPolicyAssetNetwork & BudgetAmountLimit;
+export type BudgetCallCountLimit = {
+    maxCalls: number;
+    note?: string;
+};
+export type BudgetPolicy = {
+    schemaVersion: 'reddi.budget-policy.v1';
+    limits: {
+        perRequest?: BudgetAmountLimit;
+        perSession?: BudgetAmountLimit;
+        perSource?: Record<string, BudgetAmountLimit>;
+        perSpecialist?: Record<string, BudgetAmountLimit>;
+        perAssetNetwork?: BudgetAssetNetworkLimit[];
+        callCount?: BudgetCallCountLimit;
+    };
+};
+export type BudgetPolicyUsage = {
+    sessionSpent?: BudgetPolicyAmount;
+    sourceSpent?: Record<string, BudgetPolicyAmount>;
+    specialistSpent?: Record<string, BudgetPolicyAmount>;
+    assetNetworkSpent?: Record<string, BudgetPolicyAmount>;
+    callCount?: number;
+};
+export type BudgetPolicyQuote = BudgetPolicyAssetNetwork & {
+    /** Quoted spend in the asset's smallest unit. */
+    amount: BudgetPolicyAmount;
+    source?: string;
+    specialist?: string;
+};
+export type BudgetRemaining = {
+    perRequest?: string;
+    perSession?: string;
+    perSource?: string;
+    perSpecialist?: string;
+    perAssetNetwork?: string;
+    callCount?: number;
+};
+export type BudgetPolicyDecision = {
+    schemaVersion: 'reddi.budget-policy-decision.v1';
+    allowed: boolean;
+    reasonCodes: BudgetPolicyReasonCode[];
+    quotedAmount: {
+        amount: string;
+        asset: string;
+        network: string;
+        source?: string;
+        specialist?: string;
+    } | null;
+    remainingBudget: BudgetRemaining;
+    auditNotes: string[];
+};
+export declare function evaluateBudgetPolicy(input: {
+    policy?: BudgetPolicy | null;
+    quote: BudgetPolicyQuote;
+    usage?: BudgetPolicyUsage;
+}): BudgetPolicyDecision;
+export declare function assetNetworkKey(asset: string, network: string): string;

--- a/packages/x402-solana/dist/budget-policy.js
+++ b/packages/x402-solana/dist/budget-policy.js
@@ -1,0 +1,234 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.evaluateBudgetPolicy = evaluateBudgetPolicy;
+exports.assetNetworkKey = assetNetworkKey;
+function evaluateBudgetPolicy(input) {
+    const state = { reasonCodes: [], remainingBudget: {}, auditNotes: [] };
+    const quoted = normalizeQuote(input.quote, state);
+    if (!input.policy) {
+        state.reasonCodes.push('budget_policy_missing');
+        state.auditNotes.push('Denied: budget policy is required before buyer preflight can authorize spend.');
+        return decision(false, state, quoted);
+    }
+    if (!quoted)
+        return decision(false, state, null);
+    if (input.policy.schemaVersion !== 'reddi.budget-policy.v1') {
+        malformed(state, 'policy.schemaVersion must be reddi.budget-policy.v1');
+        return decision(false, state, quoted);
+    }
+    if (!isPlainObject(input.policy.limits)) {
+        malformed(state, 'policy.limits must be a plain object');
+        return decision(false, state, quoted);
+    }
+    const usage = input.usage ?? {};
+    checkPerRequest(input.policy.limits.perRequest, quoted.amount, state);
+    checkPerSession(input.policy.limits.perSession, quoted.amount, usage.sessionSpent, state);
+    checkSourceLimit('perSource', input.policy.limits.perSource, quoted.source, quoted.amount, usage.sourceSpent, state);
+    checkSourceLimit('perSpecialist', input.policy.limits.perSpecialist, quoted.specialist, quoted.amount, usage.specialistSpent, state);
+    checkAssetNetworkLimit(input.policy.limits.perAssetNetwork, quoted, usage.assetNetworkSpent, state);
+    checkCallCount(input.policy.limits.callCount, usage.callCount, state);
+    const allowed = state.reasonCodes.length === 0;
+    if (allowed) {
+        state.reasonCodes.push('allowed');
+        state.auditNotes.push('Allowed: quoted spend is within all configured local buyer budget limits.');
+    }
+    return decision(allowed, state, quoted);
+}
+function normalizeQuote(quote, state) {
+    const amount = normalizeAmount(quote.amount);
+    if (amount === undefined || amount <= 0n || !quote.asset || !quote.network) {
+        state.reasonCodes.push('invalid_quote');
+        state.auditNotes.push('Denied: quote must include a positive integer amount, asset, and network.');
+        return null;
+    }
+    return {
+        amount,
+        asset: normalizeAsset(quote.asset),
+        network: normalizeNetwork(quote.network),
+        source: quote.source,
+        specialist: quote.specialist,
+    };
+}
+function checkPerRequest(limit, amount, state) {
+    if (!limit)
+        return;
+    const max = normalizeLimit(limit, 'perRequest', state);
+    if (max === undefined)
+        return;
+    const remaining = max - amount;
+    state.remainingBudget.perRequest = stringifyRemaining(remaining);
+    if (remaining < 0n) {
+        state.reasonCodes.push('request_amount_exceeds_limit');
+        state.auditNotes.push(`Denied: request quote ${amount} exceeds per-request limit ${max}.`);
+    }
+}
+function checkPerSession(limit, amount, spent, state) {
+    if (!limit)
+        return;
+    const max = normalizeLimit(limit, 'perSession', state);
+    const used = normalizeUsage(spent, 'sessionSpent', state);
+    if (max === undefined || used === undefined)
+        return;
+    const remaining = max - used - amount;
+    state.remainingBudget.perSession = stringifyRemaining(remaining);
+    if (remaining < 0n) {
+        state.reasonCodes.push('session_budget_exceeded');
+        state.auditNotes.push(`Denied: session spend ${used} plus quote ${amount} exceeds session limit ${max}.`);
+    }
+}
+function checkSourceLimit(kind, limits, id, amount, usage, state) {
+    if (!limits)
+        return;
+    if (!isPlainObject(limits)) {
+        malformed(state, `${kind} must be a plain object keyed by source or specialist id`);
+        return;
+    }
+    if (!id)
+        return;
+    const key = id;
+    const limit = limits[key];
+    if (!limit)
+        return;
+    const max = normalizeLimit(limit, `${kind}.${key}`, state);
+    const used = normalizeUsage(usage?.[key], `${kind}.${key}.spent`, state);
+    if (max === undefined || used === undefined)
+        return;
+    const remaining = max - used - amount;
+    if (kind === 'perSource')
+        state.remainingBudget.perSource = stringifyRemaining(remaining);
+    else
+        state.remainingBudget.perSpecialist = stringifyRemaining(remaining);
+    if (remaining < 0n) {
+        state.reasonCodes.push(kind === 'perSource' ? 'source_budget_exceeded' : 'specialist_budget_exceeded');
+        state.auditNotes.push(`Denied: ${kind} spend ${used} plus quote ${amount} exceeds limit ${max} for ${key}.`);
+    }
+}
+function checkAssetNetworkLimit(limits, quote, usage, state) {
+    if (!limits)
+        return;
+    if (!Array.isArray(limits) || limits.length === 0) {
+        malformed(state, 'perAssetNetwork must be a non-empty array');
+        return;
+    }
+    for (const limit of limits) {
+        if (!isPlainObject(limit)) {
+            malformed(state, 'perAssetNetwork entries must be plain objects');
+            return;
+        }
+        if (typeof limit.asset !== 'string' || typeof limit.network !== 'string') {
+            malformed(state, 'perAssetNetwork entries must include string asset and network');
+            return;
+        }
+    }
+    const matches = limits.filter((limit) => normalizeAsset(limit.asset) === quote.asset && normalizeNetwork(limit.network) === quote.network);
+    if (matches.length === 0) {
+        state.reasonCodes.push('unsupported_asset_network');
+        state.auditNotes.push(`Denied: ${quote.asset} on ${quote.network} is not in the local budget policy asset/network allowlist.`);
+        return;
+    }
+    const max = normalizeLimit(matches[0], `perAssetNetwork.${quote.asset}.${quote.network}`, state);
+    const used = normalizeUsage(usage?.[assetNetworkKey(quote.asset, quote.network)], `perAssetNetwork.${quote.asset}.${quote.network}.spent`, state);
+    if (max === undefined || used === undefined)
+        return;
+    const remaining = max - used - quote.amount;
+    state.remainingBudget.perAssetNetwork = stringifyRemaining(remaining);
+    if (remaining < 0n) {
+        state.reasonCodes.push('asset_network_budget_exceeded');
+        state.auditNotes.push(`Denied: ${quote.asset}/${quote.network} spend ${used} plus quote ${quote.amount} exceeds limit ${max}.`);
+    }
+}
+function checkCallCount(limit, usedCalls, state) {
+    if (!limit)
+        return;
+    if (!isPlainObject(limit)) {
+        malformed(state, 'callCount must be a plain object');
+        return;
+    }
+    if (!Number.isInteger(limit.maxCalls) || limit.maxCalls < 0) {
+        malformed(state, 'callCount.maxCalls must be a non-negative integer');
+        return;
+    }
+    const used = usedCalls ?? 0;
+    if (!Number.isInteger(used) || used < 0) {
+        malformed(state, 'usage.callCount must be a non-negative integer');
+        return;
+    }
+    const remaining = limit.maxCalls - used - 1;
+    state.remainingBudget.callCount = Math.max(0, remaining);
+    if (remaining < 0) {
+        state.reasonCodes.push('call_count_exceeded');
+        state.auditNotes.push(`Denied: call count ${used} plus this call exceeds limit ${limit.maxCalls}.`);
+    }
+}
+function normalizeLimit(limit, path, state) {
+    if (!isPlainObject(limit)) {
+        malformed(state, `${path} must be a plain object`);
+        return undefined;
+    }
+    const amount = normalizeAmount(limit.maxAmount);
+    if (amount === undefined || amount < 0n) {
+        malformed(state, `${path}.maxAmount must be a non-negative integer amount`);
+        return undefined;
+    }
+    return amount;
+}
+function normalizeUsage(amount, path, state) {
+    if (amount === undefined)
+        return 0n;
+    const normalized = normalizeAmount(amount);
+    if (normalized === undefined || normalized < 0n) {
+        malformed(state, `${path} must be a non-negative integer amount`);
+        return undefined;
+    }
+    return normalized;
+}
+function normalizeAmount(amount) {
+    if (typeof amount === 'bigint')
+        return amount;
+    if (typeof amount === 'number') {
+        if (!Number.isSafeInteger(amount))
+            return undefined;
+        return BigInt(amount);
+    }
+    if (typeof amount === 'string' && /^\d+$/.test(amount))
+        return BigInt(amount);
+    return undefined;
+}
+function isPlainObject(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value) && Object.getPrototypeOf(value) === Object.prototype;
+}
+function decision(allowed, state, quote) {
+    return {
+        schemaVersion: 'reddi.budget-policy-decision.v1',
+        allowed,
+        reasonCodes: dedupeReasons(state.reasonCodes),
+        quotedAmount: quote ? {
+            amount: String(quote.amount),
+            asset: quote.asset,
+            network: quote.network,
+            source: quote.source,
+            specialist: quote.specialist,
+        } : null,
+        remainingBudget: state.remainingBudget,
+        auditNotes: state.auditNotes,
+    };
+}
+function malformed(state, note) {
+    state.reasonCodes.push('malformed_limit');
+    state.auditNotes.push(`Denied: ${note}.`);
+}
+function stringifyRemaining(value) {
+    return String(value < 0n ? 0n : value);
+}
+function dedupeReasons(reasons) {
+    return Array.from(new Set(reasons));
+}
+function assetNetworkKey(asset, network) {
+    return `${normalizeAsset(asset)}:${normalizeNetwork(network)}`;
+}
+function normalizeAsset(asset) {
+    return asset.trim().toUpperCase();
+}
+function normalizeNetwork(network) {
+    return network.trim().toLowerCase();
+}

--- a/packages/x402-solana/dist/index.d.ts
+++ b/packages/x402-solana/dist/index.d.ts
@@ -10,3 +10,4 @@ export * from './payment';
 export * from './middleware';
 export * from './jupiter';
 export * from './client';
+export * from './budget-policy';

--- a/packages/x402-solana/dist/index.js
+++ b/packages/x402-solana/dist/index.js
@@ -26,3 +26,4 @@ __exportStar(require("./payment"), exports);
 __exportStar(require("./middleware"), exports);
 __exportStar(require("./jupiter"), exports);
 __exportStar(require("./client"), exports);
+__exportStar(require("./budget-policy"), exports);

--- a/packages/x402-solana/package-lock.json
+++ b/packages/x402-solana/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@reddi/x402-solana",
       "version": "0.1.0",
       "dependencies": {
+        "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.95.8"
       },
       "devDependencies": {
@@ -1123,6 +1124,37 @@
         "node": ">=5.10"
       }
     },
+    "node_modules/@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
     "node_modules/@solana/codecs-core": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
@@ -1136,6 +1168,70 @@
       },
       "peerDependencies": {
         "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@solana/codecs-numbers": {
@@ -1152,6 +1248,121 @@
       },
       "peerDependencies": {
         "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@solana/errors": {
@@ -1171,6 +1382,121 @@
       },
       "peerDependencies": {
         "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/options/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/spl-token": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz",
+      "integrity": "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.7",
+        "@solana/spl-token-metadata": "^0.1.6",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.5"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
+      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
       }
     },
     "node_modules/@solana/web3.js": {
@@ -1626,6 +1952,37 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bn.js": {
@@ -2250,6 +2607,13 @@
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2259,6 +2623,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/packages/x402-solana/src/budget-policy.ts
+++ b/packages/x402-solana/src/budget-policy.ts
@@ -1,0 +1,345 @@
+export type BudgetPolicyAmount = bigint | number | string;
+
+export type BudgetPolicyReasonCode =
+  | 'allowed'
+  | 'budget_policy_missing'
+  | 'invalid_quote'
+  | 'malformed_limit'
+  | 'request_amount_exceeds_limit'
+  | 'session_budget_exceeded'
+  | 'source_budget_exceeded'
+  | 'specialist_budget_exceeded'
+  | 'asset_network_budget_exceeded'
+  | 'call_count_exceeded'
+  | 'unsupported_asset_network';
+
+export type BudgetPolicyAssetNetwork = {
+  asset: string;
+  network: string;
+};
+
+export type BudgetAmountLimit = {
+  /** Maximum spend in the asset's smallest unit. */
+  maxAmount: BudgetPolicyAmount;
+  note?: string;
+};
+
+export type BudgetAssetNetworkLimit = BudgetPolicyAssetNetwork & BudgetAmountLimit;
+
+export type BudgetCallCountLimit = {
+  maxCalls: number;
+  note?: string;
+};
+
+export type BudgetPolicy = {
+  schemaVersion: 'reddi.budget-policy.v1';
+  limits: {
+    perRequest?: BudgetAmountLimit;
+    perSession?: BudgetAmountLimit;
+    perSource?: Record<string, BudgetAmountLimit>;
+    perSpecialist?: Record<string, BudgetAmountLimit>;
+    perAssetNetwork?: BudgetAssetNetworkLimit[];
+    callCount?: BudgetCallCountLimit;
+  };
+};
+
+export type BudgetPolicyUsage = {
+  sessionSpent?: BudgetPolicyAmount;
+  sourceSpent?: Record<string, BudgetPolicyAmount>;
+  specialistSpent?: Record<string, BudgetPolicyAmount>;
+  assetNetworkSpent?: Record<string, BudgetPolicyAmount>;
+  callCount?: number;
+};
+
+export type BudgetPolicyQuote = BudgetPolicyAssetNetwork & {
+  /** Quoted spend in the asset's smallest unit. */
+  amount: BudgetPolicyAmount;
+  source?: string;
+  specialist?: string;
+};
+
+export type BudgetRemaining = {
+  perRequest?: string;
+  perSession?: string;
+  perSource?: string;
+  perSpecialist?: string;
+  perAssetNetwork?: string;
+  callCount?: number;
+};
+
+export type BudgetPolicyDecision = {
+  schemaVersion: 'reddi.budget-policy-decision.v1';
+  allowed: boolean;
+  reasonCodes: BudgetPolicyReasonCode[];
+  quotedAmount: {
+    amount: string;
+    asset: string;
+    network: string;
+    source?: string;
+    specialist?: string;
+  } | null;
+  remainingBudget: BudgetRemaining;
+  auditNotes: string[];
+};
+
+type EvaluationState = {
+  reasonCodes: BudgetPolicyReasonCode[];
+  remainingBudget: BudgetRemaining;
+  auditNotes: string[];
+};
+
+export function evaluateBudgetPolicy(input: {
+  policy?: BudgetPolicy | null;
+  quote: BudgetPolicyQuote;
+  usage?: BudgetPolicyUsage;
+}): BudgetPolicyDecision {
+  const state: EvaluationState = { reasonCodes: [], remainingBudget: {}, auditNotes: [] };
+  const quoted = normalizeQuote(input.quote, state);
+
+  if (!input.policy) {
+    state.reasonCodes.push('budget_policy_missing');
+    state.auditNotes.push('Denied: budget policy is required before buyer preflight can authorize spend.');
+    return decision(false, state, quoted);
+  }
+
+  if (!quoted) return decision(false, state, null);
+
+  if (input.policy.schemaVersion !== 'reddi.budget-policy.v1') {
+    malformed(state, 'policy.schemaVersion must be reddi.budget-policy.v1');
+    return decision(false, state, quoted);
+  }
+
+  if (!isPlainObject(input.policy.limits)) {
+    malformed(state, 'policy.limits must be a plain object');
+    return decision(false, state, quoted);
+  }
+
+  const usage = input.usage ?? {};
+  checkPerRequest(input.policy.limits.perRequest, quoted.amount, state);
+  checkPerSession(input.policy.limits.perSession, quoted.amount, usage.sessionSpent, state);
+  checkSourceLimit('perSource', input.policy.limits.perSource, quoted.source, quoted.amount, usage.sourceSpent, state);
+  checkSourceLimit('perSpecialist', input.policy.limits.perSpecialist, quoted.specialist, quoted.amount, usage.specialistSpent, state);
+  checkAssetNetworkLimit(input.policy.limits.perAssetNetwork, quoted, usage.assetNetworkSpent, state);
+  checkCallCount(input.policy.limits.callCount, usage.callCount, state);
+
+  const allowed = state.reasonCodes.length === 0;
+  if (allowed) {
+    state.reasonCodes.push('allowed');
+    state.auditNotes.push('Allowed: quoted spend is within all configured local buyer budget limits.');
+  }
+  return decision(allowed, state, quoted);
+}
+
+function normalizeQuote(quote: BudgetPolicyQuote, state: EvaluationState): (Omit<BudgetPolicyQuote, 'amount'> & { amount: bigint }) | null {
+  const amount = normalizeAmount(quote.amount);
+  if (amount === undefined || amount <= 0n || !quote.asset || !quote.network) {
+    state.reasonCodes.push('invalid_quote');
+    state.auditNotes.push('Denied: quote must include a positive integer amount, asset, and network.');
+    return null;
+  }
+  return {
+    amount,
+    asset: normalizeAsset(quote.asset),
+    network: normalizeNetwork(quote.network),
+    source: quote.source,
+    specialist: quote.specialist,
+  };
+}
+
+function checkPerRequest(limit: BudgetAmountLimit | undefined, amount: bigint, state: EvaluationState): void {
+  if (!limit) return;
+  const max = normalizeLimit(limit, 'perRequest', state);
+  if (max === undefined) return;
+  const remaining = max - amount;
+  state.remainingBudget.perRequest = stringifyRemaining(remaining);
+  if (remaining < 0n) {
+    state.reasonCodes.push('request_amount_exceeds_limit');
+    state.auditNotes.push(`Denied: request quote ${amount} exceeds per-request limit ${max}.`);
+  }
+}
+
+function checkPerSession(limit: BudgetAmountLimit | undefined, amount: bigint, spent: BudgetPolicyAmount | undefined, state: EvaluationState): void {
+  if (!limit) return;
+  const max = normalizeLimit(limit, 'perSession', state);
+  const used = normalizeUsage(spent, 'sessionSpent', state);
+  if (max === undefined || used === undefined) return;
+  const remaining = max - used - amount;
+  state.remainingBudget.perSession = stringifyRemaining(remaining);
+  if (remaining < 0n) {
+    state.reasonCodes.push('session_budget_exceeded');
+    state.auditNotes.push(`Denied: session spend ${used} plus quote ${amount} exceeds session limit ${max}.`);
+  }
+}
+
+function checkSourceLimit(
+  kind: 'perSource' | 'perSpecialist',
+  limits: Record<string, BudgetAmountLimit> | undefined,
+  id: string | undefined,
+  amount: bigint,
+  usage: Record<string, BudgetPolicyAmount> | undefined,
+  state: EvaluationState,
+): void {
+  if (!limits) return;
+  if (!isPlainObject(limits)) {
+    malformed(state, `${kind} must be a plain object keyed by source or specialist id`);
+    return;
+  }
+  if (!id) return;
+  const key = id;
+  const limit = limits[key];
+  if (!limit) return;
+  const max = normalizeLimit(limit, `${kind}.${key}`, state);
+  const used = normalizeUsage(usage?.[key], `${kind}.${key}.spent`, state);
+  if (max === undefined || used === undefined) return;
+  const remaining = max - used - amount;
+  if (kind === 'perSource') state.remainingBudget.perSource = stringifyRemaining(remaining);
+  else state.remainingBudget.perSpecialist = stringifyRemaining(remaining);
+  if (remaining < 0n) {
+    state.reasonCodes.push(kind === 'perSource' ? 'source_budget_exceeded' : 'specialist_budget_exceeded');
+    state.auditNotes.push(`Denied: ${kind} spend ${used} plus quote ${amount} exceeds limit ${max} for ${key}.`);
+  }
+}
+
+function checkAssetNetworkLimit(
+  limits: BudgetAssetNetworkLimit[] | undefined,
+  quote: Omit<BudgetPolicyQuote, 'amount'> & { amount: bigint },
+  usage: Record<string, BudgetPolicyAmount> | undefined,
+  state: EvaluationState,
+): void {
+  if (!limits) return;
+  if (!Array.isArray(limits) || limits.length === 0) {
+    malformed(state, 'perAssetNetwork must be a non-empty array');
+    return;
+  }
+  for (const limit of limits) {
+    if (!isPlainObject(limit)) {
+      malformed(state, 'perAssetNetwork entries must be plain objects');
+      return;
+    }
+    if (typeof limit.asset !== 'string' || typeof limit.network !== 'string') {
+      malformed(state, 'perAssetNetwork entries must include string asset and network');
+      return;
+    }
+  }
+  const matches = limits.filter((limit) => normalizeAsset(limit.asset) === quote.asset && normalizeNetwork(limit.network) === quote.network);
+  if (matches.length === 0) {
+    state.reasonCodes.push('unsupported_asset_network');
+    state.auditNotes.push(`Denied: ${quote.asset} on ${quote.network} is not in the local budget policy asset/network allowlist.`);
+    return;
+  }
+  const max = normalizeLimit(matches[0], `perAssetNetwork.${quote.asset}.${quote.network}`, state);
+  const used = normalizeUsage(usage?.[assetNetworkKey(quote.asset, quote.network)], `perAssetNetwork.${quote.asset}.${quote.network}.spent`, state);
+  if (max === undefined || used === undefined) return;
+  const remaining = max - used - quote.amount;
+  state.remainingBudget.perAssetNetwork = stringifyRemaining(remaining);
+  if (remaining < 0n) {
+    state.reasonCodes.push('asset_network_budget_exceeded');
+    state.auditNotes.push(`Denied: ${quote.asset}/${quote.network} spend ${used} plus quote ${quote.amount} exceeds limit ${max}.`);
+  }
+}
+
+function checkCallCount(limit: BudgetCallCountLimit | undefined, usedCalls: number | undefined, state: EvaluationState): void {
+  if (!limit) return;
+  if (!isPlainObject(limit)) {
+    malformed(state, 'callCount must be a plain object');
+    return;
+  }
+  if (!Number.isInteger(limit.maxCalls) || limit.maxCalls < 0) {
+    malformed(state, 'callCount.maxCalls must be a non-negative integer');
+    return;
+  }
+  const used = usedCalls ?? 0;
+  if (!Number.isInteger(used) || used < 0) {
+    malformed(state, 'usage.callCount must be a non-negative integer');
+    return;
+  }
+  const remaining = limit.maxCalls - used - 1;
+  state.remainingBudget.callCount = Math.max(0, remaining);
+  if (remaining < 0) {
+    state.reasonCodes.push('call_count_exceeded');
+    state.auditNotes.push(`Denied: call count ${used} plus this call exceeds limit ${limit.maxCalls}.`);
+  }
+}
+
+function normalizeLimit(limit: BudgetAmountLimit, path: string, state: EvaluationState): bigint | undefined {
+  if (!isPlainObject(limit)) {
+    malformed(state, `${path} must be a plain object`);
+    return undefined;
+  }
+  const amount = normalizeAmount(limit.maxAmount);
+  if (amount === undefined || amount < 0n) {
+    malformed(state, `${path}.maxAmount must be a non-negative integer amount`);
+    return undefined;
+  }
+  return amount;
+}
+
+function normalizeUsage(amount: BudgetPolicyAmount | undefined, path: string, state: EvaluationState): bigint | undefined {
+  if (amount === undefined) return 0n;
+  const normalized = normalizeAmount(amount);
+  if (normalized === undefined || normalized < 0n) {
+    malformed(state, `${path} must be a non-negative integer amount`);
+    return undefined;
+  }
+  return normalized;
+}
+
+function normalizeAmount(amount: BudgetPolicyAmount): bigint | undefined {
+  if (typeof amount === 'bigint') return amount;
+  if (typeof amount === 'number') {
+    if (!Number.isSafeInteger(amount)) return undefined;
+    return BigInt(amount);
+  }
+  if (typeof amount === 'string' && /^\d+$/.test(amount)) return BigInt(amount);
+  return undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function decision(
+  allowed: boolean,
+  state: EvaluationState,
+  quote: (Omit<BudgetPolicyQuote, 'amount'> & { amount: bigint }) | null,
+): BudgetPolicyDecision {
+  return {
+    schemaVersion: 'reddi.budget-policy-decision.v1',
+    allowed,
+    reasonCodes: dedupeReasons(state.reasonCodes),
+    quotedAmount: quote ? {
+      amount: String(quote.amount),
+      asset: quote.asset,
+      network: quote.network,
+      source: quote.source,
+      specialist: quote.specialist,
+    } : null,
+    remainingBudget: state.remainingBudget,
+    auditNotes: state.auditNotes,
+  };
+}
+
+function malformed(state: EvaluationState, note: string): void {
+  state.reasonCodes.push('malformed_limit');
+  state.auditNotes.push(`Denied: ${note}.`);
+}
+
+function stringifyRemaining(value: bigint): string {
+  return String(value < 0n ? 0n : value);
+}
+
+function dedupeReasons(reasons: BudgetPolicyReasonCode[]): BudgetPolicyReasonCode[] {
+  return Array.from(new Set(reasons));
+}
+
+export function assetNetworkKey(asset: string, network: string): string {
+  return `${normalizeAsset(asset)}:${normalizeNetwork(network)}`;
+}
+
+function normalizeAsset(asset: string): string {
+  return asset.trim().toUpperCase();
+}
+
+function normalizeNetwork(network: string): string {
+  return network.trim().toLowerCase();
+}

--- a/packages/x402-solana/src/index.ts
+++ b/packages/x402-solana/src/index.ts
@@ -11,3 +11,4 @@ export * from './payment';
 export * from './middleware';
 export * from './jupiter';
 export * from './client';
+export * from './budget-policy';

--- a/packages/x402-solana/tests/budget-policy.test.ts
+++ b/packages/x402-solana/tests/budget-policy.test.ts
@@ -1,0 +1,227 @@
+import {
+  assetNetworkKey,
+  evaluateBudgetPolicy,
+  type BudgetPolicy,
+} from '../src/budget-policy';
+
+const basePolicy: BudgetPolicy = {
+  schemaVersion: 'reddi.budget-policy.v1',
+  limits: {
+    perRequest: { maxAmount: '100000' },
+    perSession: { maxAmount: '500000' },
+    perSource: {
+      'source:planning': { maxAmount: '250000' },
+    },
+    perSpecialist: {
+      'specialist:coder': { maxAmount: '300000' },
+    },
+    perAssetNetwork: [
+      { asset: 'USDC', network: 'solana-devnet', maxAmount: '400000' },
+    ],
+    callCount: { maxCalls: 5 },
+  },
+};
+
+const quote = {
+  amount: '50000',
+  asset: 'USDC',
+  network: 'solana-devnet',
+  source: 'source:planning',
+  specialist: 'specialist:coder',
+};
+
+describe('local buyer budget policy evaluator', () => {
+  it('denies when a budget policy is missing', () => {
+    const decision = evaluateBudgetPolicy({ policy: null, quote });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasonCodes).toContain('budget_policy_missing');
+    expect(decision.quotedAmount?.amount).toBe('50000');
+    expect(decision.auditNotes.join(' ')).toContain('budget policy is required');
+  });
+
+  it('denies malformed limits without throwing', () => {
+    const decision = evaluateBudgetPolicy({
+      policy: {
+        schemaVersion: 'reddi.budget-policy.v1',
+        limits: {
+          perRequest: { maxAmount: '1.5' },
+          callCount: { maxCalls: 1.2 },
+        },
+      },
+      quote,
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasonCodes).toContain('malformed_limit');
+    expect(decision.auditNotes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('denies unsupported policy schema versions instead of authorizing spend', () => {
+    const decision = evaluateBudgetPolicy({
+      policy: {
+        ...basePolicy,
+        // @ts-expect-error exercising runtime fail-closed validation
+        schemaVersion: 'reddi.budget-policy.v2',
+      },
+      quote,
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasonCodes).toContain('malformed_limit');
+    expect(decision.auditNotes.join(' ')).toContain('policy.schemaVersion');
+  });
+
+  it('denies array policy limits instead of treating them as empty limits', () => {
+    const decision = evaluateBudgetPolicy({
+      policy: {
+        schemaVersion: 'reddi.budget-policy.v1',
+        // @ts-expect-error exercising runtime fail-closed validation
+        limits: [],
+      },
+      quote,
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasonCodes).toContain('malformed_limit');
+    expect(decision.auditNotes.join(' ')).toContain('policy.limits');
+  });
+
+  it('denies non-plain policy limits instead of treating them as empty limits', () => {
+    class LimitEnvelope {
+      perRequest = { maxAmount: '100000' };
+    }
+    const probes = [
+      new LimitEnvelope(),
+      new Date(),
+      Object.create(null),
+    ];
+
+    for (const limits of probes) {
+      const decision = evaluateBudgetPolicy({
+        policy: {
+          schemaVersion: 'reddi.budget-policy.v1',
+          limits,
+        },
+        quote,
+      });
+      expect(decision.allowed).toBe(false);
+      expect(decision.reasonCodes).toContain('malformed_limit');
+      expect(decision.auditNotes.join(' ')).toContain('policy.limits');
+    }
+  });
+
+  it('denies malformed nested limit maps instead of ignoring them', () => {
+    const decision = evaluateBudgetPolicy({
+      policy: {
+        schemaVersion: 'reddi.budget-policy.v1',
+        limits: {
+          // @ts-expect-error exercising runtime fail-closed validation
+          perSource: new Date(),
+        },
+      },
+      quote,
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasonCodes).toContain('malformed_limit');
+    expect(decision.auditNotes.join(' ')).toContain('perSource');
+  });
+
+  it('denies malformed asset-network entries without throwing', () => {
+    const probes = [
+      new Date(),
+      Object.create(null),
+      { asset: 123, network: 'solana-devnet', maxAmount: '100000' },
+    ];
+
+    for (const entry of probes) {
+      const decision = evaluateBudgetPolicy({
+        policy: {
+          schemaVersion: 'reddi.budget-policy.v1',
+          limits: {
+            perAssetNetwork: [entry],
+          },
+        },
+        quote,
+      });
+      expect(decision.allowed).toBe(false);
+      expect(decision.reasonCodes).toContain('malformed_limit');
+      expect(decision.auditNotes.join(' ')).toContain('perAssetNetwork');
+    }
+  });
+
+  it('denies over-spend at request, session, source, specialist, and asset-network levels', () => {
+    const decision = evaluateBudgetPolicy({
+      policy: basePolicy,
+      quote: { ...quote, amount: '150000' },
+      usage: {
+        sessionSpent: '400000',
+        sourceSpent: { 'source:planning': '150000' },
+        specialistSpent: { 'specialist:coder': '200000' },
+        assetNetworkSpent: { [assetNetworkKey('USDC', 'solana-devnet')]: '300000' },
+      },
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasonCodes).toEqual(expect.arrayContaining([
+      'request_amount_exceeds_limit',
+      'session_budget_exceeded',
+      'source_budget_exceeded',
+      'specialist_budget_exceeded',
+      'asset_network_budget_exceeded',
+    ]));
+    expect(decision.remainingBudget.perRequest).toBe('0');
+    expect(decision.remainingBudget.perSession).toBe('0');
+    expect(decision.remainingBudget.perSource).toBe('0');
+    expect(decision.remainingBudget.perSpecialist).toBe('0');
+    expect(decision.remainingBudget.perAssetNetwork).toBe('0');
+  });
+
+  it('denies when the local call-count budget is exhausted', () => {
+    const decision = evaluateBudgetPolicy({
+      policy: basePolicy,
+      quote,
+      usage: { callCount: 5 },
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasonCodes).toContain('call_count_exceeded');
+    expect(decision.remainingBudget.callCount).toBe(0);
+  });
+
+  it('denies unsupported asset/network pairs', () => {
+    const decision = evaluateBudgetPolicy({
+      policy: basePolicy,
+      quote: { ...quote, asset: 'SOL', network: 'solana-mainnet-beta' },
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasonCodes).toContain('unsupported_asset_network');
+    expect(decision.quotedAmount).toMatchObject({ asset: 'SOL', network: 'solana-mainnet-beta' });
+  });
+
+  it('allows a quote within every configured local budget and reports remaining budget', () => {
+    const decision = evaluateBudgetPolicy({
+      policy: basePolicy,
+      quote,
+      usage: {
+        sessionSpent: '100000',
+        sourceSpent: { 'source:planning': '25000' },
+        specialistSpent: { 'specialist:coder': '50000' },
+        assetNetworkSpent: { [assetNetworkKey('usdc', 'SOLANA-DEVNET')]: '100000' },
+        callCount: 2,
+      },
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.reasonCodes).toEqual(['allowed']);
+    expect(decision.quotedAmount).toEqual({
+      amount: '50000',
+      asset: 'USDC',
+      network: 'solana-devnet',
+      source: 'source:planning',
+      specialist: 'specialist:coder',
+    });
+    expect(decision.remainingBudget).toEqual({
+      perRequest: '50000',
+      perSession: '350000',
+      perSource: '175000',
+      perSpecialist: '200000',
+      perAssetNetwork: '250000',
+      callCount: 2,
+    });
+    expect(decision.auditNotes.join(' ')).toContain('Allowed');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #159.

Adds a pure local RAP buyer budget policy evaluator to `@reddi/x402-solana`:

- New `budget-policy` module and public export.
- Per-request, per-session, per-source, per-specialist, per-asset/network, and call-count limits.
- Structured allow/deny decisions with reason codes, quoted amount, remaining budget, and audit notes.
- Fail-closed validation for missing policy, unsupported schema versions, malformed/array/non-plain limits, malformed nested maps, malformed asset-network entries, invalid quotes, over-spend, exhausted call count, and unsupported asset/network.
- README guidance for #342 buyer-client integration.

## Validation

From `packages/x402-solana`:

- `npm ci` — passed; existing audit/deprecation/install-script warnings reported
- `git diff --check`
- `npm test -- --runInBand` — 3 suites / 45 tests passed
- `npm run build`

## UI evidence

No UI changes. Package/API only.

## Guardrails

- Pure local evaluator only.
- No network calls, signer/private-key access, hosted Reddi dependency, live x402/OpenRouter call, paid provider call, or mainnet/devnet spend.
