### PR TITLE
Add local EvidenceArchive primitives

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -108,6 +108,31 @@ if (candidates.ok) {
 
 Discovery candidates are source-neutral buyer-client inputs for local specialists, direct AI Catalogs, ARD registry/search fixtures, source adapters, and future hosted RAP registries. Candidate relevance is informational only; it is never used as a trust, safety, payment, or budget decision. Quotes, policy preflight, payment approval, invocation, receipts, evidence, attestations, and reputation remain separate RAP steps.
 
+## EvidenceArchive
+
+```typescript
+import {
+  createEvidenceArchiveRecord,
+  createLocalEvidenceArchive,
+} from '@reddi/agent-protocol/evidence-archive';
+
+const record = createEvidenceArchiveRecord({
+  id: 'evidence:demo:001',
+  receiptId: 'receipt:demo:001',
+  sourceId: 'source:demo',
+  requestHash: 'sha256:7b2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15',
+  responseHash: 'sha256:8c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501',
+  evidenceRef: 'file://fixtures/evidence/demo-001.json',
+  createdAt: new Date().toISOString(),
+  evidencePayload: { result: 'private payload stays outside the receipt' },
+});
+
+const archive = createLocalEvidenceArchive();
+archive.put(record);
+```
+
+EvidenceArchive v1 stores request, response, receipt, source, attestation, and evidence hash references without embedding private payloads in public receipts. The local archive is deterministic for tests and demos. Walrus, Seal, IPFS, and custom archive pointers are represented as future sidecar references, not required product-core dependencies.
+
 ## Local Validation
 
 ```bash

--- a/packages/agent-protocol/dist/evidence-archive.d.ts
+++ b/packages/agent-protocol/dist/evidence-archive.d.ts
@@ -1,0 +1,67 @@
+export declare const EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION: "reddi.evidence-archive.v1";
+export type EvidenceArchiveRecord = {
+    schemaVersion: typeof EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION;
+    id: string;
+    receiptId: string;
+    sourceId: string;
+    requestHash: string;
+    responseHash: string;
+    evidenceHash: string;
+    evidenceRef: string;
+    attestationId?: string;
+    externalArchivePointer?: {
+        provider: 'walrus' | 'seal' | 'ipfs' | 'custom';
+        uri: string;
+        contentHash?: string;
+    };
+    createdAt: string;
+    metadata?: Record<string, unknown>;
+};
+export type EvidenceArchiveValidationErrorCode = 'malformed_evidence_record' | 'hash_mismatch' | 'evidence_missing' | 'credential_leakage_rejected';
+export type EvidenceArchiveValidationError = {
+    code: EvidenceArchiveValidationErrorCode;
+    path: string;
+    message: string;
+};
+export type EvidenceArchiveValidationResult = {
+    ok: true;
+    record: EvidenceArchiveRecord;
+} | {
+    ok: false;
+    errors: EvidenceArchiveValidationError[];
+};
+export type EvidenceArchiveLookupResult = {
+    ok: true;
+    record: EvidenceArchiveRecord;
+} | {
+    ok: false;
+    error: EvidenceArchiveValidationError;
+};
+export type EvidenceArchiveCreateInput = Omit<EvidenceArchiveRecord, 'schemaVersion' | 'evidenceHash'> & {
+    evidencePayload?: unknown;
+    evidenceHash?: string;
+};
+export type EvidenceArchiveValidationOptions = {
+    requireEvidencePayloadOrPointer?: boolean;
+};
+export type LocalEvidenceArchive = {
+    put(record: EvidenceArchiveRecord): EvidenceArchiveValidationResult;
+    get(id: string): EvidenceArchiveLookupResult;
+    has(id: string): boolean;
+    list(): EvidenceArchiveRecord[];
+};
+export declare function validateEvidenceArchiveRecord(input: unknown, evidencePayload?: unknown, options?: EvidenceArchiveValidationOptions): EvidenceArchiveValidationResult;
+export declare function createEvidenceArchiveRecord(input: EvidenceArchiveCreateInput): EvidenceArchiveRecord;
+export declare function createLocalEvidenceArchive(initialRecords?: EvidenceArchiveRecord[]): LocalEvidenceArchive;
+export declare const evidenceArchiveFixtures: {
+    readonly evidencePayload: {
+        readonly request: {
+            readonly hash: "sha256:7b2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15";
+        };
+        readonly response: {
+            readonly hash: "sha256:8c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501";
+        };
+        readonly resultSummary: "Planning specialist completed a deterministic no-spend fixture run.";
+    };
+};
+export declare const evidenceArchiveFixtureRecord: EvidenceArchiveRecord;

--- a/packages/agent-protocol/dist/evidence-archive.js
+++ b/packages/agent-protocol/dist/evidence-archive.js
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 export const EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION = 'reddi.evidence-archive.v1';
 const HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
-const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey/i;
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|signature|sig|signed|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
 const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
 function error(code, path, message) {
     return { code, path, message };

--- a/packages/agent-protocol/dist/evidence-archive.js
+++ b/packages/agent-protocol/dist/evidence-archive.js
@@ -1,0 +1,188 @@
+import { createHash } from 'node:crypto';
+export const EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION = 'reddi.evidence-archive.v1';
+const HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+function error(code, path, message) {
+    return { code, path, message };
+}
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function hashJson(value) {
+    try {
+        return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+    }
+    catch {
+        return undefined;
+    }
+}
+function findCredentialMaterial(value, path = '$') {
+    if (typeof value === 'string')
+        return SENSITIVE_VALUE_PATTERN.test(value) ? path : undefined;
+    if (!value || typeof value !== 'object')
+        return undefined;
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index += 1) {
+            const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+            if (found)
+                return found;
+        }
+        return undefined;
+    }
+    for (const [key, nested] of Object.entries(value)) {
+        const nextPath = `${path}.${key}`;
+        if (SENSITIVE_KEY_PATTERN.test(key))
+            return nextPath;
+        const found = findCredentialMaterial(nested, nextPath);
+        if (found)
+            return found;
+    }
+    return undefined;
+}
+function requireString(value, path, errors) {
+    if (!isNonEmptyString(value))
+        errors.push(error('malformed_evidence_record', path, 'required string is missing'));
+}
+function requireHash(value, path, errors) {
+    if (!isNonEmptyString(value) || !HASH_PATTERN.test(value)) {
+        errors.push(error('malformed_evidence_record', path, 'hash must be a sha256:<hex> reference'));
+    }
+}
+function validateExternalPointer(value, errors) {
+    if (value === undefined)
+        return;
+    if (!isPlainObject(value)) {
+        errors.push(error('malformed_evidence_record', '$.externalArchivePointer', 'externalArchivePointer must be an object'));
+        return;
+    }
+    if (!['walrus', 'seal', 'ipfs', 'custom'].includes(String(value.provider))) {
+        errors.push(error('malformed_evidence_record', '$.externalArchivePointer.provider', 'external archive provider is unsupported'));
+    }
+    requireString(value.uri, '$.externalArchivePointer.uri', errors);
+    if (value.contentHash !== undefined)
+        requireHash(value.contentHash, '$.externalArchivePointer.contentHash', errors);
+}
+export function validateEvidenceArchiveRecord(input, evidencePayload, options = {}) {
+    const errors = [];
+    if (!isPlainObject(input)) {
+        return { ok: false, errors: [error('malformed_evidence_record', '$', 'evidence archive record must be a plain object')] };
+    }
+    const record = input;
+    if (record.schemaVersion !== EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION) {
+        errors.push(error('malformed_evidence_record', '$.schemaVersion', `expected ${EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION}`));
+    }
+    requireString(record.id, '$.id', errors);
+    requireString(record.receiptId, '$.receiptId', errors);
+    requireString(record.sourceId, '$.sourceId', errors);
+    requireHash(record.requestHash, '$.requestHash', errors);
+    requireHash(record.responseHash, '$.responseHash', errors);
+    requireHash(record.evidenceHash, '$.evidenceHash', errors);
+    requireString(record.evidenceRef, '$.evidenceRef', errors);
+    if (record.attestationId !== undefined)
+        requireString(record.attestationId, '$.attestationId', errors);
+    if (!isNonEmptyString(record.createdAt) || Number.isNaN(Date.parse(record.createdAt))) {
+        errors.push(error('malformed_evidence_record', '$.createdAt', 'createdAt must be an ISO timestamp'));
+    }
+    validateExternalPointer(record.externalArchivePointer, errors);
+    const credentialPath = findCredentialMaterial(record.metadata);
+    if (credentialPath) {
+        errors.push(error('credential_leakage_rejected', `$.metadata${credentialPath.slice(1)}`, 'evidence metadata contains credential-shaped material'));
+    }
+    const requireEvidencePayloadOrPointer = options.requireEvidencePayloadOrPointer ?? true;
+    if (requireEvidencePayloadOrPointer && evidencePayload === undefined && !record.externalArchivePointer) {
+        errors.push(error('evidence_missing', '$.evidencePayload', 'local evidence payload or external archive pointer is required'));
+    }
+    if (evidencePayload !== undefined) {
+        const payloadCredentialPath = findCredentialMaterial(evidencePayload);
+        if (payloadCredentialPath) {
+            errors.push(error('credential_leakage_rejected', `$.evidencePayload${payloadCredentialPath.slice(1)}`, 'evidence payload contains credential-shaped material'));
+        }
+        const expectedHash = hashJson(evidencePayload);
+        if (!expectedHash) {
+            errors.push(error('malformed_evidence_record', '$.evidencePayload', 'evidence payload must be JSON-serializable'));
+        }
+        else if (record.evidenceHash && expectedHash !== record.evidenceHash) {
+            errors.push(error('hash_mismatch', '$.evidenceHash', 'evidenceHash does not match the supplied evidence payload'));
+        }
+    }
+    return errors.length === 0 ? { ok: true, record } : { ok: false, errors };
+}
+export function createEvidenceArchiveRecord(input) {
+    const evidenceHash = input.evidenceHash ?? hashJson(input.evidencePayload);
+    const record = {
+        schemaVersion: EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION,
+        id: input.id,
+        receiptId: input.receiptId,
+        sourceId: input.sourceId,
+        requestHash: input.requestHash,
+        responseHash: input.responseHash,
+        evidenceHash: evidenceHash ?? '',
+        evidenceRef: input.evidenceRef,
+        attestationId: input.attestationId,
+        externalArchivePointer: input.externalArchivePointer,
+        createdAt: input.createdAt,
+        metadata: input.metadata,
+    };
+    const validation = validateEvidenceArchiveRecord(record, input.evidencePayload);
+    if (!validation.ok) {
+        throw new Error(`invalid_evidence_archive_record:${validation.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+    }
+    return validation.record;
+}
+export function createLocalEvidenceArchive(initialRecords = []) {
+    const records = new Map();
+    for (const record of initialRecords) {
+        const result = validateEvidenceArchiveRecord(record, undefined, { requireEvidencePayloadOrPointer: false });
+        if (!result.ok) {
+            throw new Error(`invalid_initial_evidence_archive_record:${result.errors.map((item) => item.code).join(',')}`);
+        }
+        records.set(record.id, record);
+    }
+    return {
+        put(record) {
+            const result = validateEvidenceArchiveRecord(record, undefined, { requireEvidencePayloadOrPointer: false });
+            if (!result.ok)
+                return result;
+            records.set(record.id, result.record);
+            return result;
+        },
+        get(id) {
+            const record = records.get(id);
+            if (!record) {
+                return { ok: false, error: error('evidence_missing', '$.id', `No evidence archive record found for ${id}`) };
+            }
+            return { ok: true, record };
+        },
+        has(id) {
+            return records.has(id);
+        },
+        list() {
+            return [...records.values()];
+        },
+    };
+}
+export const evidenceArchiveFixtures = {
+    evidencePayload: {
+        request: { hash: 'sha256:7b2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15' },
+        response: { hash: 'sha256:8c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501' },
+        resultSummary: 'Planning specialist completed a deterministic no-spend fixture run.',
+    },
+};
+export const evidenceArchiveFixtureRecord = createEvidenceArchiveRecord({
+    id: 'evidence:planning-001',
+    receiptId: 'job:planning-001',
+    sourceId: 'source:planning',
+    requestHash: 'sha256:7b2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15',
+    responseHash: 'sha256:8c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501',
+    evidenceRef: 'file://fixtures/evidence/planning-001.json',
+    attestationId: 'attestation:planning-001',
+    createdAt: '2026-06-18T12:15:00.000Z',
+    evidencePayload: evidenceArchiveFixtures.evidencePayload,
+});

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -4,3 +4,4 @@ export * from './fixtures.js';
 export * from './ai-catalog.js';
 export * from './provider-trust.js';
 export * from './discovery-source.js';
