### PR TITLE
Add buyer/seller SDK primitives

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -170,6 +170,50 @@ Attestation v1 records include schema version, evidence reference, evidence hash
 
 Reputation updates are deterministic and local-first. Invalid or incomplete rubrics fail closed and return the previous reputation state unchanged. Failed, disputed, and refunded work produce explicit status and routing-impact reason codes. Self-attested and external-attested records are evidence inputs, not verified claims; `reddi_attested` and `verified` boundaries must come from RAP-side verification or operator-controlled attestations.
 
+## Buyer Client And Seller Middleware
+
+```typescript
+import {
+  createPaymentChallenge,
+  evaluateBuyerPaymentChallenge,
+  handlePaidSpecialistRequest,
+} from '@reddi/agent-protocol/buyer-seller';
+
+const challenge = createPaymentChallenge({
+  mode: 'dry-run',
+  quote: {
+    amount: '50000',
+    asset: 'USDC',
+    network: 'solana-devnet',
+    source: 'source:planning',
+    specialist: 'specialist:coder',
+  },
+  payTo: 'solana:seller-demo',
+  nonce: 'unit-001',
+  endpoint: 'http://localhost:4021/specialist',
+});
+
+const buyerDecision = evaluateBuyerPaymentChallenge(challenge, {
+  allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+  paymentProofRef: 'dry-run:unit-001',
+});
+
+const response = await handlePaidSpecialistRequest({
+  challenge,
+  request: { body: { task: 'plan' }, paymentProofRef: buyerDecision.paymentProofRef },
+  policyDecision: buyerDecision.policyDecision,
+  specialist: async (body) => ({ ok: true, body }),
+});
+```
+
+The buyer/seller helpers are local OSS SDK primitives. They do not run a server, submit payment, access a wallet, fetch a hosted registry, or invoke external providers by themselves. Seller middleware can return a structured `402` challenge in dry-run, fixture, or separately approved live mode. Buyer preflight parses the challenge, checks allowed rails, can call the completed local budget evaluator from `@reddi/x402-solana`, and returns machine-readable denial reasons before any payment or invocation. Approved dry-run requests execute only the bounded specialist function supplied by the caller and return a Reddi receipt plus EvidenceArchive record.
+
+Run the local no-spend example:
+
+```bash
+npm run example:buyer-seller:dry-run
+```
+
 ## Local Validation
 
 ```bash

--- a/packages/agent-protocol/dist/buyer-seller.d.ts
+++ b/packages/agent-protocol/dist/buyer-seller.d.ts
@@ -1,0 +1,94 @@
+import { type EvidenceArchiveRecord } from './evidence-archive.js';
+import { type ReddiPolicyDecision } from './policy.js';
+import { type ReddiReceipt } from './receipts.js';
+export declare const PAYMENT_CHALLENGE_SCHEMA_VERSION: "reddi.payment-challenge.v1";
+export type PaymentChallengeMode = 'dry-run' | 'fixture' | 'live';
+export type PaymentChallenge = {
+    schemaVersion: typeof PAYMENT_CHALLENGE_SCHEMA_VERSION;
+    status: 402;
+    mode: PaymentChallengeMode;
+    quote: {
+        amount: string;
+        asset: string;
+        network: string;
+        source: string;
+        specialist: string;
+    };
+    payTo: string;
+    nonce: string;
+    endpoint: string;
+    policyMetadata?: Record<string, unknown>;
+};
+export type BuyerPreflightReasonCode = 'buyer_policy_allowed' | 'challenge_malformed' | 'live_payment_not_approved' | 'unsupported_payment_rail' | 'budget_policy_denied' | 'budget_policy_malformed';
+export type BuyerPreflightDecision = {
+    allowed: boolean;
+    reasonCodes: BuyerPreflightReasonCode[];
+    paymentProofRef?: string;
+    policyDecision?: ReddiPolicyDecision;
+    auditNotes: string[];
+};
+export type BudgetPolicyEvaluator = (quote: PaymentChallenge['quote']) => {
+    allowed: boolean;
+    reasonCodes: string[];
+    quotedAmount: {
+        amount: string;
+        asset: string;
+        network: string;
+        source?: string;
+        specialist?: string;
+    } | null;
+    remainingBudget?: Record<string, string | number | boolean | null>;
+    auditNotes: string[];
+};
+export type BuyerPreflightOptions = {
+    allowedRails?: Array<{
+        asset: string;
+        network: string;
+    }>;
+    approveLivePayment?: boolean;
+    paymentProofRef?: string;
+    evaluateBudgetPolicy?: BudgetPolicyEvaluator;
+};
+export type SellerSpecialistFunction = (input: unknown) => unknown | Promise<unknown>;
+export type SellerRequest = {
+    body?: unknown;
+    paymentProofRef?: string;
+};
+export type SellerResponse = {
+    status: 400;
+    error: {
+        code: 'challenge_malformed';
+        message: string;
+    };
+} | {
+    status: 402;
+    challenge: PaymentChallenge;
+} | {
+    status: 403;
+    error: {
+        code: 'live_payment_not_approved' | 'policy_denied' | 'policy_mismatch' | 'policy_not_approved' | 'policy_required';
+        reasonCodes?: string[];
+        message: string;
+    };
+} | {
+    status: 200;
+    result: unknown;
+    receipt: ReddiReceipt;
+    evidence: EvidenceArchiveRecord;
+} | {
+    status: 500;
+    error: {
+        code: 'specialist_failed';
+        message: string;
+    };
+};
+export declare function createPaymentChallenge(input: Omit<PaymentChallenge, 'schemaVersion' | 'status'>): PaymentChallenge;
+export declare function evaluateBuyerPaymentChallenge(challengeInput: unknown, options?: BuyerPreflightOptions): BuyerPreflightDecision;
+export declare function handlePaidSpecialistRequest(input: {
+    challenge: PaymentChallenge;
+    request: SellerRequest;
+    specialist: SellerSpecialistFunction;
+    policyDecision?: ReddiPolicyDecision;
+    approveLivePayment?: boolean;
+    createdAt?: string;
+}): Promise<SellerResponse>;

--- a/packages/agent-protocol/dist/buyer-seller.js
+++ b/packages/agent-protocol/dist/buyer-seller.js
@@ -1,0 +1,256 @@
+import { createHash } from 'node:crypto';
+import { createEvidenceArchiveRecord } from './evidence-archive.js';
+import { policyDecisionFromBudgetPolicyDecision } from './policy.js';
+import { createReddiReceipt } from './receipts.js';
+export const PAYMENT_CHALLENGE_SCHEMA_VERSION = 'reddi.payment-challenge.v1';
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function positiveAmount(value) {
+    return typeof value === 'string' && /^[1-9]\d*$/.test(value);
+}
+function hashJson(value) {
+    return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}
+function validateChallenge(challenge) {
+    if (!isPlainObject(challenge))
+        return false;
+    if (challenge.schemaVersion !== PAYMENT_CHALLENGE_SCHEMA_VERSION || challenge.status !== 402)
+        return false;
+    if (!['dry-run', 'fixture', 'live'].includes(String(challenge.mode)))
+        return false;
+    if (!isPlainObject(challenge.quote))
+        return false;
+    return positiveAmount(challenge.quote.amount)
+        && isNonEmptyString(challenge.quote.asset)
+        && isNonEmptyString(challenge.quote.network)
+        && isNonEmptyString(challenge.quote.source)
+        && isNonEmptyString(challenge.quote.specialist)
+        && isNonEmptyString(challenge.payTo)
+        && isNonEmptyString(challenge.nonce)
+        && isNonEmptyString(challenge.endpoint);
+}
+function railAllowed(challenge, allowedRails) {
+    if (!allowedRails || allowedRails.length === 0)
+        return true;
+    return allowedRails.some((rail) => (rail.asset.toUpperCase() === challenge.quote.asset.toUpperCase()
+        && rail.network.toLowerCase() === challenge.quote.network.toLowerCase()));
+}
+function defaultPolicyDecision(challenge) {
+    return {
+        schemaVersion: 'reddi.policy-decision.v1',
+        allowed: true,
+        reasonCodes: ['allowed'],
+        quotedAmount: {
+            amount: challenge.quote.amount,
+            asset: challenge.quote.asset,
+            network: challenge.quote.network,
+            source: challenge.quote.source,
+            specialist: challenge.quote.specialist,
+        },
+        limits: {},
+        asset: challenge.quote.asset,
+        network: challenge.quote.network,
+        approvalState: 'approved',
+        auditNotes: ['Allowed: local buyer preflight accepted the dry-run challenge.'],
+    };
+}
+function policyMatchesChallenge(policyDecision, challenge) {
+    const quoted = policyDecision.quotedAmount;
+    return policyDecision.allowed
+        && policyDecision.approvalState === 'approved'
+        && quoted !== null
+        && quoted.amount === challenge.quote.amount
+        && quoted.asset.toUpperCase() === challenge.quote.asset.toUpperCase()
+        && quoted.network.toLowerCase() === challenge.quote.network.toLowerCase()
+        && quoted.source === challenge.quote.source
+        && quoted.specialist === challenge.quote.specialist
+        && policyDecision.asset.toUpperCase() === challenge.quote.asset.toUpperCase()
+        && policyDecision.network.toLowerCase() === challenge.quote.network.toLowerCase();
+}
+export function createPaymentChallenge(input) {
+    const challenge = {
+        schemaVersion: PAYMENT_CHALLENGE_SCHEMA_VERSION,
+        status: 402,
+        ...input,
+    };
+    if (!validateChallenge(challenge))
+        throw new Error('invalid_payment_challenge');
+    return challenge;
+}
+export function evaluateBuyerPaymentChallenge(challengeInput, options = {}) {
+    if (!validateChallenge(challengeInput)) {
+        return {
+            allowed: false,
+            reasonCodes: ['challenge_malformed'],
+            auditNotes: ['Denied: payment challenge is malformed.'],
+        };
+    }
+    const challenge = challengeInput;
+    if (challenge.mode === 'live' && !options.approveLivePayment) {
+        return {
+            allowed: false,
+            reasonCodes: ['live_payment_not_approved'],
+            auditNotes: ['Denied: live payment requires explicit buyer approval.'],
+        };
+    }
+    if (!railAllowed(challenge, options.allowedRails)) {
+        return {
+            allowed: false,
+            reasonCodes: ['unsupported_payment_rail'],
+            auditNotes: [`Denied: ${challenge.quote.asset} on ${challenge.quote.network} is not allowed by buyer rails.`],
+        };
+    }
+    if (options.evaluateBudgetPolicy) {
+        let budgetDecision;
+        let policyDecision;
+        try {
+            budgetDecision = options.evaluateBudgetPolicy(challenge.quote);
+            policyDecision = policyDecisionFromBudgetPolicyDecision(budgetDecision);
+        }
+        catch (err) {
+            return {
+                allowed: false,
+                reasonCodes: ['budget_policy_malformed'],
+                auditNotes: [err instanceof Error ? `Denied: budget policy output is malformed: ${err.message}` : 'Denied: budget policy output is malformed.'],
+            };
+        }
+        if (!budgetDecision.allowed) {
+            return {
+                allowed: false,
+                reasonCodes: ['budget_policy_denied'],
+                policyDecision,
+                auditNotes: budgetDecision.auditNotes ?? ['Denied: local budget policy rejected the challenge.'],
+            };
+        }
+        return {
+            allowed: true,
+            reasonCodes: ['buyer_policy_allowed'],
+            paymentProofRef: options.paymentProofRef ?? `dry-run:${challenge.nonce}`,
+            policyDecision,
+            auditNotes: budgetDecision.auditNotes ?? ['Allowed: local budget policy accepted the challenge.'],
+        };
+    }
+    return {
+        allowed: true,
+        reasonCodes: ['buyer_policy_allowed'],
+        paymentProofRef: options.paymentProofRef ?? `dry-run:${challenge.nonce}`,
+        policyDecision: defaultPolicyDecision(challenge),
+        auditNotes: ['Allowed: no local budget policy evaluator was supplied for this dry-run challenge.'],
+    };
+}
+export async function handlePaidSpecialistRequest(input) {
+    if (!validateChallenge(input.challenge)) {
+        return {
+            status: 400,
+            error: {
+                code: 'challenge_malformed',
+                message: 'payment challenge is malformed',
+            },
+        };
+    }
+    if (!input.request.paymentProofRef) {
+        return { status: 402, challenge: input.challenge };
+    }
+    if (input.challenge.mode === 'live' && !input.approveLivePayment) {
+        return {
+            status: 403,
+            error: {
+                code: 'live_payment_not_approved',
+                message: 'live payment requires explicit seller approval before execution',
+            },
+        };
+    }
+    if (!input.policyDecision) {
+        return {
+            status: 403,
+            error: {
+                code: 'policy_required',
+                message: 'an approved buyer policy decision is required before execution',
+            },
+        };
+    }
+    if (!input.policyDecision.allowed) {
+        return {
+            status: 403,
+            error: {
+                code: 'policy_denied',
+                reasonCodes: input.policyDecision.reasonCodes,
+                message: 'policy decision denied this paid specialist request',
+            },
+        };
+    }
+    if (input.policyDecision.approvalState !== 'approved') {
+        return {
+            status: 403,
+            error: {
+                code: 'policy_not_approved',
+                reasonCodes: input.policyDecision.reasonCodes,
+                message: 'policy decision must be approved before specialist execution',
+            },
+        };
+    }
+    if (!policyMatchesChallenge(input.policyDecision, input.challenge)) {
+        return {
+            status: 403,
+            error: {
+                code: 'policy_mismatch',
+                reasonCodes: input.policyDecision.reasonCodes,
+                message: 'policy decision does not match this payment challenge',
+            },
+        };
+    }
+    try {
+        const result = await input.specialist(input.request.body);
+        const createdAt = input.createdAt ?? new Date().toISOString();
+        const requestHash = hashJson(input.request.body ?? null);
+        const responseHash = hashJson(result);
+        const evidencePayload = { requestHash, responseHash, resultSummary: result };
+        const evidence = createEvidenceArchiveRecord({
+            id: `evidence:${input.challenge.nonce}`,
+            receiptId: `receipt:${input.challenge.nonce}`,
+            sourceId: input.challenge.quote.source,
+            requestHash,
+            responseHash,
+            evidenceRef: `file://fixtures/evidence/${input.challenge.nonce}.json`,
+            createdAt,
+            evidencePayload,
+        });
+        const receipt = createReddiReceipt({
+            schemaVersion: 'reddi.receipt.v1',
+            job: { id: `job:${input.challenge.nonce}`, type: 'specialist-call' },
+            source: { id: input.challenge.quote.source, type: 'seller-middleware', uri: input.challenge.endpoint },
+            payer: { id: 'buyer:local-dry-run' },
+            specialist: { id: input.challenge.quote.specialist, endpoint: input.challenge.endpoint },
+            protocol: { name: 'Reddi Agent Protocol', version: '0.1.0' },
+            payment: {
+                network: input.challenge.quote.network,
+                asset: input.challenge.quote.asset,
+                amount: input.challenge.quote.amount,
+                paymentProofRef: input.request.paymentProofRef,
+            },
+            requestHash,
+            responseHash,
+            evidenceRef: evidence.evidenceRef,
+            policyDecision: input.policyDecision,
+            attestationStatus: 'not_requested',
+            createdAt,
+        });
+        return { status: 200, result, receipt, evidence };
+    }
+    catch (err) {
+        return {
+            status: 500,
+            error: {
+                code: 'specialist_failed',
+                message: err instanceof Error ? err.message : 'specialist failed',
+            },
+        };
+    }
+}

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -7,3 +7,4 @@ export * from './discovery-source.js';
 export * from './evidence-archive.js';
 export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
