### PR TITLE
Add ARD provider trust records

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -48,12 +48,30 @@ const snapshot = createAiCatalogSnapshot(aiCatalogFixtures.happyPath, {
 });
 
 console.log(snapshot.publisher.id); // reddi.tech
-console.log(snapshot.resources[0].type); // agent
+console.log(snapshot.resources[0].mediaType); // application/mcp-server-card+json
 ```
 
 AI Catalog ingestion stores discovery results as untrusted external metadata. Validation fails closed for malformed catalogs, unsupported resource types, invalid `urn:ai:*` identifiers, unsafe URLs, credential-bearing metadata, oversized catalogs, and nested-catalog boundary violations.
 
 Catalog ingestion never performs network fetches, paid invocations, wallet actions, or auto-execution. Buyer policy preflight, quote/payment approval, receipts, evidence, attestations, and reputation remain separate RAP steps after discovery.
+
+## Provider Trust Records
+
+```typescript
+import { createAiCatalogProviderTrustRecord, providerTrustFixtures } from '@reddi/agent-protocol/provider-trust';
+
+const trust = createAiCatalogProviderTrustRecord(
+  providerTrustFixtures.verifiedCatalog,
+  'urn:ai:reddi.tech:specialists:code-review',
+  { verification: { status: 'verified', verifier: 'rap:local-check' } },
+);
+
+console.log(trust.verification.status); // verified
+```
+
+Provider trust records normalize ARD trust manifests, provenance links, attestations, detached-signature metadata, publisher identity, and verification references into a RAP-side trust shape.
+
+External ARD trust metadata is treated as a claim until RAP-side verification marks it `verified` or `failed_verification`. Missing metadata remains `unverified`, malformed trust metadata fails closed, and credential-bearing auth/payment/trust metadata is rejected.
 
 ## Local Validation
 

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -2,3 +2,4 @@ export * from './policy.js';
 export * from './receipts.js';
 export * from './fixtures.js';
 export * from './ai-catalog.js';
+export * from './provider-trust.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -2,3 +2,4 @@ export * from './policy.js';
 export * from './receipts.js';
 export * from './fixtures.js';
 export * from './ai-catalog.js';
+export * from './provider-trust.js';

--- a/packages/agent-protocol/dist/provider-trust.d.ts
+++ b/packages/agent-protocol/dist/provider-trust.d.ts
@@ -1,0 +1,113 @@
+import { type AiCatalogSnapshot } from './ai-catalog.js';
+export declare const PROVIDER_TRUST_RECORD_SCHEMA_VERSION: "reddi.provider-trust.v1";
+export type ProviderTrustVerificationStatus = 'claimed' | 'verified' | 'unverified' | 'failed_verification';
+export type ProviderTrustReasonCode = 'rap_verified' | 'rap_verification_failed' | 'external_claim_not_verified_by_rap' | 'no_trust_metadata' | 'provider_not_found' | 'malformed_trust_metadata' | 'credential_leakage_rejected';
+export type ProviderTrustValidationError = {
+    code: ProviderTrustReasonCode;
+    path: string;
+    message: string;
+};
+export type ProviderTrustRecord = {
+    schemaVersion: typeof PROVIDER_TRUST_RECORD_SCHEMA_VERSION;
+    provider: {
+        id: string;
+        name: string;
+        mediaType: string;
+        url?: string;
+    };
+    publisher: {
+        id: string;
+        name?: string;
+        domain?: string;
+    };
+    source: {
+        kind: 'ai-catalog';
+        rawSnapshotRef?: string;
+        catalogPublisherId: string;
+    };
+    verification: {
+        status: ProviderTrustVerificationStatus;
+        reasonCodes: ProviderTrustReasonCode[];
+        verifier?: string;
+        checkedAt?: string;
+        failureReasons: string[];
+    };
+    trustMetadata: {
+        trustManifest?: unknown;
+        provenanceLinks: unknown[];
+        attestations: unknown[];
+        detachedSignature?: unknown;
+        verificationReferences: unknown[];
+        publisherIdentity?: unknown;
+    };
+};
+export type ProviderTrustVerificationInput = {
+    status?: Extract<ProviderTrustVerificationStatus, 'verified' | 'failed_verification'>;
+    verifier?: string;
+    checkedAt?: string;
+    failureReasons?: string[];
+};
+export type NormalizeAiCatalogTrustOptions = {
+    verification?: ProviderTrustVerificationInput;
+};
+export type ProviderTrustNormalizationResult = {
+    ok: true;
+    record: ProviderTrustRecord;
+} | {
+    ok: false;
+    errors: ProviderTrustValidationError[];
+};
+export type ProviderTrustFixtureCase = {
+    description: string;
+    catalog: AiCatalogSnapshot;
+    resourceId: string;
+    options?: NormalizeAiCatalogTrustOptions;
+    expectedValid: boolean;
+    expectedStatus?: ProviderTrustVerificationStatus;
+    expectedReasonCodes: ProviderTrustReasonCode[];
+};
+export declare function normalizeAiCatalogProviderTrustRecord(catalog: AiCatalogSnapshot, resourceId: string, options?: NormalizeAiCatalogTrustOptions): ProviderTrustNormalizationResult;
+export declare function createAiCatalogProviderTrustRecord(catalog: AiCatalogSnapshot, resourceId: string, options?: NormalizeAiCatalogTrustOptions): ProviderTrustRecord;
+export declare const providerTrustFixtures: {
+    readonly verifiedCatalog: AiCatalogSnapshot;
+    readonly unverifiedCatalog: AiCatalogSnapshot;
+    readonly malformedTrustCatalog: AiCatalogSnapshot;
+    readonly credentialBearingCatalog: {
+        schemaVersion: "ai-catalog.v1";
+        publisher: {
+            id: string;
+        };
+        rawSnapshotRef: string;
+        resources: {
+            id: string;
+            type: string;
+            mediaType: string;
+            name: string;
+            url: string;
+            trustManifest: {
+                identity: string;
+            };
+            auth: {
+                token: string;
+            };
+            raw: {
+                identifier: string;
+                displayName: string;
+                mediaType: string;
+                url: string;
+                trustManifest: {
+                    identity: string;
+                };
+                metadata: {
+                    trust: {
+                        provenance: string[];
+                    };
+                };
+                auth: {
+                    token: string;
+                };
+            };
+        }[];
+    };
+};
+export declare const providerTrustFixtureCases: Record<string, ProviderTrustFixtureCase>;

--- a/packages/agent-protocol/dist/provider-trust.js
+++ b/packages/agent-protocol/dist/provider-trust.js
@@ -1,0 +1,329 @@
+import { aiCatalogFixtures, createAiCatalogSnapshot } from './ai-catalog.js';
+export const PROVIDER_TRUST_RECORD_SCHEMA_VERSION = 'reddi.provider-trust.v1';
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function asString(value) {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+function asArray(value) {
+    return Array.isArray(value) ? value : value === undefined ? [] : [value];
+}
+function error(code, path, message) {
+    return { code, path, message };
+}
+function findCredentialMaterial(value, path = '$') {
+    if (typeof value === 'string')
+        return SENSITIVE_VALUE_PATTERN.test(value) ? path : undefined;
+    if (!value || typeof value !== 'object')
+        return undefined;
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index += 1) {
+            const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+            if (found)
+                return found;
+        }
+        return undefined;
+    }
+    for (const [key, child] of Object.entries(value)) {
+        const childPath = `${path}.${key}`;
+        if (SENSITIVE_KEY_PATTERN.test(key))
+            return childPath;
+        const found = findCredentialMaterial(child, childPath);
+        if (found)
+            return found;
+    }
+    return undefined;
+}
+function metadataObject(resource) {
+    return isPlainObject(resource.raw) && isPlainObject(resource.raw.metadata) ? resource.raw.metadata : undefined;
+}
+function trustObject(resource) {
+    const metadata = metadataObject(resource);
+    if (metadata && isPlainObject(metadata.trust))
+        return metadata.trust;
+    return undefined;
+}
+function hasTrustMetadata(record) {
+    return Boolean(record.trustManifest
+        || record.detachedSignature
+        || record.publisherIdentity
+        || record.provenanceLinks.length > 0
+        || record.attestations.length > 0
+        || record.verificationReferences.length > 0);
+}
+function collectTrustMetadata(resource, errors) {
+    const raw = isPlainObject(resource.raw) ? resource.raw : {};
+    const metadata = metadataObject(resource);
+    const trust = trustObject(resource);
+    const trustManifest = resource.trustManifest ?? trust?.trustManifest ?? metadata?.trustManifest;
+    if (trustManifest !== undefined && typeof trustManifest !== 'string' && !isPlainObject(trustManifest)) {
+        errors.push(error('malformed_trust_metadata', '$.trustManifest', 'trustManifest must be a URL string or object.'));
+    }
+    const manifestObject = isPlainObject(trustManifest) ? trustManifest : undefined;
+    const detachedSignature = raw.detachedSignature ?? raw.signature ?? trust?.detachedSignature ?? trust?.signature ?? manifestObject?.signature;
+    if (detachedSignature !== undefined && typeof detachedSignature !== 'string' && !isPlainObject(detachedSignature)) {
+        errors.push(error('malformed_trust_metadata', '$.detachedSignature', 'detached-signature metadata must be a string or object.'));
+    }
+    return {
+        trustManifest,
+        provenanceLinks: [
+            ...asArray(manifestObject?.provenance),
+            ...asArray(manifestObject?.provenanceLinks),
+            ...asArray(raw.provenance),
+            ...asArray(raw.provenanceLinks),
+            ...asArray(trust?.provenance),
+            ...asArray(trust?.provenanceLinks),
+        ],
+        attestations: [
+            ...asArray(manifestObject?.attestations),
+            ...asArray(raw.attestations),
+            ...asArray(trust?.attestations),
+        ],
+        detachedSignature,
+        verificationReferences: [
+            ...asArray(manifestObject?.verification),
+            ...asArray(manifestObject?.verificationReferences),
+            ...asArray(raw.verification),
+            ...asArray(raw.verificationReferences),
+            ...asArray(trust?.verification),
+            ...asArray(trust?.verificationReferences),
+        ],
+        publisherIdentity: raw.publisherIdentity ?? trust?.publisherIdentity ?? metadata?.publisherIdentity ?? manifestObject?.publisherIdentity,
+    };
+}
+function buildVerification(metadata, verification) {
+    const failureReasons = verification?.failureReasons ?? [];
+    if (verification?.status === 'verified') {
+        return {
+            status: 'verified',
+            reasonCodes: ['rap_verified'],
+            verifier: verification.verifier,
+            checkedAt: verification.checkedAt,
+            failureReasons: [],
+        };
+    }
+    if (verification?.status === 'failed_verification') {
+        return {
+            status: 'failed_verification',
+            reasonCodes: ['rap_verification_failed'],
+            verifier: verification.verifier,
+            checkedAt: verification.checkedAt,
+            failureReasons,
+        };
+    }
+    if (hasTrustMetadata(metadata)) {
+        return {
+            status: 'claimed',
+            reasonCodes: ['external_claim_not_verified_by_rap'],
+            failureReasons: [],
+        };
+    }
+    return {
+        status: 'unverified',
+        reasonCodes: ['no_trust_metadata'],
+        failureReasons: [],
+    };
+}
+export function normalizeAiCatalogProviderTrustRecord(catalog, resourceId, options = {}) {
+    const resource = catalog.resources.find((item) => item.id === resourceId);
+    if (!resource) {
+        return {
+            ok: false,
+            errors: [error('provider_not_found', '$.resourceId', `No AI Catalog resource found for ${resourceId}.`)],
+        };
+    }
+    const errors = [];
+    const credentialPath = findCredentialMaterial({
+        trustManifest: resource.trustManifest,
+        payment: resource.payment,
+        auth: resource.auth,
+        raw: resource.raw,
+    });
+    if (credentialPath) {
+        errors.push(error('credential_leakage_rejected', credentialPath, 'provider trust metadata contains credential-shaped material.'));
+    }
+    const trustMetadata = collectTrustMetadata(resource, errors);
+    if (errors.length > 0)
+        return { ok: false, errors };
+    const record = {
+        schemaVersion: PROVIDER_TRUST_RECORD_SCHEMA_VERSION,
+        provider: {
+            id: resource.id,
+            name: resource.name,
+            mediaType: resource.mediaType,
+            url: resource.url ?? resource.endpoint ?? resource.catalogUrl,
+        },
+        publisher: {
+            id: catalog.publisher.id,
+            name: catalog.publisher.name,
+            domain: catalog.publisher.domain,
+        },
+        source: {
+            kind: 'ai-catalog',
+            rawSnapshotRef: catalog.rawSnapshotRef,
+            catalogPublisherId: catalog.publisher.id,
+        },
+        verification: buildVerification(trustMetadata, options.verification),
+        trustMetadata,
+    };
+    return { ok: true, record };
+}
+export function createAiCatalogProviderTrustRecord(catalog, resourceId, options = {}) {
+    const result = normalizeAiCatalogProviderTrustRecord(catalog, resourceId, options);
+    if (!result.ok) {
+        throw new Error(`invalid_provider_trust_record:${result.errors.map((item) => item.code).join(',')}`);
+    }
+    return result.record;
+}
+export const providerTrustFixtures = {
+    verifiedCatalog: createAiCatalogSnapshot({
+        ...aiCatalogFixtures.happyPath,
+        entries: [
+            {
+                ...aiCatalogFixtures.happyPath.entries[0],
+                trustManifest: {
+                    identity: 'urn:ai:reddi.tech:specialists:code-review',
+                    provenance: ['https://agents.reddi.tech/provenance/code-review.json'],
+                    attestations: [{ type: 'build-provenance', ref: 'sha256:attestation-fixture' }],
+                    signature: {
+                        format: 'dsse',
+                        ref: 'https://agents.reddi.tech/signatures/code-review.dsse',
+                        status: 'claimed',
+                    },
+                },
+                metadata: {
+                    ...aiCatalogFixtures.happyPath.entries[0].metadata,
+                    trust: {
+                        verificationReferences: ['https://agents.reddi.tech/verification/code-review.json'],
+                        publisherIdentity: { domain: 'reddi.tech', status: 'claimed' },
+                    },
+                },
+            },
+        ],
+    }, { rawSnapshotRef: 'sha256:verified-catalog-fixture' }),
+    unverifiedCatalog: createAiCatalogSnapshot({
+        specVersion: '1.0',
+        host: { identifier: 'example.com', displayName: 'Example Agents' },
+        entries: [
+            {
+                identifier: 'urn:example:agents:summary',
+                displayName: 'Summary Agent',
+                mediaType: 'application/mcp-server-card+json',
+                url: 'https://agents.example.com/summary/mcp.json',
+            },
+        ],
+    }, { rawSnapshotRef: 'sha256:unverified-catalog-fixture' }),
+    malformedTrustCatalog: createAiCatalogSnapshot({
+        specVersion: '1.0',
+        host: 'example.com',
+        entries: [
+            {
+                identifier: 'urn:example:agents:malformed-trust',
+                displayName: 'Malformed Trust Agent',
+                mediaType: 'application/mcp-server-card+json',
+                url: 'https://agents.example.com/malformed/mcp.json',
+                trustManifest: 42,
+            },
+        ],
+    }, { rawSnapshotRef: 'sha256:malformed-trust-fixture' }),
+    credentialBearingCatalog: {
+        schemaVersion: 'ai-catalog.v1',
+        publisher: { id: 'example.com' },
+        rawSnapshotRef: 'sha256:credential-bearing-trust-fixture',
+        resources: [
+            {
+                id: 'urn:example:agents:credential-bearing',
+                type: 'application/mcp-server-card+json',
+                mediaType: 'application/mcp-server-card+json',
+                name: 'Credential Bearing Agent',
+                url: 'https://agents.example.com/credential-safe-url/mcp.json',
+                trustManifest: { identity: 'urn:example:agents:credential-bearing' },
+                auth: {
+                    token: 'redacted-but-still-secret-shaped',
+                },
+                raw: {
+                    identifier: 'urn:example:agents:credential-bearing',
+                    displayName: 'Credential Bearing Agent',
+                    mediaType: 'application/mcp-server-card+json',
+                    url: 'https://agents.example.com/credential-safe-url/mcp.json',
+                    trustManifest: { identity: 'urn:example:agents:credential-bearing' },
+                    metadata: {
+                        trust: { provenance: ['https://agents.example.com/provenance.json'] },
+                    },
+                    auth: {
+                        token: 'redacted-but-still-secret-shaped',
+                    },
+                },
+            },
+        ],
+    },
+};
+export const providerTrustFixtureCases = {
+    verified: {
+        description: 'RAP-side verification upgrades externally claimed metadata to verified.',
+        catalog: providerTrustFixtures.verifiedCatalog,
+        resourceId: 'urn:ai:reddi.tech:specialists:code-review',
+        options: {
+            verification: {
+                status: 'verified',
+                verifier: 'rap:local-fixture',
+                checkedAt: '2026-06-18T10:55:00.000Z',
+            },
+        },
+        expectedValid: true,
+        expectedStatus: 'verified',
+        expectedReasonCodes: ['rap_verified'],
+    },
+    claimed: {
+        description: 'External trust metadata remains claimed until RAP verifies it.',
+        catalog: providerTrustFixtures.verifiedCatalog,
+        resourceId: 'urn:ai:reddi.tech:specialists:code-review',
+        expectedValid: true,
+        expectedStatus: 'claimed',
+        expectedReasonCodes: ['external_claim_not_verified_by_rap'],
+    },
+    unverified: {
+        description: 'Provider without trust metadata stays unverified.',
+        catalog: providerTrustFixtures.unverifiedCatalog,
+        resourceId: 'urn:example:agents:summary',
+        expectedValid: true,
+        expectedStatus: 'unverified',
+        expectedReasonCodes: ['no_trust_metadata'],
+    },
+    failedVerification: {
+        description: 'RAP-side verification failure is explicit and carries failure reasons.',
+        catalog: providerTrustFixtures.verifiedCatalog,
+        resourceId: 'urn:ai:reddi.tech:specialists:code-review',
+        options: {
+            verification: {
+                status: 'failed_verification',
+                verifier: 'rap:local-fixture',
+                checkedAt: '2026-06-18T10:55:00.000Z',
+                failureReasons: ['signature_ref_not_available'],
+            },
+        },
+        expectedValid: true,
+        expectedStatus: 'failed_verification',
+        expectedReasonCodes: ['rap_verification_failed'],
+    },
+    malformedTrustManifest: {
+        description: 'Malformed trust manifest fails closed.',
+        catalog: providerTrustFixtures.malformedTrustCatalog,
+        resourceId: 'urn:example:agents:malformed-trust',
+        expectedValid: false,
+        expectedReasonCodes: ['malformed_trust_metadata'],
+    },
+    credentialBearingMetadata: {
+        description: 'Credential-bearing auth/payment/trust metadata fails closed.',
+        catalog: providerTrustFixtures.credentialBearingCatalog,
+        resourceId: 'urn:example:agents:credential-bearing',
+        expectedValid: false,
+        expectedReasonCodes: ['credential_leakage_rejected'],
+    },
+};

--- a/packages/agent-protocol/dist/provider-trust.js
+++ b/packages/agent-protocol/dist/provider-trust.js
@@ -11,8 +11,25 @@ function isPlainObject(value) {
 function asString(value) {
     return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
-function asArray(value) {
-    return Array.isArray(value) ? value : value === undefined ? [] : [value];
+function collectTrustList(value, path, errors) {
+    if (value === undefined)
+        return [];
+    const values = Array.isArray(value) ? value : [value];
+    for (let index = 0; index < values.length; index += 1) {
+        const item = values[index];
+        if (typeof item !== 'string' && !isPlainObject(item)) {
+            errors.push(error('malformed_trust_metadata', `${path}${Array.isArray(value) ? `[${index}]` : ''}`, 'trust metadata references must be strings or objects.'));
+        }
+    }
+    return values;
+}
+function validateOptionalStringOrObject(value, path, errors) {
+    if (value === undefined)
+        return undefined;
+    if (typeof value === 'string' || isPlainObject(value))
+        return value;
+    errors.push(error('malformed_trust_metadata', path, 'trust metadata field must be a string or object.'));
+    return undefined;
 }
 function error(code, path, message) {
     return { code, path, message };
@@ -73,28 +90,28 @@ function collectTrustMetadata(resource, errors) {
     return {
         trustManifest,
         provenanceLinks: [
-            ...asArray(manifestObject?.provenance),
-            ...asArray(manifestObject?.provenanceLinks),
-            ...asArray(raw.provenance),
-            ...asArray(raw.provenanceLinks),
-            ...asArray(trust?.provenance),
-            ...asArray(trust?.provenanceLinks),
+            ...collectTrustList(manifestObject?.provenance, '$.trustManifest.provenance', errors),
+            ...collectTrustList(manifestObject?.provenanceLinks, '$.trustManifest.provenanceLinks', errors),
+            ...collectTrustList(raw.provenance, '$.provenance', errors),
+            ...collectTrustList(raw.provenanceLinks, '$.provenanceLinks', errors),
+            ...collectTrustList(trust?.provenance, '$.metadata.trust.provenance', errors),
+            ...collectTrustList(trust?.provenanceLinks, '$.metadata.trust.provenanceLinks', errors),
         ],
         attestations: [
-            ...asArray(manifestObject?.attestations),
-            ...asArray(raw.attestations),
-            ...asArray(trust?.attestations),
+            ...collectTrustList(manifestObject?.attestations, '$.trustManifest.attestations', errors),
+            ...collectTrustList(raw.attestations, '$.attestations', errors),
+            ...collectTrustList(trust?.attestations, '$.metadata.trust.attestations', errors),
         ],
         detachedSignature,
         verificationReferences: [
-            ...asArray(manifestObject?.verification),
-            ...asArray(manifestObject?.verificationReferences),
-            ...asArray(raw.verification),
-            ...asArray(raw.verificationReferences),
-            ...asArray(trust?.verification),
-            ...asArray(trust?.verificationReferences),
+            ...collectTrustList(manifestObject?.verification, '$.trustManifest.verification', errors),
+            ...collectTrustList(manifestObject?.verificationReferences, '$.trustManifest.verificationReferences', errors),
+            ...collectTrustList(raw.verification, '$.verification', errors),
+            ...collectTrustList(raw.verificationReferences, '$.verificationReferences', errors),
+            ...collectTrustList(trust?.verification, '$.metadata.trust.verification', errors),
+            ...collectTrustList(trust?.verificationReferences, '$.metadata.trust.verificationReferences', errors),
         ],
-        publisherIdentity: raw.publisherIdentity ?? trust?.publisherIdentity ?? metadata?.publisherIdentity ?? manifestObject?.publisherIdentity,
+        publisherIdentity: validateOptionalStringOrObject(raw.publisherIdentity ?? trust?.publisherIdentity ?? metadata?.publisherIdentity ?? manifestObject?.publisherIdentity, '$.publisherIdentity', errors),
     };
 }
 function buildVerification(metadata, verification) {

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -26,6 +26,10 @@
       "types": "./dist/ai-catalog.d.ts",
       "import": "./dist/ai-catalog.js"
     },
+    "./provider-trust": {
+      "types": "./dist/provider-trust.d.ts",
+      "import": "./dist/provider-trust.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -2,3 +2,4 @@ export * from './policy.js';
 export * from './receipts.js';
 export * from './fixtures.js';
 export * from './ai-catalog.js';
+export * from './provider-trust.js';

--- a/packages/agent-protocol/src/provider-trust.ts
+++ b/packages/agent-protocol/src/provider-trust.ts
@@ -1,0 +1,442 @@
+import { aiCatalogFixtures, createAiCatalogSnapshot, type AiCatalogResourceSnapshot, type AiCatalogSnapshot } from './ai-catalog.js';
+
+export const PROVIDER_TRUST_RECORD_SCHEMA_VERSION = 'reddi.provider-trust.v1' as const;
+
+export type ProviderTrustVerificationStatus =
+  | 'claimed'
+  | 'verified'
+  | 'unverified'
+  | 'failed_verification';
+
+export type ProviderTrustReasonCode =
+  | 'rap_verified'
+  | 'rap_verification_failed'
+  | 'external_claim_not_verified_by_rap'
+  | 'no_trust_metadata'
+  | 'provider_not_found'
+  | 'malformed_trust_metadata'
+  | 'credential_leakage_rejected';
+
+export type ProviderTrustValidationError = {
+  code: ProviderTrustReasonCode;
+  path: string;
+  message: string;
+};
+
+export type ProviderTrustRecord = {
+  schemaVersion: typeof PROVIDER_TRUST_RECORD_SCHEMA_VERSION;
+  provider: {
+    id: string;
+    name: string;
+    mediaType: string;
+    url?: string;
+  };
+  publisher: {
+    id: string;
+    name?: string;
+    domain?: string;
+  };
+  source: {
+    kind: 'ai-catalog';
+    rawSnapshotRef?: string;
+    catalogPublisherId: string;
+  };
+  verification: {
+    status: ProviderTrustVerificationStatus;
+    reasonCodes: ProviderTrustReasonCode[];
+    verifier?: string;
+    checkedAt?: string;
+    failureReasons: string[];
+  };
+  trustMetadata: {
+    trustManifest?: unknown;
+    provenanceLinks: unknown[];
+    attestations: unknown[];
+    detachedSignature?: unknown;
+    verificationReferences: unknown[];
+    publisherIdentity?: unknown;
+  };
+};
+
+export type ProviderTrustVerificationInput = {
+  status?: Extract<ProviderTrustVerificationStatus, 'verified' | 'failed_verification'>;
+  verifier?: string;
+  checkedAt?: string;
+  failureReasons?: string[];
+};
+
+export type NormalizeAiCatalogTrustOptions = {
+  verification?: ProviderTrustVerificationInput;
+};
+
+export type ProviderTrustNormalizationResult =
+  | { ok: true; record: ProviderTrustRecord }
+  | { ok: false; errors: ProviderTrustValidationError[] };
+
+export type ProviderTrustFixtureCase = {
+  description: string;
+  catalog: AiCatalogSnapshot;
+  resourceId: string;
+  options?: NormalizeAiCatalogTrustOptions;
+  expectedValid: boolean;
+  expectedStatus?: ProviderTrustVerificationStatus;
+  expectedReasonCodes: ProviderTrustReasonCode[];
+};
+
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : value === undefined ? [] : [value];
+}
+
+function error(code: ProviderTrustReasonCode, path: string, message: string): ProviderTrustValidationError {
+  return { code, path, message };
+}
+
+function findCredentialMaterial(value: unknown, path = '$'): string | undefined {
+  if (typeof value === 'string') return SENSITIVE_VALUE_PATTERN.test(value) ? path : undefined;
+  if (!value || typeof value !== 'object') return undefined;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`;
+    if (SENSITIVE_KEY_PATTERN.test(key)) return childPath;
+    const found = findCredentialMaterial(child, childPath);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function metadataObject(resource: AiCatalogResourceSnapshot): Record<string, unknown> | undefined {
+  return isPlainObject(resource.raw) && isPlainObject(resource.raw.metadata) ? resource.raw.metadata : undefined;
+}
+
+function trustObject(resource: AiCatalogResourceSnapshot): Record<string, unknown> | undefined {
+  const metadata = metadataObject(resource);
+  if (metadata && isPlainObject(metadata.trust)) return metadata.trust;
+  return undefined;
+}
+
+function hasTrustMetadata(record: ProviderTrustRecord['trustMetadata']): boolean {
+  return Boolean(
+    record.trustManifest
+      || record.detachedSignature
+      || record.publisherIdentity
+      || record.provenanceLinks.length > 0
+      || record.attestations.length > 0
+      || record.verificationReferences.length > 0,
+  );
+}
+
+function collectTrustMetadata(resource: AiCatalogResourceSnapshot, errors: ProviderTrustValidationError[]): ProviderTrustRecord['trustMetadata'] {
+  const raw = isPlainObject(resource.raw) ? resource.raw : {};
+  const metadata = metadataObject(resource);
+  const trust = trustObject(resource);
+  const trustManifest = resource.trustManifest ?? trust?.trustManifest ?? metadata?.trustManifest;
+
+  if (trustManifest !== undefined && typeof trustManifest !== 'string' && !isPlainObject(trustManifest)) {
+    errors.push(error('malformed_trust_metadata', '$.trustManifest', 'trustManifest must be a URL string or object.'));
+  }
+
+  const manifestObject = isPlainObject(trustManifest) ? trustManifest : undefined;
+  const detachedSignature = raw.detachedSignature ?? raw.signature ?? trust?.detachedSignature ?? trust?.signature ?? manifestObject?.signature;
+  if (detachedSignature !== undefined && typeof detachedSignature !== 'string' && !isPlainObject(detachedSignature)) {
+    errors.push(error('malformed_trust_metadata', '$.detachedSignature', 'detached-signature metadata must be a string or object.'));
+  }
+
+  return {
+    trustManifest,
+    provenanceLinks: [
+      ...asArray(manifestObject?.provenance),
+      ...asArray(manifestObject?.provenanceLinks),
+      ...asArray(raw.provenance),
+      ...asArray(raw.provenanceLinks),
+      ...asArray(trust?.provenance),
+      ...asArray(trust?.provenanceLinks),
+    ],
+    attestations: [
+      ...asArray(manifestObject?.attestations),
+      ...asArray(raw.attestations),
+      ...asArray(trust?.attestations),
+    ],
+    detachedSignature,
+    verificationReferences: [
+      ...asArray(manifestObject?.verification),
+      ...asArray(manifestObject?.verificationReferences),
+      ...asArray(raw.verification),
+      ...asArray(raw.verificationReferences),
+      ...asArray(trust?.verification),
+      ...asArray(trust?.verificationReferences),
+    ],
+    publisherIdentity: raw.publisherIdentity ?? trust?.publisherIdentity ?? metadata?.publisherIdentity ?? manifestObject?.publisherIdentity,
+  };
+}
+
+function buildVerification(
+  metadata: ProviderTrustRecord['trustMetadata'],
+  verification?: ProviderTrustVerificationInput,
+): ProviderTrustRecord['verification'] {
+  const failureReasons = verification?.failureReasons ?? [];
+
+  if (verification?.status === 'verified') {
+    return {
+      status: 'verified',
+      reasonCodes: ['rap_verified'],
+      verifier: verification.verifier,
+      checkedAt: verification.checkedAt,
+      failureReasons: [],
+    };
+  }
+
+  if (verification?.status === 'failed_verification') {
+    return {
+      status: 'failed_verification',
+      reasonCodes: ['rap_verification_failed'],
+      verifier: verification.verifier,
+      checkedAt: verification.checkedAt,
+      failureReasons,
+    };
+  }
+
+  if (hasTrustMetadata(metadata)) {
+    return {
+      status: 'claimed',
+      reasonCodes: ['external_claim_not_verified_by_rap'],
+      failureReasons: [],
+    };
+  }
+
+  return {
+    status: 'unverified',
+    reasonCodes: ['no_trust_metadata'],
+    failureReasons: [],
+  };
+}
+
+export function normalizeAiCatalogProviderTrustRecord(
+  catalog: AiCatalogSnapshot,
+  resourceId: string,
+  options: NormalizeAiCatalogTrustOptions = {},
+): ProviderTrustNormalizationResult {
+  const resource = catalog.resources.find((item) => item.id === resourceId);
+  if (!resource) {
+    return {
+      ok: false,
+      errors: [error('provider_not_found', '$.resourceId', `No AI Catalog resource found for ${resourceId}.`)],
+    };
+  }
+
+  const errors: ProviderTrustValidationError[] = [];
+  const credentialPath = findCredentialMaterial({
+    trustManifest: resource.trustManifest,
+    payment: resource.payment,
+    auth: resource.auth,
+    raw: resource.raw,
+  });
+  if (credentialPath) {
+    errors.push(error('credential_leakage_rejected', credentialPath, 'provider trust metadata contains credential-shaped material.'));
+  }
+
+  const trustMetadata = collectTrustMetadata(resource, errors);
+  if (errors.length > 0) return { ok: false, errors };
+
+  const record: ProviderTrustRecord = {
+    schemaVersion: PROVIDER_TRUST_RECORD_SCHEMA_VERSION,
+    provider: {
+      id: resource.id,
+      name: resource.name,
+      mediaType: resource.mediaType,
+      url: resource.url ?? resource.endpoint ?? resource.catalogUrl,
+    },
+    publisher: {
+      id: catalog.publisher.id,
+      name: catalog.publisher.name,
+      domain: catalog.publisher.domain,
+    },
+    source: {
+      kind: 'ai-catalog',
+      rawSnapshotRef: catalog.rawSnapshotRef,
+      catalogPublisherId: catalog.publisher.id,
+    },
+    verification: buildVerification(trustMetadata, options.verification),
+    trustMetadata,
+  };
+
+  return { ok: true, record };
+}
+
+export function createAiCatalogProviderTrustRecord(
+  catalog: AiCatalogSnapshot,
+  resourceId: string,
+  options: NormalizeAiCatalogTrustOptions = {},
+): ProviderTrustRecord {
+  const result = normalizeAiCatalogProviderTrustRecord(catalog, resourceId, options);
+  if (!result.ok) {
+    throw new Error(`invalid_provider_trust_record:${result.errors.map((item) => item.code).join(',')}`);
+  }
+  return result.record;
+}
+
+export const providerTrustFixtures = {
+  verifiedCatalog: createAiCatalogSnapshot({
+    ...aiCatalogFixtures.happyPath,
+    entries: [
+      {
+        ...aiCatalogFixtures.happyPath.entries[0],
+        trustManifest: {
+          identity: 'urn:ai:reddi.tech:specialists:code-review',
+          provenance: ['https://agents.reddi.tech/provenance/code-review.json'],
+          attestations: [{ type: 'build-provenance', ref: 'sha256:attestation-fixture' }],
+          signature: {
+            format: 'dsse',
+            ref: 'https://agents.reddi.tech/signatures/code-review.dsse',
+            status: 'claimed',
+          },
+        },
+        metadata: {
+          ...aiCatalogFixtures.happyPath.entries[0].metadata,
+          trust: {
+            verificationReferences: ['https://agents.reddi.tech/verification/code-review.json'],
+            publisherIdentity: { domain: 'reddi.tech', status: 'claimed' },
+          },
+        },
+      },
+    ],
+  }, { rawSnapshotRef: 'sha256:verified-catalog-fixture' }),
+  unverifiedCatalog: createAiCatalogSnapshot({
+    specVersion: '1.0',
+    host: { identifier: 'example.com', displayName: 'Example Agents' },
+    entries: [
+      {
+        identifier: 'urn:example:agents:summary',
+        displayName: 'Summary Agent',
+        mediaType: 'application/mcp-server-card+json',
+        url: 'https://agents.example.com/summary/mcp.json',
+      },
+    ],
+  }, { rawSnapshotRef: 'sha256:unverified-catalog-fixture' }),
+  malformedTrustCatalog: createAiCatalogSnapshot({
+    specVersion: '1.0',
+    host: 'example.com',
+    entries: [
+      {
+        identifier: 'urn:example:agents:malformed-trust',
+        displayName: 'Malformed Trust Agent',
+        mediaType: 'application/mcp-server-card+json',
+        url: 'https://agents.example.com/malformed/mcp.json',
+        trustManifest: 42,
+      },
+    ],
+  }, { rawSnapshotRef: 'sha256:malformed-trust-fixture' }),
+  credentialBearingCatalog: {
+    schemaVersion: 'ai-catalog.v1',
+    publisher: { id: 'example.com' },
+    rawSnapshotRef: 'sha256:credential-bearing-trust-fixture',
+    resources: [
+      {
+        id: 'urn:example:agents:credential-bearing',
+        type: 'application/mcp-server-card+json',
+        mediaType: 'application/mcp-server-card+json',
+        name: 'Credential Bearing Agent',
+        url: 'https://agents.example.com/credential-safe-url/mcp.json',
+        trustManifest: { identity: 'urn:example:agents:credential-bearing' },
+        auth: {
+          token: 'redacted-but-still-secret-shaped',
+        },
+        raw: {
+          identifier: 'urn:example:agents:credential-bearing',
+          displayName: 'Credential Bearing Agent',
+          mediaType: 'application/mcp-server-card+json',
+          url: 'https://agents.example.com/credential-safe-url/mcp.json',
+          trustManifest: { identity: 'urn:example:agents:credential-bearing' },
+          metadata: {
+            trust: { provenance: ['https://agents.example.com/provenance.json'] },
+          },
+          auth: {
+            token: 'redacted-but-still-secret-shaped',
+          },
+        },
+      },
+    ],
+  } satisfies AiCatalogSnapshot,
+} as const;
+
+export const providerTrustFixtureCases: Record<string, ProviderTrustFixtureCase> = {
+  verified: {
+    description: 'RAP-side verification upgrades externally claimed metadata to verified.',
+    catalog: providerTrustFixtures.verifiedCatalog,
+    resourceId: 'urn:ai:reddi.tech:specialists:code-review',
+    options: {
+      verification: {
+        status: 'verified',
+        verifier: 'rap:local-fixture',
+        checkedAt: '2026-06-18T10:55:00.000Z',
+      },
+    },
+    expectedValid: true,
+    expectedStatus: 'verified',
+    expectedReasonCodes: ['rap_verified'],
+  },
+  claimed: {
+    description: 'External trust metadata remains claimed until RAP verifies it.',
+    catalog: providerTrustFixtures.verifiedCatalog,
+    resourceId: 'urn:ai:reddi.tech:specialists:code-review',
+    expectedValid: true,
+    expectedStatus: 'claimed',
+    expectedReasonCodes: ['external_claim_not_verified_by_rap'],
+  },
+  unverified: {
+    description: 'Provider without trust metadata stays unverified.',
+    catalog: providerTrustFixtures.unverifiedCatalog,
+    resourceId: 'urn:example:agents:summary',
+    expectedValid: true,
+    expectedStatus: 'unverified',
+    expectedReasonCodes: ['no_trust_metadata'],
+  },
+  failedVerification: {
+    description: 'RAP-side verification failure is explicit and carries failure reasons.',
+    catalog: providerTrustFixtures.verifiedCatalog,
+    resourceId: 'urn:ai:reddi.tech:specialists:code-review',
+    options: {
+      verification: {
+        status: 'failed_verification',
+        verifier: 'rap:local-fixture',
+        checkedAt: '2026-06-18T10:55:00.000Z',
+        failureReasons: ['signature_ref_not_available'],
+      },
+    },
+    expectedValid: true,
+    expectedStatus: 'failed_verification',
+    expectedReasonCodes: ['rap_verification_failed'],
+  },
+  malformedTrustManifest: {
+    description: 'Malformed trust manifest fails closed.',
+    catalog: providerTrustFixtures.malformedTrustCatalog,
+    resourceId: 'urn:example:agents:malformed-trust',
+    expectedValid: false,
+    expectedReasonCodes: ['malformed_trust_metadata'],
+  },
+  credentialBearingMetadata: {
+    description: 'Credential-bearing auth/payment/trust metadata fails closed.',
+    catalog: providerTrustFixtures.credentialBearingCatalog,
+    resourceId: 'urn:example:agents:credential-bearing',
+    expectedValid: false,
+    expectedReasonCodes: ['credential_leakage_rejected'],
+  },
+};

