### PR TITLE
Add RAP discovery source candidates

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -73,6 +73,41 @@ Provider trust records normalize ARD trust manifests, provenance links, attestat
 
 External ARD trust metadata is treated as a claim until RAP-side verification marks it `verified` or `failed_verification`. Missing metadata remains `unverified`, malformed trust metadata fails closed, and credential-bearing auth/payment/trust metadata is rejected.
 
+## Discovery Source Candidates
+
+```typescript
+import {
+  createAiCatalogDiscoveryCandidates,
+  evaluateDiscoveryCandidatePolicyPreflight,
+} from '@reddi/agent-protocol/discovery-source';
+import { providerTrustFixtures } from '@reddi/agent-protocol/provider-trust';
+
+const candidates = createAiCatalogDiscoveryCandidates(providerTrustFixtures.verifiedCatalog, {
+  relevanceScores: {
+    'urn:ai:reddi.tech:specialists:code-review': 0.91,
+  },
+});
+
+if (candidates.ok) {
+  const decision = evaluateDiscoveryCandidatePolicyPreflight(
+    {
+      ...candidates.candidates[0],
+      quote: { amount: '5000', asset: 'AUDD', network: 'solana-devnet' },
+    },
+    {
+      allowedSourceKinds: ['direct-ai-catalog'],
+      allowedAssets: ['AUDD'],
+      allowedNetworks: ['solana-devnet'],
+      maxQuote: { amount: '10000', asset: 'AUDD', network: 'solana-devnet' },
+    },
+  );
+
+  console.log(decision.allowed); // true only after explicit RAP policy preflight
+}
+```
+
+Discovery candidates are source-neutral buyer-client inputs for local specialists, direct AI Catalogs, ARD registry/search fixtures, source adapters, and future hosted RAP registries. Candidate relevance is informational only; it is never used as a trust, safety, payment, or budget decision. Quotes, policy preflight, payment approval, invocation, receipts, evidence, attestations, and reputation remain separate RAP steps.
+
 ## Local Validation
 
 ```bash

--- a/packages/agent-protocol/dist/discovery-source.d.ts
+++ b/packages/agent-protocol/dist/discovery-source.d.ts
@@ -1,0 +1,115 @@
+import { type AiCatalogSnapshot } from './ai-catalog.js';
+import { type NormalizeAiCatalogTrustOptions, type ProviderTrustRecord, type ProviderTrustVerificationStatus } from './provider-trust.js';
+export declare const DISCOVERY_CANDIDATE_SCHEMA_VERSION: "reddi.discovery-candidate.v1";
+export type DiscoverySourceKind = 'local-specialist' | 'direct-ai-catalog' | 'ard-registry' | 'source-adapter' | 'hosted-rap-registry';
+export type DiscoveryCandidateReasonCode = 'candidate_ready_for_policy_preflight' | 'malformed_candidate' | 'provider_trust_mismatch' | 'missing_quote' | 'source_not_allowed' | 'trust_verification_required' | 'unsupported_asset' | 'unsupported_network' | 'over_budget';
+export type DiscoveryCandidateDiagnostic = {
+    code: DiscoveryCandidateReasonCode;
+    path: string;
+    message: string;
+};
+export type DiscoveryCandidateQuote = {
+    amount: string;
+    asset: string;
+    network: string;
+    expiresAt?: string;
+    payee?: string;
+};
+export type DiscoveryCandidate = {
+    schemaVersion: typeof DISCOVERY_CANDIDATE_SCHEMA_VERSION;
+    sourceKind: DiscoverySourceKind;
+    identifier: string;
+    publisher?: {
+        id: string;
+        name?: string;
+        domain?: string;
+    };
+    name: string;
+    description?: string;
+    resourceType: string;
+    mediaType: string;
+    url?: string;
+    endpoint?: string;
+    trustMetadata?: ProviderTrustRecord['trustMetadata'];
+    providerTrust?: ProviderTrustRecord;
+    relevance?: {
+        score?: number;
+        reason?: string;
+        source?: string;
+    };
+    rawSnapshotRef?: string;
+    quote?: DiscoveryCandidateQuote;
+    policyPreflightRequired: true;
+};
+export type DiscoveryCandidateNormalizationResult = {
+    ok: true;
+    candidates: DiscoveryCandidate[];
+    diagnostics: DiscoveryCandidateDiagnostic[];
+} | {
+    ok: false;
+    errors: DiscoveryCandidateDiagnostic[];
+};
+export type DiscoveryCandidateValidationResult = {
+    ok: true;
+    candidate: DiscoveryCandidate;
+    diagnostics: DiscoveryCandidateDiagnostic[];
+} | {
+    ok: false;
+    errors: DiscoveryCandidateDiagnostic[];
+};
+export type CreateAiCatalogDiscoveryCandidatesOptions = {
+    sourceKind?: Extract<DiscoverySourceKind, 'direct-ai-catalog' | 'ard-registry' | 'hosted-rap-registry'>;
+    trustOptionsByResourceId?: Record<string, NormalizeAiCatalogTrustOptions>;
+    relevanceScores?: Record<string, number>;
+};
+export type DiscoveryCandidatePolicy = {
+    allowedSourceKinds?: DiscoverySourceKind[];
+    requireVerifiedTrust?: boolean;
+    allowedAssets?: string[];
+    allowedNetworks?: string[];
+    maxQuote?: {
+        amount: string;
+        asset: string;
+        network: string;
+    };
+};
+export type DiscoveryCandidatePolicyPreflightDecision = {
+    allowed: boolean;
+    reasonCodes: DiscoveryCandidateReasonCode[];
+    auditNotes: string[];
+    candidate: {
+        identifier: string;
+        sourceKind: DiscoverySourceKind;
+        relevanceScore?: number;
+        trustStatus?: ProviderTrustVerificationStatus;
+    };
+    quote?: DiscoveryCandidateQuote;
+};
+export declare function validateDiscoveryCandidate(input: unknown): DiscoveryCandidateValidationResult;
+export declare function createAiCatalogDiscoveryCandidates(catalog: AiCatalogSnapshot, options?: CreateAiCatalogDiscoveryCandidatesOptions): DiscoveryCandidateNormalizationResult;
+export declare function evaluateDiscoveryCandidatePolicyPreflight(candidate: DiscoveryCandidate, policy: DiscoveryCandidatePolicy): DiscoveryCandidatePolicyPreflightDecision;
+export declare const discoverySourceFixtures: {
+    readonly localSpecialistCandidate: {
+        readonly schemaVersion: "reddi.discovery-candidate.v1";
+        readonly sourceKind: "local-specialist";
+        readonly identifier: "urn:ai:local:specialists:lint";
+        readonly publisher: {
+            readonly id: "local";
+        };
+        readonly name: "Local Lint Specialist";
+        readonly resourceType: "application/mcp-server-card+json";
+        readonly mediaType: "application/mcp-server-card+json";
+        readonly endpoint: "http://localhost:4100/mcp";
+        readonly relevance: {
+            readonly score: 0.4;
+            readonly source: "local-fixture";
+        };
+        readonly rawSnapshotRef: "sha256:local-specialist-fixture";
+        readonly quote: {
+            readonly amount: "1000";
+            readonly asset: "AUDD";
+            readonly network: "solana-devnet";
+        };
+        readonly policyPreflightRequired: true;
+    };
+};

--- a/packages/agent-protocol/dist/discovery-source.js
+++ b/packages/agent-protocol/dist/discovery-source.js
@@ -1,0 +1,251 @@
+import { normalizeAiCatalogProviderTrustRecord, } from './provider-trust.js';
+export const DISCOVERY_CANDIDATE_SCHEMA_VERSION = 'reddi.discovery-candidate.v1';
+const SOURCE_KINDS = new Set([
+    'local-specialist',
+    'direct-ai-catalog',
+    'ard-registry',
+    'source-adapter',
+    'hosted-rap-registry',
+]);
+function diagnostic(code, path, message) {
+    return { code, path, message };
+}
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function asString(value) {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+function asDiscoverySourceKind(value) {
+    return typeof value === 'string' && SOURCE_KINDS.has(value)
+        ? value
+        : undefined;
+}
+function amountToBigInt(value) {
+    if (typeof value !== 'string')
+        return undefined;
+    if (!/^[0-9]+$/.test(value))
+        return undefined;
+    return BigInt(value);
+}
+function resourceReference(resource) {
+    return {
+        url: resource.url ?? resource.catalogUrl,
+        endpoint: resource.endpoint,
+    };
+}
+export function validateDiscoveryCandidate(input) {
+    const errors = [];
+    if (!isPlainObject(input)) {
+        return { ok: false, errors: [diagnostic('malformed_candidate', '$', 'Discovery candidate must be a plain object.')] };
+    }
+    const sourceKind = asDiscoverySourceKind(input.sourceKind);
+    if (!sourceKind) {
+        errors.push(diagnostic('malformed_candidate', '$.sourceKind', 'Discovery candidate must include a supported sourceKind.'));
+    }
+    const identifier = asString(input.identifier);
+    if (!identifier) {
+        errors.push(diagnostic('malformed_candidate', '$.identifier', 'Discovery candidate must include an identifier.'));
+    }
+    const name = asString(input.name);
+    if (!name) {
+        errors.push(diagnostic('malformed_candidate', '$.name', 'Discovery candidate must include a name.'));
+    }
+    const resourceType = asString(input.resourceType);
+    const mediaType = asString(input.mediaType);
+    if (!resourceType || !mediaType) {
+        errors.push(diagnostic('malformed_candidate', '$.mediaType', 'Discovery candidate must include resourceType and mediaType.'));
+    }
+    const relevance = isPlainObject(input.relevance) ? input.relevance : undefined;
+    const relevanceScore = relevance?.score;
+    if (relevanceScore !== undefined && (typeof relevanceScore !== 'number' || !Number.isFinite(relevanceScore) || relevanceScore < 0 || relevanceScore > 1)) {
+        errors.push(diagnostic('malformed_candidate', '$.relevance.score', 'Relevance score must be a finite number between 0 and 1.'));
+    }
+    const providerTrust = input.providerTrust;
+    if (providerTrust !== undefined) {
+        if (!isPlainObject(providerTrust) || providerTrust.schemaVersion !== 'reddi.provider-trust.v1') {
+            errors.push(diagnostic('malformed_candidate', '$.providerTrust', 'Provider trust must be a reddi.provider-trust.v1 record.'));
+        }
+        else if (!isPlainObject(providerTrust.provider) || !asString(providerTrust.provider.id)) {
+            errors.push(diagnostic('malformed_candidate', '$.providerTrust.provider.id', 'Provider trust record must include a provider id.'));
+        }
+        else if (identifier && providerTrust.provider.id !== identifier) {
+            errors.push(diagnostic('provider_trust_mismatch', '$.providerTrust.provider.id', 'Provider trust record must match the discovery candidate identifier.'));
+        }
+    }
+    const quote = input.quote;
+    if (quote !== undefined) {
+        if (!isPlainObject(quote)) {
+            errors.push(diagnostic('malformed_candidate', '$.quote', 'Discovery candidate quote must be an object.'));
+        }
+        else if (!asString(quote.amount) || amountToBigInt(asString(quote.amount)) === undefined || !asString(quote.asset) || !asString(quote.network)) {
+            errors.push(diagnostic('malformed_candidate', '$.quote', 'Discovery candidate quote must include decimal amount, asset, and network.'));
+        }
+    }
+    if (errors.length > 0)
+        return { ok: false, errors };
+    return {
+        ok: true,
+        candidate: {
+            schemaVersion: DISCOVERY_CANDIDATE_SCHEMA_VERSION,
+            sourceKind: sourceKind,
+            identifier: identifier,
+            publisher: isPlainObject(input.publisher)
+                ? {
+                    id: asString(input.publisher.id) ?? 'unknown',
+                    name: asString(input.publisher.name),
+                    domain: asString(input.publisher.domain),
+                }
+                : undefined,
+            name: name,
+            description: asString(input.description),
+            resourceType: resourceType,
+            mediaType: mediaType,
+            url: asString(input.url),
+            endpoint: asString(input.endpoint),
+            trustMetadata: providerTrust?.trustMetadata ?? input.trustMetadata,
+            providerTrust,
+            relevance: relevance
+                ? {
+                    score: relevanceScore,
+                    reason: asString(relevance.reason),
+                    source: asString(relevance.source),
+                }
+                : undefined,
+            rawSnapshotRef: asString(input.rawSnapshotRef),
+            quote: isPlainObject(input.quote)
+                ? {
+                    amount: asString(input.quote.amount) ?? '',
+                    asset: asString(input.quote.asset) ?? '',
+                    network: asString(input.quote.network) ?? '',
+                    expiresAt: asString(input.quote.expiresAt),
+                    payee: asString(input.quote.payee),
+                }
+                : undefined,
+            policyPreflightRequired: true,
+        },
+        diagnostics: [diagnostic('candidate_ready_for_policy_preflight', '$', 'Discovery candidate is normalized for explicit RAP policy preflight.')],
+    };
+}
+export function createAiCatalogDiscoveryCandidates(catalog, options = {}) {
+    const sourceKind = options.sourceKind ?? 'direct-ai-catalog';
+    const candidates = [];
+    const errors = [];
+    for (const resource of catalog.resources) {
+        const trust = normalizeAiCatalogProviderTrustRecord(catalog, resource.id, options.trustOptionsByResourceId?.[resource.id]);
+        if (!trust.ok) {
+            for (const trustError of trust.errors) {
+                errors.push(diagnostic('malformed_candidate', `$.resources[${resource.id}]${trustError.path}`, trustError.message));
+            }
+            continue;
+        }
+        const reference = resourceReference(resource);
+        const validation = validateDiscoveryCandidate({
+            schemaVersion: DISCOVERY_CANDIDATE_SCHEMA_VERSION,
+            sourceKind,
+            identifier: resource.id,
+            publisher: catalog.publisher,
+            name: resource.name,
+            description: resource.description,
+            resourceType: resource.type,
+            mediaType: resource.mediaType,
+            url: reference.url,
+            endpoint: reference.endpoint,
+            providerTrust: trust.record,
+            trustMetadata: trust.record.trustMetadata,
+            relevance: {
+                score: options.relevanceScores?.[resource.id],
+                source: sourceKind,
+            },
+            rawSnapshotRef: catalog.rawSnapshotRef,
+            policyPreflightRequired: true,
+        });
+        if (validation.ok)
+            candidates.push(validation.candidate);
+        else
+            errors.push(...validation.errors);
+    }
+    if (errors.length > 0)
+        return { ok: false, errors };
+    return {
+        ok: true,
+        candidates,
+        diagnostics: [diagnostic('candidate_ready_for_policy_preflight', '$', 'Discovery candidates require explicit policy preflight before quote/payment/invocation.')],
+    };
+}
+export function evaluateDiscoveryCandidatePolicyPreflight(candidate, policy) {
+    const reasonCodes = [];
+    const auditNotes = [
+        'Discovery relevance is informational only and is not used for trust, safety, payment, or budget approval.',
+    ];
+    if (policy.allowedSourceKinds && !policy.allowedSourceKinds.includes(candidate.sourceKind)) {
+        reasonCodes.push('source_not_allowed');
+        auditNotes.push(`Denied: discovery source ${candidate.sourceKind} is not allowed by policy.`);
+    }
+    const trustStatus = candidate.providerTrust?.verification?.status;
+    if (policy.requireVerifiedTrust && trustStatus !== 'verified') {
+        reasonCodes.push('trust_verification_required');
+        auditNotes.push(`Denied: provider trust status is ${trustStatus ?? 'missing'}, but policy requires verified trust.`);
+    }
+    if (!candidate.quote) {
+        reasonCodes.push('missing_quote');
+        auditNotes.push('Denied: discovery candidate has no quote; RAP quote/payment preflight must happen before invocation.');
+    }
+    else {
+        const quoted = amountToBigInt(candidate.quote.amount);
+        if (quoted === undefined || !candidate.quote.asset || !candidate.quote.network) {
+            reasonCodes.push('malformed_candidate');
+            auditNotes.push('Denied: discovery candidate quote must include decimal amount, asset, and network.');
+        }
+        if (policy.allowedAssets && !policy.allowedAssets.includes(candidate.quote.asset)) {
+            reasonCodes.push('unsupported_asset');
+            auditNotes.push(`Denied: quote asset ${candidate.quote.asset} is not allowed by policy.`);
+        }
+        if (policy.allowedNetworks && !policy.allowedNetworks.includes(candidate.quote.network)) {
+            reasonCodes.push('unsupported_network');
+            auditNotes.push(`Denied: quote network ${candidate.quote.network} is not allowed by policy.`);
+        }
+        if (policy.maxQuote) {
+            const maximum = amountToBigInt(policy.maxQuote.amount);
+            if (quoted === undefined
+                || maximum === undefined
+                || candidate.quote.asset !== policy.maxQuote.asset
+                || candidate.quote.network !== policy.maxQuote.network
+                || quoted > maximum) {
+                reasonCodes.push('over_budget');
+                auditNotes.push('Denied: quote exceeds the policy maximum or does not match the expected asset/network.');
+            }
+        }
+    }
+    return {
+        allowed: reasonCodes.length === 0,
+        reasonCodes: reasonCodes.length === 0 ? ['candidate_ready_for_policy_preflight'] : reasonCodes,
+        auditNotes,
+        candidate: {
+            identifier: candidate.identifier,
+            sourceKind: candidate.sourceKind,
+            relevanceScore: candidate.relevance?.score,
+            trustStatus,
+        },
+        quote: candidate.quote,
+    };
+}
+export const discoverySourceFixtures = {
+    localSpecialistCandidate: {
+        schemaVersion: DISCOVERY_CANDIDATE_SCHEMA_VERSION,
+        sourceKind: 'local-specialist',
+        identifier: 'urn:ai:local:specialists:lint',
+        publisher: { id: 'local' },
+        name: 'Local Lint Specialist',
+        resourceType: 'application/mcp-server-card+json',
+        mediaType: 'application/mcp-server-card+json',
+        endpoint: 'http://localhost:4100/mcp',
+        relevance: { score: 0.4, source: 'local-fixture' },
+        rawSnapshotRef: 'sha256:local-specialist-fixture',
+        quote: { amount: '1000', asset: 'AUDD', network: 'solana-devnet' },
+        policyPreflightRequired: true,
+    },
+};

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -3,3 +3,4 @@ export * from './receipts.js';
 export * from './fixtures.js';
 export * from './ai-catalog.js';
 export * from './provider-trust.js';
+export * from './discovery-source.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -3,3 +3,4 @@ export * from './receipts.js';
 export * from './fixtures.js';
 export * from './ai-catalog.js';
 export * from './provider-trust.js';
+export * from './discovery-source.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/provider-trust.d.ts",
       "import": "./dist/provider-trust.js"
     },
+    "./discovery-source": {
+      "types": "./dist/discovery-source.d.ts",
+      "import": "./dist/discovery-source.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/discovery-source.ts
+++ b/packages/agent-protocol/src/discovery-source.ts
@@ -1,0 +1,391 @@
+import {
+  type AiCatalogSnapshot,
+  type AiCatalogResourceSnapshot,
+} from './ai-catalog.js';
+import {
+  normalizeAiCatalogProviderTrustRecord,
+  type NormalizeAiCatalogTrustOptions,
+  type ProviderTrustRecord,
+  type ProviderTrustVerificationStatus,
+} from './provider-trust.js';
+
+export const DISCOVERY_CANDIDATE_SCHEMA_VERSION = 'reddi.discovery-candidate.v1' as const;
+
+export type DiscoverySourceKind =
+  | 'local-specialist'
+  | 'direct-ai-catalog'
+  | 'ard-registry'
+  | 'source-adapter'
+  | 'hosted-rap-registry';
+
+export type DiscoveryCandidateReasonCode =
+  | 'candidate_ready_for_policy_preflight'
+  | 'malformed_candidate'
+  | 'provider_trust_mismatch'
+  | 'missing_quote'
+  | 'source_not_allowed'
+  | 'trust_verification_required'
+  | 'unsupported_asset'
+  | 'unsupported_network'
+  | 'over_budget';
+
+export type DiscoveryCandidateDiagnostic = {
+  code: DiscoveryCandidateReasonCode;
+  path: string;
+  message: string;
+};
+
+export type DiscoveryCandidateQuote = {
+  amount: string;
+  asset: string;
+  network: string;
+  expiresAt?: string;
+  payee?: string;
+};
+
+export type DiscoveryCandidate = {
+  schemaVersion: typeof DISCOVERY_CANDIDATE_SCHEMA_VERSION;
+  sourceKind: DiscoverySourceKind;
+  identifier: string;
+  publisher?: {
+    id: string;
+    name?: string;
+    domain?: string;
+  };
+  name: string;
+  description?: string;
+  resourceType: string;
+  mediaType: string;
+  url?: string;
+  endpoint?: string;
+  trustMetadata?: ProviderTrustRecord['trustMetadata'];
+  providerTrust?: ProviderTrustRecord;
+  relevance?: {
+    score?: number;
+    reason?: string;
+    source?: string;
+  };
+  rawSnapshotRef?: string;
+  quote?: DiscoveryCandidateQuote;
+  policyPreflightRequired: true;
+};
+
+export type DiscoveryCandidateNormalizationResult =
+  | { ok: true; candidates: DiscoveryCandidate[]; diagnostics: DiscoveryCandidateDiagnostic[] }
+  | { ok: false; errors: DiscoveryCandidateDiagnostic[] };
+
+export type DiscoveryCandidateValidationResult =
+  | { ok: true; candidate: DiscoveryCandidate; diagnostics: DiscoveryCandidateDiagnostic[] }
+  | { ok: false; errors: DiscoveryCandidateDiagnostic[] };
+
+export type CreateAiCatalogDiscoveryCandidatesOptions = {
+  sourceKind?: Extract<DiscoverySourceKind, 'direct-ai-catalog' | 'ard-registry' | 'hosted-rap-registry'>;
+  trustOptionsByResourceId?: Record<string, NormalizeAiCatalogTrustOptions>;
+  relevanceScores?: Record<string, number>;
+};
+
+export type DiscoveryCandidatePolicy = {
+  allowedSourceKinds?: DiscoverySourceKind[];
+  requireVerifiedTrust?: boolean;
+  allowedAssets?: string[];
+  allowedNetworks?: string[];
+  maxQuote?: {
+    amount: string;
+    asset: string;
+    network: string;
+  };
+};
+
+export type DiscoveryCandidatePolicyPreflightDecision = {
+  allowed: boolean;
+  reasonCodes: DiscoveryCandidateReasonCode[];
+  auditNotes: string[];
+  candidate: {
+    identifier: string;
+    sourceKind: DiscoverySourceKind;
+    relevanceScore?: number;
+    trustStatus?: ProviderTrustVerificationStatus;
+  };
+  quote?: DiscoveryCandidateQuote;
+};
+
+const SOURCE_KINDS = new Set<DiscoverySourceKind>([
+  'local-specialist',
+  'direct-ai-catalog',
+  'ard-registry',
+  'source-adapter',
+  'hosted-rap-registry',
+]);
+
+function diagnostic(code: DiscoveryCandidateReasonCode, path: string, message: string): DiscoveryCandidateDiagnostic {
+  return { code, path, message };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asDiscoverySourceKind(value: unknown): DiscoverySourceKind | undefined {
+  return typeof value === 'string' && SOURCE_KINDS.has(value as DiscoverySourceKind)
+    ? (value as DiscoverySourceKind)
+    : undefined;
+}
+
+function amountToBigInt(value: unknown): bigint | undefined {
+  if (typeof value !== 'string') return undefined;
+  if (!/^[0-9]+$/.test(value)) return undefined;
+  return BigInt(value);
+}
+
+function resourceReference(resource: AiCatalogResourceSnapshot): { url?: string; endpoint?: string } {
+  return {
+    url: resource.url ?? resource.catalogUrl,
+    endpoint: resource.endpoint,
+  };
+}
+
+export function validateDiscoveryCandidate(input: unknown): DiscoveryCandidateValidationResult {
+  const errors: DiscoveryCandidateDiagnostic[] = [];
+  if (!isPlainObject(input)) {
+    return { ok: false, errors: [diagnostic('malformed_candidate', '$', 'Discovery candidate must be a plain object.')] };
+  }
+
+  const sourceKind = asDiscoverySourceKind(input.sourceKind);
+  if (!sourceKind) {
+    errors.push(diagnostic('malformed_candidate', '$.sourceKind', 'Discovery candidate must include a supported sourceKind.'));
+  }
+
+  const identifier = asString(input.identifier);
+  if (!identifier) {
+    errors.push(diagnostic('malformed_candidate', '$.identifier', 'Discovery candidate must include an identifier.'));
+  }
+
+  const name = asString(input.name);
+  if (!name) {
+    errors.push(diagnostic('malformed_candidate', '$.name', 'Discovery candidate must include a name.'));
+  }
+
+  const resourceType = asString(input.resourceType);
+  const mediaType = asString(input.mediaType);
+  if (!resourceType || !mediaType) {
+    errors.push(diagnostic('malformed_candidate', '$.mediaType', 'Discovery candidate must include resourceType and mediaType.'));
+  }
+
+  const relevance = isPlainObject(input.relevance) ? input.relevance : undefined;
+  const relevanceScore = relevance?.score;
+  if (relevanceScore !== undefined && (typeof relevanceScore !== 'number' || !Number.isFinite(relevanceScore) || relevanceScore < 0 || relevanceScore > 1)) {
+    errors.push(diagnostic('malformed_candidate', '$.relevance.score', 'Relevance score must be a finite number between 0 and 1.'));
+  }
+
+  const providerTrust = input.providerTrust as ProviderTrustRecord | undefined;
+  if (providerTrust !== undefined) {
+    if (!isPlainObject(providerTrust) || providerTrust.schemaVersion !== 'reddi.provider-trust.v1') {
+      errors.push(diagnostic('malformed_candidate', '$.providerTrust', 'Provider trust must be a reddi.provider-trust.v1 record.'));
+    } else if (!isPlainObject(providerTrust.provider) || !asString(providerTrust.provider.id)) {
+      errors.push(diagnostic('malformed_candidate', '$.providerTrust.provider.id', 'Provider trust record must include a provider id.'));
+    } else if (identifier && providerTrust.provider.id !== identifier) {
+      errors.push(diagnostic('provider_trust_mismatch', '$.providerTrust.provider.id', 'Provider trust record must match the discovery candidate identifier.'));
+    }
+  }
+
+  const quote = input.quote;
+  if (quote !== undefined) {
+    if (!isPlainObject(quote)) {
+      errors.push(diagnostic('malformed_candidate', '$.quote', 'Discovery candidate quote must be an object.'));
+    } else if (!asString(quote.amount) || amountToBigInt(asString(quote.amount)!) === undefined || !asString(quote.asset) || !asString(quote.network)) {
+      errors.push(diagnostic('malformed_candidate', '$.quote', 'Discovery candidate quote must include decimal amount, asset, and network.'));
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    candidate: {
+      schemaVersion: DISCOVERY_CANDIDATE_SCHEMA_VERSION,
+      sourceKind: sourceKind!,
+      identifier: identifier!,
+      publisher: isPlainObject(input.publisher)
+        ? {
+            id: asString(input.publisher.id) ?? 'unknown',
+            name: asString(input.publisher.name),
+            domain: asString(input.publisher.domain),
+          }
+        : undefined,
+      name: name!,
+      description: asString(input.description),
+      resourceType: resourceType!,
+      mediaType: mediaType!,
+      url: asString(input.url),
+      endpoint: asString(input.endpoint),
+      trustMetadata: providerTrust?.trustMetadata ?? (input.trustMetadata as ProviderTrustRecord['trustMetadata'] | undefined),
+      providerTrust,
+      relevance: relevance
+        ? {
+            score: relevanceScore as number | undefined,
+            reason: asString(relevance.reason),
+            source: asString(relevance.source),
+          }
+        : undefined,
+      rawSnapshotRef: asString(input.rawSnapshotRef),
+      quote: isPlainObject(input.quote)
+        ? {
+            amount: asString(input.quote.amount) ?? '',
+            asset: asString(input.quote.asset) ?? '',
+            network: asString(input.quote.network) ?? '',
+            expiresAt: asString(input.quote.expiresAt),
+            payee: asString(input.quote.payee),
+          }
+        : undefined,
+      policyPreflightRequired: true,
+    },
+    diagnostics: [diagnostic('candidate_ready_for_policy_preflight', '$', 'Discovery candidate is normalized for explicit RAP policy preflight.')],
+  };
+}
+
+export function createAiCatalogDiscoveryCandidates(
+  catalog: AiCatalogSnapshot,
+  options: CreateAiCatalogDiscoveryCandidatesOptions = {},
+): DiscoveryCandidateNormalizationResult {
+  const sourceKind = options.sourceKind ?? 'direct-ai-catalog';
+  const candidates: DiscoveryCandidate[] = [];
+  const errors: DiscoveryCandidateDiagnostic[] = [];
+
+  for (const resource of catalog.resources) {
+    const trust = normalizeAiCatalogProviderTrustRecord(
+      catalog,
+      resource.id,
+      options.trustOptionsByResourceId?.[resource.id],
+    );
+    if (!trust.ok) {
+      for (const trustError of trust.errors) {
+        errors.push(diagnostic('malformed_candidate', `$.resources[${resource.id}]${trustError.path}`, trustError.message));
+      }
+      continue;
+    }
+
+    const reference = resourceReference(resource);
+    const validation = validateDiscoveryCandidate({
+      schemaVersion: DISCOVERY_CANDIDATE_SCHEMA_VERSION,
+      sourceKind,
+      identifier: resource.id,
+      publisher: catalog.publisher,
+      name: resource.name,
+      description: resource.description,
+      resourceType: resource.type,
+      mediaType: resource.mediaType,
+      url: reference.url,
+      endpoint: reference.endpoint,
+      providerTrust: trust.record,
+      trustMetadata: trust.record.trustMetadata,
+      relevance: {
+        score: options.relevanceScores?.[resource.id],
+        source: sourceKind,
+      },
+      rawSnapshotRef: catalog.rawSnapshotRef,
+      policyPreflightRequired: true,
+    });
+
+    if (validation.ok) candidates.push(validation.candidate);
+    else errors.push(...validation.errors);
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    candidates,
+    diagnostics: [diagnostic('candidate_ready_for_policy_preflight', '$', 'Discovery candidates require explicit policy preflight before quote/payment/invocation.')],
+  };
+}
+
+export function evaluateDiscoveryCandidatePolicyPreflight(
+  candidate: DiscoveryCandidate,
+  policy: DiscoveryCandidatePolicy,
+): DiscoveryCandidatePolicyPreflightDecision {
+  const reasonCodes: DiscoveryCandidateReasonCode[] = [];
+  const auditNotes: string[] = [
+    'Discovery relevance is informational only and is not used for trust, safety, payment, or budget approval.',
+  ];
+
+  if (policy.allowedSourceKinds && !policy.allowedSourceKinds.includes(candidate.sourceKind)) {
+    reasonCodes.push('source_not_allowed');
+    auditNotes.push(`Denied: discovery source ${candidate.sourceKind} is not allowed by policy.`);
+  }
+
+  const trustStatus = candidate.providerTrust?.verification?.status;
+  if (policy.requireVerifiedTrust && trustStatus !== 'verified') {
+    reasonCodes.push('trust_verification_required');
+    auditNotes.push(`Denied: provider trust status is ${trustStatus ?? 'missing'}, but policy requires verified trust.`);
+  }
+
+  if (!candidate.quote) {
+    reasonCodes.push('missing_quote');
+    auditNotes.push('Denied: discovery candidate has no quote; RAP quote/payment preflight must happen before invocation.');
+  } else {
+    const quoted = amountToBigInt(candidate.quote.amount);
+    if (quoted === undefined || !candidate.quote.asset || !candidate.quote.network) {
+      reasonCodes.push('malformed_candidate');
+      auditNotes.push('Denied: discovery candidate quote must include decimal amount, asset, and network.');
+    }
+
+    if (policy.allowedAssets && !policy.allowedAssets.includes(candidate.quote.asset)) {
+      reasonCodes.push('unsupported_asset');
+      auditNotes.push(`Denied: quote asset ${candidate.quote.asset} is not allowed by policy.`);
+    }
+
+    if (policy.allowedNetworks && !policy.allowedNetworks.includes(candidate.quote.network)) {
+      reasonCodes.push('unsupported_network');
+      auditNotes.push(`Denied: quote network ${candidate.quote.network} is not allowed by policy.`);
+    }
+
+    if (policy.maxQuote) {
+      const maximum = amountToBigInt(policy.maxQuote.amount);
+      if (
+        quoted === undefined
+        || maximum === undefined
+        || candidate.quote.asset !== policy.maxQuote.asset
+        || candidate.quote.network !== policy.maxQuote.network
+        || quoted > maximum
+      ) {
+        reasonCodes.push('over_budget');
+        auditNotes.push('Denied: quote exceeds the policy maximum or does not match the expected asset/network.');
+      }
+    }
+  }
+
+  return {
+    allowed: reasonCodes.length === 0,
+    reasonCodes: reasonCodes.length === 0 ? ['candidate_ready_for_policy_preflight'] : reasonCodes,
+    auditNotes,
+    candidate: {
+      identifier: candidate.identifier,
+      sourceKind: candidate.sourceKind,
+      relevanceScore: candidate.relevance?.score,
+      trustStatus,
+    },
+    quote: candidate.quote,
+  };
+}
+
+export const discoverySourceFixtures = {
+  localSpecialistCandidate: {
+    schemaVersion: DISCOVERY_CANDIDATE_SCHEMA_VERSION,
+    sourceKind: 'local-specialist',
+    identifier: 'urn:ai:local:specialists:lint',
+    publisher: { id: 'local' },
+    name: 'Local Lint Specialist',
+    resourceType: 'application/mcp-server-card+json',
+    mediaType: 'application/mcp-server-card+json',
+    endpoint: 'http://localhost:4100/mcp',
+    relevance: { score: 0.4, source: 'local-fixture' },
+    rawSnapshotRef: 'sha256:local-specialist-fixture',
+    quote: { amount: '1000', asset: 'AUDD', network: 'solana-devnet' },
+    policyPreflightRequired: true,
+  },
+} as const;

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -3,3 +3,4 @@ export * from './receipts.js';
 export * from './fixtures.js';
 export * from './ai-catalog.js';
 export * from './provider-trust.js';
+export * from './discovery-source.js';

--- a/packages/agent-protocol/tests/discovery-source.test.ts
+++ b/packages/agent-protocol/tests/discovery-source.test.ts
@@ -1,0 +1,270 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createAiCatalogDiscoveryCandidates,
+  discoverySourceFixtures,
+  evaluateDiscoveryCandidatePolicyPreflight,
+  providerTrustFixtures,
+  validateDiscoveryCandidate,
+  type DiscoveryCandidate,
+  type DiscoveryCandidateReasonCode,
+} from '../dist/index.js';
+
+function assertReasonCodes(actual: DiscoveryCandidateReasonCode[], expected: DiscoveryCandidateReasonCode[]): void {
+  for (const code of expected) {
+    assert.ok(actual.includes(code), `expected discovery reason codes to include ${code}`);
+  }
+}
+
+describe('RAP discovery source candidates', () => {
+  it('normalizes direct AI Catalog resources into policy-preflight candidates with trust records', () => {
+    const result = createAiCatalogDiscoveryCandidates(providerTrustFixtures.verifiedCatalog, {
+      relevanceScores: {
+        'urn:ai:reddi.tech:specialists:code-review': 0.91,
+      },
+      trustOptionsByResourceId: {
+        'urn:ai:reddi.tech:specialists:code-review': {
+          verification: {
+            status: 'verified',
+            verifier: 'rap:unit-test',
+          },
+        },
+      },
+    });
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.candidates.length, 1);
+      const candidate = result.candidates[0];
+      assert.equal(candidate.schemaVersion, 'reddi.discovery-candidate.v1');
+      assert.equal(candidate.sourceKind, 'direct-ai-catalog');
+      assert.equal(candidate.identifier, 'urn:ai:reddi.tech:specialists:code-review');
+      assert.equal(candidate.publisher?.id, 'reddi.tech');
+      assert.equal(candidate.resourceType, 'application/mcp-server-card+json');
+      assert.equal(candidate.relevance?.score, 0.91);
+      assert.equal(candidate.providerTrust?.schemaVersion, 'reddi.provider-trust.v1');
+      assert.equal(candidate.providerTrust?.verification.status, 'verified');
+      assert.equal(candidate.rawSnapshotRef, 'sha256:verified-catalog-fixture');
+      assert.equal(candidate.policyPreflightRequired, true);
+      assert.equal(candidate.quote, undefined);
+    }
+  });
+
+  it('keeps unverified AI Catalog candidates separate from policy approval', () => {
+    const result = createAiCatalogDiscoveryCandidates(providerTrustFixtures.unverifiedCatalog, {
+      sourceKind: 'ard-registry',
+      relevanceScores: {
+        'urn:example:agents:summary': 0.84,
+      },
+    });
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      const candidate = result.candidates[0];
+      assert.equal(candidate.sourceKind, 'ard-registry');
+      assert.equal(candidate.providerTrust?.verification.status, 'unverified');
+
+      const decision = evaluateDiscoveryCandidatePolicyPreflight(
+        {
+          ...candidate,
+          quote: { amount: '5000', asset: 'AUDD', network: 'solana-devnet' },
+        },
+        {
+          allowedSourceKinds: ['ard-registry'],
+          requireVerifiedTrust: true,
+          allowedAssets: ['AUDD'],
+          allowedNetworks: ['solana-devnet'],
+          maxQuote: { amount: '10000', asset: 'AUDD', network: 'solana-devnet' },
+        },
+      );
+
+      assert.equal(decision.allowed, false);
+      assertReasonCodes(decision.reasonCodes, ['trust_verification_required']);
+      assert.equal(decision.candidate.relevanceScore, 0.84);
+      assert.equal(decision.candidate.trustStatus, 'unverified');
+    }
+  });
+
+  it('validates local specialist and source-adapter candidate shapes without hosted infrastructure', () => {
+    const local = validateDiscoveryCandidate(discoverySourceFixtures.localSpecialistCandidate);
+    assert.equal(local.ok, true);
+    if (local.ok) {
+      assert.equal(local.candidate.sourceKind, 'local-specialist');
+      assert.equal(local.candidate.endpoint, 'http://localhost:4100/mcp');
+    }
+
+    const sourceAdapter = validateDiscoveryCandidate({
+      ...discoverySourceFixtures.localSpecialistCandidate,
+      sourceKind: 'source-adapter',
+      identifier: 'urn:ai:source-adapter:circle-x402:search',
+      url: 'https://example.com/.well-known/source-adapter.json',
+      endpoint: undefined,
+    });
+    assert.equal(sourceAdapter.ok, true);
+    if (sourceAdapter.ok) assert.equal(sourceAdapter.candidate.sourceKind, 'source-adapter');
+  });
+
+  it('fails closed for malformed candidates and mismatched trust records', () => {
+    const malformed = validateDiscoveryCandidate({
+      sourceKind: 'direct-ai-catalog',
+      identifier: 'urn:ai:bad',
+      name: 'Bad Candidate',
+      mediaType: 'application/mcp-server-card+json',
+      relevance: { score: 2 },
+    });
+    assert.equal(malformed.ok, false);
+    if (!malformed.ok) assertReasonCodes(malformed.errors.map((item) => item.code), ['malformed_candidate']);
+
+    const malformedTrust = validateDiscoveryCandidate({
+      ...discoverySourceFixtures.localSpecialistCandidate,
+      providerTrust: {
+        schemaVersion: 'reddi.provider-trust.v1',
+      },
+    });
+    assert.equal(malformedTrust.ok, false);
+    if (!malformedTrust.ok) assertReasonCodes(malformedTrust.errors.map((item) => item.code), ['malformed_candidate']);
+
+    const malformedQuote = validateDiscoveryCandidate({
+      ...discoverySourceFixtures.localSpecialistCandidate,
+      quote: { amount: 'not-decimal', asset: 'AUDD', network: 'solana-devnet' },
+    });
+    assert.equal(malformedQuote.ok, false);
+    if (!malformedQuote.ok) assertReasonCodes(malformedQuote.errors.map((item) => item.code), ['malformed_candidate']);
+
+    const catalog = createAiCatalogDiscoveryCandidates(providerTrustFixtures.verifiedCatalog);
+    assert.equal(catalog.ok, true);
+    if (catalog.ok) {
+      const mismatched = validateDiscoveryCandidate({
+        ...catalog.candidates[0],
+        identifier: 'urn:ai:other',
+      });
+      assert.equal(mismatched.ok, false);
+      if (!mismatched.ok) assertReasonCodes(mismatched.errors.map((item) => item.code), ['provider_trust_mismatch']);
+    }
+  });
+
+  it('requires explicit quote/payment preflight before invocation', () => {
+    const candidate = discoverySourceFixtures.localSpecialistCandidate as DiscoveryCandidate;
+    const decision = evaluateDiscoveryCandidatePolicyPreflight(
+      {
+        ...candidate,
+        quote: undefined,
+      },
+      {
+        allowedSourceKinds: ['local-specialist'],
+        allowedAssets: ['AUDD'],
+        allowedNetworks: ['solana-devnet'],
+        maxQuote: { amount: '10000', asset: 'AUDD', network: 'solana-devnet' },
+      },
+    );
+
+    assert.equal(decision.allowed, false);
+    assertReasonCodes(decision.reasonCodes, ['missing_quote']);
+    assert.ok(decision.auditNotes.some((note) => note.includes('quote/payment preflight')));
+
+    const malformedQuote = evaluateDiscoveryCandidatePolicyPreflight(
+      {
+        ...candidate,
+        quote: { amount: 'not-decimal', asset: 'AUDD', network: 'solana-devnet' },
+      },
+      {
+        allowedSourceKinds: ['local-specialist'],
+      },
+    );
+    assert.equal(malformedQuote.allowed, false);
+    assertReasonCodes(malformedQuote.reasonCodes, ['malformed_candidate']);
+
+    const numericQuote = evaluateDiscoveryCandidatePolicyPreflight(
+      {
+        ...candidate,
+        quote: { amount: 5000, asset: 'AUDD', network: 'solana-devnet' } as unknown as DiscoveryCandidate['quote'],
+      },
+      {
+        allowedSourceKinds: ['local-specialist'],
+      },
+    );
+    assert.equal(numericQuote.allowed, false);
+    assertReasonCodes(numericQuote.reasonCodes, ['malformed_candidate']);
+
+    const boxedStringQuote = evaluateDiscoveryCandidatePolicyPreflight(
+      {
+        ...candidate,
+        quote: { amount: new String('5000'), asset: 'AUDD', network: 'solana-devnet' } as unknown as DiscoveryCandidate['quote'],
+      },
+      {
+        allowedSourceKinds: ['local-specialist'],
+      },
+    );
+    assert.equal(boxedStringQuote.allowed, false);
+    assertReasonCodes(boxedStringQuote.reasonCodes, ['malformed_candidate']);
+
+    const malformedTrust = evaluateDiscoveryCandidatePolicyPreflight(
+      {
+        ...candidate,
+        providerTrust: { schemaVersion: 'reddi.provider-trust.v1' } as DiscoveryCandidate['providerTrust'],
+      },
+      {
+        allowedSourceKinds: ['local-specialist'],
+        requireVerifiedTrust: true,
+      },
+    );
+    assert.equal(malformedTrust.allowed, false);
+    assertReasonCodes(malformedTrust.reasonCodes, ['trust_verification_required']);
+  });
+
+  it('does not let high relevance override budget, network, source, or trust policy', () => {
+    const candidate = {
+      ...(discoverySourceFixtures.localSpecialistCandidate as DiscoveryCandidate),
+      sourceKind: 'direct-ai-catalog' as const,
+      relevance: { score: 0.99, source: 'ard-registry' },
+      quote: { amount: '20000', asset: 'AUDD', network: 'solana-mainnet' },
+    };
+
+    const decision = evaluateDiscoveryCandidatePolicyPreflight(candidate, {
+      allowedSourceKinds: ['hosted-rap-registry'],
+      requireVerifiedTrust: true,
+      allowedAssets: ['AUDD'],
+      allowedNetworks: ['solana-devnet'],
+      maxQuote: { amount: '10000', asset: 'AUDD', network: 'solana-devnet' },
+    });
+
+    assert.equal(decision.allowed, false);
+    assert.equal(decision.candidate.relevanceScore, 0.99);
+    assertReasonCodes(decision.reasonCodes, [
+      'source_not_allowed',
+      'trust_verification_required',
+      'unsupported_network',
+      'over_budget',
+    ]);
+    assert.ok(decision.auditNotes[0].includes('Discovery relevance is informational only'));
+  });
+
+  it('allows a candidate only after source, quote, budget, network, asset, and trust policy pass', () => {
+    const catalog = createAiCatalogDiscoveryCandidates(providerTrustFixtures.verifiedCatalog, {
+      trustOptionsByResourceId: {
+        'urn:ai:reddi.tech:specialists:code-review': {
+          verification: { status: 'verified', verifier: 'rap:unit-test' },
+        },
+      },
+    });
+
+    assert.equal(catalog.ok, true);
+    if (catalog.ok) {
+      const candidate = {
+        ...catalog.candidates[0],
+        quote: { amount: '5000', asset: 'AUDD', network: 'solana-devnet' },
+      };
+      const decision = evaluateDiscoveryCandidatePolicyPreflight(candidate, {
+        allowedSourceKinds: ['direct-ai-catalog'],
+        requireVerifiedTrust: true,
+        allowedAssets: ['AUDD'],
+        allowedNetworks: ['solana-devnet'],
+        maxQuote: { amount: '10000', asset: 'AUDD', network: 'solana-devnet' },
+      });
+
+      assert.equal(decision.allowed, true);
+      assert.deepEqual(decision.reasonCodes, ['candidate_ready_for_policy_preflight']);
+      assert.equal(decision.candidate.trustStatus, 'verified');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `reddi.discovery-candidate.v1` as a source-neutral buyer-client candidate shape
- normalize AI Catalog resources plus `reddi.provider-trust.v1` records into discovery candidates
- add explicit policy-preflight helper for source, trust, quote, asset/network, and budget gates while keeping relevance informational only
- document and export `@reddi/agent-protocol/discovery-source`

## Boundaries
- no live ARD registry fetches
- no hosted RAP dependency
- no wallet action, payment, or invocation
- no trust elevation from ARD relevance/search scores

## Validation
- `npm test` in `packages/agent-protocol` passed with 35 tests
- `npm run release:dry-run` in `packages/agent-protocol` passed
- `npm run check:rap:naming` passed
- `git diff --check` passed

Closes #366.