+export * from './buyer-seller.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -7,3 +7,4 @@ export * from './discovery-source.js';
 export * from './evidence-archive.js';
 export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
+export * from './buyer-seller.js';

--- a/packages/agent-protocol/examples/buyer-seller-dry-run.mjs
+++ b/packages/agent-protocol/examples/buyer-seller-dry-run.mjs
@@ -1,0 +1,59 @@
+import {
+  createPaymentChallenge,
+  evaluateBuyerPaymentChallenge,
+  handlePaidSpecialistRequest,
+} from '../dist/index.js';
+
+const challenge = createPaymentChallenge({
+  mode: 'dry-run',
+  quote: {
+    amount: '50000',
+    asset: 'USDC',
+    network: 'solana-devnet',
+    source: 'source:planning',
+    specialist: 'specialist:coder',
+  },
+  payTo: 'solana:seller-demo',
+  nonce: 'example-001',
+  endpoint: 'http://localhost:4021/specialist',
+});
+
+const buyerDecision = evaluateBuyerPaymentChallenge(challenge, {
+  allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+  paymentProofRef: 'dry-run:example-001',
+  evaluateBudgetPolicy: (quote) => ({
+    allowed: true,
+    reasonCodes: ['allowed'],
+    quotedAmount: quote,
+    remainingBudget: { perRequest: '50000' },
+    auditNotes: ['Allowed by local dry-run budget policy.'],
+  }),
+});
+
+if (!buyerDecision.allowed) {
+  console.log(JSON.stringify({ ok: false, stage: 'buyer-preflight', buyerDecision }, null, 2));
+  process.exitCode = 1;
+} else {
+  const response = await handlePaidSpecialistRequest({
+    challenge,
+    request: {
+      body: { task: 'draft a local implementation plan' },
+      paymentProofRef: buyerDecision.paymentProofRef,
+    },
+    policyDecision: buyerDecision.policyDecision,
+    createdAt: '2026-06-18T13:45:00.000Z',
+    specialist: async (body) => ({
+      ok: true,
+      summary: 'Local dry-run specialist completed without spend.',
+      request: body,
+    }),
+  });
+
+  console.log(JSON.stringify({
+    ok: response.status === 200,
+    status: response.status,
+    receiptId: response.status === 200 ? response.receipt.job.id : undefined,
+    evidenceId: response.status === 200 ? response.evidence.id : undefined,
+    paymentProofRef: buyerDecision.paymentProofRef,
+  }, null, 2));
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -46,6 +46,10 @@
       "types": "./dist/attestation-reputation.d.ts",
       "import": "./dist/attestation-reputation.js"
     },
