### PR TITLE
Add ARD AI Catalog ingestion primitives

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -38,6 +38,23 @@ const policyDecision = policyDecisionFromBudgetPolicyDecision({
 
 Use payment-rail packages to settle and verify payment-specific proofs. RAP receipts record the policy, payment-proof reference, evidence reference, and trust metadata around the paid agent workflow.
 
+## AI Catalog Ingestion
+
+```typescript
+import { createAiCatalogSnapshot, aiCatalogFixtures } from '@reddi/agent-protocol/ai-catalog';
+
+const snapshot = createAiCatalogSnapshot(aiCatalogFixtures.happyPath, {
+  rawSnapshotRef: 'sha256:catalog-response',
+});
+
+console.log(snapshot.publisher.id); // reddi.tech
+console.log(snapshot.resources[0].type); // agent
+```
+
+AI Catalog ingestion stores discovery results as untrusted external metadata. Validation fails closed for malformed catalogs, unsupported resource types, invalid `urn:ai:*` identifiers, unsafe URLs, credential-bearing metadata, oversized catalogs, and nested-catalog boundary violations.
+
+Catalog ingestion never performs network fetches, paid invocations, wallet actions, or auto-execution. Buyer policy preflight, quote/payment approval, receipts, evidence, attestations, and reputation remain separate RAP steps after discovery.
+
 ## Local Validation
 
 ```bash

--- a/packages/agent-protocol/dist/ai-catalog.d.ts
+++ b/packages/agent-protocol/dist/ai-catalog.d.ts
@@ -1,5 +1,5 @@
 export declare const AI_CATALOG_SCHEMA_VERSION: "ai-catalog.v1";
-export type AiCatalogResourceType = 'agent' | 'api' | 'mcp_server' | 'mcp-server' | 'skill' | 'tool' | 'catalog' | 'a2a_agent' | 'a2a-agent';
+export type AiCatalogResourceType = string;
 export type AiCatalogValidationErrorCode = 'malformed_catalog' | 'unsupported_resource_type' | 'invalid_identifier' | 'invalid_reference' | 'unsafe_url' | 'nested_catalog_boundary' | 'credential_leakage_rejected' | 'catalog_too_large';
 export type AiCatalogValidationError = {
     code: AiCatalogValidationErrorCode;
@@ -14,6 +14,7 @@ export type AiCatalogPublisherSnapshot = {
 export type AiCatalogResourceSnapshot = {
     id: string;
     type: AiCatalogResourceType;
+    mediaType: string;
     name: string;
     description?: string;
     url?: string;
@@ -55,61 +56,72 @@ export declare function validateAiCatalog(input: unknown, options?: AiCatalogVal
 export declare function createAiCatalogSnapshot(input: unknown, options?: AiCatalogValidationOptions): AiCatalogSnapshot;
 export declare const aiCatalogFixtures: {
     readonly happyPath: {
-        readonly publisher: {
-            readonly id: "reddi.tech";
-            readonly name: "Reddi";
-            readonly domain: "reddi.tech";
+        readonly specVersion: "1.0";
+        readonly host: {
+            readonly identifier: "reddi.tech";
+            readonly displayName: "Reddi";
         };
-        readonly resources: readonly [{
-            readonly id: "urn:ai:reddi.tech:specialists:code-review";
-            readonly type: "agent";
-            readonly name: "Code Review Specialist";
+        readonly entries: readonly [{
+            readonly identifier: "urn:ai:reddi.tech:specialists:code-review";
+            readonly mediaType: "application/mcp-server-card+json";
+            readonly displayName: "Code Review Specialist";
             readonly description: "Reviews pull requests and emits RAP-compatible evidence.";
-            readonly endpoint: "https://agents.reddi.tech/code-review";
-            readonly capabilities: readonly ["code_review", "risk_analysis"];
+            readonly url: "https://agents.reddi.tech/code-review/mcp.json";
+            readonly metadata: {
+                readonly capabilities: readonly ["code_review", "risk_analysis"];
+                readonly rap: {
+                    readonly payment: {
+                        readonly protocol: "rap";
+                        readonly quoteMode: "preflight";
+                        readonly assets: readonly [{
+                            readonly asset: "AUDD";
+                            readonly network: "solana-devnet";
+                        }];
+                    };
+                    readonly auth: {
+                        readonly type: "oauth";
+                        readonly scopes: readonly ["repo:read"];
+                    };
+                };
+            };
             readonly trustManifest: {
-                readonly url: "https://agents.reddi.tech/.well-known/trust/code-review.json";
+                readonly identity: "urn:ai:reddi.tech:specialists:code-review";
                 readonly signature: {
                     readonly format: "dsse";
                     readonly status: "claimed";
                 };
             };
-            readonly payment: {
-                readonly protocol: "rap";
-                readonly quoteMode: "preflight";
-                readonly assets: readonly [{
-                    readonly asset: "AUDD";
-                    readonly network: "solana-devnet";
-                }];
-            };
-            readonly auth: {
-                readonly type: "oauth";
-                readonly scopes: readonly ["repo:read"];
-            };
         }, {
-            readonly id: "urn:ai:reddi.tech:apis:receipt-validator";
-            readonly type: "api";
-            readonly name: "Receipt Validator API";
+            readonly identifier: "urn:ai:reddi.tech:apis:receipt-validator";
+            readonly mediaType: "application/openapi+json";
+            readonly displayName: "Receipt Validator API";
             readonly url: "https://agents.reddi.tech/apis/receipt-validator";
-            readonly capabilities: readonly ["receipt_validation"];
+            readonly metadata: {
+                readonly capabilities: readonly ["receipt_validation"];
+            };
         }];
     };
     readonly nestedCatalog: {
-        readonly publisher: "reddi.tech";
-        readonly resources: readonly [{
-            readonly id: "urn:ai:reddi.tech:catalogs:local-specialists";
-            readonly type: "catalog";
-            readonly name: "Local Specialists Catalog";
-            readonly catalogUrl: "https://agents.reddi.tech/.well-known/local-specialists.ai-catalog.json";
+        readonly specVersion: "1.0";
+        readonly host: {
+            readonly displayName: "Reddi";
+            readonly identifier: "reddi.tech";
+        };
+        readonly entries: readonly [{
+            readonly identifier: "urn:ai:reddi.tech:catalogs:local-specialists";
+            readonly mediaType: "application/ai-catalog+json";
+            readonly displayName: "Local Specialists Catalog";
+            readonly url: "https://agents.reddi.tech/.well-known/local-specialists.ai-catalog.json";
         }];
     };
     readonly localhostFixture: {
-        readonly publisher: "localhost";
-        readonly resources: readonly [{
-            readonly id: "urn:ai:localhost:fixtures:demo-specialist";
-            readonly type: "mcp_server";
-            readonly name: "Demo MCP Specialist";
-            readonly endpoint: "http://localhost:4317/mcp";
+        readonly specVersion: "1.0";
+        readonly host: "localhost";
+        readonly entries: readonly [{
+            readonly identifier: "urn:ai:localhost:fixtures:demo-specialist";
+            readonly mediaType: "application/mcp-server-card+json";
+            readonly displayName: "Demo MCP Specialist";
+            readonly url: "http://localhost:4317/mcp";
         }];
     };
 };

--- a/packages/agent-protocol/dist/ai-catalog.d.ts
+++ b/packages/agent-protocol/dist/ai-catalog.d.ts
@@ -1,0 +1,116 @@
+export declare const AI_CATALOG_SCHEMA_VERSION: "ai-catalog.v1";
+export type AiCatalogResourceType = 'agent' | 'api' | 'mcp_server' | 'mcp-server' | 'skill' | 'tool' | 'catalog' | 'a2a_agent' | 'a2a-agent';
+export type AiCatalogValidationErrorCode = 'malformed_catalog' | 'unsupported_resource_type' | 'invalid_identifier' | 'invalid_reference' | 'unsafe_url' | 'nested_catalog_boundary' | 'credential_leakage_rejected' | 'catalog_too_large';
+export type AiCatalogValidationError = {
+    code: AiCatalogValidationErrorCode;
+    path: string;
+    message: string;
+};
+export type AiCatalogPublisherSnapshot = {
+    id: string;
+    name?: string;
+    domain?: string;
+};
+export type AiCatalogResourceSnapshot = {
+    id: string;
+    type: AiCatalogResourceType;
+    name: string;
+    description?: string;
+    url?: string;
+    endpoint?: string;
+    catalogUrl?: string;
+    trustManifest?: unknown;
+    capabilities?: unknown;
+    payment?: unknown;
+    auth?: unknown;
+    raw: unknown;
+};
+export type AiCatalogSnapshot = {
+    schemaVersion: typeof AI_CATALOG_SCHEMA_VERSION;
+    publisher: AiCatalogPublisherSnapshot;
+    resources: AiCatalogResourceSnapshot[];
+    rawSnapshotRef?: string;
+};
+export type AiCatalogValidationSuccess = {
+    ok: true;
+    catalog: AiCatalogSnapshot;
+    warnings: AiCatalogValidationError[];
+};
+export type AiCatalogValidationFailure = {
+    ok: false;
+    errors: AiCatalogValidationError[];
+};
+export type AiCatalogValidationResult = AiCatalogValidationSuccess | AiCatalogValidationFailure;
+export type AiCatalogValidationOptions = {
+    rawSnapshotRef?: string;
+    maxBytes?: number;
+};
+export type AiCatalogFixtureCase = {
+    description: string;
+    catalog: unknown;
+    expectedValid: boolean;
+    expectedErrorCodes: AiCatalogValidationErrorCode[];
+};
+export declare function validateAiCatalog(input: unknown, options?: AiCatalogValidationOptions): AiCatalogValidationResult;
+export declare function createAiCatalogSnapshot(input: unknown, options?: AiCatalogValidationOptions): AiCatalogSnapshot;
+export declare const aiCatalogFixtures: {
+    readonly happyPath: {
+        readonly publisher: {
+            readonly id: "reddi.tech";
+            readonly name: "Reddi";
+            readonly domain: "reddi.tech";
+        };
+        readonly resources: readonly [{
+            readonly id: "urn:ai:reddi.tech:specialists:code-review";
+            readonly type: "agent";
+            readonly name: "Code Review Specialist";
+            readonly description: "Reviews pull requests and emits RAP-compatible evidence.";
+            readonly endpoint: "https://agents.reddi.tech/code-review";
+            readonly capabilities: readonly ["code_review", "risk_analysis"];
+            readonly trustManifest: {
+                readonly url: "https://agents.reddi.tech/.well-known/trust/code-review.json";
+                readonly signature: {
+                    readonly format: "dsse";
+                    readonly status: "claimed";
+                };
+            };
+            readonly payment: {
+                readonly protocol: "rap";
+                readonly quoteMode: "preflight";
+                readonly assets: readonly [{
+                    readonly asset: "AUDD";
+                    readonly network: "solana-devnet";
+                }];
+            };
+            readonly auth: {
+                readonly type: "oauth";
+                readonly scopes: readonly ["repo:read"];
+            };
+        }, {
+            readonly id: "urn:ai:reddi.tech:apis:receipt-validator";
+            readonly type: "api";
+            readonly name: "Receipt Validator API";
+            readonly url: "https://agents.reddi.tech/apis/receipt-validator";
+            readonly capabilities: readonly ["receipt_validation"];
+        }];
+    };
+    readonly nestedCatalog: {
+        readonly publisher: "reddi.tech";
+        readonly resources: readonly [{
+            readonly id: "urn:ai:reddi.tech:catalogs:local-specialists";
+            readonly type: "catalog";
+            readonly name: "Local Specialists Catalog";
+            readonly catalogUrl: "https://agents.reddi.tech/.well-known/local-specialists.ai-catalog.json";
+        }];
+    };
+    readonly localhostFixture: {
+        readonly publisher: "localhost";
+        readonly resources: readonly [{
+            readonly id: "urn:ai:localhost:fixtures:demo-specialist";
+            readonly type: "mcp_server";
+            readonly name: "Demo MCP Specialist";
+            readonly endpoint: "http://localhost:4317/mcp";
+        }];
+    };
+};
+export declare const aiCatalogFixtureCases: Record<string, AiCatalogFixtureCase>;

--- a/packages/agent-protocol/dist/ai-catalog.js
+++ b/packages/agent-protocol/dist/ai-catalog.js
@@ -1,0 +1,337 @@
+export const AI_CATALOG_SCHEMA_VERSION = 'ai-catalog.v1';
+const SUPPORTED_RESOURCE_TYPES = new Set([
+    'agent',
+    'api',
+    'mcp_server',
+    'mcp-server',
+    'skill',
+    'tool',
+    'catalog',
+    'a2a_agent',
+    'a2a-agent',
+]);
+const AI_URN_PATTERN = /^urn:ai:[a-z0-9][a-z0-9.-]*:[a-z0-9][a-z0-9._-]*:[a-z0-9][a-z0-9._-]*$/i;
+const SECRET_KEY_PATTERN = /(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|password|secret)/i;
+const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
+function error(code, path, message) {
+    return { code, path, message };
+}
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object')
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function asString(value) {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+function byteLength(value) {
+    return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+function containsCredentialMaterial(value, path = '$') {
+    if (typeof value === 'string') {
+        if (SECRET_VALUE_PATTERN.test(value)) {
+            return error('credential_leakage_rejected', path, 'Credential-shaped string values are not allowed in AI Catalog metadata.');
+        }
+        return undefined;
+    }
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index += 1) {
+            const child = containsCredentialMaterial(value[index], `${path}[${index}]`);
+            if (child)
+                return child;
+        }
+        return undefined;
+    }
+    if (isPlainObject(value)) {
+        for (const [key, childValue] of Object.entries(value)) {
+            const childPath = `${path}.${key}`;
+            if (SECRET_KEY_PATTERN.test(key)) {
+                return error('credential_leakage_rejected', childPath, 'Credential-shaped keys are not allowed in AI Catalog metadata.');
+            }
+            const child = containsCredentialMaterial(childValue, childPath);
+            if (child)
+                return child;
+        }
+    }
+    return undefined;
+}
+function validateSafeUrl(value, path) {
+    let parsed;
+    try {
+        parsed = new URL(value);
+    }
+    catch {
+        return error('invalid_reference', path, 'Reference must be a valid URL.');
+    }
+    if (parsed.username || parsed.password) {
+        return error('unsafe_url', path, 'Reference URLs must not embed credentials.');
+    }
+    if (parsed.protocol === 'https:')
+        return undefined;
+    const localhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
+    if (parsed.protocol === 'http:' && localhost)
+        return undefined;
+    return error('unsafe_url', path, 'Reference URLs must use HTTPS, except localhost HTTP fixtures.');
+}
+function parsePublisher(value, errors) {
+    if (typeof value === 'string' && value.trim())
+        return { id: value.trim() };
+    if (!isPlainObject(value)) {
+        errors.push(error('malformed_catalog', '$.publisher', 'Catalog publisher must be a string or object.'));
+        return undefined;
+    }
+    const id = asString(value.id) ?? asString(value.domain) ?? asString(value.name);
+    if (!id) {
+        errors.push(error('malformed_catalog', '$.publisher.id', 'Catalog publisher must include id, domain, or name.'));
+        return undefined;
+    }
+    return {
+        id,
+        name: asString(value.name),
+        domain: asString(value.domain),
+    };
+}
+function parseResources(value, errors) {
+    const rawResources = value.resources ?? value.items;
+    if (!Array.isArray(rawResources)) {
+        errors.push(error('malformed_catalog', '$.resources', 'Catalog must include a resources or items array.'));
+        return [];
+    }
+    const resources = [];
+    for (let index = 0; index < rawResources.length; index += 1) {
+        const path = `$.resources[${index}]`;
+        const raw = rawResources[index];
+        if (!isPlainObject(raw)) {
+            errors.push(error('malformed_catalog', path, 'Catalog resource must be an object.'));
+            continue;
+        }
+        const id = asString(raw.id);
+        if (!id || !AI_URN_PATTERN.test(id)) {
+            errors.push(error('invalid_identifier', `${path}.id`, 'Resource id must be a domain-anchored urn:ai identifier.'));
+        }
+        const type = asString(raw.type);
+        if (!type || !SUPPORTED_RESOURCE_TYPES.has(type)) {
+            errors.push(error('unsupported_resource_type', `${path}.type`, 'Resource type is not supported by RAP AI Catalog ingestion.'));
+        }
+        const name = asString(raw.name);
+        if (!name) {
+            errors.push(error('malformed_catalog', `${path}.name`, 'Catalog resource must include a non-empty name.'));
+        }
+        const url = asString(raw.url);
+        const endpoint = asString(raw.endpoint);
+        const catalogUrl = asString(raw.catalogUrl) ?? asString(raw.catalog_url);
+        const hasInlineData = Object.prototype.hasOwnProperty.call(raw, 'data');
+        const referenceCount = [url, endpoint, catalogUrl].filter(Boolean).length;
+        if (hasInlineData && referenceCount > 0) {
+            errors.push(error('invalid_reference', path, 'Catalog resources must not mix inline data with URL references.'));
+        }
+        if (!hasInlineData && referenceCount > 1) {
+            errors.push(error('invalid_reference', path, 'Catalog resources must include exactly one URL reference.'));
+        }
+        if (!hasInlineData && referenceCount === 0) {
+            errors.push(error('invalid_reference', path, 'Catalog resources must include inline data or one URL reference.'));
+        }
+        for (const [key, reference] of Object.entries({ url, endpoint, catalogUrl })) {
+            if (!reference)
+                continue;
+            const invalidUrl = validateSafeUrl(reference, `${path}.${key}`);
+            if (invalidUrl)
+                errors.push(invalidUrl);
+        }
+        if (type === 'catalog') {
+            if (!catalogUrl || hasInlineData || url || endpoint) {
+                errors.push(error('nested_catalog_boundary', path, 'Nested catalog resources must use catalogUrl only.'));
+            }
+        }
+        else if (catalogUrl) {
+            errors.push(error('nested_catalog_boundary', `${path}.catalogUrl`, 'Only catalog resources may reference nested catalogs.'));
+        }
+        if (id && type && SUPPORTED_RESOURCE_TYPES.has(type) && name) {
+            resources.push({
+                id,
+                type,
+                name,
+                description: asString(raw.description),
+                url,
+                endpoint,
+                catalogUrl,
+                trustManifest: raw.trustManifest,
+                capabilities: raw.capabilities,
+                payment: raw.payment,
+                auth: raw.auth,
+                raw,
+            });
+        }
+    }
+    return resources;
+}
+export function validateAiCatalog(input, options = {}) {
+    const maxBytes = options.maxBytes ?? 64_000;
+    const errors = [];
+    if (!isPlainObject(input)) {
+        return { ok: false, errors: [error('malformed_catalog', '$', 'AI Catalog must be a plain object.')] };
+    }
+    if (byteLength(input) > maxBytes) {
+        return { ok: false, errors: [error('catalog_too_large', '$', `AI Catalog exceeds ${maxBytes} bytes.`)] };
+    }
+    const credentialLeak = containsCredentialMaterial(input);
+    if (credentialLeak)
+        return { ok: false, errors: [credentialLeak] };
+    const publisher = parsePublisher(input.publisher, errors);
+    const resources = parseResources(input, errors);
+    if (!publisher || errors.length > 0)
+        return { ok: false, errors };
+    return {
+        ok: true,
+        catalog: {
+            schemaVersion: AI_CATALOG_SCHEMA_VERSION,
+            publisher,
+            resources,
+            rawSnapshotRef: options.rawSnapshotRef,
+        },
+        warnings: [],
+    };
+}
+export function createAiCatalogSnapshot(input, options = {}) {
+    const result = validateAiCatalog(input, options);
+    if (!result.ok) {
+        throw new Error(`invalid_ai_catalog:${result.errors.map((item) => item.code).join(',')}`);
+    }
+    return result.catalog;
+}
+export const aiCatalogFixtures = {
+    happyPath: {
+        publisher: {
+            id: 'reddi.tech',
+            name: 'Reddi',
+            domain: 'reddi.tech',
+        },
+        resources: [
+            {
+                id: 'urn:ai:reddi.tech:specialists:code-review',
+                type: 'agent',
+                name: 'Code Review Specialist',
+                description: 'Reviews pull requests and emits RAP-compatible evidence.',
+                endpoint: 'https://agents.reddi.tech/code-review',
+                capabilities: ['code_review', 'risk_analysis'],
+                trustManifest: {
+                    url: 'https://agents.reddi.tech/.well-known/trust/code-review.json',
+                    signature: {
+                        format: 'dsse',
+                        status: 'claimed',
+                    },
+                },
+                payment: {
+                    protocol: 'rap',
+                    quoteMode: 'preflight',
+                    assets: [{ asset: 'AUDD', network: 'solana-devnet' }],
+                },
+                auth: {
+                    type: 'oauth',
+                    scopes: ['repo:read'],
+                },
+            },
+            {
+                id: 'urn:ai:reddi.tech:apis:receipt-validator',
+                type: 'api',
+                name: 'Receipt Validator API',
+                url: 'https://agents.reddi.tech/apis/receipt-validator',
+                capabilities: ['receipt_validation'],
+            },
+        ],
+    },
+    nestedCatalog: {
+        publisher: 'reddi.tech',
+        resources: [
+            {
+                id: 'urn:ai:reddi.tech:catalogs:local-specialists',
+                type: 'catalog',
+                name: 'Local Specialists Catalog',
+                catalogUrl: 'https://agents.reddi.tech/.well-known/local-specialists.ai-catalog.json',
+            },
+        ],
+    },
+    localhostFixture: {
+        publisher: 'localhost',
+        resources: [
+            {
+                id: 'urn:ai:localhost:fixtures:demo-specialist',
+                type: 'mcp_server',
+                name: 'Demo MCP Specialist',
+                endpoint: 'http://localhost:4317/mcp',
+            },
+        ],
+    },
+};
+export const aiCatalogFixtureCases = {
+    happyPath: {
+        description: 'Valid AI Catalog with RAP-compatible agent and API resources.',
+        catalog: aiCatalogFixtures.happyPath,
+        expectedValid: true,
+        expectedErrorCodes: [],
+    },
+    nestedCatalog: {
+        description: 'Valid nested catalog reference that keeps catalog boundaries explicit.',
+        catalog: aiCatalogFixtures.nestedCatalog,
+        expectedValid: true,
+        expectedErrorCodes: [],
+    },
+    malformedCatalog: {
+        description: 'Missing publisher and resources fails closed.',
+        catalog: { name: 'not enough catalog shape' },
+        expectedValid: false,
+        expectedErrorCodes: ['malformed_catalog'],
+    },
+    unsupportedResourceType: {
+        description: 'Unknown resource types are rejected.',
+        catalog: {
+            publisher: 'reddi.tech',
+            resources: [
+                {
+                    id: 'urn:ai:reddi.tech:unknown:thing',
+                    type: 'model_context_plugin',
+                    name: 'Unsupported Thing',
+                    endpoint: 'https://agents.reddi.tech/unsupported',
+                },
+            ],
+        },
+        expectedValid: false,
+        expectedErrorCodes: ['unsupported_resource_type'],
+    },
+    unsafeUrl: {
+        description: 'Non-HTTPS non-localhost references are rejected.',
+        catalog: {
+            publisher: 'reddi.tech',
+            resources: [
+                {
+                    id: 'urn:ai:reddi.tech:specialists:unsafe',
+                    type: 'agent',
+                    name: 'Unsafe Specialist',
+                    endpoint: 'http://agents.reddi.tech/unsafe',
+                },
+            ],
+        },
+        expectedValid: false,
+        expectedErrorCodes: ['unsafe_url'],
+    },
+    credentialLeakage: {
+        description: 'Credential-shaped metadata is rejected before ingestion.',
+        catalog: {
+            publisher: 'reddi.tech',
+            resources: [
+                {
+                    id: 'urn:ai:reddi.tech:specialists:leaky',
+                    type: 'agent',
+                    name: 'Leaky Specialist',
+                    endpoint: 'https://agents.reddi.tech/leaky',
+                    auth: {
+                        accessToken: 'tok_should_not_be_in_catalogs',
+                    },
+                },
+            ],
+        },
+        expectedValid: false,
+        expectedErrorCodes: ['credential_leakage_rejected'],
+    },
+};

--- a/packages/agent-protocol/dist/ai-catalog.js
+++ b/packages/agent-protocol/dist/ai-catalog.js
@@ -1,17 +1,9 @@
 export const AI_CATALOG_SCHEMA_VERSION = 'ai-catalog.v1';
-const SUPPORTED_RESOURCE_TYPES = new Set([
-    'agent',
-    'api',
-    'mcp_server',
-    'mcp-server',
-    'skill',
-    'tool',
-    'catalog',
-    'a2a_agent',
-    'a2a-agent',
-]);
-const AI_URN_PATTERN = /^urn:ai:[a-z0-9][a-z0-9.-]*:[a-z0-9][a-z0-9._-]*:[a-z0-9][a-z0-9._-]*$/i;
-const SECRET_KEY_PATTERN = /(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|password|secret)/i;
+const AI_CATALOG_MEDIA_TYPE = 'application/ai-catalog+json';
+const AI_IDENTIFIER_PATTERN = /^(urn:[a-z0-9][a-z0-9-]*:.+|https?:\/\/.+)$/i;
+const MEDIA_TYPE_PATTERN = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*(?:\+[a-z0-9][a-z0-9!#$&^_.+-]*)?$/i;
+const LEGACY_TYPE_PATTERN = /^[a-z0-9][a-z0-9._-]*$/i;
+const SECRET_KEY_PATTERN = /(^|[_-])(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|password|secret|token)($|[_-])/i;
 const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
 function error(code, path, message) {
     return { code, path, message };
@@ -26,7 +18,12 @@ function asString(value) {
     return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 function byteLength(value) {
-    return new TextEncoder().encode(JSON.stringify(value)).length;
+    try {
+        return new TextEncoder().encode(JSON.stringify(value)).length;
+    }
+    catch {
+        return undefined;
+    }
 }
 function containsCredentialMaterial(value, path = '$') {
     if (typeof value === 'string') {
@@ -67,6 +64,16 @@ function validateSafeUrl(value, path) {
     if (parsed.username || parsed.password) {
         return error('unsafe_url', path, 'Reference URLs must not embed credentials.');
     }
+    for (const key of parsed.searchParams.keys()) {
+        if (SECRET_KEY_PATTERN.test(key)) {
+            return error('credential_leakage_rejected', `${path}.${key}`, 'Reference URLs must not include credential-shaped query parameters.');
+        }
+    }
+    for (const value of parsed.searchParams.values()) {
+        if (SECRET_VALUE_PATTERN.test(value)) {
+            return error('credential_leakage_rejected', path, 'Reference URLs must not include credential-shaped query values.');
+        }
+    }
     if (parsed.protocol === 'https:')
         return undefined;
     const localhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
@@ -74,55 +81,58 @@ function validateSafeUrl(value, path) {
         return undefined;
     return error('unsafe_url', path, 'Reference URLs must use HTTPS, except localhost HTTP fixtures.');
 }
-function parsePublisher(value, errors) {
+function parsePublisher(value, path, errors) {
     if (typeof value === 'string' && value.trim())
         return { id: value.trim() };
     if (!isPlainObject(value)) {
-        errors.push(error('malformed_catalog', '$.publisher', 'Catalog publisher must be a string or object.'));
+        errors.push(error('malformed_catalog', path, 'Catalog host/publisher must be a string or object.'));
         return undefined;
     }
-    const id = asString(value.id) ?? asString(value.domain) ?? asString(value.name);
+    const id = asString(value.identifier) ?? asString(value.id) ?? asString(value.domain) ?? asString(value.displayName) ?? asString(value.name);
     if (!id) {
-        errors.push(error('malformed_catalog', '$.publisher.id', 'Catalog publisher must include id, domain, or name.'));
+        errors.push(error('malformed_catalog', `${path}.identifier`, 'Catalog host/publisher must include identifier, id, domain, displayName, or name.'));
         return undefined;
     }
     return {
         id,
-        name: asString(value.name),
+        name: asString(value.displayName) ?? asString(value.name),
         domain: asString(value.domain),
     };
 }
 function parseResources(value, errors) {
-    const rawResources = value.resources ?? value.items;
+    const rawResources = value.entries ?? value.resources ?? value.items;
+    const resourcesPath = Array.isArray(value.entries) ? '$.entries' : Array.isArray(value.resources) ? '$.resources' : '$.items';
     if (!Array.isArray(rawResources)) {
-        errors.push(error('malformed_catalog', '$.resources', 'Catalog must include a resources or items array.'));
+        errors.push(error('malformed_catalog', '$.entries', 'Catalog must include an entries array.'));
         return [];
     }
     const resources = [];
     for (let index = 0; index < rawResources.length; index += 1) {
-        const path = `$.resources[${index}]`;
+        const path = `${resourcesPath}[${index}]`;
         const raw = rawResources[index];
         if (!isPlainObject(raw)) {
             errors.push(error('malformed_catalog', path, 'Catalog resource must be an object.'));
             continue;
         }
-        const id = asString(raw.id);
-        if (!id || !AI_URN_PATTERN.test(id)) {
-            errors.push(error('invalid_identifier', `${path}.id`, 'Resource id must be a domain-anchored urn:ai identifier.'));
+        const id = asString(raw.identifier) ?? asString(raw.id);
+        if (!id || !AI_IDENTIFIER_PATTERN.test(id)) {
+            errors.push(error('invalid_identifier', `${path}.identifier`, 'Catalog entry identifier must be a stable URN or URL.'));
         }
-        const type = asString(raw.type);
-        if (!type || !SUPPORTED_RESOURCE_TYPES.has(type)) {
-            errors.push(error('unsupported_resource_type', `${path}.type`, 'Resource type is not supported by RAP AI Catalog ingestion.'));
+        const mediaType = asString(raw.mediaType) ?? asString(raw.type);
+        if (!mediaType || (!MEDIA_TYPE_PATTERN.test(mediaType) && !LEGACY_TYPE_PATTERN.test(mediaType))) {
+            errors.push(error('unsupported_resource_type', `${path}.mediaType`, 'Catalog entry mediaType must be a valid media type or legacy resource type.'));
         }
-        const name = asString(raw.name);
+        const name = asString(raw.displayName) ?? asString(raw.name);
         if (!name) {
-            errors.push(error('malformed_catalog', `${path}.name`, 'Catalog resource must include a non-empty name.'));
+            errors.push(error('malformed_catalog', `${path}.displayName`, 'Catalog entry must include a non-empty displayName.'));
         }
         const url = asString(raw.url);
         const endpoint = asString(raw.endpoint);
-        const catalogUrl = asString(raw.catalogUrl) ?? asString(raw.catalog_url);
+        const catalogUrlRaw = asString(raw.catalogUrl) ?? asString(raw.catalog_url);
+        const isNestedCatalog = mediaType === AI_CATALOG_MEDIA_TYPE || mediaType === 'catalog';
+        const catalogUrl = isNestedCatalog ? (catalogUrlRaw ?? url) : catalogUrlRaw;
         const hasInlineData = Object.prototype.hasOwnProperty.call(raw, 'data');
-        const referenceCount = [url, endpoint, catalogUrl].filter(Boolean).length;
+        const referenceCount = [url, endpoint, catalogUrlRaw].filter(Boolean).length;
         if (hasInlineData && referenceCount > 0) {
             errors.push(error('invalid_reference', path, 'Catalog resources must not mix inline data with URL references.'));
         }
@@ -139,27 +149,30 @@ function parseResources(value, errors) {
             if (invalidUrl)
                 errors.push(invalidUrl);
         }
-        if (type === 'catalog') {
-            if (!catalogUrl || hasInlineData || url || endpoint) {
-                errors.push(error('nested_catalog_boundary', path, 'Nested catalog resources must use catalogUrl only.'));
+        if (isNestedCatalog) {
+            if (!catalogUrl || hasInlineData || endpoint || (url && catalogUrlRaw)) {
+                errors.push(error('nested_catalog_boundary', path, 'Nested catalog entries must use a single URL reference.'));
             }
         }
         else if (catalogUrl) {
             errors.push(error('nested_catalog_boundary', `${path}.catalogUrl`, 'Only catalog resources may reference nested catalogs.'));
         }
-        if (id && type && SUPPORTED_RESOURCE_TYPES.has(type) && name) {
+        const metadata = isPlainObject(raw.metadata) ? raw.metadata : undefined;
+        const rapMetadata = metadata && isPlainObject(metadata.rap) ? metadata.rap : undefined;
+        if (id && mediaType && name) {
             resources.push({
                 id,
-                type,
+                type: mediaType,
+                mediaType,
                 name,
                 description: asString(raw.description),
                 url,
                 endpoint,
                 catalogUrl,
                 trustManifest: raw.trustManifest,
-                capabilities: raw.capabilities,
-                payment: raw.payment,
-                auth: raw.auth,
+                capabilities: raw.capabilities ?? metadata?.capabilities,
+                payment: raw.payment ?? rapMetadata?.payment ?? metadata?.payment,
+                auth: raw.auth ?? rapMetadata?.auth ?? metadata?.auth,
                 raw,
             });
         }
@@ -172,13 +185,22 @@ export function validateAiCatalog(input, options = {}) {
     if (!isPlainObject(input)) {
         return { ok: false, errors: [error('malformed_catalog', '$', 'AI Catalog must be a plain object.')] };
     }
-    if (byteLength(input) > maxBytes) {
+    const size = byteLength(input);
+    if (size === undefined) {
+        return { ok: false, errors: [error('malformed_catalog', '$', 'AI Catalog must be JSON-serializable.')] };
+    }
+    if (size > maxBytes) {
         return { ok: false, errors: [error('catalog_too_large', '$', `AI Catalog exceeds ${maxBytes} bytes.`)] };
     }
     const credentialLeak = containsCredentialMaterial(input);
     if (credentialLeak)
         return { ok: false, errors: [credentialLeak] };
-    const publisher = parsePublisher(input.publisher, errors);
+    if (!asString(input.specVersion) && Object.prototype.hasOwnProperty.call(input, 'entries')) {
+        errors.push(error('malformed_catalog', '$.specVersion', 'AI Catalog entries require a specVersion string.'));
+    }
+    const hostOrPublisher = input.host ?? input.publisher;
+    const publisherPath = Object.prototype.hasOwnProperty.call(input, 'host') ? '$.host' : '$.publisher';
+    const publisher = hostOrPublisher === undefined ? { id: 'unknown' } : parsePublisher(hostOrPublisher, publisherPath, errors);
     const resources = parseResources(input, errors);
     if (!publisher || errors.length > 0)
         return { ok: false, errors };
@@ -202,64 +224,75 @@ export function createAiCatalogSnapshot(input, options = {}) {
 }
 export const aiCatalogFixtures = {
     happyPath: {
-        publisher: {
-            id: 'reddi.tech',
-            name: 'Reddi',
-            domain: 'reddi.tech',
+        specVersion: '1.0',
+        host: {
+            identifier: 'reddi.tech',
+            displayName: 'Reddi',
         },
-        resources: [
+        entries: [
             {
-                id: 'urn:ai:reddi.tech:specialists:code-review',
-                type: 'agent',
-                name: 'Code Review Specialist',
+                identifier: 'urn:ai:reddi.tech:specialists:code-review',
+                mediaType: 'application/mcp-server-card+json',
+                displayName: 'Code Review Specialist',
                 description: 'Reviews pull requests and emits RAP-compatible evidence.',
-                endpoint: 'https://agents.reddi.tech/code-review',
-                capabilities: ['code_review', 'risk_analysis'],
+                url: 'https://agents.reddi.tech/code-review/mcp.json',
+                metadata: {
+                    capabilities: ['code_review', 'risk_analysis'],
+                    rap: {
+                        payment: {
+                            protocol: 'rap',
+                            quoteMode: 'preflight',
+                            assets: [{ asset: 'AUDD', network: 'solana-devnet' }],
+                        },
+                        auth: {
+                            type: 'oauth',
+                            scopes: ['repo:read'],
+                        },
+                    },
+                },
                 trustManifest: {
-                    url: 'https://agents.reddi.tech/.well-known/trust/code-review.json',
+                    identity: 'urn:ai:reddi.tech:specialists:code-review',
                     signature: {
                         format: 'dsse',
                         status: 'claimed',
                     },
                 },
-                payment: {
-                    protocol: 'rap',
-                    quoteMode: 'preflight',
-                    assets: [{ asset: 'AUDD', network: 'solana-devnet' }],
-                },
-                auth: {
-                    type: 'oauth',
-                    scopes: ['repo:read'],
-                },
             },
             {
-                id: 'urn:ai:reddi.tech:apis:receipt-validator',
-                type: 'api',
-                name: 'Receipt Validator API',
+                identifier: 'urn:ai:reddi.tech:apis:receipt-validator',
+                mediaType: 'application/openapi+json',
+                displayName: 'Receipt Validator API',
                 url: 'https://agents.reddi.tech/apis/receipt-validator',
-                capabilities: ['receipt_validation'],
+                metadata: {
+                    capabilities: ['receipt_validation'],
+                },
             },
         ],
     },
     nestedCatalog: {
-        publisher: 'reddi.tech',
-        resources: [
+        specVersion: '1.0',
+        host: {
+            displayName: 'Reddi',
+            identifier: 'reddi.tech',
+        },
+        entries: [
             {
-                id: 'urn:ai:reddi.tech:catalogs:local-specialists',
-                type: 'catalog',
-                name: 'Local Specialists Catalog',
-                catalogUrl: 'https://agents.reddi.tech/.well-known/local-specialists.ai-catalog.json',
+                identifier: 'urn:ai:reddi.tech:catalogs:local-specialists',
+                mediaType: AI_CATALOG_MEDIA_TYPE,
+                displayName: 'Local Specialists Catalog',
+                url: 'https://agents.reddi.tech/.well-known/local-specialists.ai-catalog.json',
             },
         ],
     },
     localhostFixture: {
-        publisher: 'localhost',
-        resources: [
+        specVersion: '1.0',
+        host: 'localhost',
+        entries: [
             {
-                id: 'urn:ai:localhost:fixtures:demo-specialist',
-                type: 'mcp_server',
-                name: 'Demo MCP Specialist',
-                endpoint: 'http://localhost:4317/mcp',
+                identifier: 'urn:ai:localhost:fixtures:demo-specialist',
+                mediaType: 'application/mcp-server-card+json',
+                displayName: 'Demo MCP Specialist',
+                url: 'http://localhost:4317/mcp',
             },
         ],
     },
@@ -286,13 +319,14 @@ export const aiCatalogFixtureCases = {
     unsupportedResourceType: {
         description: 'Unknown resource types are rejected.',
         catalog: {
-            publisher: 'reddi.tech',
-            resources: [
+            specVersion: '1.0',
+            host: 'reddi.tech',
+            entries: [
                 {
-                    id: 'urn:ai:reddi.tech:unknown:thing',
-                    type: 'model_context_plugin',
-                    name: 'Unsupported Thing',
-                    endpoint: 'https://agents.reddi.tech/unsupported',
+                    identifier: 'urn:ai:reddi.tech:unknown:thing',
+                    mediaType: 'not a media type!',
+                    displayName: 'Unsupported Thing',
+                    url: 'https://agents.reddi.tech/unsupported',
                 },
             ],
         },
@@ -302,13 +336,14 @@ export const aiCatalogFixtureCases = {
     unsafeUrl: {
         description: 'Non-HTTPS non-localhost references are rejected.',
         catalog: {
-            publisher: 'reddi.tech',
-            resources: [
+            specVersion: '1.0',
+            host: 'reddi.tech',
+            entries: [
                 {
-                    id: 'urn:ai:reddi.tech:specialists:unsafe',
-                    type: 'agent',
-                    name: 'Unsafe Specialist',
-                    endpoint: 'http://agents.reddi.tech/unsafe',
+                    identifier: 'urn:ai:reddi.tech:specialists:unsafe',
+                    mediaType: 'application/mcp-server-card+json',
+                    displayName: 'Unsafe Specialist',
+                    url: 'http://agents.reddi.tech/unsafe',
                 },
             ],
         },
@@ -318,13 +353,14 @@ export const aiCatalogFixtureCases = {
     credentialLeakage: {
         description: 'Credential-shaped metadata is rejected before ingestion.',
         catalog: {
-            publisher: 'reddi.tech',
-            resources: [
+            specVersion: '1.0',
+            host: 'reddi.tech',
+            entries: [
                 {
-                    id: 'urn:ai:reddi.tech:specialists:leaky',
-                    type: 'agent',
-                    name: 'Leaky Specialist',
-                    endpoint: 'https://agents.reddi.tech/leaky',
+                    identifier: 'urn:ai:reddi.tech:specialists:leaky',
+                    mediaType: 'application/mcp-server-card+json',
+                    displayName: 'Leaky Specialist',
+                    url: 'https://agents.reddi.tech/leaky',
                     auth: {
                         accessToken: 'tok_should_not_be_in_catalogs',
                     },

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -1,3 +1,4 @@
 export * from './policy.js';
 export * from './receipts.js';
 export * from './fixtures.js';
+export * from './ai-catalog.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -1,3 +1,4 @@
 export * from './policy.js';
 export * from './receipts.js';
 export * from './fixtures.js';
+export * from './ai-catalog.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -22,6 +22,10 @@
       "types": "./dist/fixtures.d.ts",
       "import": "./dist/fixtures.js"
     },
+    "./ai-catalog": {
+      "types": "./dist/ai-catalog.d.ts",
+      "import": "./dist/ai-catalog.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/ai-catalog.ts
+++ b/packages/agent-protocol/src/ai-catalog.ts
@@ -1,15 +1,6 @@
 export const AI_CATALOG_SCHEMA_VERSION = 'ai-catalog.v1' as const;
 
-export type AiCatalogResourceType =
-  | 'agent'
-  | 'api'
-  | 'mcp_server'
-  | 'mcp-server'
-  | 'skill'
-  | 'tool'
-  | 'catalog'
-  | 'a2a_agent'
-  | 'a2a-agent';
+export type AiCatalogResourceType = string;
 
 export type AiCatalogValidationErrorCode =
   | 'malformed_catalog'
@@ -36,6 +27,7 @@ export type AiCatalogPublisherSnapshot = {
 export type AiCatalogResourceSnapshot = {
   id: string;
   type: AiCatalogResourceType;
+  mediaType: string;
   name: string;
   description?: string;
   url?: string;
@@ -80,20 +72,11 @@ export type AiCatalogFixtureCase = {
   expectedErrorCodes: AiCatalogValidationErrorCode[];
 };
 
-const SUPPORTED_RESOURCE_TYPES = new Set<AiCatalogResourceType>([
-  'agent',
-  'api',
-  'mcp_server',
-  'mcp-server',
-  'skill',
-  'tool',
-  'catalog',
-  'a2a_agent',
-  'a2a-agent',
-]);
-
-const AI_URN_PATTERN = /^urn:ai:[a-z0-9][a-z0-9.-]*:[a-z0-9][a-z0-9._-]*:[a-z0-9][a-z0-9._-]*$/i;
-const SECRET_KEY_PATTERN = /(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|password|secret)/i;
+const AI_CATALOG_MEDIA_TYPE = 'application/ai-catalog+json';
+const AI_IDENTIFIER_PATTERN = /^(urn:[a-z0-9][a-z0-9-]*:.+|https?:\/\/.+)$/i;
+const MEDIA_TYPE_PATTERN = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*(?:\+[a-z0-9][a-z0-9!#$&^_.+-]*)?$/i;
+const LEGACY_TYPE_PATTERN = /^[a-z0-9][a-z0-9._-]*$/i;
+const SECRET_KEY_PATTERN = /(^|[_-])(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|password|secret|token)($|[_-])/i;
 const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
 
 function error(code: AiCatalogValidationErrorCode, path: string, message: string): AiCatalogValidationError {
@@ -110,8 +93,12 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
-function byteLength(value: unknown): number {
-  return new TextEncoder().encode(JSON.stringify(value)).length;
+function byteLength(value: unknown): number | undefined {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).length;
+  } catch {
+    return undefined;
+  }
 }
 
 function containsCredentialMaterial(value: unknown, path = '$'): AiCatalogValidationError | undefined {
@@ -156,6 +143,18 @@ function validateSafeUrl(value: string, path: string): AiCatalogValidationError 
     return error('unsafe_url', path, 'Reference URLs must not embed credentials.');
   }
 
+  for (const key of parsed.searchParams.keys()) {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      return error('credential_leakage_rejected', `${path}.${key}`, 'Reference URLs must not include credential-shaped query parameters.');
+    }
+  }
+
+  for (const value of parsed.searchParams.values()) {
+    if (SECRET_VALUE_PATTERN.test(value)) {
+      return error('credential_leakage_rejected', path, 'Reference URLs must not include credential-shaped query values.');
+    }
+  }
+
   if (parsed.protocol === 'https:') return undefined;
 
   const localhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
@@ -164,62 +163,65 @@ function validateSafeUrl(value: string, path: string): AiCatalogValidationError 
   return error('unsafe_url', path, 'Reference URLs must use HTTPS, except localhost HTTP fixtures.');
 }
 
-function parsePublisher(value: unknown, errors: AiCatalogValidationError[]): AiCatalogPublisherSnapshot | undefined {
+function parsePublisher(value: unknown, path: string, errors: AiCatalogValidationError[]): AiCatalogPublisherSnapshot | undefined {
   if (typeof value === 'string' && value.trim()) return { id: value.trim() };
   if (!isPlainObject(value)) {
-    errors.push(error('malformed_catalog', '$.publisher', 'Catalog publisher must be a string or object.'));
+    errors.push(error('malformed_catalog', path, 'Catalog host/publisher must be a string or object.'));
     return undefined;
   }
 
-  const id = asString(value.id) ?? asString(value.domain) ?? asString(value.name);
+  const id = asString(value.identifier) ?? asString(value.id) ?? asString(value.domain) ?? asString(value.displayName) ?? asString(value.name);
   if (!id) {
-    errors.push(error('malformed_catalog', '$.publisher.id', 'Catalog publisher must include id, domain, or name.'));
+    errors.push(error('malformed_catalog', `${path}.identifier`, 'Catalog host/publisher must include identifier, id, domain, displayName, or name.'));
     return undefined;
   }
 
   return {
     id,
-    name: asString(value.name),
+    name: asString(value.displayName) ?? asString(value.name),
     domain: asString(value.domain),
   };
 }
 
 function parseResources(value: Record<string, unknown>, errors: AiCatalogValidationError[]): AiCatalogResourceSnapshot[] {
-  const rawResources = value.resources ?? value.items;
+  const rawResources = value.entries ?? value.resources ?? value.items;
+  const resourcesPath = Array.isArray(value.entries) ? '$.entries' : Array.isArray(value.resources) ? '$.resources' : '$.items';
   if (!Array.isArray(rawResources)) {
-    errors.push(error('malformed_catalog', '$.resources', 'Catalog must include a resources or items array.'));
+    errors.push(error('malformed_catalog', '$.entries', 'Catalog must include an entries array.'));
     return [];
   }
 
   const resources: AiCatalogResourceSnapshot[] = [];
   for (let index = 0; index < rawResources.length; index += 1) {
-    const path = `$.resources[${index}]`;
+    const path = `${resourcesPath}[${index}]`;
     const raw = rawResources[index];
     if (!isPlainObject(raw)) {
       errors.push(error('malformed_catalog', path, 'Catalog resource must be an object.'));
       continue;
     }
 
-    const id = asString(raw.id);
-    if (!id || !AI_URN_PATTERN.test(id)) {
-      errors.push(error('invalid_identifier', `${path}.id`, 'Resource id must be a domain-anchored urn:ai identifier.'));
+    const id = asString(raw.identifier) ?? asString(raw.id);
+    if (!id || !AI_IDENTIFIER_PATTERN.test(id)) {
+      errors.push(error('invalid_identifier', `${path}.identifier`, 'Catalog entry identifier must be a stable URN or URL.'));
     }
 
-    const type = asString(raw.type) as AiCatalogResourceType | undefined;
-    if (!type || !SUPPORTED_RESOURCE_TYPES.has(type)) {
-      errors.push(error('unsupported_resource_type', `${path}.type`, 'Resource type is not supported by RAP AI Catalog ingestion.'));
+    const mediaType = asString(raw.mediaType) ?? asString(raw.type);
+    if (!mediaType || (!MEDIA_TYPE_PATTERN.test(mediaType) && !LEGACY_TYPE_PATTERN.test(mediaType))) {
+      errors.push(error('unsupported_resource_type', `${path}.mediaType`, 'Catalog entry mediaType must be a valid media type or legacy resource type.'));
     }
 
-    const name = asString(raw.name);
+    const name = asString(raw.displayName) ?? asString(raw.name);
     if (!name) {
-      errors.push(error('malformed_catalog', `${path}.name`, 'Catalog resource must include a non-empty name.'));
+      errors.push(error('malformed_catalog', `${path}.displayName`, 'Catalog entry must include a non-empty displayName.'));
     }
 
     const url = asString(raw.url);
     const endpoint = asString(raw.endpoint);
-    const catalogUrl = asString(raw.catalogUrl) ?? asString(raw.catalog_url);
+    const catalogUrlRaw = asString(raw.catalogUrl) ?? asString(raw.catalog_url);
+    const isNestedCatalog = mediaType === AI_CATALOG_MEDIA_TYPE || mediaType === 'catalog';
+    const catalogUrl = isNestedCatalog ? (catalogUrlRaw ?? url) : catalogUrlRaw;
     const hasInlineData = Object.prototype.hasOwnProperty.call(raw, 'data');
-    const referenceCount = [url, endpoint, catalogUrl].filter(Boolean).length;
+    const referenceCount = [url, endpoint, catalogUrlRaw].filter(Boolean).length;
 
     if (hasInlineData && referenceCount > 0) {
       errors.push(error('invalid_reference', path, 'Catalog resources must not mix inline data with URL references.'));
@@ -237,27 +239,31 @@ function parseResources(value: Record<string, unknown>, errors: AiCatalogValidat
       if (invalidUrl) errors.push(invalidUrl);
     }
 
-    if (type === 'catalog') {
-      if (!catalogUrl || hasInlineData || url || endpoint) {
-        errors.push(error('nested_catalog_boundary', path, 'Nested catalog resources must use catalogUrl only.'));
+    if (isNestedCatalog) {
+      if (!catalogUrl || hasInlineData || endpoint || (url && catalogUrlRaw)) {
+        errors.push(error('nested_catalog_boundary', path, 'Nested catalog entries must use a single URL reference.'));
       }
     } else if (catalogUrl) {
       errors.push(error('nested_catalog_boundary', `${path}.catalogUrl`, 'Only catalog resources may reference nested catalogs.'));
     }
 
-    if (id && type && SUPPORTED_RESOURCE_TYPES.has(type) && name) {
+    const metadata = isPlainObject(raw.metadata) ? raw.metadata : undefined;
+    const rapMetadata = metadata && isPlainObject(metadata.rap) ? metadata.rap : undefined;
+
+    if (id && mediaType && name) {
       resources.push({
         id,
-        type,
+        type: mediaType,
+        mediaType,
         name,
         description: asString(raw.description),
         url,
         endpoint,
         catalogUrl,
         trustManifest: raw.trustManifest,
-        capabilities: raw.capabilities,
-        payment: raw.payment,
-        auth: raw.auth,
+        capabilities: raw.capabilities ?? metadata?.capabilities,
+        payment: raw.payment ?? rapMetadata?.payment ?? metadata?.payment,
+        auth: raw.auth ?? rapMetadata?.auth ?? metadata?.auth,
         raw,
       });
     }
@@ -274,14 +280,25 @@ export function validateAiCatalog(input: unknown, options: AiCatalogValidationOp
     return { ok: false, errors: [error('malformed_catalog', '$', 'AI Catalog must be a plain object.')] };
   }
 
-  if (byteLength(input) > maxBytes) {
+  const size = byteLength(input);
+  if (size === undefined) {
+    return { ok: false, errors: [error('malformed_catalog', '$', 'AI Catalog must be JSON-serializable.')] };
+  }
+
+  if (size > maxBytes) {
     return { ok: false, errors: [error('catalog_too_large', '$', `AI Catalog exceeds ${maxBytes} bytes.`)] };
   }
 
   const credentialLeak = containsCredentialMaterial(input);
   if (credentialLeak) return { ok: false, errors: [credentialLeak] };
 
-  const publisher = parsePublisher(input.publisher, errors);
+  if (!asString(input.specVersion) && Object.prototype.hasOwnProperty.call(input, 'entries')) {
+    errors.push(error('malformed_catalog', '$.specVersion', 'AI Catalog entries require a specVersion string.'));
+  }
+
+  const hostOrPublisher = input.host ?? input.publisher;
+  const publisherPath = Object.prototype.hasOwnProperty.call(input, 'host') ? '$.host' : '$.publisher';
+  const publisher = hostOrPublisher === undefined ? { id: 'unknown' } : parsePublisher(hostOrPublisher, publisherPath, errors);
   const resources = parseResources(input, errors);
   if (!publisher || errors.length > 0) return { ok: false, errors };
 
@@ -307,64 +324,75 @@ export function createAiCatalogSnapshot(input: unknown, options: AiCatalogValida
 
 export const aiCatalogFixtures = {
   happyPath: {
-    publisher: {
-      id: 'reddi.tech',
-      name: 'Reddi',
-      domain: 'reddi.tech',
+    specVersion: '1.0',
+    host: {
+      identifier: 'reddi.tech',
+      displayName: 'Reddi',
     },
-    resources: [
+    entries: [
       {
-        id: 'urn:ai:reddi.tech:specialists:code-review',
-        type: 'agent',
-        name: 'Code Review Specialist',
+        identifier: 'urn:ai:reddi.tech:specialists:code-review',
+        mediaType: 'application/mcp-server-card+json',
+        displayName: 'Code Review Specialist',
         description: 'Reviews pull requests and emits RAP-compatible evidence.',
-        endpoint: 'https://agents.reddi.tech/code-review',
-        capabilities: ['code_review', 'risk_analysis'],
+        url: 'https://agents.reddi.tech/code-review/mcp.json',
+        metadata: {
+          capabilities: ['code_review', 'risk_analysis'],
+          rap: {
+            payment: {
+              protocol: 'rap',
+              quoteMode: 'preflight',
+              assets: [{ asset: 'AUDD', network: 'solana-devnet' }],
+            },
+            auth: {
+              type: 'oauth',
+              scopes: ['repo:read'],
+            },
+          },
+        },
         trustManifest: {
-          url: 'https://agents.reddi.tech/.well-known/trust/code-review.json',
+          identity: 'urn:ai:reddi.tech:specialists:code-review',
           signature: {
             format: 'dsse',
             status: 'claimed',
           },
         },
-        payment: {
-          protocol: 'rap',
-          quoteMode: 'preflight',
-          assets: [{ asset: 'AUDD', network: 'solana-devnet' }],
-        },
-        auth: {
-          type: 'oauth',
-          scopes: ['repo:read'],
-        },
       },
       {
-        id: 'urn:ai:reddi.tech:apis:receipt-validator',
-        type: 'api',
-        name: 'Receipt Validator API',
+        identifier: 'urn:ai:reddi.tech:apis:receipt-validator',
+        mediaType: 'application/openapi+json',
+        displayName: 'Receipt Validator API',
         url: 'https://agents.reddi.tech/apis/receipt-validator',
-        capabilities: ['receipt_validation'],
+        metadata: {
+          capabilities: ['receipt_validation'],
+        },
       },
     ],
   },
   nestedCatalog: {
-    publisher: 'reddi.tech',
-    resources: [
+    specVersion: '1.0',
+    host: {
+      displayName: 'Reddi',
+      identifier: 'reddi.tech',
+    },
+    entries: [
       {
-        id: 'urn:ai:reddi.tech:catalogs:local-specialists',
-        type: 'catalog',
-        name: 'Local Specialists Catalog',
-        catalogUrl: 'https://agents.reddi.tech/.well-known/local-specialists.ai-catalog.json',
+        identifier: 'urn:ai:reddi.tech:catalogs:local-specialists',
+        mediaType: AI_CATALOG_MEDIA_TYPE,
+        displayName: 'Local Specialists Catalog',
+        url: 'https://agents.reddi.tech/.well-known/local-specialists.ai-catalog.json',
       },
     ],
   },
   localhostFixture: {
-    publisher: 'localhost',
-    resources: [
+    specVersion: '1.0',
+    host: 'localhost',
+    entries: [
       {
-        id: 'urn:ai:localhost:fixtures:demo-specialist',
-        type: 'mcp_server',
-        name: 'Demo MCP Specialist',
-        endpoint: 'http://localhost:4317/mcp',
+        identifier: 'urn:ai:localhost:fixtures:demo-specialist',
+        mediaType: 'application/mcp-server-card+json',
+        displayName: 'Demo MCP Specialist',
+        url: 'http://localhost:4317/mcp',
       },
     ],
   },
@@ -392,13 +420,14 @@ export const aiCatalogFixtureCases: Record<string, AiCatalogFixtureCase> = {
   unsupportedResourceType: {
     description: 'Unknown resource types are rejected.',
     catalog: {
-      publisher: 'reddi.tech',
-      resources: [
+      specVersion: '1.0',
+      host: 'reddi.tech',
+      entries: [
         {
-          id: 'urn:ai:reddi.tech:unknown:thing',
-          type: 'model_context_plugin',
-          name: 'Unsupported Thing',
-          endpoint: 'https://agents.reddi.tech/unsupported',
+          identifier: 'urn:ai:reddi.tech:unknown:thing',
+          mediaType: 'not a media type!',
+          displayName: 'Unsupported Thing',
+          url: 'https://agents.reddi.tech/unsupported',
         },
       ],
     },
@@ -408,13 +437,14 @@ export const aiCatalogFixtureCases: Record<string, AiCatalogFixtureCase> = {
   unsafeUrl: {
     description: 'Non-HTTPS non-localhost references are rejected.',
     catalog: {
-      publisher: 'reddi.tech',
-      resources: [
+      specVersion: '1.0',
+      host: 'reddi.tech',
+      entries: [
         {
-          id: 'urn:ai:reddi.tech:specialists:unsafe',
-          type: 'agent',
-          name: 'Unsafe Specialist',
-          endpoint: 'http://agents.reddi.tech/unsafe',
+          identifier: 'urn:ai:reddi.tech:specialists:unsafe',
+          mediaType: 'application/mcp-server-card+json',
+          displayName: 'Unsafe Specialist',
+          url: 'http://agents.reddi.tech/unsafe',
         },
       ],
     },
@@ -424,13 +454,14 @@ export const aiCatalogFixtureCases: Record<string, AiCatalogFixtureCase> = {
   credentialLeakage: {
     description: 'Credential-shaped metadata is rejected before ingestion.',
     catalog: {
-      publisher: 'reddi.tech',
-      resources: [
+      specVersion: '1.0',
+      host: 'reddi.tech',
+      entries: [
         {
-          id: 'urn:ai:reddi.tech:specialists:leaky',
-          type: 'agent',
-          name: 'Leaky Specialist',
-          endpoint: 'https://agents.reddi.tech/leaky',
+          identifier: 'urn:ai:reddi.tech:specialists:leaky',
+          mediaType: 'application/mcp-server-card+json',
+          displayName: 'Leaky Specialist',
+          url: 'https://agents.reddi.tech/leaky',
           auth: {
             accessToken: 'tok_should_not_be_in_catalogs',
           },

--- a/packages/agent-protocol/src/ai-catalog.ts
+++ b/packages/agent-protocol/src/ai-catalog.ts
@@ -1,0 +1,443 @@
+export const AI_CATALOG_SCHEMA_VERSION = 'ai-catalog.v1' as const;
+
+export type AiCatalogResourceType =
+  | 'agent'
+  | 'api'
+  | 'mcp_server'
+  | 'mcp-server'
+  | 'skill'
+  | 'tool'
+  | 'catalog'
+  | 'a2a_agent'
+  | 'a2a-agent';
+
+export type AiCatalogValidationErrorCode =
+  | 'malformed_catalog'
+  | 'unsupported_resource_type'
+  | 'invalid_identifier'
+  | 'invalid_reference'
+  | 'unsafe_url'
+  | 'nested_catalog_boundary'
+  | 'credential_leakage_rejected'
+  | 'catalog_too_large';
+
+export type AiCatalogValidationError = {
+  code: AiCatalogValidationErrorCode;
+  path: string;
+  message: string;
+};
+
+export type AiCatalogPublisherSnapshot = {
+  id: string;
+  name?: string;
+  domain?: string;
+};
+
+export type AiCatalogResourceSnapshot = {
+  id: string;
+  type: AiCatalogResourceType;
+  name: string;
+  description?: string;
+  url?: string;
+  endpoint?: string;
+  catalogUrl?: string;
+  trustManifest?: unknown;
+  capabilities?: unknown;
+  payment?: unknown;
+  auth?: unknown;
+  raw: unknown;
+};
+
+export type AiCatalogSnapshot = {
+  schemaVersion: typeof AI_CATALOG_SCHEMA_VERSION;
+  publisher: AiCatalogPublisherSnapshot;
+  resources: AiCatalogResourceSnapshot[];
+  rawSnapshotRef?: string;
+};
+
+export type AiCatalogValidationSuccess = {
+  ok: true;
+  catalog: AiCatalogSnapshot;
+  warnings: AiCatalogValidationError[];
+};
+
+export type AiCatalogValidationFailure = {
+  ok: false;
+  errors: AiCatalogValidationError[];
+};
+
+export type AiCatalogValidationResult = AiCatalogValidationSuccess | AiCatalogValidationFailure;
+
+export type AiCatalogValidationOptions = {
+  rawSnapshotRef?: string;
+  maxBytes?: number;
+};
+
+export type AiCatalogFixtureCase = {
+  description: string;
+  catalog: unknown;
+  expectedValid: boolean;
+  expectedErrorCodes: AiCatalogValidationErrorCode[];
+};
+
+const SUPPORTED_RESOURCE_TYPES = new Set<AiCatalogResourceType>([
+  'agent',
+  'api',
+  'mcp_server',
+  'mcp-server',
+  'skill',
+  'tool',
+  'catalog',
+  'a2a_agent',
+  'a2a-agent',
+]);
+
+const AI_URN_PATTERN = /^urn:ai:[a-z0-9][a-z0-9.-]*:[a-z0-9][a-z0-9._-]*:[a-z0-9][a-z0-9._-]*$/i;
+const SECRET_KEY_PATTERN = /(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|password|secret)/i;
+const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
+
+function error(code: AiCatalogValidationErrorCode, path: string, message: string): AiCatalogValidationError {
+  return { code, path, message };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function byteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}
+
+function containsCredentialMaterial(value: unknown, path = '$'): AiCatalogValidationError | undefined {
+  if (typeof value === 'string') {
+    if (SECRET_VALUE_PATTERN.test(value)) {
+      return error('credential_leakage_rejected', path, 'Credential-shaped string values are not allowed in AI Catalog metadata.');
+    }
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const child = containsCredentialMaterial(value[index], `${path}[${index}]`);
+      if (child) return child;
+    }
+    return undefined;
+  }
+
+  if (isPlainObject(value)) {
+    for (const [key, childValue] of Object.entries(value)) {
+      const childPath = `${path}.${key}`;
+      if (SECRET_KEY_PATTERN.test(key)) {
+        return error('credential_leakage_rejected', childPath, 'Credential-shaped keys are not allowed in AI Catalog metadata.');
+      }
+      const child = containsCredentialMaterial(childValue, childPath);
+      if (child) return child;
+    }
+  }
+
+  return undefined;
+}
+
+function validateSafeUrl(value: string, path: string): AiCatalogValidationError | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return error('invalid_reference', path, 'Reference must be a valid URL.');
+  }
+
+  if (parsed.username || parsed.password) {
+    return error('unsafe_url', path, 'Reference URLs must not embed credentials.');
+  }
+
+  if (parsed.protocol === 'https:') return undefined;
+
+  const localhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
+  if (parsed.protocol === 'http:' && localhost) return undefined;
+
+  return error('unsafe_url', path, 'Reference URLs must use HTTPS, except localhost HTTP fixtures.');
+}
+
+function parsePublisher(value: unknown, errors: AiCatalogValidationError[]): AiCatalogPublisherSnapshot | undefined {
+  if (typeof value === 'string' && value.trim()) return { id: value.trim() };
+  if (!isPlainObject(value)) {
+    errors.push(error('malformed_catalog', '$.publisher', 'Catalog publisher must be a string or object.'));
+    return undefined;
+  }
+
+  const id = asString(value.id) ?? asString(value.domain) ?? asString(value.name);
+  if (!id) {
+    errors.push(error('malformed_catalog', '$.publisher.id', 'Catalog publisher must include id, domain, or name.'));
+    return undefined;
+  }
+
+  return {
+    id,
+    name: asString(value.name),
+    domain: asString(value.domain),
+  };
+}
+
+function parseResources(value: Record<string, unknown>, errors: AiCatalogValidationError[]): AiCatalogResourceSnapshot[] {
+  const rawResources = value.resources ?? value.items;
+  if (!Array.isArray(rawResources)) {
+    errors.push(error('malformed_catalog', '$.resources', 'Catalog must include a resources or items array.'));
+    return [];
+  }
+
+  const resources: AiCatalogResourceSnapshot[] = [];
+  for (let index = 0; index < rawResources.length; index += 1) {
+    const path = `$.resources[${index}]`;
+    const raw = rawResources[index];
+    if (!isPlainObject(raw)) {
+      errors.push(error('malformed_catalog', path, 'Catalog resource must be an object.'));
+      continue;
+    }
+
+    const id = asString(raw.id);
+    if (!id || !AI_URN_PATTERN.test(id)) {
+      errors.push(error('invalid_identifier', `${path}.id`, 'Resource id must be a domain-anchored urn:ai identifier.'));
+    }
+
+    const type = asString(raw.type) as AiCatalogResourceType | undefined;
+    if (!type || !SUPPORTED_RESOURCE_TYPES.has(type)) {
+      errors.push(error('unsupported_resource_type', `${path}.type`, 'Resource type is not supported by RAP AI Catalog ingestion.'));
+    }
+
+    const name = asString(raw.name);
+    if (!name) {
+      errors.push(error('malformed_catalog', `${path}.name`, 'Catalog resource must include a non-empty name.'));
+    }
+
+    const url = asString(raw.url);
+    const endpoint = asString(raw.endpoint);
+    const catalogUrl = asString(raw.catalogUrl) ?? asString(raw.catalog_url);
+    const hasInlineData = Object.prototype.hasOwnProperty.call(raw, 'data');
+    const referenceCount = [url, endpoint, catalogUrl].filter(Boolean).length;
+
+    if (hasInlineData && referenceCount > 0) {
+      errors.push(error('invalid_reference', path, 'Catalog resources must not mix inline data with URL references.'));
+    }
+    if (!hasInlineData && referenceCount > 1) {
+      errors.push(error('invalid_reference', path, 'Catalog resources must include exactly one URL reference.'));
+    }
+    if (!hasInlineData && referenceCount === 0) {
+      errors.push(error('invalid_reference', path, 'Catalog resources must include inline data or one URL reference.'));
+    }
+
+    for (const [key, reference] of Object.entries({ url, endpoint, catalogUrl })) {
+      if (!reference) continue;
+      const invalidUrl = validateSafeUrl(reference, `${path}.${key}`);
+      if (invalidUrl) errors.push(invalidUrl);
+    }
+
+    if (type === 'catalog') {
+      if (!catalogUrl || hasInlineData || url || endpoint) {
+        errors.push(error('nested_catalog_boundary', path, 'Nested catalog resources must use catalogUrl only.'));
+      }
+    } else if (catalogUrl) {
+      errors.push(error('nested_catalog_boundary', `${path}.catalogUrl`, 'Only catalog resources may reference nested catalogs.'));
+    }
+
+    if (id && type && SUPPORTED_RESOURCE_TYPES.has(type) && name) {
+      resources.push({
+        id,
+        type,
+        name,
+        description: asString(raw.description),
+        url,
+        endpoint,
+        catalogUrl,
+        trustManifest: raw.trustManifest,
+        capabilities: raw.capabilities,
+        payment: raw.payment,
+        auth: raw.auth,
+        raw,
+      });
+    }
+  }
+
+  return resources;
+}
+
+export function validateAiCatalog(input: unknown, options: AiCatalogValidationOptions = {}): AiCatalogValidationResult {
+  const maxBytes = options.maxBytes ?? 64_000;
+  const errors: AiCatalogValidationError[] = [];
+
+  if (!isPlainObject(input)) {
+    return { ok: false, errors: [error('malformed_catalog', '$', 'AI Catalog must be a plain object.')] };
+  }
+
+  if (byteLength(input) > maxBytes) {
+    return { ok: false, errors: [error('catalog_too_large', '$', `AI Catalog exceeds ${maxBytes} bytes.`)] };
+  }
+
+  const credentialLeak = containsCredentialMaterial(input);
+  if (credentialLeak) return { ok: false, errors: [credentialLeak] };
+
+  const publisher = parsePublisher(input.publisher, errors);
+  const resources = parseResources(input, errors);
+  if (!publisher || errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    catalog: {
+      schemaVersion: AI_CATALOG_SCHEMA_VERSION,
+      publisher,
+      resources,
+      rawSnapshotRef: options.rawSnapshotRef,
+    },
+    warnings: [],
+  };
+}
+
+export function createAiCatalogSnapshot(input: unknown, options: AiCatalogValidationOptions = {}): AiCatalogSnapshot {
+  const result = validateAiCatalog(input, options);
+  if (!result.ok) {
+    throw new Error(`invalid_ai_catalog:${result.errors.map((item) => item.code).join(',')}`);
+  }
+  return result.catalog;
+}
+
+export const aiCatalogFixtures = {
+  happyPath: {
+    publisher: {
+      id: 'reddi.tech',
+      name: 'Reddi',
+      domain: 'reddi.tech',
+    },
+    resources: [
+      {
+        id: 'urn:ai:reddi.tech:specialists:code-review',
+        type: 'agent',
+        name: 'Code Review Specialist',
+        description: 'Reviews pull requests and emits RAP-compatible evidence.',
+        endpoint: 'https://agents.reddi.tech/code-review',
+        capabilities: ['code_review', 'risk_analysis'],
+        trustManifest: {
+          url: 'https://agents.reddi.tech/.well-known/trust/code-review.json',
+          signature: {
+            format: 'dsse',
+            status: 'claimed',
+          },
+        },
+        payment: {
+          protocol: 'rap',
+          quoteMode: 'preflight',
+          assets: [{ asset: 'AUDD', network: 'solana-devnet' }],
+        },
+        auth: {
+          type: 'oauth',
+          scopes: ['repo:read'],
+        },
+      },
+      {
+        id: 'urn:ai:reddi.tech:apis:receipt-validator',
+        type: 'api',
+        name: 'Receipt Validator API',
+        url: 'https://agents.reddi.tech/apis/receipt-validator',
+        capabilities: ['receipt_validation'],
+      },
+    ],
+  },
+  nestedCatalog: {
+    publisher: 'reddi.tech',
+    resources: [
+      {
+        id: 'urn:ai:reddi.tech:catalogs:local-specialists',
+        type: 'catalog',
+        name: 'Local Specialists Catalog',
+        catalogUrl: 'https://agents.reddi.tech/.well-known/local-specialists.ai-catalog.json',
+      },
+    ],
+  },
+  localhostFixture: {
+    publisher: 'localhost',
+    resources: [
+      {
+        id: 'urn:ai:localhost:fixtures:demo-specialist',
+        type: 'mcp_server',
+        name: 'Demo MCP Specialist',
+        endpoint: 'http://localhost:4317/mcp',
+      },
+    ],
+  },
+} as const;
+
+export const aiCatalogFixtureCases: Record<string, AiCatalogFixtureCase> = {
+  happyPath: {
+    description: 'Valid AI Catalog with RAP-compatible agent and API resources.',
+    catalog: aiCatalogFixtures.happyPath,
+    expectedValid: true,
+    expectedErrorCodes: [],
+  },
+  nestedCatalog: {
+    description: 'Valid nested catalog reference that keeps catalog boundaries explicit.',
+    catalog: aiCatalogFixtures.nestedCatalog,
+    expectedValid: true,
+    expectedErrorCodes: [],
+  },
+  malformedCatalog: {
+    description: 'Missing publisher and resources fails closed.',
+    catalog: { name: 'not enough catalog shape' },
+    expectedValid: false,
+    expectedErrorCodes: ['malformed_catalog'],
+  },
+  unsupportedResourceType: {
+    description: 'Unknown resource types are rejected.',
+    catalog: {
+      publisher: 'reddi.tech',
+      resources: [
+        {
+          id: 'urn:ai:reddi.tech:unknown:thing',
+          type: 'model_context_plugin',
+          name: 'Unsupported Thing',
+          endpoint: 'https://agents.reddi.tech/unsupported',
+        },
+      ],
+    },
+    expectedValid: false,
+    expectedErrorCodes: ['unsupported_resource_type'],
+  },
+  unsafeUrl: {
+    description: 'Non-HTTPS non-localhost references are rejected.',
+    catalog: {
+      publisher: 'reddi.tech',
+      resources: [
+        {
+          id: 'urn:ai:reddi.tech:specialists:unsafe',
+          type: 'agent',
+          name: 'Unsafe Specialist',
+          endpoint: 'http://agents.reddi.tech/unsafe',
+        },
+      ],
+    },
+    expectedValid: false,
+    expectedErrorCodes: ['unsafe_url'],
+  },
+  credentialLeakage: {
+    description: 'Credential-shaped metadata is rejected before ingestion.',
+    catalog: {
+      publisher: 'reddi.tech',
+      resources: [
+        {
+          id: 'urn:ai:reddi.tech:specialists:leaky',
+          type: 'agent',
+          name: 'Leaky Specialist',
+          endpoint: 'https://agents.reddi.tech/leaky',
+          auth: {
+            accessToken: 'tok_should_not_be_in_catalogs',
+          },
+        },
+      ],
+    },
+    expectedValid: false,
+    expectedErrorCodes: ['credential_leakage_rejected'],
+  },
+};

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -1,3 +1,4 @@
 export * from './policy.js';
 export * from './receipts.js';
 export * from './fixtures.js';
+export * from './ai-catalog.js';

--- a/packages/agent-protocol/tests/ai-catalog.test.ts
+++ b/packages/agent-protocol/tests/ai-catalog.test.ts
@@ -1,0 +1,222 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  aiCatalogFixtureCases,
+  aiCatalogFixtures,
+  createAiCatalogSnapshot,
+  validateAiCatalog,
+  type AiCatalogValidationErrorCode,
+} from '../dist/index.js';
+
+function assertErrorCodes(actual: AiCatalogValidationErrorCode[], expected: AiCatalogValidationErrorCode[]): void {
+  for (const code of expected) {
+    assert.ok(actual.includes(code), `expected validation errors to include ${code}`);
+  }
+}
+
+describe('AI Catalog ingestion', () => {
+  it('validates fixture-backed catalog cases with expected outcomes', () => {
+    const expectedCases = [
+      'happyPath',
+      'nestedCatalog',
+      'malformedCatalog',
+      'unsupportedResourceType',
+      'unsafeUrl',
+      'credentialLeakage',
+    ];
+
+    assert.deepEqual(Object.keys(aiCatalogFixtureCases).sort(), expectedCases.sort());
+    for (const fixture of Object.values(aiCatalogFixtureCases)) {
+      const result = validateAiCatalog(fixture.catalog, { rawSnapshotRef: `fixture:${fixture.description}` });
+      assert.equal(result.ok, fixture.expectedValid, fixture.description);
+      if (!result.ok) {
+        assertErrorCodes(result.errors.map((item) => item.code), fixture.expectedErrorCodes);
+      }
+    }
+  });
+
+  it('stores valid AI Catalog resources as untrusted external snapshots', () => {
+    const result = validateAiCatalog(aiCatalogFixtures.happyPath, {
+      rawSnapshotRef: 'sha256:fixture-happy-path',
+    });
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.catalog.schemaVersion, 'ai-catalog.v1');
+      assert.equal(result.catalog.publisher.id, 'reddi.tech');
+      assert.equal(result.catalog.rawSnapshotRef, 'sha256:fixture-happy-path');
+      assert.equal(result.catalog.resources.length, 2);
+      assert.equal(result.catalog.resources[0].id, 'urn:ai:reddi.tech:specialists:code-review');
+      assert.equal(result.catalog.resources[0].type, 'agent');
+      assert.equal(result.catalog.resources[0].endpoint, 'https://agents.reddi.tech/code-review');
+      assert.deepEqual(result.catalog.resources[0].payment, {
+        protocol: 'rap',
+        quoteMode: 'preflight',
+        assets: [{ asset: 'AUDD', network: 'solana-devnet' }],
+      });
+      assert.deepEqual(result.catalog.resources[0].auth, {
+        type: 'oauth',
+        scopes: ['repo:read'],
+      });
+      assert.deepEqual(result.catalog.resources[0].trustManifest, {
+        url: 'https://agents.reddi.tech/.well-known/trust/code-review.json',
+        signature: {
+          format: 'dsse',
+          status: 'claimed',
+        },
+      });
+    }
+  });
+
+  it('accepts localhost HTTP only for local fixtures', () => {
+    const result = validateAiCatalog(aiCatalogFixtures.localhostFixture);
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.catalog.resources[0].endpoint, 'http://localhost:4317/mcp');
+    }
+  });
+
+  it('rejects malformed or oversized catalogs before callers can persist them', () => {
+    const malformed = validateAiCatalog(null);
+    assert.equal(malformed.ok, false);
+    if (!malformed.ok) {
+      assert.ok(malformed.errors.some((item) => item.code === 'malformed_catalog' && item.path === '$'));
+    }
+
+    const oversized = validateAiCatalog(aiCatalogFixtures.happyPath, { maxBytes: 16 });
+    assert.equal(oversized.ok, false);
+    if (!oversized.ok) {
+      assert.ok(oversized.errors.some((item) => item.code === 'catalog_too_large' && item.path === '$'));
+    }
+  });
+
+  it('rejects unsafe references including embedded credentials and non-HTTPS URLs', () => {
+    const probes = [
+      {
+        expected: 'unsafe_url',
+        catalog: {
+          publisher: 'reddi.tech',
+          resources: [
+            {
+              id: 'urn:ai:reddi.tech:specialists:embedded-creds',
+              type: 'agent',
+              name: 'Embedded Credentials',
+              endpoint: 'https://user:pass@agents.reddi.tech/unsafe',
+            },
+          ],
+        },
+      },
+      {
+        expected: 'unsafe_url',
+        catalog: {
+          publisher: 'reddi.tech',
+          resources: [
+            {
+              id: 'urn:ai:reddi.tech:specialists:http',
+              type: 'agent',
+              name: 'Plain HTTP',
+              endpoint: 'http://agents.reddi.tech/unsafe',
+            },
+          ],
+        },
+      },
+      {
+        expected: 'invalid_reference',
+        catalog: {
+          publisher: 'reddi.tech',
+          resources: [
+            {
+              id: 'urn:ai:reddi.tech:specialists:not-url',
+              type: 'agent',
+              name: 'Not URL',
+              endpoint: 'not-a-url',
+            },
+          ],
+        },
+      },
+    ] as const;
+
+    for (const probe of probes) {
+      const result = validateAiCatalog(probe.catalog);
+      assert.equal(result.ok, false);
+      if (!result.ok) {
+        assert.ok(result.errors.some((item) => item.code === probe.expected), `${probe.expected} should be present`);
+      }
+    }
+  });
+
+  it('enforces nested catalog and value/reference boundaries', () => {
+    const catalogWithEndpoint = validateAiCatalog({
+      publisher: 'reddi.tech',
+      resources: [
+        {
+          id: 'urn:ai:reddi.tech:catalogs:bad-boundary',
+          type: 'catalog',
+          name: 'Bad Boundary',
+          endpoint: 'https://agents.reddi.tech/catalog-endpoint',
+        },
+      ],
+    });
+    assert.equal(catalogWithEndpoint.ok, false);
+    if (!catalogWithEndpoint.ok) {
+      assert.ok(catalogWithEndpoint.errors.some((item) => item.code === 'nested_catalog_boundary'));
+    }
+
+    const nonCatalogWithCatalogUrl = validateAiCatalog({
+      publisher: 'reddi.tech',
+      resources: [
+        {
+          id: 'urn:ai:reddi.tech:specialists:bad-nested-reference',
+          type: 'agent',
+          name: 'Bad Nested Reference',
+          catalogUrl: 'https://agents.reddi.tech/.well-known/catalog.json',
+        },
+      ],
+    });
+    assert.equal(nonCatalogWithCatalogUrl.ok, false);
+    if (!nonCatalogWithCatalogUrl.ok) {
+      assert.ok(nonCatalogWithCatalogUrl.errors.some((item) => item.code === 'nested_catalog_boundary'));
+    }
+
+    const mixedInlineAndReference = validateAiCatalog({
+      publisher: 'reddi.tech',
+      resources: [
+        {
+          id: 'urn:ai:reddi.tech:specialists:mixed',
+          type: 'agent',
+          name: 'Mixed',
+          endpoint: 'https://agents.reddi.tech/mixed',
+          data: { transport: 'mcp' },
+        },
+      ],
+    });
+    assert.equal(mixedInlineAndReference.ok, false);
+    if (!mixedInlineAndReference.ok) {
+      assert.ok(mixedInlineAndReference.errors.some((item) => item.code === 'invalid_reference'));
+    }
+
+    const multipleReferences = validateAiCatalog({
+      publisher: 'reddi.tech',
+      resources: [
+        {
+          id: 'urn:ai:reddi.tech:specialists:multi-ref',
+          type: 'agent',
+          name: 'Multi Reference',
+          url: 'https://agents.reddi.tech/multi-ref',
+          endpoint: 'https://agents.reddi.tech/multi-ref/invoke',
+        },
+      ],
+    });
+    assert.equal(multipleReferences.ok, false);
+    if (!multipleReferences.ok) {
+      assert.ok(multipleReferences.errors.some((item) => item.code === 'invalid_reference'));
+    }
+  });
+
+  it('throws when creating an invalid snapshot', () => {
+    assert.throws(
+      () => createAiCatalogSnapshot(aiCatalogFixtureCases.credentialLeakage.catalog),
+      /invalid_ai_catalog:credential_leakage_rejected/,
+    );
+  });
+});

--- a/packages/agent-protocol/tests/ai-catalog.test.ts
+++ b/packages/agent-protocol/tests/ai-catalog.test.ts
@@ -47,8 +47,9 @@ describe('AI Catalog ingestion', () => {
       assert.equal(result.catalog.rawSnapshotRef, 'sha256:fixture-happy-path');
       assert.equal(result.catalog.resources.length, 2);
       assert.equal(result.catalog.resources[0].id, 'urn:ai:reddi.tech:specialists:code-review');
-      assert.equal(result.catalog.resources[0].type, 'agent');
-      assert.equal(result.catalog.resources[0].endpoint, 'https://agents.reddi.tech/code-review');
+      assert.equal(result.catalog.resources[0].type, 'application/mcp-server-card+json');
+      assert.equal(result.catalog.resources[0].mediaType, 'application/mcp-server-card+json');
+      assert.equal(result.catalog.resources[0].url, 'https://agents.reddi.tech/code-review/mcp.json');
       assert.deepEqual(result.catalog.resources[0].payment, {
         protocol: 'rap',
         quoteMode: 'preflight',
@@ -59,7 +60,7 @@ describe('AI Catalog ingestion', () => {
         scopes: ['repo:read'],
       });
       assert.deepEqual(result.catalog.resources[0].trustManifest, {
-        url: 'https://agents.reddi.tech/.well-known/trust/code-review.json',
+        identity: 'urn:ai:reddi.tech:specialists:code-review',
         signature: {
           format: 'dsse',
           status: 'claimed',
@@ -72,7 +73,29 @@ describe('AI Catalog ingestion', () => {
     const result = validateAiCatalog(aiCatalogFixtures.localhostFixture);
     assert.equal(result.ok, true);
     if (result.ok) {
-      assert.equal(result.catalog.resources[0].endpoint, 'http://localhost:4317/mcp');
+      assert.equal(result.catalog.resources[0].url, 'http://localhost:4317/mcp');
+    }
+  });
+
+  it('accepts current AI Catalog spec-shaped entries', () => {
+    const result = validateAiCatalog({
+      specVersion: '1.0',
+      entries: [
+        {
+          identifier: 'urn:example:mcp:weather',
+          displayName: 'Weather Service',
+          mediaType: 'application/mcp-server-card+json',
+          url: 'https://api.example.com/.well-known/mcp/server-card.json',
+        },
+      ],
+    });
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.catalog.publisher.id, 'unknown');
+      assert.equal(result.catalog.resources[0].id, 'urn:example:mcp:weather');
+      assert.equal(result.catalog.resources[0].name, 'Weather Service');
+      assert.equal(result.catalog.resources[0].mediaType, 'application/mcp-server-card+json');
     }
   });
 
@@ -95,13 +118,14 @@ describe('AI Catalog ingestion', () => {
       {
         expected: 'unsafe_url',
         catalog: {
-          publisher: 'reddi.tech',
-          resources: [
+          specVersion: '1.0',
+          host: 'reddi.tech',
+          entries: [
             {
-              id: 'urn:ai:reddi.tech:specialists:embedded-creds',
-              type: 'agent',
-              name: 'Embedded Credentials',
-              endpoint: 'https://user:pass@agents.reddi.tech/unsafe',
+              identifier: 'urn:ai:reddi.tech:specialists:embedded-creds',
+              mediaType: 'application/mcp-server-card+json',
+              displayName: 'Embedded Credentials',
+              url: 'https://user:pass@agents.reddi.tech/unsafe',
             },
           ],
         },
@@ -109,13 +133,29 @@ describe('AI Catalog ingestion', () => {
       {
         expected: 'unsafe_url',
         catalog: {
-          publisher: 'reddi.tech',
-          resources: [
+          specVersion: '1.0',
+          host: 'reddi.tech',
+          entries: [
             {
-              id: 'urn:ai:reddi.tech:specialists:http',
-              type: 'agent',
-              name: 'Plain HTTP',
-              endpoint: 'http://agents.reddi.tech/unsafe',
+              identifier: 'urn:ai:reddi.tech:specialists:http',
+              mediaType: 'application/mcp-server-card+json',
+              displayName: 'Plain HTTP',
+              url: 'http://agents.reddi.tech/unsafe',
+            },
+          ],
+        },
+      },
+      {
+        expected: 'credential_leakage_rejected',
+        catalog: {
+          specVersion: '1.0',
+          host: 'reddi.tech',
+          entries: [
+            {
+              identifier: 'urn:ai:reddi.tech:specialists:query-secret',
+              mediaType: 'application/mcp-server-card+json',
+              displayName: 'Query Secret',
+              url: 'https://agents.reddi.tech/unsafe?access_token=redacted',
             },
           ],
         },
@@ -123,13 +163,14 @@ describe('AI Catalog ingestion', () => {
       {
         expected: 'invalid_reference',
         catalog: {
-          publisher: 'reddi.tech',
-          resources: [
+          specVersion: '1.0',
+          host: 'reddi.tech',
+          entries: [
             {
-              id: 'urn:ai:reddi.tech:specialists:not-url',
-              type: 'agent',
-              name: 'Not URL',
-              endpoint: 'not-a-url',
+              identifier: 'urn:ai:reddi.tech:specialists:not-url',
+              mediaType: 'application/mcp-server-card+json',
+              displayName: 'Not URL',
+              url: 'not-a-url',
             },
           ],
         },
@@ -147,12 +188,13 @@ describe('AI Catalog ingestion', () => {
 
   it('enforces nested catalog and value/reference boundaries', () => {
     const catalogWithEndpoint = validateAiCatalog({
-      publisher: 'reddi.tech',
-      resources: [
+      specVersion: '1.0',
+      host: 'reddi.tech',
+      entries: [
         {
-          id: 'urn:ai:reddi.tech:catalogs:bad-boundary',
-          type: 'catalog',
-          name: 'Bad Boundary',
+          identifier: 'urn:ai:reddi.tech:catalogs:bad-boundary',
+          mediaType: 'application/ai-catalog+json',
+          displayName: 'Bad Boundary',
           endpoint: 'https://agents.reddi.tech/catalog-endpoint',
         },
       ],
@@ -179,13 +221,14 @@ describe('AI Catalog ingestion', () => {
     }
 
     const mixedInlineAndReference = validateAiCatalog({
-      publisher: 'reddi.tech',
-      resources: [
+      specVersion: '1.0',
+      host: 'reddi.tech',
+      entries: [
         {
-          id: 'urn:ai:reddi.tech:specialists:mixed',
-          type: 'agent',
-          name: 'Mixed',
-          endpoint: 'https://agents.reddi.tech/mixed',
+          identifier: 'urn:ai:reddi.tech:specialists:mixed',
+          mediaType: 'application/mcp-server-card+json',
+          displayName: 'Mixed',
+          url: 'https://agents.reddi.tech/mixed',
           data: { transport: 'mcp' },
         },
       ],
@@ -196,12 +239,13 @@ describe('AI Catalog ingestion', () => {
     }
 
     const multipleReferences = validateAiCatalog({
-      publisher: 'reddi.tech',
-      resources: [
+      specVersion: '1.0',
+      host: 'reddi.tech',
+      entries: [
         {
-          id: 'urn:ai:reddi.tech:specialists:multi-ref',
-          type: 'agent',
-          name: 'Multi Reference',
+          identifier: 'urn:ai:reddi.tech:specialists:multi-ref',
+          mediaType: 'application/mcp-server-card+json',
+          displayName: 'Multi Reference',
           url: 'https://agents.reddi.tech/multi-ref',
           endpoint: 'https://agents.reddi.tech/multi-ref/invoke',
         },
@@ -210,6 +254,44 @@ describe('AI Catalog ingestion', () => {
     assert.equal(multipleReferences.ok, false);
     if (!multipleReferences.ok) {
       assert.ok(multipleReferences.errors.some((item) => item.code === 'invalid_reference'));
+    }
+  });
+
+  it('rejects credential-shaped keys and non-serializable malformed catalogs without throwing', () => {
+    const bareToken = validateAiCatalog({
+      specVersion: '1.0',
+      host: 'reddi.tech',
+      entries: [
+        {
+          identifier: 'urn:ai:reddi.tech:specialists:token-key',
+          mediaType: 'application/mcp-server-card+json',
+          displayName: 'Token Key',
+          url: 'https://agents.reddi.tech/token-key',
+          metadata: {
+            token: 'redacted',
+          },
+        },
+      ],
+    });
+    assert.equal(bareToken.ok, false);
+    if (!bareToken.ok) {
+      assert.ok(bareToken.errors.some((item) => item.code === 'credential_leakage_rejected'));
+    }
+
+    const circular: Record<string, unknown> = { specVersion: '1.0', entries: [] };
+    circular.self = circular;
+    assert.doesNotThrow(() => validateAiCatalog(circular));
+    const circularResult = validateAiCatalog(circular);
+    assert.equal(circularResult.ok, false);
+    if (!circularResult.ok) {
+      assert.ok(circularResult.errors.some((item) => item.code === 'malformed_catalog'));
+    }
+
+    assert.doesNotThrow(() => validateAiCatalog({ specVersion: '1.0', entries: [], metadata: { count: 1n } }));
+    const bigintResult = validateAiCatalog({ specVersion: '1.0', entries: [], metadata: { count: 1n } });
+    assert.equal(bigintResult.ok, false);
+    if (!bigintResult.ok) {
+      assert.ok(bigintResult.errors.some((item) => item.code === 'malformed_catalog'));
     }
   });
 


### PR DESCRIPTION
## Summary

Closes #364.

Adds fixture-backed ARD / AI Catalog ingestion primitives to `@reddi/agent-protocol` so RAP can normalize provider discovery metadata without treating discovery as authorization, trust, payment, or invocation.

## What changed

- Added `validateAiCatalog` and `createAiCatalogSnapshot` in `packages/agent-protocol/src/ai-catalog.ts`.
- Added exported AI Catalog fixtures and fixture-case expectations.
- Added `@reddi/agent-protocol/ai-catalog` package export.
- Documented AI Catalog ingestion boundaries in the package README.
- Added tests for valid catalogs, nested catalog boundaries, malformed catalogs, unsupported resource types, unsafe URLs, credential leakage, oversized catalogs, localhost fixtures, and invalid snapshot creation.

## Safety boundaries

- Catalog data is stored as untrusted external metadata snapshots.
- No network fetches, wallet actions, paid invocations, or auto-execution are performed.
- Credential-shaped keys/values fail closed.
- ARD/AI Catalog discovery remains separate from RAP policy preflight, quote/payment approval, receipts, evidence, attestations, and reputation.

## Validation

- `npm test` in `packages/agent-protocol` passed: 19 tests.
- `npm run release:dry-run` in `packages/agent-protocol` passed.
- `npm run check:rap:naming` passed.
- `git diff --check` passed.

## UI evidence

No UI changes in this PR, so screenshots/video are not required.
