### PR TITLE
Add attestation and reputation primitives

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -149,6 +149,27 @@ console.log(diagnostics.policyDecision.reasonCodes); // machine-readable allow/d
 
 Source-aware diagnostics expose separate lanes for capability match, discovery source, publisher identity, trust evidence, policy decision, payment fit, and reputation evidence. ARD and registry relevance scores are always labelled as relevance only; they are never collapsed into trust, policy, payment, or reputation approval.
 
+## Attestation And Reputation
+
+```typescript
+import {
+  applyAttestationToReputation,
+  createInitialReputationState,
+} from '@reddi/agent-protocol/attestation-reputation';
+
+const state = createInitialReputationState({ id: 'specialist:coder', type: 'specialist' });
+const update = applyAttestationToReputation(attestationRecord, state);
+
+if (update.ok) {
+  console.log(update.event.schemaVersion); // reddi.reputation-event.v1
+  console.log(update.state.routingImpact); // eligible / watch / deprioritized / etc.
+}
+```
+
+Attestation v1 records include schema version, evidence reference, evidence hash, rubric dimensions, confidence, verdict, work status, and trust boundary. The required rubric dimensions are `evidence_integrity`, `policy_compliance`, and `delivery_quality`.
+
+Reputation updates are deterministic and local-first. Invalid or incomplete rubrics fail closed and return the previous reputation state unchanged. Failed, disputed, and refunded work produce explicit status and routing-impact reason codes. Self-attested and external-attested records are evidence inputs, not verified claims; `reddi_attested` and `verified` boundaries must come from RAP-side verification or operator-controlled attestations.
+
 ## Local Validation
 
 ```bash

--- a/packages/agent-protocol/dist/attestation-reputation.d.ts
+++ b/packages/agent-protocol/dist/attestation-reputation.d.ts
@@ -1,0 +1,102 @@
+export declare const ATTESTATION_RECORD_SCHEMA_VERSION: "reddi.attestation.v1";
+export declare const REPUTATION_EVENT_SCHEMA_VERSION: "reddi.reputation-event.v1";
+export declare const REPUTATION_STATE_SCHEMA_VERSION: "reddi.reputation-state.v1";
+export declare const DEFAULT_ATTESTATION_RUBRIC_DIMENSIONS: readonly ["evidence_integrity", "policy_compliance", "delivery_quality"];
+export type AttestationVerdict = 'passed' | 'failed' | 'disputed' | 'refunded';
+export type AttestationWorkStatus = 'completed' | 'failed' | 'disputed' | 'refunded';
+export type AttestationTrustBoundary = 'self_attested' | 'external_attested' | 'reddi_attested' | 'verified';
+export type ReputationRoutingImpact = 'preferred' | 'eligible' | 'watch' | 'deprioritized' | 'blocked' | 'unproven';
+export type AttestationRubricDimension = {
+    id: string;
+    score: number;
+    weight: number;
+    summary: string;
+    reasonCodes: string[];
+};
+export type AttestationRecord = {
+    schemaVersion: typeof ATTESTATION_RECORD_SCHEMA_VERSION;
+    id: string;
+    receiptId: string;
+    evidenceId: string;
+    evidenceRef: string;
+    evidenceHash: string;
+    attestor: {
+        id: string;
+        type: 'self' | 'external' | 'reddi' | 'local-fixture';
+    };
+    trustBoundary: AttestationTrustBoundary;
+    verdict: AttestationVerdict;
+    workStatus: AttestationWorkStatus;
+    confidence: number;
+    rubric: {
+        dimensions: AttestationRubricDimension[];
+    };
+    createdAt: string;
+    metadata?: Record<string, unknown>;
+};
+export type ReputationState = {
+    schemaVersion: typeof REPUTATION_STATE_SCHEMA_VERSION;
+    subject: {
+        id: string;
+        type: 'specialist' | 'provider' | 'listing';
+    };
+    score: number;
+    routingImpact: ReputationRoutingImpact;
+    completedJobs: number;
+    attestedJobs: number;
+    failedJobs: number;
+    disputedJobs: number;
+    refundedJobs: number;
+    lastEventId?: string;
+    updatedAt: string;
+};
+export type ReputationEventReasonCode = 'attestation_passed' | 'attestation_failed' | 'work_disputed' | 'work_refunded' | 'low_confidence' | 'rubric_below_threshold' | 'evidence_attached';
+export type ReputationEvent = {
+    schemaVersion: typeof REPUTATION_EVENT_SCHEMA_VERSION;
+    id: string;
+    subjectId: string;
+    receiptId: string;
+    attestationId: string;
+    evidenceId: string;
+    verdict: AttestationVerdict;
+    workStatus: AttestationWorkStatus;
+    trustBoundary: AttestationTrustBoundary;
+    confidence: number;
+    rubricScore: number;
+    delta: number;
+    previousScore: number;
+    nextScore: number;
+    routingImpact: ReputationRoutingImpact;
+    reasonCodes: ReputationEventReasonCode[];
+    createdAt: string;
+};
+export type AttestationValidationErrorCode = 'malformed_attestation' | 'missing_rubric_dimension' | 'invalid_rubric_dimension' | 'credential_leakage_rejected';
+export type AttestationValidationError = {
+    code: AttestationValidationErrorCode;
+    path: string;
+    message: string;
+};
+export type AttestationValidationResult = {
+    ok: true;
+    attestation: AttestationRecord;
+} | {
+    ok: false;
+    errors: AttestationValidationError[];
+};
+export type ReputationUpdateResult = {
+    ok: true;
+    event: ReputationEvent;
+    state: ReputationState;
+} | {
+    ok: false;
+    errors: AttestationValidationError[];
+    state: ReputationState;
+};
+export type ReputationApplyOptions = {
+    subject?: ReputationState['subject'];
+    now?: string;
+};
+export declare function validateAttestationRecord(input: unknown): AttestationValidationResult;
+export declare function createAttestationRecord(input: AttestationRecord): AttestationRecord;
+export declare function createInitialReputationState(subject: ReputationState['subject'], updatedAt?: string): ReputationState;
+export declare function applyAttestationToReputation(attestationInput: unknown, previousState?: ReputationState, options?: ReputationApplyOptions): ReputationUpdateResult;

--- a/packages/agent-protocol/dist/attestation-reputation.js
+++ b/packages/agent-protocol/dist/attestation-reputation.js
@@ -1,0 +1,279 @@
+export const ATTESTATION_RECORD_SCHEMA_VERSION = 'reddi.attestation.v1';
+export const REPUTATION_EVENT_SCHEMA_VERSION = 'reddi.reputation-event.v1';
+export const REPUTATION_STATE_SCHEMA_VERSION = 'reddi.reputation-state.v1';
+export const DEFAULT_ATTESTATION_RUBRIC_DIMENSIONS = [
+    'evidence_integrity',
+    'policy_compliance',
+    'delivery_quality',
+];
+const HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|signature|sig|signed|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+function error(code, path, message) {
+    return { code, path, message };
+}
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function requireString(value, path, errors) {
+    if (!isNonEmptyString(value))
+        errors.push(error('malformed_attestation', path, 'required string is missing'));
+}
+function requireHash(value, path, errors) {
+    if (!isNonEmptyString(value) || !HASH_PATTERN.test(value)) {
+        errors.push(error('malformed_attestation', path, 'hash must be a sha256:<hex> reference'));
+    }
+}
+function validatePublicReference(value, path, errors) {
+    if (!isNonEmptyString(value))
+        return;
+    if (SENSITIVE_VALUE_PATTERN.test(value)) {
+        errors.push(error('credential_leakage_rejected', path, 'public attestation references must not include credential-shaped values'));
+        return;
+    }
+    let parsed;
+    try {
+        parsed = new URL(value);
+    }
+    catch {
+        return;
+    }
+    if (parsed.username || parsed.password) {
+        errors.push(error('credential_leakage_rejected', path, 'public attestation references must not embed credentials'));
+    }
+    for (const key of parsed.searchParams.keys()) {
+        if (SENSITIVE_KEY_PATTERN.test(key)) {
+            errors.push(error('credential_leakage_rejected', `${path}.${key}`, 'public attestation references must not include credential-shaped query keys'));
+        }
+    }
+    for (const queryValue of parsed.searchParams.values()) {
+        if (SENSITIVE_VALUE_PATTERN.test(queryValue)) {
+            errors.push(error('credential_leakage_rejected', path, 'public attestation references must not include credential-shaped query values'));
+        }
+    }
+}
+function findCredentialMaterial(value, path = '$') {
+    if (typeof value === 'string')
+        return SENSITIVE_VALUE_PATTERN.test(value) ? path : undefined;
+    if (!value || typeof value !== 'object')
+        return undefined;
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index += 1) {
+            const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+            if (found)
+                return found;
+        }
+        return undefined;
+    }
+    for (const [key, nested] of Object.entries(value)) {
+        const nextPath = `${path}.${key}`;
+        if (SENSITIVE_KEY_PATTERN.test(key))
+            return nextPath;
+        const found = findCredentialMaterial(nested, nextPath);
+        if (found)
+            return found;
+    }
+    return undefined;
+}
+function weightedRubricScore(dimensions) {
+    const totalWeight = dimensions.reduce((sum, dimension) => sum + dimension.weight, 0);
+    if (totalWeight <= 0)
+        return 0;
+    const weighted = dimensions.reduce((sum, dimension) => sum + (dimension.score * dimension.weight), 0);
+    return Math.round(weighted / totalWeight);
+}
+function clampScore(score) {
+    return Math.max(0, Math.min(1000, score));
+}
+function routingImpact(score) {
+    if (score >= 750)
+        return 'preferred';
+    if (score >= 500)
+        return 'eligible';
+    if (score >= 350)
+        return 'watch';
+    if (score > 0)
+        return 'deprioritized';
+    return 'blocked';
+}
+function baseDelta(attestation, rubricScore) {
+    if (attestation.workStatus === 'failed' || attestation.verdict === 'failed')
+        return -80;
+    if (attestation.workStatus === 'disputed' || attestation.verdict === 'disputed')
+        return -50;
+    if (attestation.workStatus === 'refunded' || attestation.verdict === 'refunded')
+        return -35;
+    if (rubricScore < 60)
+        return -25;
+    if (rubricScore < 75)
+        return 5;
+    if (rubricScore < 90)
+        return 18;
+    return 30;
+}
+function eventReasonCodes(attestation, rubricScore) {
+    const codes = ['evidence_attached'];
+    if (attestation.verdict === 'passed')
+        codes.push('attestation_passed');
+    if (attestation.verdict === 'failed')
+        codes.push('attestation_failed');
+    if (attestation.workStatus === 'disputed' || attestation.verdict === 'disputed')
+        codes.push('work_disputed');
+    if (attestation.workStatus === 'refunded' || attestation.verdict === 'refunded')
+        codes.push('work_refunded');
+    if (attestation.confidence < 70)
+        codes.push('low_confidence');
+    if (rubricScore < 75)
+        codes.push('rubric_below_threshold');
+    return codes;
+}
+export function validateAttestationRecord(input) {
+    const errors = [];
+    if (!isPlainObject(input)) {
+        return { ok: false, errors: [error('malformed_attestation', '$', 'attestation record must be a plain object')] };
+    }
+    const attestation = input;
+    if (attestation.schemaVersion !== ATTESTATION_RECORD_SCHEMA_VERSION) {
+        errors.push(error('malformed_attestation', '$.schemaVersion', `expected ${ATTESTATION_RECORD_SCHEMA_VERSION}`));
+    }
+    requireString(attestation.id, '$.id', errors);
+    requireString(attestation.receiptId, '$.receiptId', errors);
+    requireString(attestation.evidenceId, '$.evidenceId', errors);
+    requireString(attestation.evidenceRef, '$.evidenceRef', errors);
+    validatePublicReference(attestation.evidenceRef, '$.evidenceRef', errors);
+    requireHash(attestation.evidenceHash, '$.evidenceHash', errors);
+    requireString(attestation.attestor?.id, '$.attestor.id', errors);
+    if (!['self', 'external', 'reddi', 'local-fixture'].includes(String(attestation.attestor?.type))) {
+        errors.push(error('malformed_attestation', '$.attestor.type', 'attestor type is unsupported'));
+    }
+    if (!['self_attested', 'external_attested', 'reddi_attested', 'verified'].includes(String(attestation.trustBoundary))) {
+        errors.push(error('malformed_attestation', '$.trustBoundary', 'trust boundary is unsupported'));
+    }
+    if (!['passed', 'failed', 'disputed', 'refunded'].includes(String(attestation.verdict))) {
+        errors.push(error('malformed_attestation', '$.verdict', 'verdict is unsupported'));
+    }
+    if (!['completed', 'failed', 'disputed', 'refunded'].includes(String(attestation.workStatus))) {
+        errors.push(error('malformed_attestation', '$.workStatus', 'work status is unsupported'));
+    }
+    if (!Number.isInteger(attestation.confidence) || attestation.confidence < 0 || attestation.confidence > 100) {
+        errors.push(error('malformed_attestation', '$.confidence', 'confidence must be an integer from 0 to 100'));
+    }
+    if (!isNonEmptyString(attestation.createdAt) || Number.isNaN(Date.parse(attestation.createdAt))) {
+        errors.push(error('malformed_attestation', '$.createdAt', 'createdAt must be an ISO timestamp'));
+    }
+    if (!isPlainObject(attestation.rubric) || !Array.isArray(attestation.rubric.dimensions)) {
+        errors.push(error('missing_rubric_dimension', '$.rubric.dimensions', 'rubric dimensions are required'));
+    }
+    else {
+        const seen = new Set();
+        for (const [index, dimension] of attestation.rubric.dimensions.entries()) {
+            const path = `$.rubric.dimensions[${index}]`;
+            if (!isPlainObject(dimension)) {
+                errors.push(error('invalid_rubric_dimension', path, 'rubric dimension must be an object'));
+                continue;
+            }
+            requireString(dimension.id, `${path}.id`, errors);
+            if (isNonEmptyString(dimension.id))
+                seen.add(dimension.id);
+            if (!Number.isInteger(dimension.score) || dimension.score < 0 || dimension.score > 100) {
+                errors.push(error('invalid_rubric_dimension', `${path}.score`, 'rubric score must be an integer from 0 to 100'));
+            }
+            if (!Number.isInteger(dimension.weight) || dimension.weight <= 0) {
+                errors.push(error('invalid_rubric_dimension', `${path}.weight`, 'rubric weight must be a positive integer'));
+            }
+            requireString(dimension.summary, `${path}.summary`, errors);
+            if (!Array.isArray(dimension.reasonCodes) || dimension.reasonCodes.some((code) => typeof code !== 'string' || code.trim().length === 0)) {
+                errors.push(error('invalid_rubric_dimension', `${path}.reasonCodes`, 'reasonCodes must be a non-empty string array'));
+            }
+        }
+        for (const dimensionId of DEFAULT_ATTESTATION_RUBRIC_DIMENSIONS) {
+            if (!seen.has(dimensionId)) {
+                errors.push(error('missing_rubric_dimension', '$.rubric.dimensions', `missing required rubric dimension ${dimensionId}`));
+            }
+        }
+    }
+    const credentialPath = findCredentialMaterial(attestation.metadata);
+    if (credentialPath) {
+        errors.push(error('credential_leakage_rejected', `$.metadata${credentialPath.slice(1)}`, 'attestation metadata contains credential-shaped material'));
+    }
+    return errors.length === 0 ? { ok: true, attestation } : { ok: false, errors };
+}
+export function createAttestationRecord(input) {
+    const result = validateAttestationRecord(input);
+    if (!result.ok) {
+        throw new Error(`invalid_attestation_record:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+    }
+    return result.attestation;
+}
+export function createInitialReputationState(subject, updatedAt = '1970-01-01T00:00:00.000Z') {
+    return {
+        schemaVersion: REPUTATION_STATE_SCHEMA_VERSION,
+        subject,
+        score: 500,
+        routingImpact: 'unproven',
+        completedJobs: 0,
+        attestedJobs: 0,
+        failedJobs: 0,
+        disputedJobs: 0,
+        refundedJobs: 0,
+        updatedAt,
+    };
+}
+export function applyAttestationToReputation(attestationInput, previousState, options = {}) {
+    const validation = validateAttestationRecord(attestationInput);
+    const state = previousState ?? createInitialReputationState(options.subject ?? { id: 'unknown', type: 'specialist' }, options.now ?? '1970-01-01T00:00:00.000Z');
+    if (!validation.ok) {
+        return { ok: false, errors: validation.errors, state };
+    }
+    const attestation = validation.attestation;
+    const subject = previousState?.subject ?? options.subject ?? { id: attestation.receiptId, type: 'specialist' };
+    const rubricScore = weightedRubricScore(attestation.rubric.dimensions);
+    const rawDelta = baseDelta(attestation, rubricScore);
+    const delta = Math.round((rawDelta * attestation.confidence) / 100);
+    const previousScore = state.score;
+    const nextScore = clampScore(previousScore + delta);
+    const nextImpact = routingImpact(nextScore);
+    const createdAt = options.now ?? attestation.createdAt;
+    const event = {
+        schemaVersion: REPUTATION_EVENT_SCHEMA_VERSION,
+        id: `reputation:${attestation.id}`,
+        subjectId: subject.id,
+        receiptId: attestation.receiptId,
+        attestationId: attestation.id,
+        evidenceId: attestation.evidenceId,
+        verdict: attestation.verdict,
+        workStatus: attestation.workStatus,
+        trustBoundary: attestation.trustBoundary,
+        confidence: attestation.confidence,
+        rubricScore,
+        delta,
+        previousScore,
+        nextScore,
+        routingImpact: nextImpact,
+        reasonCodes: eventReasonCodes(attestation, rubricScore),
+        createdAt,
+    };
+    return {
+        ok: true,
+        event,
+        state: {
+            ...state,
+            subject,
+            score: nextScore,
+            routingImpact: nextImpact,
+            completedJobs: state.completedJobs + (attestation.workStatus === 'completed' ? 1 : 0),
+            attestedJobs: state.attestedJobs + 1,
+            failedJobs: state.failedJobs + (attestation.workStatus === 'failed' ? 1 : 0),
+            disputedJobs: state.disputedJobs + (attestation.workStatus === 'disputed' ? 1 : 0),
+            refundedJobs: state.refundedJobs + (attestation.workStatus === 'refunded' ? 1 : 0),
+            lastEventId: event.id,
+            updatedAt: createdAt,
+        },
+    };
+}

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -6,3 +6,4 @@ export * from './provider-trust.js';
 export * from './discovery-source.js';
 export * from './evidence-archive.js';
 export * from './source-diagnostics.js';