+    "./buyer-seller": {
+      "types": "./dist/buyer-seller.d.ts",
+      "import": "./dist/buyer-seller.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -57,6 +61,7 @@
     "clean": "rm -rf dist dist-tests",
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && tsc -p tsconfig.test.json && node --test dist-tests/*.test.js",
+    "example:buyer-seller:dry-run": "npm run build && node examples/buyer-seller-dry-run.mjs",
     "release:dry-run": "npm run clean && npm run build && npm test && npm pack --dry-run"
   },
   "devDependencies": {

--- a/packages/agent-protocol/src/buyer-seller.ts
+++ b/packages/agent-protocol/src/buyer-seller.ts
@@ -1,0 +1,351 @@
+import { createHash } from 'node:crypto';
+import { createEvidenceArchiveRecord, type EvidenceArchiveRecord } from './evidence-archive.js';
+import { policyDecisionFromBudgetPolicyDecision, type ReddiPolicyDecision } from './policy.js';
+import { createReddiReceipt, type ReddiReceipt } from './receipts.js';
+
+export const PAYMENT_CHALLENGE_SCHEMA_VERSION = 'reddi.payment-challenge.v1' as const;
+
+export type PaymentChallengeMode = 'dry-run' | 'fixture' | 'live';
+
+export type PaymentChallenge = {
+  schemaVersion: typeof PAYMENT_CHALLENGE_SCHEMA_VERSION;
+  status: 402;
+  mode: PaymentChallengeMode;
+  quote: {
+    amount: string;
+    asset: string;
+    network: string;
+    source: string;
+    specialist: string;
+  };
+  payTo: string;
+  nonce: string;
+  endpoint: string;
+  policyMetadata?: Record<string, unknown>;
+};
+
+export type BuyerPreflightReasonCode =
+  | 'buyer_policy_allowed'
+  | 'challenge_malformed'
+  | 'live_payment_not_approved'
+  | 'unsupported_payment_rail'
+  | 'budget_policy_denied'
+  | 'budget_policy_malformed';
+
+export type BuyerPreflightDecision = {
+  allowed: boolean;
+  reasonCodes: BuyerPreflightReasonCode[];
+  paymentProofRef?: string;
+  policyDecision?: ReddiPolicyDecision;
+  auditNotes: string[];
+};
+
+export type BudgetPolicyEvaluator = (quote: PaymentChallenge['quote']) => {
+  allowed: boolean;
+  reasonCodes: string[];
+  quotedAmount: {
+    amount: string;
+    asset: string;
+    network: string;
+    source?: string;
+    specialist?: string;
+  } | null;
+  remainingBudget?: Record<string, string | number | boolean | null>;
+  auditNotes: string[];
+};
+
+export type BuyerPreflightOptions = {
+  allowedRails?: Array<{ asset: string; network: string }>;
+  approveLivePayment?: boolean;
+  paymentProofRef?: string;
+  evaluateBudgetPolicy?: BudgetPolicyEvaluator;
+};
+
+export type SellerSpecialistFunction = (input: unknown) => unknown | Promise<unknown>;
+
+export type SellerRequest = {
+  body?: unknown;
+  paymentProofRef?: string;
+};
+
+export type SellerResponse =
+  | { status: 400; error: { code: 'challenge_malformed'; message: string } }
+  | { status: 402; challenge: PaymentChallenge }
+  | {
+      status: 403;
+      error: {
+        code: 'live_payment_not_approved' | 'policy_denied' | 'policy_mismatch' | 'policy_not_approved' | 'policy_required';
+        reasonCodes?: string[];
+        message: string;
+      };
+    }
+  | { status: 200; result: unknown; receipt: ReddiReceipt; evidence: EvidenceArchiveRecord }
+  | { status: 500; error: { code: 'specialist_failed'; message: string } };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function positiveAmount(value: unknown): value is string {
+  return typeof value === 'string' && /^[1-9]\d*$/.test(value);
+}
+
+function hashJson(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}
+
+function validateChallenge(challenge: unknown): challenge is PaymentChallenge {
+  if (!isPlainObject(challenge)) return false;
+  if (challenge.schemaVersion !== PAYMENT_CHALLENGE_SCHEMA_VERSION || challenge.status !== 402) return false;
+  if (!['dry-run', 'fixture', 'live'].includes(String(challenge.mode))) return false;
+  if (!isPlainObject(challenge.quote)) return false;
+  return positiveAmount(challenge.quote.amount)
+    && isNonEmptyString(challenge.quote.asset)
+    && isNonEmptyString(challenge.quote.network)
+    && isNonEmptyString(challenge.quote.source)
+    && isNonEmptyString(challenge.quote.specialist)
+    && isNonEmptyString(challenge.payTo)
+    && isNonEmptyString(challenge.nonce)
+    && isNonEmptyString(challenge.endpoint);
+}
+
+function railAllowed(challenge: PaymentChallenge, allowedRails: BuyerPreflightOptions['allowedRails']): boolean {
+  if (!allowedRails || allowedRails.length === 0) return true;
+  return allowedRails.some((rail) => (
+    rail.asset.toUpperCase() === challenge.quote.asset.toUpperCase()
+    && rail.network.toLowerCase() === challenge.quote.network.toLowerCase()
+  ));
+}
+
+function defaultPolicyDecision(challenge: PaymentChallenge): ReddiPolicyDecision {
+  return {
+    schemaVersion: 'reddi.policy-decision.v1',
+    allowed: true,
+    reasonCodes: ['allowed'],
+    quotedAmount: {
+      amount: challenge.quote.amount,
+      asset: challenge.quote.asset,
+      network: challenge.quote.network,
+      source: challenge.quote.source,
+      specialist: challenge.quote.specialist,
+    },
+    limits: {},
+    asset: challenge.quote.asset,
+    network: challenge.quote.network,
+    approvalState: 'approved',
+    auditNotes: ['Allowed: local buyer preflight accepted the dry-run challenge.'],
+  };
+}
+
+function policyMatchesChallenge(policyDecision: ReddiPolicyDecision, challenge: PaymentChallenge): boolean {
+  const quoted = policyDecision.quotedAmount;
+  return policyDecision.allowed
+    && policyDecision.approvalState === 'approved'
+    && quoted !== null
+    && quoted.amount === challenge.quote.amount
+    && quoted.asset.toUpperCase() === challenge.quote.asset.toUpperCase()
+    && quoted.network.toLowerCase() === challenge.quote.network.toLowerCase()
+    && quoted.source === challenge.quote.source
+    && quoted.specialist === challenge.quote.specialist
+    && policyDecision.asset.toUpperCase() === challenge.quote.asset.toUpperCase()
+    && policyDecision.network.toLowerCase() === challenge.quote.network.toLowerCase();
+}
+
+export function createPaymentChallenge(input: Omit<PaymentChallenge, 'schemaVersion' | 'status'>): PaymentChallenge {
+  const challenge: PaymentChallenge = {
+    schemaVersion: PAYMENT_CHALLENGE_SCHEMA_VERSION,
+    status: 402,
+    ...input,
+  };
+  if (!validateChallenge(challenge)) throw new Error('invalid_payment_challenge');
+  return challenge;
+}
+
+export function evaluateBuyerPaymentChallenge(
+  challengeInput: unknown,
+  options: BuyerPreflightOptions = {},
+): BuyerPreflightDecision {
+  if (!validateChallenge(challengeInput)) {
+    return {
+      allowed: false,
+      reasonCodes: ['challenge_malformed'],
+      auditNotes: ['Denied: payment challenge is malformed.'],
+    };
+  }
+  const challenge = challengeInput;
+  if (challenge.mode === 'live' && !options.approveLivePayment) {
+    return {
+      allowed: false,
+      reasonCodes: ['live_payment_not_approved'],
+      auditNotes: ['Denied: live payment requires explicit buyer approval.'],
+    };
+  }
+  if (!railAllowed(challenge, options.allowedRails)) {
+    return {
+      allowed: false,
+      reasonCodes: ['unsupported_payment_rail'],
+      auditNotes: [`Denied: ${challenge.quote.asset} on ${challenge.quote.network} is not allowed by buyer rails.`],
+    };
+  }
+
+  if (options.evaluateBudgetPolicy) {
+    let budgetDecision: ReturnType<BudgetPolicyEvaluator>;
+    let policyDecision: ReddiPolicyDecision;
+    try {
+      budgetDecision = options.evaluateBudgetPolicy(challenge.quote);
+      policyDecision = policyDecisionFromBudgetPolicyDecision(budgetDecision);
+    } catch (err) {
+      return {
+        allowed: false,
+        reasonCodes: ['budget_policy_malformed'],
+        auditNotes: [err instanceof Error ? `Denied: budget policy output is malformed: ${err.message}` : 'Denied: budget policy output is malformed.'],
+      };
+    }
+    if (!budgetDecision.allowed) {
+      return {
+        allowed: false,
+        reasonCodes: ['budget_policy_denied'],
+        policyDecision,
+        auditNotes: budgetDecision.auditNotes ?? ['Denied: local budget policy rejected the challenge.'],
+      };
+    }
+    return {
+      allowed: true,
+      reasonCodes: ['buyer_policy_allowed'],
+      paymentProofRef: options.paymentProofRef ?? `dry-run:${challenge.nonce}`,
+      policyDecision,
+      auditNotes: budgetDecision.auditNotes ?? ['Allowed: local budget policy accepted the challenge.'],
+    };
+  }
+
+  return {
+    allowed: true,
+    reasonCodes: ['buyer_policy_allowed'],
+    paymentProofRef: options.paymentProofRef ?? `dry-run:${challenge.nonce}`,
+    policyDecision: defaultPolicyDecision(challenge),
+    auditNotes: ['Allowed: no local budget policy evaluator was supplied for this dry-run challenge.'],
+  };
+}
+
+export async function handlePaidSpecialistRequest(input: {
+  challenge: PaymentChallenge;
+  request: SellerRequest;
+  specialist: SellerSpecialistFunction;
+  policyDecision?: ReddiPolicyDecision;
+  approveLivePayment?: boolean;
+  createdAt?: string;
+}): Promise<SellerResponse> {
+  if (!validateChallenge(input.challenge)) {
+    return {
+      status: 400,
+      error: {
+        code: 'challenge_malformed',
+        message: 'payment challenge is malformed',
+      },
+    };
+  }
+  if (!input.request.paymentProofRef) {
+    return { status: 402, challenge: input.challenge };
+  }
+  if (input.challenge.mode === 'live' && !input.approveLivePayment) {
+    return {
+      status: 403,
+      error: {
+        code: 'live_payment_not_approved',
+        message: 'live payment requires explicit seller approval before execution',
+      },
+    };
+  }
+  if (!input.policyDecision) {
+    return {
+      status: 403,
+      error: {
+        code: 'policy_required',
+        message: 'an approved buyer policy decision is required before execution',
+      },
+    };
+  }
+  if (!input.policyDecision.allowed) {
+    return {
+      status: 403,
+      error: {
+        code: 'policy_denied',
+        reasonCodes: input.policyDecision.reasonCodes,
+        message: 'policy decision denied this paid specialist request',
+      },
+    };
+  }
+  if (input.policyDecision.approvalState !== 'approved') {
+    return {
+      status: 403,
+      error: {
+        code: 'policy_not_approved',
+        reasonCodes: input.policyDecision.reasonCodes,
+        message: 'policy decision must be approved before specialist execution',
+      },
+    };
+  }
+  if (!policyMatchesChallenge(input.policyDecision, input.challenge)) {
+    return {
+      status: 403,
+      error: {
+        code: 'policy_mismatch',
+        reasonCodes: input.policyDecision.reasonCodes,
+        message: 'policy decision does not match this payment challenge',
+      },
+    };
+  }
+
+  try {
+    const result = await input.specialist(input.request.body);
+    const createdAt = input.createdAt ?? new Date().toISOString();
+    const requestHash = hashJson(input.request.body ?? null);
+    const responseHash = hashJson(result);
+    const evidencePayload = { requestHash, responseHash, resultSummary: result };
+    const evidence = createEvidenceArchiveRecord({
+      id: `evidence:${input.challenge.nonce}`,
+      receiptId: `receipt:${input.challenge.nonce}`,
+      sourceId: input.challenge.quote.source,
+      requestHash,
+      responseHash,
+      evidenceRef: `file://fixtures/evidence/${input.challenge.nonce}.json`,
+      createdAt,
+      evidencePayload,
+    });
+    const receipt = createReddiReceipt({
+      schemaVersion: 'reddi.receipt.v1',
+      job: { id: `job:${input.challenge.nonce}`, type: 'specialist-call' },
+      source: { id: input.challenge.quote.source, type: 'seller-middleware', uri: input.challenge.endpoint },
+      payer: { id: 'buyer:local-dry-run' },
+      specialist: { id: input.challenge.quote.specialist, endpoint: input.challenge.endpoint },
+      protocol: { name: 'Reddi Agent Protocol', version: '0.1.0' },
+      payment: {
+        network: input.challenge.quote.network,
+        asset: input.challenge.quote.asset,
+        amount: input.challenge.quote.amount,
+        paymentProofRef: input.request.paymentProofRef,
+      },
+      requestHash,
+      responseHash,
+      evidenceRef: evidence.evidenceRef,
+      policyDecision: input.policyDecision,
+      attestationStatus: 'not_requested',
+      createdAt,
+    });
+    return { status: 200, result, receipt, evidence };
+  } catch (err) {
+    return {
+      status: 500,
+      error: {
+        code: 'specialist_failed',
+        message: err instanceof Error ? err.message : 'specialist failed',
+      },
+    };
+  }
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -7,3 +7,4 @@ export * from './discovery-source.js';
 export * from './evidence-archive.js';
 export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
+export * from './buyer-seller.js';

--- a/packages/agent-protocol/tests/buyer-seller.test.ts
+++ b/packages/agent-protocol/tests/buyer-seller.test.ts
@@ -1,0 +1,296 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createPaymentChallenge,
+  evaluateBuyerPaymentChallenge,
+  handlePaidSpecialistRequest,
+  type BudgetPolicyEvaluator,
+} from '../dist/index.js';
+
+const challenge = createPaymentChallenge({
+  mode: 'dry-run',
+  quote: {
+    amount: '50000',
+    asset: 'USDC',
+    network: 'solana-devnet',
+    source: 'source:planning',
+    specialist: 'specialist:coder',
+  },
+  payTo: 'solana:seller-demo',
+  nonce: 'unit-001',
+  endpoint: 'http://localhost:4021/specialist',
+});
+
+const allowBudget: BudgetPolicyEvaluator = (quote) => ({
+  allowed: true,
+  reasonCodes: ['allowed'],
+  quotedAmount: quote,
+  remainingBudget: { perRequest: '50000' },
+  auditNotes: ['Allowed by local budget policy.'],
+});
+
+const denyBudget: BudgetPolicyEvaluator = (quote) => ({
+  allowed: false,
+  reasonCodes: ['request_amount_exceeds_limit'],
+  quotedAmount: quote,
+  remainingBudget: { perRequest: '0' },
+  auditNotes: ['Denied by local budget policy.'],
+});
+
+const malformedBudget: BudgetPolicyEvaluator = (quote) => ({
+  allowed: false,
+  reasonCodes: ['not_a_rap_reason'],
+  quotedAmount: quote,
+  remainingBudget: {},
+  auditNotes: ['Malformed budget output.'],
+});
+
+describe('RAP buyer client and seller middleware primitives', () => {
+  it('returns a structured 402 payment challenge for unpaid requests', async () => {
+    const response = await handlePaidSpecialistRequest({
+      challenge,
+      request: { body: { task: 'plan' } },
+      specialist: () => ({ ok: true }),
+    });
+
+    assert.equal(response.status, 402);
+    if (response.status === 402) {
+      assert.equal(response.challenge.schemaVersion, 'reddi.payment-challenge.v1');
+      assert.equal(response.challenge.status, 402);
+      assert.equal(response.challenge.quote.amount, '50000');
+      assert.equal(response.challenge.mode, 'dry-run');
+    }
+  });
+
+  it('lets the buyer parse a challenge and approve local dry-run payment with budget policy', () => {
+    const decision = evaluateBuyerPaymentChallenge(challenge, {
+      allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+      evaluateBudgetPolicy: allowBudget,
+      paymentProofRef: 'dry-run:paid',
+    });
+
+    assert.equal(decision.allowed, true);
+    assert.deepEqual(decision.reasonCodes, ['buyer_policy_allowed']);
+    assert.equal(decision.paymentProofRef, 'dry-run:paid');
+    assert.equal(decision.policyDecision?.allowed, true);
+    assert.equal(decision.policyDecision?.quotedAmount?.source, 'source:planning');
+  });
+
+  it('executes a bounded specialist and returns result, receipt, and evidence for approved dry-run payment', async () => {
+    const buyerDecision = evaluateBuyerPaymentChallenge(challenge, {
+      allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+      evaluateBudgetPolicy: allowBudget,
+      paymentProofRef: 'dry-run:paid',
+    });
+    assert.equal(buyerDecision.allowed, true);
+
+    const response = await handlePaidSpecialistRequest({
+      challenge,
+      request: { body: { task: 'plan' }, paymentProofRef: buyerDecision.paymentProofRef },
+      policyDecision: buyerDecision.policyDecision,
+      createdAt: '2026-06-18T13:40:00.000Z',
+      specialist: (body) => ({ ok: true, body }),
+    });
+
+    assert.equal(response.status, 200);
+    if (response.status === 200) {
+      assert.deepEqual(response.result, { ok: true, body: { task: 'plan' } });
+      assert.equal(response.receipt.schemaVersion, 'reddi.receipt.v1');
+      assert.equal(response.receipt.payment.paymentProofRef, 'dry-run:paid');
+      assert.equal(response.receipt.policyDecision.allowed, true);
+      assert.equal(response.evidence.schemaVersion, 'reddi.evidence-archive.v1');
+      assert.equal(response.evidence.receiptId, response.receipt.job.id.replace('job:', 'receipt:'));
+      assert.equal(Object.prototype.hasOwnProperty.call(response.evidence, 'evidencePayload'), false);
+    }
+  });
+
+  it('denies over-budget challenges without producing payment proof', () => {
+    const decision = evaluateBuyerPaymentChallenge(challenge, {
+      allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+      evaluateBudgetPolicy: denyBudget,
+    });
+
+    assert.equal(decision.allowed, false);
+    assert.deepEqual(decision.reasonCodes, ['budget_policy_denied']);
+    assert.equal(decision.paymentProofRef, undefined);
+    assert.equal(decision.policyDecision?.allowed, false);
+    assert.deepEqual(decision.policyDecision?.reasonCodes, ['request_amount_exceeds_limit']);
+  });
+
+  it('fails closed for malformed budget policy hook output', () => {
+    const decision = evaluateBuyerPaymentChallenge(challenge, {
+      allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+      evaluateBudgetPolicy: malformedBudget,
+    });
+
+    assert.equal(decision.allowed, false);
+    assert.deepEqual(decision.reasonCodes, ['budget_policy_malformed']);
+    assert.equal(decision.paymentProofRef, undefined);
+  });
+
+  it('requires an approved matching policy decision before seller execution', async () => {
+    const noPolicy = await handlePaidSpecialistRequest({
+      challenge,
+      request: { body: { task: 'plan' }, paymentProofRef: 'dry-run:paid' },
+      specialist: () => ({ ok: true }),
+    });
+    assert.equal(noPolicy.status, 403);
+    if (noPolicy.status === 403) assert.equal(noPolicy.error.code, 'policy_required');
+
+    const buyerDecision = evaluateBuyerPaymentChallenge(challenge, {
+      allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+      evaluateBudgetPolicy: allowBudget,
+      paymentProofRef: 'dry-run:paid',
+    });
+    assert.equal(buyerDecision.allowed, true);
+    const mismatched = await handlePaidSpecialistRequest({
+      challenge,
+      request: { body: { task: 'plan' }, paymentProofRef: 'dry-run:paid' },
+      policyDecision: {
+        ...buyerDecision.policyDecision!,
+        quotedAmount: {
+          ...buyerDecision.policyDecision!.quotedAmount!,
+          amount: '60000',
+        },
+      },
+      specialist: () => ({ ok: true }),
+    });
+    assert.equal(mismatched.status, 403);
+    if (mismatched.status === 403) assert.equal(mismatched.error.code, 'policy_mismatch');
+  });
+
+  it('does not execute a specialist when seller receives a denied policy decision', async () => {
+    const buyerDecision = evaluateBuyerPaymentChallenge(challenge, {
+      allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+      evaluateBudgetPolicy: denyBudget,
+      paymentProofRef: 'dry-run:paid',
+    });
+    let executed = false;
+    const response = await handlePaidSpecialistRequest({
+      challenge,
+      request: { body: { task: 'plan' }, paymentProofRef: 'dry-run:paid' },
+      policyDecision: buyerDecision.policyDecision,
+      specialist: () => {
+        executed = true;
+        return { ok: true };
+      },
+    });
+
+    assert.equal(response.status, 403);
+    assert.equal(executed, false);
+    if (response.status === 403) {
+      assert.equal(response.error.code, 'policy_denied');
+      assert.deepEqual(response.error.reasonCodes, ['request_amount_exceeds_limit']);
+    }
+  });
+
+  it('does not execute a specialist when policy still requires operator approval', async () => {
+    const buyerDecision = evaluateBuyerPaymentChallenge(challenge, {
+      allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+      evaluateBudgetPolicy: allowBudget,
+      paymentProofRef: 'dry-run:paid',
+    });
+    let executed = false;
+    const response = await handlePaidSpecialistRequest({
+      challenge,
+      request: { body: { task: 'plan' }, paymentProofRef: 'dry-run:paid' },
+      policyDecision: {
+        ...buyerDecision.policyDecision!,
+        approvalState: 'requires_operator_approval',
+      },
+      specialist: () => {
+        executed = true;
+        return { ok: true };
+      },
+    });
+
+    assert.equal(response.status, 403);
+    assert.equal(executed, false);
+    if (response.status === 403) assert.equal(response.error.code, 'policy_not_approved');
+  });
+
+  it('fails closed for malformed challenges, unsupported rails, and unapproved live mode', () => {
+    const malformed = evaluateBuyerPaymentChallenge({
+      ...challenge,
+      quote: { ...challenge.quote, amount: 'abc' },
+    });
+    assert.equal(malformed.allowed, false);
+    assert.deepEqual(malformed.reasonCodes, ['challenge_malformed']);
+
+    const unsupportedRail = evaluateBuyerPaymentChallenge(challenge, {
+      allowedRails: [{ asset: 'AUDD', network: 'solana-devnet' }],
+    });
+    assert.equal(unsupportedRail.allowed, false);
+    assert.deepEqual(unsupportedRail.reasonCodes, ['unsupported_payment_rail']);
+
+    const liveChallenge = createPaymentChallenge({ ...challenge, mode: 'live' });
+    const live = evaluateBuyerPaymentChallenge(liveChallenge);
+    assert.equal(live.allowed, false);
+    assert.deepEqual(live.reasonCodes, ['live_payment_not_approved']);
+  });
+
+  it('requires explicit seller approval before executing live-mode challenges', async () => {
+    const liveChallenge = createPaymentChallenge({ ...challenge, mode: 'live' });
+    const buyerDecision = evaluateBuyerPaymentChallenge(liveChallenge, {
+      approveLivePayment: true,
+      allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+      evaluateBudgetPolicy: allowBudget,
+      paymentProofRef: 'dry-run:paid',
+    });
+    assert.equal(buyerDecision.allowed, true);
+
+    let executed = false;
+    const blocked = await handlePaidSpecialistRequest({
+      challenge: liveChallenge,
+      request: { body: { task: 'plan' }, paymentProofRef: 'dry-run:paid' },
+      policyDecision: buyerDecision.policyDecision,
+      specialist: () => {
+        executed = true;
+        return { ok: true };
+      },
+    });
+
+    assert.equal(blocked.status, 403);
+    assert.equal(executed, false);
+    if (blocked.status === 403) assert.equal(blocked.error.code, 'live_payment_not_approved');
+  });
+
+  it('fails closed on malformed seller challenges before execution', async () => {
+    let executed = false;
+    const response = await handlePaidSpecialistRequest({
+      challenge: { ...challenge, quote: { ...challenge.quote, amount: 'abc' } },
+      request: { body: { task: 'plan' }, paymentProofRef: 'dry-run:paid' },
+      specialist: () => {
+        executed = true;
+        return { ok: true };
+      },
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(executed, false);
+    if (response.status === 400) {
+      assert.equal(response.error.code, 'challenge_malformed');
+    }
+  });
+
+  it('returns specialist failure without creating a receipt', async () => {
+    const response = await handlePaidSpecialistRequest({
+      challenge,
+      request: { body: { task: 'plan' }, paymentProofRef: 'dry-run:paid' },
+      policyDecision: evaluateBuyerPaymentChallenge(challenge, {
+        allowedRails: [{ asset: 'USDC', network: 'solana-devnet' }],
+        evaluateBudgetPolicy: allowBudget,
+        paymentProofRef: 'dry-run:paid',
+      }).policyDecision,
+      specialist: () => {
+        throw new Error('boom');
+      },
+    });
+
+    assert.equal(response.status, 500);
+    if (response.status === 500) {
+      assert.equal(response.error.code, 'specialist_failed');
+      assert.equal(response.error.message, 'boom');
+    }
+  });
+});


### PR DESCRIPTION
Closes #342.

## Summary
- Add `reddi.payment-challenge.v1` and local buyer/seller SDK helpers.
- Seller helper returns structured 402 challenges for unpaid requests, blocks malformed challenges, requires an approved policy decision matching the exact challenge before execution, requires explicit seller approval for live mode, executes only a caller-supplied bounded specialist function, and returns result + Reddi receipt + EvidenceArchive record for approved dry-runs.
- Buyer helper parses challenges, denies malformed challenges, unsupported rails, unapproved live mode, malformed budget hook output, and local budget-policy failures, while accepting a #159-compatible budget evaluator hook without adding `@reddi/x402-solana` as a dependency.
- Add runnable no-spend example script: `npm run example:buyer-seller:dry-run`.
- Docs show minimum dry-run integration and make the OSS/self-hosted boundary explicit.

## Validation
- `npm test` in `packages/agent-protocol` passed with 61 tests.
- `npm run example:buyer-seller:dry-run` passed and produced receipt/evidence ids without spend.
- `npm run release:dry-run` in `packages/agent-protocol` passed and packed `dist/buyer-seller.*`.
- root `npm run check:rap:naming` passed.
- `git diff --check` passed.

No UI changes; screenshots/video not required. No server framework, network fetch, wallet action, payment settlement, hosted registry, or external provider invocation was added.