--- a/packages/agent-protocol/src/provider-trust.ts
+++ b/packages/agent-protocol/src/provider-trust.ts
@@ -96,8 +96,23 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
-function asArray(value: unknown): unknown[] {
-  return Array.isArray(value) ? value : value === undefined ? [] : [value];
+function collectTrustList(value: unknown, path: string, errors: ProviderTrustValidationError[]): unknown[] {
+  if (value === undefined) return [];
+  const values = Array.isArray(value) ? value : [value];
+  for (let index = 0; index < values.length; index += 1) {
+    const item = values[index];
+    if (typeof item !== 'string' && !isPlainObject(item)) {
+      errors.push(error('malformed_trust_metadata', `${path}${Array.isArray(value) ? `[${index}]` : ''}`, 'trust metadata references must be strings or objects.'));
+    }
+  }
+  return values;
+}
+
+function validateOptionalStringOrObject(value: unknown, path: string, errors: ProviderTrustValidationError[]): unknown {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string' || isPlainObject(value)) return value;
+  errors.push(error('malformed_trust_metadata', path, 'trust metadata field must be a string or object.'));
+  return undefined;
 }
 
 function error(code: ProviderTrustReasonCode, path: string, message: string): ProviderTrustValidationError {
@@ -163,28 +178,32 @@ function collectTrustMetadata(resource: AiCatalogResourceSnapshot, errors: Provi
   return {
     trustManifest,
     provenanceLinks: [
-      ...asArray(manifestObject?.provenance),
-      ...asArray(manifestObject?.provenanceLinks),
-      ...asArray(raw.provenance),
-      ...asArray(raw.provenanceLinks),
-      ...asArray(trust?.provenance),
-      ...asArray(trust?.provenanceLinks),
+      ...collectTrustList(manifestObject?.provenance, '$.trustManifest.provenance', errors),
+      ...collectTrustList(manifestObject?.provenanceLinks, '$.trustManifest.provenanceLinks', errors),
+      ...collectTrustList(raw.provenance, '$.provenance', errors),
+      ...collectTrustList(raw.provenanceLinks, '$.provenanceLinks', errors),
+      ...collectTrustList(trust?.provenance, '$.metadata.trust.provenance', errors),
+      ...collectTrustList(trust?.provenanceLinks, '$.metadata.trust.provenanceLinks', errors),
     ],
     attestations: [
-      ...asArray(manifestObject?.attestations),
-      ...asArray(raw.attestations),
-      ...asArray(trust?.attestations),
+      ...collectTrustList(manifestObject?.attestations, '$.trustManifest.attestations', errors),
+      ...collectTrustList(raw.attestations, '$.attestations', errors),
+      ...collectTrustList(trust?.attestations, '$.metadata.trust.attestations', errors),
     ],
     detachedSignature,
     verificationReferences: [
-      ...asArray(manifestObject?.verification),
-      ...asArray(manifestObject?.verificationReferences),
-      ...asArray(raw.verification),
-      ...asArray(raw.verificationReferences),
-      ...asArray(trust?.verification),
-      ...asArray(trust?.verificationReferences),
+      ...collectTrustList(manifestObject?.verification, '$.trustManifest.verification', errors),
+      ...collectTrustList(manifestObject?.verificationReferences, '$.trustManifest.verificationReferences', errors),
+      ...collectTrustList(raw.verification, '$.verification', errors),
+      ...collectTrustList(raw.verificationReferences, '$.verificationReferences', errors),
+      ...collectTrustList(trust?.verification, '$.metadata.trust.verification', errors),
+      ...collectTrustList(trust?.verificationReferences, '$.metadata.trust.verificationReferences', errors),
     ],
-    publisherIdentity: raw.publisherIdentity ?? trust?.publisherIdentity ?? metadata?.publisherIdentity ?? manifestObject?.publisherIdentity,
+    publisherIdentity: validateOptionalStringOrObject(
+      raw.publisherIdentity ?? trust?.publisherIdentity ?? metadata?.publisherIdentity ?? manifestObject?.publisherIdentity,
+      '$.publisherIdentity',
+      errors,
+    ),
   };
 }
 

--- a/packages/agent-protocol/tests/provider-trust.test.ts
+++ b/packages/agent-protocol/tests/provider-trust.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createAiCatalogProviderTrustRecord,
+  normalizeAiCatalogProviderTrustRecord,
+  providerTrustFixtureCases,
+  providerTrustFixtures,
+  type ProviderTrustReasonCode,
+} from '../dist/index.js';
+
+function assertReasonCodes(actual: ProviderTrustReasonCode[], expected: ProviderTrustReasonCode[]): void {
+  for (const code of expected) {
+    assert.ok(actual.includes(code), `expected provider trust reason codes to include ${code}`);
+  }
+}
+
+describe('RAP provider trust records', () => {
+  it('validates exported fixture cases with expected outcomes', () => {
+    const expectedCases = [
+      'verified',
+      'claimed',
+      'unverified',
+      'failedVerification',
+      'malformedTrustManifest',
+      'credentialBearingMetadata',
+    ];
+
+    assert.deepEqual(Object.keys(providerTrustFixtureCases).sort(), expectedCases.sort());
+    for (const fixture of Object.values(providerTrustFixtureCases)) {
+      const result = normalizeAiCatalogProviderTrustRecord(fixture.catalog, fixture.resourceId, fixture.options);
+      assert.equal(result.ok, fixture.expectedValid, fixture.description);
+      if (result.ok) {
+        assert.equal(result.record.verification.status, fixture.expectedStatus, fixture.description);
+        assertReasonCodes(result.record.verification.reasonCodes, fixture.expectedReasonCodes);
+      } else {
+        assertReasonCodes(result.errors.map((item) => item.code), fixture.expectedReasonCodes);
+      }
+    }
+  });
+
+  it('upgrades claimed trust metadata only when RAP-side verification says it is verified', () => {
+    const claimed = normalizeAiCatalogProviderTrustRecord(
+      providerTrustFixtures.verifiedCatalog,
+      'urn:ai:reddi.tech:specialists:code-review',
+    );
+    assert.equal(claimed.ok, true);
+    if (claimed.ok) {
+      assert.equal(claimed.record.schemaVersion, 'reddi.provider-trust.v1');
+      assert.equal(claimed.record.verification.status, 'claimed');
+      assert.ok(claimed.record.verification.reasonCodes.includes('external_claim_not_verified_by_rap'));
+      assert.equal(claimed.record.publisher.id, 'reddi.tech');
+      assert.equal(claimed.record.source.rawSnapshotRef, 'sha256:verified-catalog-fixture');
+      assert.equal(claimed.record.trustMetadata.provenanceLinks.length, 1);
+      assert.equal(claimed.record.trustMetadata.attestations.length, 1);
+      assert.deepEqual(claimed.record.trustMetadata.publisherIdentity, { domain: 'reddi.tech', status: 'claimed' });
+    }
+
+    const verified = createAiCatalogProviderTrustRecord(
+      providerTrustFixtures.verifiedCatalog,
+      'urn:ai:reddi.tech:specialists:code-review',
+      {
+        verification: {
+          status: 'verified',
+          verifier: 'rap:unit-test',
+          checkedAt: '2026-06-18T10:55:00.000Z',
+        },
+      },
+    );
+    assert.equal(verified.verification.status, 'verified');
+    assert.deepEqual(verified.verification.reasonCodes, ['rap_verified']);
+    assert.equal(verified.verification.verifier, 'rap:unit-test');
+  });
+
+  it('preserves failed verification reasons without converting them to policy denials', () => {
+    const result = normalizeAiCatalogProviderTrustRecord(
+      providerTrustFixtures.verifiedCatalog,
+      'urn:ai:reddi.tech:specialists:code-review',
+      {
+        verification: {
+          status: 'failed_verification',
+          verifier: 'rap:unit-test',
+          checkedAt: '2026-06-18T10:55:00.000Z',
+          failureReasons: ['signature_ref_not_available'],
+        },
+      },
+    );
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.record.verification.status, 'failed_verification');
+      assert.deepEqual(result.record.verification.reasonCodes, ['rap_verification_failed']);
+      assert.deepEqual(result.record.verification.failureReasons, ['signature_ref_not_available']);
+    }
+  });
+
+  it('keeps providers without trust metadata explicitly unverified', () => {
+    const result = normalizeAiCatalogProviderTrustRecord(providerTrustFixtures.unverifiedCatalog, 'urn:example:agents:summary');
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.record.verification.status, 'unverified');
+      assert.deepEqual(result.record.verification.reasonCodes, ['no_trust_metadata']);
+      assert.deepEqual(result.record.trustMetadata.provenanceLinks, []);
+      assert.deepEqual(result.record.trustMetadata.attestations, []);
+    }
+  });
+
+  it('fails closed for missing providers, malformed trust manifests, and credential-bearing metadata', () => {
+    const missing = normalizeAiCatalogProviderTrustRecord(providerTrustFixtures.verifiedCatalog, 'urn:ai:missing');
+    assert.equal(missing.ok, false);
+    if (!missing.ok) assertReasonCodes(missing.errors.map((item) => item.code), ['provider_not_found']);
+
+    const malformed = normalizeAiCatalogProviderTrustRecord(
+      providerTrustFixtures.malformedTrustCatalog,
+      'urn:example:agents:malformed-trust',
+    );
+    assert.equal(malformed.ok, false);
+    if (!malformed.ok) assertReasonCodes(malformed.errors.map((item) => item.code), ['malformed_trust_metadata']);
+
+    const credentialBearing = normalizeAiCatalogProviderTrustRecord(
+      providerTrustFixtures.credentialBearingCatalog,
+      'urn:example:agents:credential-bearing',
+    );
+    assert.equal(credentialBearing.ok, false);
+    if (!credentialBearing.ok) assertReasonCodes(credentialBearing.errors.map((item) => item.code), ['credential_leakage_rejected']);
+  });
+
+  it('throws when creating an invalid provider trust record', () => {
+    assert.throws(
+      () => createAiCatalogProviderTrustRecord(providerTrustFixtures.verifiedCatalog, 'urn:ai:missing'),
+      /invalid_provider_trust_record:provider_not_found/,
+    );
+  });
+});

