### PR TITLE
Add source-aware discovery diagnostics

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -108,6 +108,22 @@ if (candidates.ok) {
 
 Discovery candidates are source-neutral buyer-client inputs for local specialists, direct AI Catalogs, ARD registry/search fixtures, source adapters, and future hosted RAP registries. Candidate relevance is informational only; it is never used as a trust, safety, payment, or budget decision. Quotes, policy preflight, payment approval, invocation, receipts, evidence, attestations, and reputation remain separate RAP steps.
 
+## Source-Aware Diagnostics
+
+```typescript
+import { createSourceAwareCandidateDiagnostics } from '@reddi/agent-protocol/source-diagnostics';
+
+const diagnostics = createSourceAwareCandidateDiagnostics(candidate, {
+  policyDecision: decision,
+  reputation: { receiptCount: 2, attestationCount: 1 },
+});
+
+console.log(diagnostics.capabilityMatch.scoreMeaning); // relevance_only_not_trust
+console.log(diagnostics.policyDecision.reasonCodes); // machine-readable allow/deny reasons
+```
+
+Source-aware diagnostics expose separate lanes for capability match, discovery source, publisher identity, trust evidence, policy decision, payment fit, and reputation evidence. ARD and registry relevance scores are always labelled as relevance only; they are never collapsed into trust, policy, payment, or reputation approval.
+
 ## Local Validation
 
 ```bash

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -4,3 +4,4 @@ export * from './fixtures.js';
 export * from './ai-catalog.js';
 export * from './provider-trust.js';
 export * from './discovery-source.js';
+export * from './source-diagnostics.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -4,3 +4,4 @@ export * from './fixtures.js';
 export * from './ai-catalog.js';
 export * from './provider-trust.js';
 export * from './discovery-source.js';
+export * from './source-diagnostics.js';

--- a/packages/agent-protocol/dist/source-diagnostics.d.ts
+++ b/packages/agent-protocol/dist/source-diagnostics.d.ts
@@ -1,0 +1,84 @@
+import { type DiscoveryCandidate, type DiscoveryCandidatePolicyPreflightDecision, type DiscoveryCandidateReasonCode, type DiscoverySourceKind } from './discovery-source.js';
+import { type ProviderTrustVerificationStatus } from './provider-trust.js';
+export declare const SOURCE_DIAGNOSTICS_SCHEMA_VERSION: "reddi.source-diagnostics.v1";
+export type SourceDiagnosticLane = 'capability_match' | 'discovery_source' | 'publisher_identity' | 'trust_evidence' | 'policy_decision' | 'payment_fit' | 'reputation_evidence';
+export type SourceDiagnosticSeverity = 'info' | 'warning' | 'blocked';
+export type SourceDiagnosticReasonCode = 'capability_declared' | 'capability_match_unscored' | 'discovery_source_recorded' | 'raw_snapshot_recorded' | 'publisher_identity_recorded' | 'publisher_identity_missing' | 'trust_verified' | 'trust_claimed_unverified' | 'trust_unverified' | 'trust_failed_verification' | 'policy_allowed' | 'policy_denied' | 'payment_quote_present' | 'payment_quote_missing' | 'payment_quote_denied' | 'reputation_history_present' | 'reputation_history_absent';
+export type SourceDiagnosticMessage = {
+    lane: SourceDiagnosticLane;
+    severity: SourceDiagnosticSeverity;
+    code: SourceDiagnosticReasonCode | DiscoveryCandidateReasonCode;
+    summary: string;
+    action?: string;
+};
+export type SourceAwareCandidateDiagnostics = {
+    schemaVersion: typeof SOURCE_DIAGNOSTICS_SCHEMA_VERSION;
+    candidate: {
+        identifier: string;
+        name: string;
+        sourceKind: DiscoverySourceKind;
+        rawSnapshotRef?: string;
+    };
+    capabilityMatch: {
+        resourceType: string;
+        mediaType: string;
+        relevanceScore?: number;
+        scoreMeaning: 'relevance_only_not_trust';
+        summary: string;
+    };
+    discoverySource: {
+        sourceKind: DiscoverySourceKind;
+        url?: string;
+        endpoint?: string;
+        rawSnapshotRef?: string;
+        summary: string;
+    };
+    publisherIdentity: {
+        id?: string;
+        name?: string;
+        domain?: string;
+        trustStatus?: ProviderTrustVerificationStatus;
+        summary: string;
+    };
+    trustEvidence: {
+        status: ProviderTrustVerificationStatus | 'missing';
+        reasonCodes: string[];
+        verifier?: string;
+        checkedAt?: string;
+        failureReasons: string[];
+        provenanceCount: number;
+        attestationCount: number;
+        verificationReferenceCount: number;
+        summary: string;
+    };
+    policyDecision: {
+        allowed?: boolean;
+        reasonCodes: DiscoveryCandidateReasonCode[];
+        summaries: string[];
+    };
+    paymentFit: {
+        quote?: {
+            amount: string;
+            asset: string;
+            network: string;
+        };
+        allowed?: boolean;
+        reasonCodes: DiscoveryCandidateReasonCode[];
+        summary: string;
+    };
+    reputationEvidence: {
+        status: 'history_present' | 'no_history';
+        receiptCount?: number;
+        attestationCount?: number;
+        summary: string;
+    };
+    messages: SourceDiagnosticMessage[];
+};
+export type SourceAwareDiagnosticsOptions = {
+    policyDecision?: DiscoveryCandidatePolicyPreflightDecision;
+    reputation?: {
+        receiptCount?: number;
+        attestationCount?: number;
+    };
+};
+export declare function createSourceAwareCandidateDiagnostics(candidate: DiscoveryCandidate, options?: SourceAwareDiagnosticsOptions): SourceAwareCandidateDiagnostics;

--- a/packages/agent-protocol/dist/source-diagnostics.js
+++ b/packages/agent-protocol/dist/source-diagnostics.js
@@ -1,0 +1,193 @@
+export const SOURCE_DIAGNOSTICS_SCHEMA_VERSION = 'reddi.source-diagnostics.v1';
+function trustSummary(status) {
+    switch (status) {
+        case 'verified':
+            return 'RAP-side verification marked this provider as verified.';
+        case 'claimed':
+            return 'External trust metadata is present, but RAP has not verified it.';
+        case 'failed_verification':
+            return 'RAP-side verification failed for this provider.';
+        case 'unverified':
+            return 'No verified trust metadata is available for this provider.';
+        case 'missing':
+            return 'No provider trust record is attached to this discovery candidate.';
+    }
+}
+function trustMessageCode(status) {
+    switch (status) {
+        case 'verified':
+            return 'trust_verified';
+        case 'claimed':
+            return 'trust_claimed_unverified';
+        case 'failed_verification':
+            return 'trust_failed_verification';
+        case 'unverified':
+        case 'missing':
+            return 'trust_unverified';
+    }
+}
+function trustSeverity(status) {
+    if (status === 'verified')
+        return 'info';
+    if (status === 'failed_verification')
+        return 'blocked';
+    return 'warning';
+}
+function paymentReasonCodes(decision) {
+    if (!decision)
+        return [];
+    return decision.reasonCodes.filter((code) => (code === 'missing_quote'
+        || code === 'malformed_candidate'
+        || code === 'unsupported_asset'
+        || code === 'unsupported_network'
+        || code === 'over_budget'));
+}
+function paymentAllowed(candidate, decision) {
+    if (!candidate.quote && !decision)
+        return undefined;
+    const paymentCodes = paymentReasonCodes(decision);
+    return Boolean(candidate.quote) && paymentCodes.length === 0;
+}
+export function createSourceAwareCandidateDiagnostics(candidate, options = {}) {
+    const policyDecision = options.policyDecision;
+    const trustStatus = candidate.providerTrust?.verification?.status ?? 'missing';
+    const trustMetadata = candidate.providerTrust?.trustMetadata ?? candidate.trustMetadata;
+    const provenanceCount = trustMetadata?.provenanceLinks.length ?? 0;
+    const attestationCount = trustMetadata?.attestations.length ?? 0;
+    const verificationReferenceCount = trustMetadata?.verificationReferences.length ?? 0;
+    const publisher = candidate.publisher;
+    const paymentCodes = paymentReasonCodes(policyDecision);
+    const paymentLaneAllowed = paymentAllowed(candidate, policyDecision);
+    const hasReputation = Boolean((options.reputation?.receiptCount ?? 0) > 0 || (options.reputation?.attestationCount ?? 0) > 0);
+    const messages = [];
+    messages.push({
+        lane: 'capability_match',
+        severity: 'info',
+        code: candidate.relevance?.score === undefined ? 'capability_match_unscored' : 'capability_declared',
+        summary: candidate.relevance?.score === undefined
+            ? `Candidate ${candidate.identifier} declares ${candidate.mediaType}; no relevance score was supplied.`
+            : `Candidate ${candidate.identifier} has relevance score ${candidate.relevance.score}; this is not a trust score.`,
+    });
+    messages.push({
+        lane: 'discovery_source',
+        severity: 'info',
+        code: candidate.rawSnapshotRef ? 'raw_snapshot_recorded' : 'discovery_source_recorded',
+        summary: `Discovered from ${candidate.sourceKind}${candidate.rawSnapshotRef ? ` with snapshot ${candidate.rawSnapshotRef}` : ''}.`,
+    });
+    messages.push({
+        lane: 'publisher_identity',
+        severity: publisher?.id ? 'info' : 'warning',
+        code: publisher?.id ? 'publisher_identity_recorded' : 'publisher_identity_missing',
+        summary: publisher?.id ? `Publisher identity recorded as ${publisher.id}.` : 'No publisher identity is attached to this candidate.',
+        action: publisher?.id ? undefined : 'Require provider identity before publishing or paid invocation.',
+    });
+    messages.push({
+        lane: 'trust_evidence',
+        severity: trustSeverity(trustStatus),
+        code: trustMessageCode(trustStatus),
+        summary: trustSummary(trustStatus),
+        action: trustStatus === 'verified' ? undefined : 'Run RAP-side trust verification before treating this candidate as trusted.',
+    });
+    if (policyDecision) {
+        messages.push({
+            lane: 'policy_decision',
+            severity: policyDecision.allowed ? 'info' : 'blocked',
+            code: policyDecision.allowed ? 'policy_allowed' : 'policy_denied',
+            summary: policyDecision.allowed
+                ? 'Policy preflight allowed this candidate.'
+                : `Policy preflight denied this candidate: ${policyDecision.reasonCodes.join(', ')}.`,
+            action: policyDecision.allowed ? undefined : 'Resolve the listed policy reason codes before quote/payment/invocation.',
+        });
+    }
+    messages.push({
+        lane: 'payment_fit',
+        severity: paymentCodes.length > 0 ? 'blocked' : candidate.quote ? 'info' : 'warning',
+        code: paymentCodes.length > 0 ? 'payment_quote_denied' : candidate.quote ? 'payment_quote_present' : 'payment_quote_missing',
+        summary: paymentCodes.length > 0
+            ? `Payment or budget fit failed: ${paymentCodes.join(', ')}.`
+            : candidate.quote
+                ? `Quote is ${candidate.quote.amount} ${candidate.quote.asset} on ${candidate.quote.network}.`
+                : 'No quote is attached; quote/payment preflight is still required.',
+        action: paymentCodes.length > 0 || !candidate.quote ? 'Complete quote/payment preflight before invocation.' : undefined,
+    });
+    messages.push({
+        lane: 'reputation_evidence',
+        severity: hasReputation ? 'info' : 'warning',
+        code: hasReputation ? 'reputation_history_present' : 'reputation_history_absent',
+        summary: hasReputation
+            ? `Reputation evidence includes ${options.reputation?.receiptCount ?? 0} receipt(s) and ${options.reputation?.attestationCount ?? 0} attestation(s).`
+            : 'No prior receipt or attestation history is attached.',
+        action: hasReputation ? undefined : 'Treat this candidate as unproven until receipts or attestations exist.',
+    });
+    return {
+        schemaVersion: SOURCE_DIAGNOSTICS_SCHEMA_VERSION,
+        candidate: {
+            identifier: candidate.identifier,
+            name: candidate.name,
+            sourceKind: candidate.sourceKind,
+            rawSnapshotRef: candidate.rawSnapshotRef,
+        },
+        capabilityMatch: {
+            resourceType: candidate.resourceType,
+            mediaType: candidate.mediaType,
+            relevanceScore: candidate.relevance?.score,
+            scoreMeaning: 'relevance_only_not_trust',
+            summary: candidate.relevance?.score === undefined
+                ? 'Capability match has no supplied relevance score.'
+                : 'Relevance score is only a capability/search signal and never a trust, safety, payment, or reputation decision.',
+        },
+        discoverySource: {
+            sourceKind: candidate.sourceKind,
+            url: candidate.url,
+            endpoint: candidate.endpoint,
+            rawSnapshotRef: candidate.rawSnapshotRef,
+            summary: 'Discovery source is recorded separately from policy, trust, payment, and reputation.',
+        },
+        publisherIdentity: {
+            id: publisher?.id,
+            name: publisher?.name,
+            domain: publisher?.domain,
+            trustStatus: candidate.providerTrust?.verification.status,
+            summary: publisher?.id ? 'Publisher identity is present for audit and display.' : 'Publisher identity is missing.',
+        },
+        trustEvidence: {
+            status: trustStatus,
+            reasonCodes: candidate.providerTrust?.verification.reasonCodes ?? ['no_trust_record'],
+            verifier: candidate.providerTrust?.verification.verifier,
+            checkedAt: candidate.providerTrust?.verification.checkedAt,
+            failureReasons: candidate.providerTrust?.verification.failureReasons ?? [],
+            provenanceCount,
+            attestationCount,
+            verificationReferenceCount,
+            summary: trustSummary(trustStatus),
+        },
+        policyDecision: {
+            allowed: policyDecision?.allowed,
+            reasonCodes: policyDecision?.reasonCodes ?? [],
+            summaries: policyDecision?.auditNotes ?? [],
+        },
+        paymentFit: {
+            quote: candidate.quote
+                ? {
+                    amount: candidate.quote.amount,
+                    asset: candidate.quote.asset,
+                    network: candidate.quote.network,
+                }
+                : undefined,
+            allowed: paymentLaneAllowed,
+            reasonCodes: paymentCodes,
+            summary: paymentCodes.length > 0
+                ? 'Payment or budget policy denied this candidate.'
+                : candidate.quote
+                    ? 'Quote metadata is present; payment still requires explicit approval/settlement outside discovery.'
+                    : 'Quote metadata is missing.',
+        },
+        reputationEvidence: {
+            status: hasReputation ? 'history_present' : 'no_history',
+            receiptCount: options.reputation?.receiptCount,
+            attestationCount: options.reputation?.attestationCount,
+            summary: hasReputation ? 'Prior reputation evidence is present.' : 'No prior reputation evidence is present.',
+        },
+        messages,
+    };
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -34,6 +34,10 @@
       "types": "./dist/discovery-source.d.ts",
       "import": "./dist/discovery-source.js"
     },
+    "./source-diagnostics": {
+      "types": "./dist/source-diagnostics.d.ts",
+      "import": "./dist/source-diagnostics.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -4,3 +4,4 @@ export * from './fixtures.js';
 export * from './ai-catalog.js';
 export * from './provider-trust.js';
 export * from './discovery-source.js';
+export * from './source-diagnostics.js';

--- a/packages/agent-protocol/src/source-diagnostics.ts
+++ b/packages/agent-protocol/src/source-diagnostics.ts
@@ -1,0 +1,326 @@
+import {
+  type DiscoveryCandidate,
+  type DiscoveryCandidatePolicyPreflightDecision,
+  type DiscoveryCandidateReasonCode,
+  type DiscoverySourceKind,
+} from './discovery-source.js';
+import { type ProviderTrustVerificationStatus } from './provider-trust.js';
+
+export const SOURCE_DIAGNOSTICS_SCHEMA_VERSION = 'reddi.source-diagnostics.v1' as const;
+
+export type SourceDiagnosticLane =
+  | 'capability_match'
+  | 'discovery_source'
+  | 'publisher_identity'
+  | 'trust_evidence'
+  | 'policy_decision'
+  | 'payment_fit'
+  | 'reputation_evidence';
+
+export type SourceDiagnosticSeverity = 'info' | 'warning' | 'blocked';
+
+export type SourceDiagnosticReasonCode =
+  | 'capability_declared'
+  | 'capability_match_unscored'
+  | 'discovery_source_recorded'
+  | 'raw_snapshot_recorded'
+  | 'publisher_identity_recorded'
+  | 'publisher_identity_missing'
+  | 'trust_verified'
+  | 'trust_claimed_unverified'
+  | 'trust_unverified'
+  | 'trust_failed_verification'
+  | 'policy_allowed'
+  | 'policy_denied'
+  | 'payment_quote_present'
+  | 'payment_quote_missing'
+  | 'payment_quote_denied'
+  | 'reputation_history_present'
+  | 'reputation_history_absent';
+
+export type SourceDiagnosticMessage = {
+  lane: SourceDiagnosticLane;
+  severity: SourceDiagnosticSeverity;
+  code: SourceDiagnosticReasonCode | DiscoveryCandidateReasonCode;
+  summary: string;
+  action?: string;
+};
+
+export type SourceAwareCandidateDiagnostics = {
+  schemaVersion: typeof SOURCE_DIAGNOSTICS_SCHEMA_VERSION;
+  candidate: {
+    identifier: string;
+    name: string;
+    sourceKind: DiscoverySourceKind;
+    rawSnapshotRef?: string;
+  };
+  capabilityMatch: {
+    resourceType: string;
+    mediaType: string;
+    relevanceScore?: number;
+    scoreMeaning: 'relevance_only_not_trust';
+    summary: string;
+  };
+  discoverySource: {
+    sourceKind: DiscoverySourceKind;
+    url?: string;
+    endpoint?: string;
+    rawSnapshotRef?: string;
+    summary: string;
+  };
+  publisherIdentity: {
+    id?: string;
+    name?: string;
+    domain?: string;
+    trustStatus?: ProviderTrustVerificationStatus;
+    summary: string;
+  };
+  trustEvidence: {
+    status: ProviderTrustVerificationStatus | 'missing';
+    reasonCodes: string[];
+    verifier?: string;
+    checkedAt?: string;
+    failureReasons: string[];
+    provenanceCount: number;
+    attestationCount: number;
+    verificationReferenceCount: number;
+    summary: string;
+  };
+  policyDecision: {
+    allowed?: boolean;
+    reasonCodes: DiscoveryCandidateReasonCode[];
+    summaries: string[];
+  };
+  paymentFit: {
+    quote?: {
+      amount: string;
+      asset: string;
+      network: string;
+    };
+    allowed?: boolean;
+    reasonCodes: DiscoveryCandidateReasonCode[];
+    summary: string;
+  };
+  reputationEvidence: {
+    status: 'history_present' | 'no_history';
+    receiptCount?: number;
+    attestationCount?: number;
+    summary: string;
+  };
+  messages: SourceDiagnosticMessage[];
+};
+
+export type SourceAwareDiagnosticsOptions = {
+  policyDecision?: DiscoveryCandidatePolicyPreflightDecision;
+  reputation?: {
+    receiptCount?: number;
+    attestationCount?: number;
+  };
+};
+
+function trustSummary(status: ProviderTrustVerificationStatus | 'missing'): string {
+  switch (status) {
+    case 'verified':
+      return 'RAP-side verification marked this provider as verified.';
+    case 'claimed':
+      return 'External trust metadata is present, but RAP has not verified it.';
+    case 'failed_verification':
+      return 'RAP-side verification failed for this provider.';
+    case 'unverified':
+      return 'No verified trust metadata is available for this provider.';
+    case 'missing':
+      return 'No provider trust record is attached to this discovery candidate.';
+  }
+}
+
+function trustMessageCode(status: ProviderTrustVerificationStatus | 'missing'): SourceDiagnosticReasonCode {
+  switch (status) {
+    case 'verified':
+      return 'trust_verified';
+    case 'claimed':
+      return 'trust_claimed_unverified';
+    case 'failed_verification':
+      return 'trust_failed_verification';
+    case 'unverified':
+    case 'missing':
+      return 'trust_unverified';
+  }
+}
+
+function trustSeverity(status: ProviderTrustVerificationStatus | 'missing'): SourceDiagnosticSeverity {
+  if (status === 'verified') return 'info';
+  if (status === 'failed_verification') return 'blocked';
+  return 'warning';
+}
+
+function paymentReasonCodes(decision?: DiscoveryCandidatePolicyPreflightDecision): DiscoveryCandidateReasonCode[] {
+  if (!decision) return [];
+  return decision.reasonCodes.filter((code) => (
+    code === 'missing_quote'
+    || code === 'malformed_candidate'
+    || code === 'unsupported_asset'
+    || code === 'unsupported_network'
+    || code === 'over_budget'
+  ));
+}
+
+function paymentAllowed(candidate: DiscoveryCandidate, decision?: DiscoveryCandidatePolicyPreflightDecision): boolean | undefined {
+  if (!candidate.quote && !decision) return undefined;
+  const paymentCodes = paymentReasonCodes(decision);
+  return Boolean(candidate.quote) && paymentCodes.length === 0;
+}
+
+export function createSourceAwareCandidateDiagnostics(
+  candidate: DiscoveryCandidate,
+  options: SourceAwareDiagnosticsOptions = {},
+): SourceAwareCandidateDiagnostics {
+  const policyDecision = options.policyDecision;
+  const trustStatus = candidate.providerTrust?.verification?.status ?? 'missing';
+  const trustMetadata = candidate.providerTrust?.trustMetadata ?? candidate.trustMetadata;
+  const provenanceCount = trustMetadata?.provenanceLinks.length ?? 0;
+  const attestationCount = trustMetadata?.attestations.length ?? 0;
+  const verificationReferenceCount = trustMetadata?.verificationReferences.length ?? 0;
+  const publisher = candidate.publisher;
+  const paymentCodes = paymentReasonCodes(policyDecision);
+  const paymentLaneAllowed = paymentAllowed(candidate, policyDecision);
+  const hasReputation = Boolean((options.reputation?.receiptCount ?? 0) > 0 || (options.reputation?.attestationCount ?? 0) > 0);
+  const messages: SourceDiagnosticMessage[] = [];
+
+  messages.push({
+    lane: 'capability_match',
+    severity: 'info',
+    code: candidate.relevance?.score === undefined ? 'capability_match_unscored' : 'capability_declared',
+    summary: candidate.relevance?.score === undefined
+      ? `Candidate ${candidate.identifier} declares ${candidate.mediaType}; no relevance score was supplied.`
+      : `Candidate ${candidate.identifier} has relevance score ${candidate.relevance.score}; this is not a trust score.`,
+  });
+
+  messages.push({
+    lane: 'discovery_source',
+    severity: 'info',
+    code: candidate.rawSnapshotRef ? 'raw_snapshot_recorded' : 'discovery_source_recorded',
+    summary: `Discovered from ${candidate.sourceKind}${candidate.rawSnapshotRef ? ` with snapshot ${candidate.rawSnapshotRef}` : ''}.`,
+  });
+
+  messages.push({
+    lane: 'publisher_identity',
+    severity: publisher?.id ? 'info' : 'warning',
+    code: publisher?.id ? 'publisher_identity_recorded' : 'publisher_identity_missing',
+    summary: publisher?.id ? `Publisher identity recorded as ${publisher.id}.` : 'No publisher identity is attached to this candidate.',
+    action: publisher?.id ? undefined : 'Require provider identity before publishing or paid invocation.',
+  });
+
+  messages.push({
+    lane: 'trust_evidence',
+    severity: trustSeverity(trustStatus),
+    code: trustMessageCode(trustStatus),
+    summary: trustSummary(trustStatus),
+    action: trustStatus === 'verified' ? undefined : 'Run RAP-side trust verification before treating this candidate as trusted.',
+  });
+
+  if (policyDecision) {
+    messages.push({
+      lane: 'policy_decision',
+      severity: policyDecision.allowed ? 'info' : 'blocked',
+      code: policyDecision.allowed ? 'policy_allowed' : 'policy_denied',
+      summary: policyDecision.allowed
+        ? 'Policy preflight allowed this candidate.'
+        : `Policy preflight denied this candidate: ${policyDecision.reasonCodes.join(', ')}.`,
+      action: policyDecision.allowed ? undefined : 'Resolve the listed policy reason codes before quote/payment/invocation.',
+    });
+  }
+
+  messages.push({
+    lane: 'payment_fit',
+    severity: paymentCodes.length > 0 ? 'blocked' : candidate.quote ? 'info' : 'warning',
+    code: paymentCodes.length > 0 ? 'payment_quote_denied' : candidate.quote ? 'payment_quote_present' : 'payment_quote_missing',
+    summary: paymentCodes.length > 0
+      ? `Payment or budget fit failed: ${paymentCodes.join(', ')}.`
+      : candidate.quote
+        ? `Quote is ${candidate.quote.amount} ${candidate.quote.asset} on ${candidate.quote.network}.`
+        : 'No quote is attached; quote/payment preflight is still required.',
+    action: paymentCodes.length > 0 || !candidate.quote ? 'Complete quote/payment preflight before invocation.' : undefined,
+  });
+
+  messages.push({
+    lane: 'reputation_evidence',
+    severity: hasReputation ? 'info' : 'warning',
+    code: hasReputation ? 'reputation_history_present' : 'reputation_history_absent',
+    summary: hasReputation
+      ? `Reputation evidence includes ${options.reputation?.receiptCount ?? 0} receipt(s) and ${options.reputation?.attestationCount ?? 0} attestation(s).`
+      : 'No prior receipt or attestation history is attached.',
+    action: hasReputation ? undefined : 'Treat this candidate as unproven until receipts or attestations exist.',
+  });
+
+  return {
+    schemaVersion: SOURCE_DIAGNOSTICS_SCHEMA_VERSION,
+    candidate: {
+      identifier: candidate.identifier,
+      name: candidate.name,
+      sourceKind: candidate.sourceKind,
+      rawSnapshotRef: candidate.rawSnapshotRef,
+    },
+    capabilityMatch: {
+      resourceType: candidate.resourceType,
+      mediaType: candidate.mediaType,
+      relevanceScore: candidate.relevance?.score,
+      scoreMeaning: 'relevance_only_not_trust',
+      summary: candidate.relevance?.score === undefined
+        ? 'Capability match has no supplied relevance score.'
+        : 'Relevance score is only a capability/search signal and never a trust, safety, payment, or reputation decision.',
+    },
+    discoverySource: {
+      sourceKind: candidate.sourceKind,
+      url: candidate.url,
+      endpoint: candidate.endpoint,
+      rawSnapshotRef: candidate.rawSnapshotRef,
+      summary: 'Discovery source is recorded separately from policy, trust, payment, and reputation.',
+    },
+    publisherIdentity: {
+      id: publisher?.id,
+      name: publisher?.name,
+      domain: publisher?.domain,
+      trustStatus: candidate.providerTrust?.verification.status,
+      summary: publisher?.id ? 'Publisher identity is present for audit and display.' : 'Publisher identity is missing.',
+    },
+    trustEvidence: {
+      status: trustStatus,
+      reasonCodes: candidate.providerTrust?.verification.reasonCodes ?? ['no_trust_record'],
+      verifier: candidate.providerTrust?.verification.verifier,
+      checkedAt: candidate.providerTrust?.verification.checkedAt,
+      failureReasons: candidate.providerTrust?.verification.failureReasons ?? [],
+      provenanceCount,
+      attestationCount,
+      verificationReferenceCount,
+      summary: trustSummary(trustStatus),
+    },
+    policyDecision: {
+      allowed: policyDecision?.allowed,
+      reasonCodes: policyDecision?.reasonCodes ?? [],
+      summaries: policyDecision?.auditNotes ?? [],
+    },
+    paymentFit: {
+      quote: candidate.quote
+        ? {
+            amount: candidate.quote.amount,
+            asset: candidate.quote.asset,
+            network: candidate.quote.network,
+          }
+        : undefined,
+      allowed: paymentLaneAllowed,
+      reasonCodes: paymentCodes,
+      summary: paymentCodes.length > 0
+        ? 'Payment or budget policy denied this candidate.'
+        : candidate.quote
+          ? 'Quote metadata is present; payment still requires explicit approval/settlement outside discovery.'
+          : 'Quote metadata is missing.',
+    },
+    reputationEvidence: {
+      status: hasReputation ? 'history_present' : 'no_history',
+      receiptCount: options.reputation?.receiptCount,
+      attestationCount: options.reputation?.attestationCount,
+      summary: hasReputation ? 'Prior reputation evidence is present.' : 'No prior reputation evidence is present.',
+    },
+    messages,
+  };
+}

--- a/packages/agent-protocol/tests/source-diagnostics.test.ts
+++ b/packages/agent-protocol/tests/source-diagnostics.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createAiCatalogDiscoveryCandidates,
+  createSourceAwareCandidateDiagnostics,
+  evaluateDiscoveryCandidatePolicyPreflight,
+  providerTrustFixtures,
+  type DiscoveryCandidate,
+} from '../dist/index.js';
+
+describe('RAP source-aware candidate diagnostics', () => {
+  it('separates capability, source, publisher, trust, policy, payment, and reputation lanes', () => {
+    const candidates = createAiCatalogDiscoveryCandidates(providerTrustFixtures.verifiedCatalog, {
+      relevanceScores: {
+        'urn:ai:reddi.tech:specialists:code-review': 0.92,
+      },
+      trustOptionsByResourceId: {
+        'urn:ai:reddi.tech:specialists:code-review': {
+          verification: { status: 'verified', verifier: 'rap:unit-test' },
+        },
+      },
+    });
+    assert.equal(candidates.ok, true);
+    if (!candidates.ok) return;
+
+    const candidate = {
+      ...candidates.candidates[0],
+      quote: { amount: '5000', asset: 'AUDD', network: 'solana-devnet' },
+    };
+    const policyDecision = evaluateDiscoveryCandidatePolicyPreflight(candidate, {
+      allowedSourceKinds: ['direct-ai-catalog'],
+      requireVerifiedTrust: true,
+      allowedAssets: ['AUDD'],
+      allowedNetworks: ['solana-devnet'],
+      maxQuote: { amount: '10000', asset: 'AUDD', network: 'solana-devnet' },
+    });
+
+    const diagnostics = createSourceAwareCandidateDiagnostics(candidate, {
+      policyDecision,
+      reputation: {
+        receiptCount: 2,
+        attestationCount: 1,
+      },
+    });
+
+    assert.equal(diagnostics.schemaVersion, 'reddi.source-diagnostics.v1');
+    assert.equal(diagnostics.capabilityMatch.relevanceScore, 0.92);
+    assert.equal(diagnostics.capabilityMatch.scoreMeaning, 'relevance_only_not_trust');
+    assert.equal(diagnostics.discoverySource.sourceKind, 'direct-ai-catalog');
+    assert.equal(diagnostics.discoverySource.rawSnapshotRef, 'sha256:verified-catalog-fixture');
+    assert.equal(diagnostics.publisherIdentity.id, 'reddi.tech');
+    assert.equal(diagnostics.trustEvidence.status, 'verified');
+    assert.equal(diagnostics.policyDecision.allowed, true);
+    assert.deepEqual(diagnostics.policyDecision.reasonCodes, ['candidate_ready_for_policy_preflight']);
+    assert.equal(diagnostics.paymentFit.quote?.asset, 'AUDD');
+    assert.equal(diagnostics.reputationEvidence.status, 'history_present');
+
+    const lanes = new Set(diagnostics.messages.map((message) => message.lane));
+    assert.deepEqual([...lanes].sort(), [
+      'capability_match',
+      'discovery_source',
+      'payment_fit',
+      'policy_decision',
+      'publisher_identity',
+      'reputation_evidence',
+      'trust_evidence',
+    ].sort());
+  });
+
+  it('labels ARD relevance as relevance only and keeps high relevance from overriding denial lanes', () => {
+    const candidates = createAiCatalogDiscoveryCandidates(providerTrustFixtures.unverifiedCatalog, {
+      sourceKind: 'ard-registry',
+      relevanceScores: {
+        'urn:example:agents:summary': 0.99,
+      },
+    });
+    assert.equal(candidates.ok, true);
+    if (!candidates.ok) return;
+
+    const candidate: DiscoveryCandidate = {
+      ...candidates.candidates[0],
+      quote: { amount: '20000', asset: 'AUDD', network: 'solana-mainnet' },
+    };
+    const policyDecision = evaluateDiscoveryCandidatePolicyPreflight(candidate, {
+      allowedSourceKinds: ['ard-registry'],
+      requireVerifiedTrust: true,
+      allowedAssets: ['AUDD'],
+      allowedNetworks: ['solana-devnet'],
+      maxQuote: { amount: '10000', asset: 'AUDD', network: 'solana-devnet' },
+    });
+    assert.equal(policyDecision.allowed, false);
+
+    const diagnostics = createSourceAwareCandidateDiagnostics(candidate, { policyDecision });
+    assert.equal(diagnostics.capabilityMatch.relevanceScore, 0.99);
+    assert.equal(diagnostics.capabilityMatch.scoreMeaning, 'relevance_only_not_trust');
+    assert.equal(diagnostics.trustEvidence.status, 'unverified');
+    assert.equal(diagnostics.policyDecision.allowed, false);
+    assert.ok(diagnostics.policyDecision.reasonCodes.includes('trust_verification_required'));
+    assert.ok(diagnostics.paymentFit.reasonCodes.includes('unsupported_network'));
+    assert.ok(diagnostics.paymentFit.reasonCodes.includes('over_budget'));
+    assert.equal(diagnostics.reputationEvidence.status, 'no_history');
+
+    const blockedMessages = diagnostics.messages.filter((message) => message.severity === 'blocked');
+    assert.ok(blockedMessages.some((message) => message.lane === 'policy_decision'));
+    assert.ok(blockedMessages.some((message) => message.lane === 'payment_fit'));
+    assert.ok(diagnostics.messages.some((message) => message.summary.includes('not a trust score')));
+  });
+
+  it('keeps payment fit separate from source/trust denial and exposes failed verification details', () => {
+    const candidates = createAiCatalogDiscoveryCandidates(providerTrustFixtures.verifiedCatalog, {
+      relevanceScores: {
+        'urn:ai:reddi.tech:specialists:code-review': 0.98,
+      },
+      trustOptionsByResourceId: {
+        'urn:ai:reddi.tech:specialists:code-review': {
+          verification: {
+            status: 'failed_verification',
+            verifier: 'rap:unit-test',
+            checkedAt: '2026-06-18T11:58:00.000Z',
+            failureReasons: ['signature_ref_unavailable'],
+          },
+        },
+      },
+    });
+    assert.equal(candidates.ok, true);
+    if (!candidates.ok) return;
+
+    const candidate = {
+      ...candidates.candidates[0],
+      quote: { amount: '5000', asset: 'AUDD', network: 'solana-devnet' },
+    };
+    const policyDecision = evaluateDiscoveryCandidatePolicyPreflight(candidate, {
+      allowedSourceKinds: ['hosted-rap-registry'],
+      requireVerifiedTrust: true,
+      allowedAssets: ['AUDD'],
+      allowedNetworks: ['solana-devnet'],
+      maxQuote: { amount: '10000', asset: 'AUDD', network: 'solana-devnet' },
+    });
+
+    const diagnostics = createSourceAwareCandidateDiagnostics(candidate, { policyDecision });
+    assert.equal(diagnostics.capabilityMatch.relevanceScore, 0.98);
+    assert.equal(diagnostics.trustEvidence.status, 'failed_verification');
+    assert.equal(diagnostics.trustEvidence.verifier, 'rap:unit-test');
+    assert.equal(diagnostics.trustEvidence.checkedAt, '2026-06-18T11:58:00.000Z');
+    assert.deepEqual(diagnostics.trustEvidence.failureReasons, ['signature_ref_unavailable']);
+    assert.equal(diagnostics.policyDecision.allowed, false);
+    assert.ok(diagnostics.policyDecision.reasonCodes.includes('source_not_allowed'));
+    assert.ok(diagnostics.policyDecision.reasonCodes.includes('trust_verification_required'));
+    assert.equal(diagnostics.paymentFit.allowed, true);
+    assert.deepEqual(diagnostics.paymentFit.reasonCodes, []);
+  });
+
+  it('emits actionable machine-readable denial summaries', () => {
+    const candidates = createAiCatalogDiscoveryCandidates(providerTrustFixtures.unverifiedCatalog);
+    assert.equal(candidates.ok, true);
+    if (!candidates.ok) return;
+
+    const candidate = candidates.candidates[0];
+    const policyDecision = evaluateDiscoveryCandidatePolicyPreflight(candidate, {
+      allowedSourceKinds: ['hosted-rap-registry'],
+      requireVerifiedTrust: true,
+    });
+
+    const diagnostics = createSourceAwareCandidateDiagnostics(candidate, { policyDecision });
+    assert.equal(diagnostics.policyDecision.allowed, false);
+    assert.ok(diagnostics.policyDecision.reasonCodes.includes('source_not_allowed'));
+    assert.ok(diagnostics.policyDecision.reasonCodes.includes('trust_verification_required'));
+    assert.ok(diagnostics.policyDecision.reasonCodes.includes('missing_quote'));
+    assert.ok(diagnostics.messages.some((message) => message.action?.includes('Resolve the listed policy reason codes')));
+    assert.ok(diagnostics.messages.some((message) => message.action?.includes('Complete quote/payment preflight')));
+    assert.equal(diagnostics.trustEvidence.status, 'unverified');
+  });
+});


### PR DESCRIPTION
## Summary
- add `reddi.source-diagnostics.v1` source-aware diagnostic records
- expose separate capability, discovery source, publisher identity, trust evidence, policy, payment, and reputation lanes
- label relevance scores as `relevance_only_not_trust`
- add negative fixtures proving high relevance cannot override RAP trust or policy/payment denial
- export `@reddi/agent-protocol/source-diagnostics`

## Boundaries
- no ranking model or blended trust score
- no network fetches, hosted dependency, wallet action, payment settlement, or invocation
- diagnostics consume existing discovery candidates, provider trust records, and policy preflight decisions

## Validation
- `npm test` in `packages/agent-protocol` passed with 38 tests
- `npm run release:dry-run` in `packages/agent-protocol` passed
- `npm run check:rap:naming` passed
- `git diff --check` passed

Closes #367.