+export * from './attestation-reputation.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -6,3 +6,4 @@ export * from './provider-trust.js';
 export * from './discovery-source.js';
 export * from './evidence-archive.js';
 export * from './source-diagnostics.js';
+export * from './attestation-reputation.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -42,6 +42,10 @@
       "types": "./dist/source-diagnostics.d.ts",
       "import": "./dist/source-diagnostics.js"
     },
+    "./attestation-reputation": {
+      "types": "./dist/attestation-reputation.d.ts",
+      "import": "./dist/attestation-reputation.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/attestation-reputation.ts
+++ b/packages/agent-protocol/src/attestation-reputation.ts
@@ -1,0 +1,395 @@
+export const ATTESTATION_RECORD_SCHEMA_VERSION = 'reddi.attestation.v1' as const;
+export const REPUTATION_EVENT_SCHEMA_VERSION = 'reddi.reputation-event.v1' as const;
+export const REPUTATION_STATE_SCHEMA_VERSION = 'reddi.reputation-state.v1' as const;
+
+export const DEFAULT_ATTESTATION_RUBRIC_DIMENSIONS = [
+  'evidence_integrity',
+  'policy_compliance',
+  'delivery_quality',
+] as const;
+
+export type AttestationVerdict = 'passed' | 'failed' | 'disputed' | 'refunded';
+export type AttestationWorkStatus = 'completed' | 'failed' | 'disputed' | 'refunded';
+export type AttestationTrustBoundary = 'self_attested' | 'external_attested' | 'reddi_attested' | 'verified';
+export type ReputationRoutingImpact = 'preferred' | 'eligible' | 'watch' | 'deprioritized' | 'blocked' | 'unproven';
+
+export type AttestationRubricDimension = {
+  id: string;
+  score: number;
+  weight: number;
+  summary: string;
+  reasonCodes: string[];
+};
+
+export type AttestationRecord = {
+  schemaVersion: typeof ATTESTATION_RECORD_SCHEMA_VERSION;
+  id: string;
+  receiptId: string;
+  evidenceId: string;
+  evidenceRef: string;
+  evidenceHash: string;
+  attestor: {
+    id: string;
+    type: 'self' | 'external' | 'reddi' | 'local-fixture';
+  };
+  trustBoundary: AttestationTrustBoundary;
+  verdict: AttestationVerdict;
+  workStatus: AttestationWorkStatus;
+  confidence: number;
+  rubric: {
+    dimensions: AttestationRubricDimension[];
+  };
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type ReputationState = {
+  schemaVersion: typeof REPUTATION_STATE_SCHEMA_VERSION;
+  subject: {
+    id: string;
+    type: 'specialist' | 'provider' | 'listing';
+  };
+  score: number;
+  routingImpact: ReputationRoutingImpact;
+  completedJobs: number;
+  attestedJobs: number;
+  failedJobs: number;
+  disputedJobs: number;
+  refundedJobs: number;
+  lastEventId?: string;
+  updatedAt: string;
+};
+
+export type ReputationEventReasonCode =
+  | 'attestation_passed'
+  | 'attestation_failed'
+  | 'work_disputed'
+  | 'work_refunded'
+  | 'low_confidence'
+  | 'rubric_below_threshold'
+  | 'evidence_attached';
+
+export type ReputationEvent = {
+  schemaVersion: typeof REPUTATION_EVENT_SCHEMA_VERSION;
+  id: string;
+  subjectId: string;
+  receiptId: string;
+  attestationId: string;
+  evidenceId: string;
+  verdict: AttestationVerdict;
+  workStatus: AttestationWorkStatus;
+  trustBoundary: AttestationTrustBoundary;
+  confidence: number;
+  rubricScore: number;
+  delta: number;
+  previousScore: number;
+  nextScore: number;
+  routingImpact: ReputationRoutingImpact;
+  reasonCodes: ReputationEventReasonCode[];
+  createdAt: string;
+};
+
+export type AttestationValidationErrorCode =
+  | 'malformed_attestation'
+  | 'missing_rubric_dimension'
+  | 'invalid_rubric_dimension'
+  | 'credential_leakage_rejected';
+
+export type AttestationValidationError = {
+  code: AttestationValidationErrorCode;
+  path: string;
+  message: string;
+};
+
+export type AttestationValidationResult =
+  | { ok: true; attestation: AttestationRecord }
+  | { ok: false; errors: AttestationValidationError[] };
+
+export type ReputationUpdateResult =
+  | { ok: true; event: ReputationEvent; state: ReputationState }
+  | { ok: false; errors: AttestationValidationError[]; state: ReputationState };
+
+export type ReputationApplyOptions = {
+  subject?: ReputationState['subject'];
+  now?: string;
+};
+
+const HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|signature|sig|signed|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+
+function error(code: AttestationValidationErrorCode, path: string, message: string): AttestationValidationError {
+  return { code, path, message };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function requireString(value: unknown, path: string, errors: AttestationValidationError[]): void {
+  if (!isNonEmptyString(value)) errors.push(error('malformed_attestation', path, 'required string is missing'));
+}
+
+function requireHash(value: unknown, path: string, errors: AttestationValidationError[]): void {
+  if (!isNonEmptyString(value) || !HASH_PATTERN.test(value)) {
+    errors.push(error('malformed_attestation', path, 'hash must be a sha256:<hex> reference'));
+  }
+}
+
+function validatePublicReference(value: unknown, path: string, errors: AttestationValidationError[]): void {
+  if (!isNonEmptyString(value)) return;
+  if (SENSITIVE_VALUE_PATTERN.test(value)) {
+    errors.push(error('credential_leakage_rejected', path, 'public attestation references must not include credential-shaped values'));
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return;
+  }
+
+  if (parsed.username || parsed.password) {
+    errors.push(error('credential_leakage_rejected', path, 'public attestation references must not embed credentials'));
+  }
+
+  for (const key of parsed.searchParams.keys()) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      errors.push(error('credential_leakage_rejected', `${path}.${key}`, 'public attestation references must not include credential-shaped query keys'));
+    }
+  }
+
+  for (const queryValue of parsed.searchParams.values()) {
+    if (SENSITIVE_VALUE_PATTERN.test(queryValue)) {
+      errors.push(error('credential_leakage_rejected', path, 'public attestation references must not include credential-shaped query values'));
+    }
+  }
+}
+
+function findCredentialMaterial(value: unknown, path = '$'): string | undefined {
+  if (typeof value === 'string') return SENSITIVE_VALUE_PATTERN.test(value) ? path : undefined;
+  if (!value || typeof value !== 'object') return undefined;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  for (const [key, nested] of Object.entries(value)) {
+    const nextPath = `${path}.${key}`;
+    if (SENSITIVE_KEY_PATTERN.test(key)) return nextPath;
+    const found = findCredentialMaterial(nested, nextPath);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function weightedRubricScore(dimensions: AttestationRubricDimension[]): number {
+  const totalWeight = dimensions.reduce((sum, dimension) => sum + dimension.weight, 0);
+  if (totalWeight <= 0) return 0;
+  const weighted = dimensions.reduce((sum, dimension) => sum + (dimension.score * dimension.weight), 0);
+  return Math.round(weighted / totalWeight);
+}
+
+function clampScore(score: number): number {
+  return Math.max(0, Math.min(1000, score));
+}
+
+function routingImpact(score: number): ReputationRoutingImpact {
+  if (score >= 750) return 'preferred';
+  if (score >= 500) return 'eligible';
+  if (score >= 350) return 'watch';
+  if (score > 0) return 'deprioritized';
+  return 'blocked';
+}
+
+function baseDelta(attestation: AttestationRecord, rubricScore: number): number {
+  if (attestation.workStatus === 'failed' || attestation.verdict === 'failed') return -80;
+  if (attestation.workStatus === 'disputed' || attestation.verdict === 'disputed') return -50;
+  if (attestation.workStatus === 'refunded' || attestation.verdict === 'refunded') return -35;
+  if (rubricScore < 60) return -25;
+  if (rubricScore < 75) return 5;
+  if (rubricScore < 90) return 18;
+  return 30;
+}
+
+function eventReasonCodes(attestation: AttestationRecord, rubricScore: number): ReputationEventReasonCode[] {
+  const codes: ReputationEventReasonCode[] = ['evidence_attached'];
+  if (attestation.verdict === 'passed') codes.push('attestation_passed');
+  if (attestation.verdict === 'failed') codes.push('attestation_failed');
+  if (attestation.workStatus === 'disputed' || attestation.verdict === 'disputed') codes.push('work_disputed');
+  if (attestation.workStatus === 'refunded' || attestation.verdict === 'refunded') codes.push('work_refunded');
+  if (attestation.confidence < 70) codes.push('low_confidence');
+  if (rubricScore < 75) codes.push('rubric_below_threshold');
+  return codes;
+}
+
+export function validateAttestationRecord(input: unknown): AttestationValidationResult {
+  const errors: AttestationValidationError[] = [];
+  if (!isPlainObject(input)) {
+    return { ok: false, errors: [error('malformed_attestation', '$', 'attestation record must be a plain object')] };
+  }
+
+  const attestation = input as AttestationRecord;
+  if (attestation.schemaVersion !== ATTESTATION_RECORD_SCHEMA_VERSION) {
+    errors.push(error('malformed_attestation', '$.schemaVersion', `expected ${ATTESTATION_RECORD_SCHEMA_VERSION}`));
+  }
+  requireString(attestation.id, '$.id', errors);
+  requireString(attestation.receiptId, '$.receiptId', errors);
+  requireString(attestation.evidenceId, '$.evidenceId', errors);
+  requireString(attestation.evidenceRef, '$.evidenceRef', errors);
+  validatePublicReference(attestation.evidenceRef, '$.evidenceRef', errors);
+  requireHash(attestation.evidenceHash, '$.evidenceHash', errors);
+  requireString(attestation.attestor?.id, '$.attestor.id', errors);
+  if (!['self', 'external', 'reddi', 'local-fixture'].includes(String(attestation.attestor?.type))) {
+    errors.push(error('malformed_attestation', '$.attestor.type', 'attestor type is unsupported'));
+  }
+  if (!['self_attested', 'external_attested', 'reddi_attested', 'verified'].includes(String(attestation.trustBoundary))) {
+    errors.push(error('malformed_attestation', '$.trustBoundary', 'trust boundary is unsupported'));
+  }
+  if (!['passed', 'failed', 'disputed', 'refunded'].includes(String(attestation.verdict))) {
+    errors.push(error('malformed_attestation', '$.verdict', 'verdict is unsupported'));
+  }
+  if (!['completed', 'failed', 'disputed', 'refunded'].includes(String(attestation.workStatus))) {
+    errors.push(error('malformed_attestation', '$.workStatus', 'work status is unsupported'));
+  }
+  if (!Number.isInteger(attestation.confidence) || attestation.confidence < 0 || attestation.confidence > 100) {
+    errors.push(error('malformed_attestation', '$.confidence', 'confidence must be an integer from 0 to 100'));
+  }
+  if (!isNonEmptyString(attestation.createdAt) || Number.isNaN(Date.parse(attestation.createdAt))) {
+    errors.push(error('malformed_attestation', '$.createdAt', 'createdAt must be an ISO timestamp'));
+  }
+
+  if (!isPlainObject(attestation.rubric) || !Array.isArray(attestation.rubric.dimensions)) {
+    errors.push(error('missing_rubric_dimension', '$.rubric.dimensions', 'rubric dimensions are required'));
+  } else {
+    const seen = new Set<string>();
+    for (const [index, dimension] of attestation.rubric.dimensions.entries()) {
+      const path = `$.rubric.dimensions[${index}]`;
+      if (!isPlainObject(dimension)) {
+        errors.push(error('invalid_rubric_dimension', path, 'rubric dimension must be an object'));
+        continue;
+      }
+      requireString(dimension.id, `${path}.id`, errors);
+      if (isNonEmptyString(dimension.id)) seen.add(dimension.id);
+      if (!Number.isInteger(dimension.score) || dimension.score < 0 || dimension.score > 100) {
+        errors.push(error('invalid_rubric_dimension', `${path}.score`, 'rubric score must be an integer from 0 to 100'));
+      }
+      if (!Number.isInteger(dimension.weight) || dimension.weight <= 0) {
+        errors.push(error('invalid_rubric_dimension', `${path}.weight`, 'rubric weight must be a positive integer'));
+      }
+      requireString(dimension.summary, `${path}.summary`, errors);
+      if (!Array.isArray(dimension.reasonCodes) || dimension.reasonCodes.some((code) => typeof code !== 'string' || code.trim().length === 0)) {
+        errors.push(error('invalid_rubric_dimension', `${path}.reasonCodes`, 'reasonCodes must be a non-empty string array'));
+      }
+    }
+    for (const dimensionId of DEFAULT_ATTESTATION_RUBRIC_DIMENSIONS) {
+      if (!seen.has(dimensionId)) {
+        errors.push(error('missing_rubric_dimension', '$.rubric.dimensions', `missing required rubric dimension ${dimensionId}`));
+      }
+    }
+  }
+
+  const credentialPath = findCredentialMaterial(attestation.metadata);
+  if (credentialPath) {
+    errors.push(error('credential_leakage_rejected', `$.metadata${credentialPath.slice(1)}`, 'attestation metadata contains credential-shaped material'));
+  }
+
+  return errors.length === 0 ? { ok: true, attestation } : { ok: false, errors };
+}
+
+export function createAttestationRecord(input: AttestationRecord): AttestationRecord {
+  const result = validateAttestationRecord(input);
+  if (!result.ok) {
+    throw new Error(`invalid_attestation_record:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+  }
+  return result.attestation;
+}
+
+export function createInitialReputationState(
+  subject: ReputationState['subject'],
+  updatedAt = '1970-01-01T00:00:00.000Z',
+): ReputationState {
+  return {
+    schemaVersion: REPUTATION_STATE_SCHEMA_VERSION,
+    subject,
+    score: 500,
+    routingImpact: 'unproven',
+    completedJobs: 0,
+    attestedJobs: 0,
+    failedJobs: 0,
+    disputedJobs: 0,
+    refundedJobs: 0,
+    updatedAt,
+  };
+}
+
+export function applyAttestationToReputation(
+  attestationInput: unknown,
+  previousState?: ReputationState,
+  options: ReputationApplyOptions = {},
+): ReputationUpdateResult {
+  const validation = validateAttestationRecord(attestationInput);
+  const state = previousState ?? createInitialReputationState(
+    options.subject ?? { id: 'unknown', type: 'specialist' },
+    options.now ?? '1970-01-01T00:00:00.000Z',
+  );
+  if (!validation.ok) {
+    return { ok: false, errors: validation.errors, state };
+  }
+
+  const attestation = validation.attestation;
+  const subject = previousState?.subject ?? options.subject ?? { id: attestation.receiptId, type: 'specialist' };
+  const rubricScore = weightedRubricScore(attestation.rubric.dimensions);
+  const rawDelta = baseDelta(attestation, rubricScore);
+  const delta = Math.round((rawDelta * attestation.confidence) / 100);
+  const previousScore = state.score;
+  const nextScore = clampScore(previousScore + delta);
+  const nextImpact = routingImpact(nextScore);
+  const createdAt = options.now ?? attestation.createdAt;
+  const event: ReputationEvent = {
+    schemaVersion: REPUTATION_EVENT_SCHEMA_VERSION,
+    id: `reputation:${attestation.id}`,
+    subjectId: subject.id,
+    receiptId: attestation.receiptId,
+    attestationId: attestation.id,
+    evidenceId: attestation.evidenceId,
+    verdict: attestation.verdict,
+    workStatus: attestation.workStatus,
+    trustBoundary: attestation.trustBoundary,
+    confidence: attestation.confidence,
+    rubricScore,
+    delta,
+    previousScore,
+    nextScore,
+    routingImpact: nextImpact,
+    reasonCodes: eventReasonCodes(attestation, rubricScore),
+    createdAt,
+  };
+
+  return {
+    ok: true,
+    event,
+    state: {
+      ...state,
+      subject,
+      score: nextScore,
+      routingImpact: nextImpact,
+      completedJobs: state.completedJobs + (attestation.workStatus === 'completed' ? 1 : 0),
+      attestedJobs: state.attestedJobs + 1,
+      failedJobs: state.failedJobs + (attestation.workStatus === 'failed' ? 1 : 0),
+      disputedJobs: state.disputedJobs + (attestation.workStatus === 'disputed' ? 1 : 0),
+      refundedJobs: state.refundedJobs + (attestation.workStatus === 'refunded' ? 1 : 0),
+      lastEventId: event.id,
+      updatedAt: createdAt,
+    },
+  };
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -6,3 +6,4 @@ export * from './provider-trust.js';
 export * from './discovery-source.js';
 export * from './evidence-archive.js';
 export * from './source-diagnostics.js';
+export * from './attestation-reputation.js';

--- a/packages/agent-protocol/tests/attestation-reputation.test.ts
+++ b/packages/agent-protocol/tests/attestation-reputation.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  applyAttestationToReputation,
+  createAttestationRecord,
+  createInitialReputationState,
+  type AttestationRecord,
+} from '../dist/index.js';
+
+const baseAttestation: AttestationRecord = {
+  schemaVersion: 'reddi.attestation.v1',
+  id: 'attestation:planning-001',
+  receiptId: 'job:planning-001',
+  evidenceId: 'evidence:planning-001',
+  evidenceRef: 'file://fixtures/evidence/planning-001.json',
+  evidenceHash: 'sha256:8a9a8a7b6c5d4e3f20112233445566778899aabbccddeeff0011223344556677',
+  attestor: {
+    id: 'attestor:local',
+    type: 'local-fixture',
+  },
+  trustBoundary: 'reddi_attested',
+  verdict: 'passed',
+  workStatus: 'completed',
+  confidence: 90,
+  rubric: {
+    dimensions: [
+      {
+        id: 'evidence_integrity',
+        score: 100,
+        weight: 2,
+        summary: 'Receipt and evidence hashes are present and match the local archive.',
+        reasonCodes: ['hashes_match'],
+      },
+      {
+        id: 'policy_compliance',
+        score: 90,
+        weight: 1,
+        summary: 'Policy decision approved the dry-run quote.',
+        reasonCodes: ['policy_allowed'],
+      },
+      {
+        id: 'delivery_quality',
+        score: 80,
+        weight: 1,
+        summary: 'Specialist response met the requested planning outcome.',
+        reasonCodes: ['task_completed'],
+      },
+    ],
+  },
+  createdAt: '2026-06-18T13:20:00.000Z',
+};
+
+describe('RAP attestation and reputation v1', () => {
+  it('creates an attestation and deterministic positive reputation event', () => {
+    const attestation = createAttestationRecord(baseAttestation);
+    const initial = createInitialReputationState(
+      { id: 'specialist:coder', type: 'specialist' },
+      '2026-06-18T13:19:00.000Z',
+    );
+    const update = applyAttestationToReputation(attestation, initial);
+
+    assert.equal(update.ok, true);
+    if (update.ok) {
+      assert.equal(update.event.schemaVersion, 'reddi.reputation-event.v1');
+      assert.equal(update.event.attestationId, 'attestation:planning-001');
+      assert.equal(update.event.evidenceId, 'evidence:planning-001');
+      assert.equal(update.event.rubricScore, 93);
+      assert.equal(update.event.delta, 27);
+      assert.equal(update.state.score, 527);
+      assert.equal(update.state.completedJobs, 1);
+      assert.equal(update.state.attestedJobs, 1);
+      assert.equal(update.state.routingImpact, 'eligible');
+      assert.deepEqual(update.event.reasonCodes, ['evidence_attached', 'attestation_passed']);
+    }
+  });
+
+  it('fails closed for missing rubric dimensions and does not mutate reputation', () => {
+    const initial = createInitialReputationState(
+      { id: 'specialist:coder', type: 'specialist' },
+      '2026-06-18T13:19:00.000Z',
+    );
+    const update = applyAttestationToReputation({
+      ...baseAttestation,
+      rubric: {
+        dimensions: baseAttestation.rubric.dimensions.filter((dimension) => dimension.id !== 'policy_compliance'),
+      },
+    }, initial);
+
+    assert.equal(update.ok, false);
+    if (!update.ok) {
+      assert.deepEqual(update.state, initial);
+      assert.ok(update.errors.some((item) => item.code === 'missing_rubric_dimension'));
+    }
+  });
+
+  it('fails closed for invalid rubric dimensions and credential-bearing metadata', () => {
+    const invalidScore = applyAttestationToReputation({
+      ...baseAttestation,
+      rubric: {
+        dimensions: [
+          ...baseAttestation.rubric.dimensions.slice(0, 2),
+          {
+            ...baseAttestation.rubric.dimensions[2],
+            score: 120,
+          },
+        ],
+      },
+    });
+    assert.equal(invalidScore.ok, false);
+    if (!invalidScore.ok) {
+      assert.ok(invalidScore.errors.some((item) => item.code === 'invalid_rubric_dimension' && item.path.endsWith('.score')));
+    }
+
+    const credentialMetadata = applyAttestationToReputation({
+      ...baseAttestation,
+      metadata: { audit: { accessToken: 'redacted' } },
+    });
+    assert.equal(credentialMetadata.ok, false);
+    if (!credentialMetadata.ok) {
+      assert.ok(credentialMetadata.errors.some((item) => item.code === 'credential_leakage_rejected' && item.path === '$.metadata.audit.accessToken'));
+    }
+
+    const signedEvidenceRef = applyAttestationToReputation({
+      ...baseAttestation,
+      evidenceRef: 'https://evidence.example/attestation.json?X-Amz-Signature=redacted',
+    });
+    assert.equal(signedEvidenceRef.ok, false);
+    if (!signedEvidenceRef.ok) {
+      assert.ok(signedEvidenceRef.errors.some((item) => item.code === 'credential_leakage_rejected' && item.path === '$.evidenceRef.X-Amz-Signature'));
+    }
+  });
+
+  it('applies explicit failed, disputed, and refunded routing impacts deterministically', () => {
+    const initial = createInitialReputationState(
+      { id: 'specialist:coder', type: 'specialist' },
+      '2026-06-18T13:19:00.000Z',
+    );
+
+    const failed = applyAttestationToReputation({
+      ...baseAttestation,
+      id: 'attestation:failed',
+      verdict: 'failed',
+      workStatus: 'failed',
+      confidence: 100,
+    }, initial);
+    assert.equal(failed.ok, true);
+    if (failed.ok) {
+      assert.equal(failed.event.delta, -80);
+      assert.equal(failed.state.failedJobs, 1);
+      assert.ok(failed.event.reasonCodes.includes('attestation_failed'));
+    }
+
+    const disputed = applyAttestationToReputation({
+      ...baseAttestation,
+      id: 'attestation:disputed',
+      verdict: 'disputed',
+      workStatus: 'disputed',
+      confidence: 80,
+    }, initial);
+    assert.equal(disputed.ok, true);
+    if (disputed.ok) {
+      assert.equal(disputed.event.delta, -40);
+      assert.equal(disputed.state.disputedJobs, 1);
+      assert.ok(disputed.event.reasonCodes.includes('work_disputed'));
+    }
+
+    const refunded = applyAttestationToReputation({
+      ...baseAttestation,
+      id: 'attestation:refunded',
+      verdict: 'refunded',
+      workStatus: 'refunded',
+      confidence: 80,
+    }, initial);
+    assert.equal(refunded.ok, true);
+    if (refunded.ok) {
+      assert.equal(refunded.event.delta, -28);
+      assert.equal(refunded.state.refundedJobs, 1);
+      assert.ok(refunded.event.reasonCodes.includes('work_refunded'));
+    }
+  });
+});


### PR DESCRIPTION
Closes #348.

## Summary
- Add `reddi.attestation.v1`, `reddi.reputation-event.v1`, and `reddi.reputation-state.v1` package primitives.
- Validate required rubric dimensions (`evidence_integrity`, `policy_compliance`, `delivery_quality`) and fail closed for malformed/missing rubric data.
- Add deterministic local reputation event/state updates for passed, failed, disputed, and refunded work without mutating state when attestation validation fails.
- Document trust boundaries between self-attested, external-attested, Reddi-attested, and verified work.

## Validation
- `npm test` in `packages/agent-protocol` passed with 49 tests.
- `npm run release:dry-run` in `packages/agent-protocol` passed and packed `dist/attestation-reputation.*`.
- root `npm run check:rap:naming` passed.
- `git diff --check` passed.
- Runtime dist probe confirmed signed public evidence refs fail closed and invalid rubric input leaves reputation state unchanged.

No UI changes; screenshots/video not required. No network fetch, payment settlement, wallet action, provider invocation, or hosted dependency was added.