+export * from './evidence-archive.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -4,3 +4,4 @@ export * from './fixtures.js';
 export * from './ai-catalog.js';
 export * from './provider-trust.js';
 export * from './discovery-source.js';
+export * from './evidence-archive.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -34,6 +34,10 @@
       "types": "./dist/discovery-source.d.ts",
       "import": "./dist/discovery-source.js"
     },
+    "./evidence-archive": {
+      "types": "./dist/evidence-archive.d.ts",
+      "import": "./dist/evidence-archive.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/evidence-archive.ts
+++ b/packages/agent-protocol/src/evidence-archive.ts
@@ -58,7 +58,7 @@ export type LocalEvidenceArchive = {
 };
 
 const HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
-const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey/i;
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|signature|sig|signed|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
 const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
 
 function error(code: EvidenceArchiveValidationErrorCode, path: string, message: string): EvidenceArchiveValidationError {

--- a/packages/agent-protocol/src/evidence-archive.ts
+++ b/packages/agent-protocol/src/evidence-archive.ts
@@ -1,0 +1,255 @@
+import { createHash } from 'node:crypto';
+
+export const EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION = 'reddi.evidence-archive.v1' as const;
+
+export type EvidenceArchiveRecord = {
+  schemaVersion: typeof EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION;
+  id: string;
+  receiptId: string;
+  sourceId: string;
+  requestHash: string;
+  responseHash: string;
+  evidenceHash: string;
+  evidenceRef: string;
+  attestationId?: string;
+  externalArchivePointer?: {
+    provider: 'walrus' | 'seal' | 'ipfs' | 'custom';
+    uri: string;
+    contentHash?: string;
+  };
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type EvidenceArchiveValidationErrorCode =
+  | 'malformed_evidence_record'
+  | 'hash_mismatch'
+  | 'evidence_missing'
+  | 'credential_leakage_rejected';
+
+export type EvidenceArchiveValidationError = {
+  code: EvidenceArchiveValidationErrorCode;
+  path: string;
+  message: string;
+};
+
+export type EvidenceArchiveValidationResult =
+  | { ok: true; record: EvidenceArchiveRecord }
+  | { ok: false; errors: EvidenceArchiveValidationError[] };
+
+export type EvidenceArchiveLookupResult =
+  | { ok: true; record: EvidenceArchiveRecord }
+  | { ok: false; error: EvidenceArchiveValidationError };
+
+export type EvidenceArchiveCreateInput = Omit<EvidenceArchiveRecord, 'schemaVersion' | 'evidenceHash'> & {
+  evidencePayload?: unknown;
+  evidenceHash?: string;
+};
+
+export type EvidenceArchiveValidationOptions = {
+  requireEvidencePayloadOrPointer?: boolean;
+};
+
+export type LocalEvidenceArchive = {
+  put(record: EvidenceArchiveRecord): EvidenceArchiveValidationResult;
+  get(id: string): EvidenceArchiveLookupResult;
+  has(id: string): boolean;
+  list(): EvidenceArchiveRecord[];
+};
+
+const HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+
+function error(code: EvidenceArchiveValidationErrorCode, path: string, message: string): EvidenceArchiveValidationError {
+  return { code, path, message };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hashJson(value: unknown): string | undefined {
+  try {
+    return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function findCredentialMaterial(value: unknown, path = '$'): string | undefined {
+  if (typeof value === 'string') return SENSITIVE_VALUE_PATTERN.test(value) ? path : undefined;
+  if (!value || typeof value !== 'object') return undefined;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  for (const [key, nested] of Object.entries(value)) {
+    const nextPath = `${path}.${key}`;
+    if (SENSITIVE_KEY_PATTERN.test(key)) return nextPath;
+    const found = findCredentialMaterial(nested, nextPath);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function requireString(value: unknown, path: string, errors: EvidenceArchiveValidationError[]): void {
+  if (!isNonEmptyString(value)) errors.push(error('malformed_evidence_record', path, 'required string is missing'));
+}
+
+function requireHash(value: unknown, path: string, errors: EvidenceArchiveValidationError[]): void {
+  if (!isNonEmptyString(value) || !HASH_PATTERN.test(value)) {
+    errors.push(error('malformed_evidence_record', path, 'hash must be a sha256:<hex> reference'));
+  }
+}
+
+function validateExternalPointer(value: unknown, errors: EvidenceArchiveValidationError[]): void {
+  if (value === undefined) return;
+  if (!isPlainObject(value)) {
+    errors.push(error('malformed_evidence_record', '$.externalArchivePointer', 'externalArchivePointer must be an object'));
+    return;
+  }
+  if (!['walrus', 'seal', 'ipfs', 'custom'].includes(String(value.provider))) {
+    errors.push(error('malformed_evidence_record', '$.externalArchivePointer.provider', 'external archive provider is unsupported'));
+  }
+  requireString(value.uri, '$.externalArchivePointer.uri', errors);
+  if (value.contentHash !== undefined) requireHash(value.contentHash, '$.externalArchivePointer.contentHash', errors);
+}
+
+export function validateEvidenceArchiveRecord(
+  input: unknown,
+  evidencePayload?: unknown,
+  options: EvidenceArchiveValidationOptions = {},
+): EvidenceArchiveValidationResult {
+  const errors: EvidenceArchiveValidationError[] = [];
+  if (!isPlainObject(input)) {
+    return { ok: false, errors: [error('malformed_evidence_record', '$', 'evidence archive record must be a plain object')] };
+  }
+
+  const record = input as EvidenceArchiveRecord;
+  if (record.schemaVersion !== EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION) {
+    errors.push(error('malformed_evidence_record', '$.schemaVersion', `expected ${EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION}`));
+  }
+  requireString(record.id, '$.id', errors);
+  requireString(record.receiptId, '$.receiptId', errors);
+  requireString(record.sourceId, '$.sourceId', errors);
+  requireHash(record.requestHash, '$.requestHash', errors);
+  requireHash(record.responseHash, '$.responseHash', errors);
+  requireHash(record.evidenceHash, '$.evidenceHash', errors);
+  requireString(record.evidenceRef, '$.evidenceRef', errors);
+  if (record.attestationId !== undefined) requireString(record.attestationId, '$.attestationId', errors);
+  if (!isNonEmptyString(record.createdAt) || Number.isNaN(Date.parse(record.createdAt))) {
+    errors.push(error('malformed_evidence_record', '$.createdAt', 'createdAt must be an ISO timestamp'));
+  }
+  validateExternalPointer(record.externalArchivePointer, errors);
+
+  const credentialPath = findCredentialMaterial(record.metadata);
+  if (credentialPath) {
+    errors.push(error('credential_leakage_rejected', `$.metadata${credentialPath.slice(1)}`, 'evidence metadata contains credential-shaped material'));
+  }
+
+  const requireEvidencePayloadOrPointer = options.requireEvidencePayloadOrPointer ?? true;
+  if (requireEvidencePayloadOrPointer && evidencePayload === undefined && !record.externalArchivePointer) {
+    errors.push(error('evidence_missing', '$.evidencePayload', 'local evidence payload or external archive pointer is required'));
+  }
+
+  if (evidencePayload !== undefined) {
+    const payloadCredentialPath = findCredentialMaterial(evidencePayload);
+    if (payloadCredentialPath) {
+      errors.push(error('credential_leakage_rejected', `$.evidencePayload${payloadCredentialPath.slice(1)}`, 'evidence payload contains credential-shaped material'));
+    }
+    const expectedHash = hashJson(evidencePayload);
+    if (!expectedHash) {
+      errors.push(error('malformed_evidence_record', '$.evidencePayload', 'evidence payload must be JSON-serializable'));
+    } else if (record.evidenceHash && expectedHash !== record.evidenceHash) {
+      errors.push(error('hash_mismatch', '$.evidenceHash', 'evidenceHash does not match the supplied evidence payload'));
+    }
+  }
+
+  return errors.length === 0 ? { ok: true, record } : { ok: false, errors };
+}
+
+export function createEvidenceArchiveRecord(input: EvidenceArchiveCreateInput): EvidenceArchiveRecord {
+  const evidenceHash = input.evidenceHash ?? hashJson(input.evidencePayload);
+  const record: EvidenceArchiveRecord = {
+    schemaVersion: EVIDENCE_ARCHIVE_RECORD_SCHEMA_VERSION,
+    id: input.id,
+    receiptId: input.receiptId,
+    sourceId: input.sourceId,
+    requestHash: input.requestHash,
+    responseHash: input.responseHash,
+    evidenceHash: evidenceHash ?? '',
+    evidenceRef: input.evidenceRef,
+    attestationId: input.attestationId,
+    externalArchivePointer: input.externalArchivePointer,
+    createdAt: input.createdAt,
+    metadata: input.metadata,
+  };
+  const validation = validateEvidenceArchiveRecord(record, input.evidencePayload);
+  if (!validation.ok) {
+    throw new Error(`invalid_evidence_archive_record:${validation.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+  }
+  return validation.record;
+}
+
+export function createLocalEvidenceArchive(initialRecords: EvidenceArchiveRecord[] = []): LocalEvidenceArchive {
+  const records = new Map<string, EvidenceArchiveRecord>();
+  for (const record of initialRecords) {
+    const result = validateEvidenceArchiveRecord(record, undefined, { requireEvidencePayloadOrPointer: false });
+    if (!result.ok) {
+      throw new Error(`invalid_initial_evidence_archive_record:${result.errors.map((item) => item.code).join(',')}`);
+    }
+    records.set(record.id, record);
+  }
+
+  return {
+    put(record: EvidenceArchiveRecord): EvidenceArchiveValidationResult {
+      const result = validateEvidenceArchiveRecord(record, undefined, { requireEvidencePayloadOrPointer: false });
+      if (!result.ok) return result;
+      records.set(record.id, result.record);
+      return result;
+    },
+    get(id: string): EvidenceArchiveLookupResult {
+      const record = records.get(id);
+      if (!record) {
+        return { ok: false, error: error('evidence_missing', '$.id', `No evidence archive record found for ${id}`) };
+      }
+      return { ok: true, record };
+    },
+    has(id: string): boolean {
+      return records.has(id);
+    },
+    list(): EvidenceArchiveRecord[] {
+      return [...records.values()];
+    },
+  };
+}
+
+export const evidenceArchiveFixtures = {
+  evidencePayload: {
+    request: { hash: 'sha256:7b2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15' },
+    response: { hash: 'sha256:8c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501' },
+    resultSummary: 'Planning specialist completed a deterministic no-spend fixture run.',
+  },
+} as const;
+
+export const evidenceArchiveFixtureRecord = createEvidenceArchiveRecord({
+  id: 'evidence:planning-001',
+  receiptId: 'job:planning-001',
+  sourceId: 'source:planning',
+  requestHash: 'sha256:7b2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15',
+  responseHash: 'sha256:8c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501',
+  evidenceRef: 'file://fixtures/evidence/planning-001.json',
+  attestationId: 'attestation:planning-001',
+  createdAt: '2026-06-18T12:15:00.000Z',
+  evidencePayload: evidenceArchiveFixtures.evidencePayload,
+});

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -4,3 +4,4 @@ export * from './fixtures.js';
 export * from './ai-catalog.js';
 export * from './provider-trust.js';
 export * from './discovery-source.js';
+export * from './evidence-archive.js';

--- a/packages/agent-protocol/tests/evidence-archive.test.ts
+++ b/packages/agent-protocol/tests/evidence-archive.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createEvidenceArchiveRecord,
+  createLocalEvidenceArchive,
+  evidenceArchiveFixtureRecord,
+  evidenceArchiveFixtures,
+  validateEvidenceArchiveRecord,
+} from '../dist/index.js';
+
+describe('RAP EvidenceArchive v1', () => {
+  it('creates and validates a local evidence archive record without exposing private payload in the record', () => {
+    const record = createEvidenceArchiveRecord({
+      id: 'evidence:unit:001',
+      receiptId: 'receipt:unit:001',
+      sourceId: 'source:unit',
+      requestHash: 'sha256:7b2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15',
+      responseHash: 'sha256:8c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501',
+      evidenceRef: 'file://fixtures/evidence/unit-001.json',
+      createdAt: '2026-06-18T12:18:00.000Z',
+      evidencePayload: evidenceArchiveFixtures.evidencePayload,
+      metadata: {
+        publicNote: 'payload hash only; private payload is not embedded',
+      },
+    });
+
+    assert.equal(record.schemaVersion, 'reddi.evidence-archive.v1');
+    assert.equal(record.receiptId, 'receipt:unit:001');
+    assert.ok(record.evidenceHash.startsWith('sha256:'));
+    assert.equal(Object.prototype.hasOwnProperty.call(record, 'evidencePayload'), false);
+
+    const validation = validateEvidenceArchiveRecord(record, evidenceArchiveFixtures.evidencePayload);
+    assert.equal(validation.ok, true);
+  });
+
+  it('stores and looks up deterministic local fixture records', () => {
+    const archive = createLocalEvidenceArchive();
+    const put = archive.put(evidenceArchiveFixtureRecord);
+    assert.equal(put.ok, true);
+    assert.equal(archive.has('evidence:planning-001'), true);
+
+    const lookup = archive.get('evidence:planning-001');
+    assert.equal(lookup.ok, true);
+    if (lookup.ok) {
+      assert.equal(lookup.record.receiptId, 'job:planning-001');
+      assert.equal(lookup.record.sourceId, 'source:planning');
+      assert.equal(lookup.record.attestationId, 'attestation:planning-001');
+    }
+
+    assert.equal(archive.list().length, 1);
+  });
+
+  it('fails closed for tampered evidence payload hashes', () => {
+    const tampered = validateEvidenceArchiveRecord(evidenceArchiveFixtureRecord, {
+      ...evidenceArchiveFixtures.evidencePayload,
+      resultSummary: 'tampered result',
+    });
+
+    assert.equal(tampered.ok, false);
+    if (!tampered.ok) {
+      assert.ok(tampered.errors.some((item) => item.code === 'hash_mismatch' && item.path === '$.evidenceHash'));
+    }
+  });
+
+  it('fails closed for missing evidence when no external pointer is present', () => {
+    const missing = validateEvidenceArchiveRecord(evidenceArchiveFixtureRecord);
+    assert.equal(missing.ok, false);
+    if (!missing.ok) {
+      assert.ok(missing.errors.some((item) => item.code === 'evidence_missing' && item.path === '$.evidencePayload'));
+    }
+
+    const archive = createLocalEvidenceArchive([evidenceArchiveFixtureRecord]);
+    const lookup = archive.get('evidence:missing');
+    assert.equal(lookup.ok, false);
+    if (!lookup.ok) assert.equal(lookup.error.code, 'evidence_missing');
+  });
+
+  it('allows external archive pointer placeholders without product-core dependencies', () => {
+    const pointerRecord = createEvidenceArchiveRecord({
+      id: 'evidence:pointer:001',
+      receiptId: 'receipt:pointer:001',
+      sourceId: 'source:pointer',
+      requestHash: 'sha256:7b2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15',
+      responseHash: 'sha256:8c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501',
+      evidenceHash: 'sha256:8a9a8a7b6c5d4e3f20112233445566778899aabbccddeeff0011223344556677',
+      evidenceRef: 'walrus://future-sidecar/blob-fixture',
+      externalArchivePointer: {
+        provider: 'walrus',
+        uri: 'walrus://future-sidecar/blob-fixture',
+        contentHash: 'sha256:8a9a8a7b6c5d4e3f20112233445566778899aabbccddeeff0011223344556677',
+      },
+      createdAt: '2026-06-18T12:18:00.000Z',
+    });
+
+    assert.equal(pointerRecord.externalArchivePointer?.provider, 'walrus');
+    const validation = validateEvidenceArchiveRecord(pointerRecord);
+    assert.equal(validation.ok, true);
+  });
+
+  it('rejects malformed records and credential-bearing evidence material', () => {
+    const malformed = validateEvidenceArchiveRecord({
+      ...evidenceArchiveFixtureRecord,
+      schemaVersion: 'reddi.evidence-archive.v2',
+      evidenceHash: 'not-a-hash',
+    }, evidenceArchiveFixtures.evidencePayload);
+    assert.equal(malformed.ok, false);
+    if (!malformed.ok) {
+      assert.ok(malformed.errors.some((item) => item.code === 'malformed_evidence_record'));
+    }
+
+    const secretPayload = validateEvidenceArchiveRecord(evidenceArchiveFixtureRecord, {
+      apiKey: 'sk-should-not-be-here',
+    });
+    assert.equal(secretPayload.ok, false);
+    if (!secretPayload.ok) {
+      assert.ok(secretPayload.errors.some((item) => item.code === 'credential_leakage_rejected'));
+    }
+  });
+});

--- a/packages/agent-protocol/tests/evidence-archive.test.ts
+++ b/packages/agent-protocol/tests/evidence-archive.test.ts
@@ -136,5 +136,26 @@ describe('RAP EvidenceArchive v1', () => {
     if (!leakyExternalPointer.ok) {
       assert.ok(leakyExternalPointer.errors.some((item) => item.code === 'credential_leakage_rejected' && item.path === '$.externalArchivePointer.uri.api_key'));
     }
+
+    const signedEvidenceRef = validateEvidenceArchiveRecord({
+      ...evidenceArchiveFixtureRecord,
+      evidenceRef: 'https://evidence.example/archive.json?X-Goog-Signature=redacted',
+    }, evidenceArchiveFixtures.evidencePayload);
+    assert.equal(signedEvidenceRef.ok, false);
+    if (!signedEvidenceRef.ok) {
+      assert.ok(signedEvidenceRef.errors.some((item) => item.code === 'credential_leakage_rejected' && item.path === '$.evidenceRef.X-Goog-Signature'));
+    }
+
+    const signedExternalPointer = validateEvidenceArchiveRecord({
+      ...evidenceArchiveFixtureRecord,
+      externalArchivePointer: {
+        provider: 'custom',
+        uri: 'https://evidence.example/archive.json?sig=redacted',
+      },
+    });
+    assert.equal(signedExternalPointer.ok, false);
+    if (!signedExternalPointer.ok) {
+      assert.ok(signedExternalPointer.errors.some((item) => item.code === 'credential_leakage_rejected' && item.path === '$.externalArchivePointer.uri.sig'));
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add `reddi.evidence-archive.v1` records for local-first evidence references
- include request/response/evidence hashes, receipt/source/attestation refs, and optional external archive pointer
- add deterministic local archive storage helpers for fixture/demo use
- document privacy boundary: private payloads stay outside public receipts
- represent Walrus/Seal/IPFS/custom pointers as future sidecar references, not package dependencies

## Validation
- `npm test` in `packages/agent-protocol` passed with 41 tests
- `npm run release:dry-run` in `packages/agent-protocol` passed
- `npm run check:rap:naming` passed
- `git diff --check` passed

Closes #347.