--- a/packages/agent-protocol/tests/provider-trust.test.ts
+++ b/packages/agent-protocol/tests/provider-trust.test.ts
@@ -124,6 +124,63 @@ describe('RAP provider trust records', () => {
     if (!credentialBearing.ok) assertReasonCodes(credentialBearing.errors.map((item) => item.code), ['credential_leakage_rejected']);
   });
 
+  it('fails closed for malformed child trust metadata', () => {
+    const malformedProvenanceCatalog = {
+      ...providerTrustFixtures.verifiedCatalog,
+      resources: [
+        {
+          ...providerTrustFixtures.verifiedCatalog.resources[0],
+          trustManifest: {
+            identity: 'urn:ai:reddi.tech:specialists:code-review',
+            provenance: 42,
+          },
+          raw: {
+            ...(providerTrustFixtures.verifiedCatalog.resources[0].raw as Record<string, unknown>),
+            trustManifest: {
+              identity: 'urn:ai:reddi.tech:specialists:code-review',
+              provenance: 42,
+            },
+          },
+        },
+      ],
+    };
+
+    const malformedProvenance = normalizeAiCatalogProviderTrustRecord(
+      malformedProvenanceCatalog,
+      'urn:ai:reddi.tech:specialists:code-review',
+    );
+    assert.equal(malformedProvenance.ok, false);
+    if (!malformedProvenance.ok) {
+      assertReasonCodes(malformedProvenance.errors.map((item) => item.code), ['malformed_trust_metadata']);
+    }
+
+    const malformedPublisherIdentityCatalog = {
+      ...providerTrustFixtures.verifiedCatalog,
+      resources: [
+        {
+          ...providerTrustFixtures.verifiedCatalog.resources[0],
+          raw: {
+            ...(providerTrustFixtures.verifiedCatalog.resources[0].raw as Record<string, unknown>),
+            metadata: {
+              trust: {
+                publisherIdentity: 42,
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    const malformedPublisherIdentity = normalizeAiCatalogProviderTrustRecord(
+      malformedPublisherIdentityCatalog,
+      'urn:ai:reddi.tech:specialists:code-review',
+    );
+    assert.equal(malformedPublisherIdentity.ok, false);
+    if (!malformedPublisherIdentity.ok) {
+      assertReasonCodes(malformedPublisherIdentity.errors.map((item) => item.code), ['malformed_trust_metadata']);
+    }
+  });
+
   it('throws when creating an invalid provider trust record', () => {
     assert.throws(
       () => createAiCatalogProviderTrustRecord(providerTrustFixtures.verifiedCatalog, 'urn:ai:missing'),


### PR DESCRIPTION
## Summary

Closes #365.

Adds RAP provider trust-record primitives for ARD / AI Catalog resources. The new `provider-trust` surface normalizes trust manifests, provenance links, attestations, detached-signature metadata, publisher identity, and verification references into explicit RAP-side trust states.

## What changed

- Added `normalizeAiCatalogProviderTrustRecord` and `createAiCatalogProviderTrustRecord`.
- Added `reddi.provider-trust.v1` records with explicit `claimed`, `verified`, `unverified`, and `failed_verification` states.
- Added exported provider trust fixtures and fixture cases.
- Added `@reddi/agent-protocol/provider-trust` package export.
- Documented provider trust records in the package README.
- Added tests for verified, claimed-but-unverified, unverified, failed verification, malformed trust manifest, missing provider, and credential-bearing metadata.

## Safety boundaries

- External ARD trust metadata is treated as a claim unless RAP-side verification input marks it verified.
- Failed verification stays explicit with failure reasons.
- Missing metadata remains unverified.
- Malformed trust metadata fails closed.
- Credential-bearing auth/payment/trust metadata is rejected.
- No network fetches, payment, wallet action, endpoint invocation, or live signature verification is performed in this PR.

## Validation

- `npm test` in `packages/agent-protocol` passed: 27 tests.
- `npm run release:dry-run` in `packages/agent-protocol` passed.
- `npm run check:rap:naming` passed.
- `git diff --check` passed.

## UI evidence

No UI changes in this PR, so screenshots/video are not required.
