### PR TITLE
Add AUDD payment plan adapter

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -214,6 +214,60 @@ Run the local no-spend example:
 npm run example:buyer-seller:dry-run
 ```
 
+## AUDD/Solana Payment Plans
+
+```typescript
+import {
+  createAuddPaymentChallenge,
+  createAuddSolanaPaymentPlan,
+  evaluateAuddPaymentPlanPreflight,
+} from '@reddi/agent-protocol/audd-payment-plan';
+
+const paymentPlan = createAuddSolanaPaymentPlan({
+  network: 'solana-devnet',
+  mint: 'AUDDdev111111111111111111111111111111111111',
+  payee: 'solana:seller-demo',
+  settlementAccount: 'solana:seller-demo',
+  amount: '2500000',
+  quoteExpiresAt: '2026-06-18T15:00:00.000Z',
+  failurePolicy: {
+    mode: 'no_charge_on_failure',
+    description: 'Dry-run jobs do not charge when the specialist fails.',
+  },
+  refundPolicy: {
+    mode: 'manual_review',
+    description: 'Live refunds require operator review before settlement.',
+  },
+  evidenceRequired: true,
+  paymentMode: 'dry-run',
+});
+
+const auddChallenge = createAuddPaymentChallenge({
+  mode: 'dry-run',
+  paymentPlan,
+  quote: {
+    source: 'source:ard-catalog',
+    specialist: 'specialist:listing-writer',
+  },
+  nonce: 'audd-001',
+  endpoint: 'http://localhost:4021/specialist',
+});
+
+const decision = evaluateAuddPaymentPlanPreflight(auddChallenge, {
+  allowedNetworks: ['solana-devnet'],
+  allowedMints: ['AUDDdev111111111111111111111111111111111111'],
+  allowedPayees: ['solana:seller-demo'],
+  allowedSettlementAccounts: ['solana:seller-demo'],
+  maxAmount: '3000000',
+  requireEvidence: true,
+  approvalState: 'approved',
+  paymentProofRef: 'dry-run:audd-001',
+  now: '2026-06-18T14:00:00.000Z',
+});
+```
+
+AUDD/Solana payment plans are metadata and policy-preflight helpers for RAP buyer/seller middleware. They represent AUDD quote amount, Solana network, mint, payee/settlement account, expiry, failure/refund policy, and evidence requirements without submitting transactions or requiring hosted RAP infrastructure. Buyer preflight fails closed unless the caller supplies explicit allowed networks, mints, payees, settlement accounts, evidence policy, operator approval, and either a max amount or budget evaluator. Live payment remains fail-closed unless buyer/operator approval is explicit; actual wallet actions, SPL custody, Quasar escrow, and settlement proof verification belong in payment-rail integrations and the Quasar boundary work.
+
 ## Local Validation
 
 ```bash

--- a/packages/agent-protocol/dist/audd-payment-plan.d.ts
+++ b/packages/agent-protocol/dist/audd-payment-plan.d.ts
@@ -1,0 +1,58 @@
+import { type BudgetPolicyEvaluator, type PaymentChallenge } from './buyer-seller.js';
+import type { ReddiPolicyApprovalState, ReddiPolicyDecision } from './policy.js';
+export declare const AUDD_PAYMENT_PLAN_SCHEMA_VERSION: "reddi.audd-payment-plan.v1";
+export declare const AUDD_ASSET: "AUDD";
+export type AuddSolanaPaymentPlan = {
+    schemaVersion: typeof AUDD_PAYMENT_PLAN_SCHEMA_VERSION;
+    asset: typeof AUDD_ASSET;
+    network: string;
+    mint: string;
+    payee: string;
+    settlementAccount: string;
+    amount: string;
+    quoteExpiresAt: string;
+    failurePolicy: {
+        mode: 'no_charge_on_failure' | 'refund_on_failure' | 'manual_review';
+        description: string;
+    };
+    refundPolicy: {
+        mode: 'none' | 'automatic' | 'manual_review';
+        description: string;
+    };
+    evidenceRequired: boolean;
+    paymentMode: 'dry-run' | 'live';
+};
+export type AuddPaymentPlanInput = Omit<AuddSolanaPaymentPlan, 'schemaVersion' | 'asset'> & {
+    asset?: typeof AUDD_ASSET;
+};
+export type AuddPaymentPlanPreflightReasonCode = 'audd_payment_plan_allowed' | 'challenge_malformed' | 'missing_audd_payment_plan' | 'payment_plan_malformed' | 'credential_leakage_rejected' | 'buyer_policy_missing' | 'quote_payment_plan_mismatch' | 'wrong_asset' | 'wrong_network' | 'wrong_mint' | 'missing_payee' | 'quote_expired' | 'evidence_required' | 'operator_approval_required' | 'live_payment_not_approved' | 'amount_exceeds_max' | 'budget_policy_denied' | 'budget_policy_malformed' | 'unsupported_payment_rail';
+export type AuddPaymentPlanPreflightDecision = {
+    allowed: boolean;
+    reasonCodes: AuddPaymentPlanPreflightReasonCode[];
+    paymentProofRef?: string;
+    policyDecision?: ReddiPolicyDecision;
+    paymentPlan?: AuddSolanaPaymentPlan;
+    auditNotes: string[];
+};
+export type AuddPaymentPlanPreflightOptions = {
+    allowedNetworks?: string[];
+    allowedMints?: string[];
+    allowedPayees?: string[];
+    allowedSettlementAccounts?: string[];
+    maxAmount?: string;
+    requireEvidence?: boolean;
+    approvalState?: ReddiPolicyApprovalState;
+    approveLivePayment?: boolean;
+    paymentProofRef?: string;
+    now?: string | Date;
+    evaluateBudgetPolicy?: BudgetPolicyEvaluator;
+};
+export declare function validateAuddSolanaPaymentPlan(value: unknown): value is AuddSolanaPaymentPlan;
+export declare function createAuddSolanaPaymentPlan(input: AuddPaymentPlanInput): AuddSolanaPaymentPlan;
+export declare function createAuddPaymentChallenge(input: Omit<PaymentChallenge, 'schemaVersion' | 'status' | 'quote' | 'payTo' | 'policyMetadata'> & {
+    paymentPlan: AuddSolanaPaymentPlan;
+    quote?: Partial<PaymentChallenge['quote']>;
+    payTo?: string;
+    policyMetadata?: Record<string, unknown>;
+}): PaymentChallenge;
+export declare function evaluateAuddPaymentPlanPreflight(challengeInput: unknown, options?: AuddPaymentPlanPreflightOptions): AuddPaymentPlanPreflightDecision;

--- a/packages/agent-protocol/dist/audd-payment-plan.js
+++ b/packages/agent-protocol/dist/audd-payment-plan.js
@@ -1,0 +1,331 @@
+import { evaluateBuyerPaymentChallenge, PAYMENT_CHALLENGE_SCHEMA_VERSION, } from './buyer-seller.js';
+export const AUDD_PAYMENT_PLAN_SCHEMA_VERSION = 'reddi.audd-payment-plan.v1';
+export const AUDD_ASSET = 'AUDD';
+const CREDENTIAL_KEYS = new Set([
+    'api_key',
+    'apikey',
+    'access_token',
+    'auth',
+    'authorization',
+    'bearer',
+    'credential',
+    'password',
+    'private_key',
+    'secret',
+    'signature',
+    'sig',
+    'token',
+    'x-amz-signature',
+    'x-goog-signature',
+]);
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function positiveAmount(value) {
+    return typeof value === 'string' && /^[1-9]\d*$/.test(value);
+}
+function amountToBigInt(value) {
+    return BigInt(value);
+}
+function normalized(value) {
+    return value.trim().toLowerCase();
+}
+function hasOnlyNonEmptyStrings(value) {
+    return Array.isArray(value) && value.length > 0 && value.every(isNonEmptyString);
+}
+function containsCredentialMaterial(value, seen = new WeakSet()) {
+    if (typeof value === 'string') {
+        try {
+            const url = new URL(value);
+            if (url.username || url.password)
+                return true;
+            for (const [key, item] of url.searchParams.entries()) {
+                if (CREDENTIAL_KEYS.has(normalized(key)))
+                    return true;
+                if (/bearer\s+[a-z0-9._-]+/i.test(item))
+                    return true;
+            }
+        }
+        catch {
+            if (/bearer\s+[a-z0-9._-]+/i.test(value))
+                return true;
+        }
+        return false;
+    }
+    if (Array.isArray(value)) {
+        if (seen.has(value))
+            return false;
+        seen.add(value);
+        return value.some((item) => containsCredentialMaterial(item, seen));
+    }
+    if (!isPlainObject(value))
+        return false;
+    if (seen.has(value))
+        return false;
+    seen.add(value);
+    return Object.entries(value).some(([key, item]) => (CREDENTIAL_KEYS.has(normalized(key)) || containsCredentialMaterial(item, seen)));
+}
+function containsCircularReference(value, seen = new WeakSet()) {
+    if (Array.isArray(value)) {
+        if (seen.has(value))
+            return true;
+        seen.add(value);
+        return value.some((item) => containsCircularReference(item, seen));
+    }
+    if (!isPlainObject(value))
+        return false;
+    if (seen.has(value))
+        return true;
+    seen.add(value);
+    return Object.values(value).some((item) => containsCircularReference(item, seen));
+}
+function isPaymentChallenge(value) {
+    if (!isPlainObject(value))
+        return false;
+    if (value.schemaVersion !== PAYMENT_CHALLENGE_SCHEMA_VERSION || value.status !== 402)
+        return false;
+    if (!['dry-run', 'fixture', 'live'].includes(String(value.mode)))
+        return false;
+    if (!isPlainObject(value.quote))
+        return false;
+    return positiveAmount(value.quote.amount)
+        && isNonEmptyString(value.quote.asset)
+        && isNonEmptyString(value.quote.network)
+        && isNonEmptyString(value.quote.source)
+        && isNonEmptyString(value.quote.specialist)
+        && isNonEmptyString(value.payTo)
+        && isNonEmptyString(value.nonce)
+        && isNonEmptyString(value.endpoint);
+}
+function validatePolicyText(value) {
+    if (!isPlainObject(value))
+        return false;
+    return ['no_charge_on_failure', 'refund_on_failure', 'manual_review'].includes(String(value.mode))
+        && isNonEmptyString(value.description);
+}
+function validateRefundText(value) {
+    if (!isPlainObject(value))
+        return false;
+    return ['none', 'automatic', 'manual_review'].includes(String(value.mode))
+        && isNonEmptyString(value.description);
+}
+export function validateAuddSolanaPaymentPlan(value) {
+    if (!isPlainObject(value))
+        return false;
+    if (value.schemaVersion !== AUDD_PAYMENT_PLAN_SCHEMA_VERSION)
+        return false;
+    if (value.asset !== AUDD_ASSET)
+        return false;
+    if (!isNonEmptyString(value.network))
+        return false;
+    if (!isNonEmptyString(value.mint))
+        return false;
+    if (!isNonEmptyString(value.payee))
+        return false;
+    if (!isNonEmptyString(value.settlementAccount))
+        return false;
+    if (!positiveAmount(value.amount))
+        return false;
+    if (!isNonEmptyString(value.quoteExpiresAt) || Number.isNaN(Date.parse(value.quoteExpiresAt)))
+        return false;
+    if (!validatePolicyText(value.failurePolicy))
+        return false;
+    if (!validateRefundText(value.refundPolicy))
+        return false;
+    if (typeof value.evidenceRequired !== 'boolean')
+        return false;
+    if (!['dry-run', 'live'].includes(String(value.paymentMode)))
+        return false;
+    if (containsCircularReference(value))
+        return false;
+    return !containsCredentialMaterial(value);
+}
+export function createAuddSolanaPaymentPlan(input) {
+    const plan = {
+        schemaVersion: AUDD_PAYMENT_PLAN_SCHEMA_VERSION,
+        asset: AUDD_ASSET,
+        ...input,
+    };
+    if (!validateAuddSolanaPaymentPlan(plan))
+        throw new Error('invalid_audd_payment_plan');
+    return plan;
+}
+export function createAuddPaymentChallenge(input) {
+    const { paymentPlan, quote, payTo, policyMetadata, ...rest } = input;
+    if (!validateAuddSolanaPaymentPlan(paymentPlan))
+        throw new Error('invalid_audd_payment_plan');
+    const challenge = {
+        schemaVersion: PAYMENT_CHALLENGE_SCHEMA_VERSION,
+        status: 402,
+        ...rest,
+        quote: {
+            amount: paymentPlan.amount,
+            asset: AUDD_ASSET,
+            network: paymentPlan.network,
+            source: quote?.source ?? '',
+            specialist: quote?.specialist ?? '',
+        },
+        payTo: payTo ?? paymentPlan.payee,
+        policyMetadata: {
+            ...policyMetadata,
+            auddPaymentPlan: paymentPlan,
+        },
+    };
+    if (!isPaymentChallenge(challenge))
+        throw new Error('invalid_payment_challenge');
+    return challenge;
+}
+function planFromChallenge(challenge) {
+    const plan = isPlainObject(challenge.policyMetadata)
+        ? challenge.policyMetadata.auddPaymentPlan
+        : undefined;
+    return validateAuddSolanaPaymentPlan(plan) ? plan : undefined;
+}
+function deny(reasonCode, auditNote, extras = {}) {
+    return {
+        allowed: false,
+        reasonCodes: [reasonCode],
+        auditNotes: [auditNote],
+        ...extras,
+    };
+}
+function adaptBuyerDecision(decision, plan, challenge) {
+    if (decision.allowed) {
+        const quoted = decision.policyDecision?.quotedAmount;
+        const matchesAuddPlan = decision.policyDecision?.allowed === true
+            && decision.policyDecision.approvalState === 'approved'
+            && quoted !== null
+            && quoted?.amount === plan.amount
+            && quoted.asset.toUpperCase() === AUDD_ASSET
+            && quoted.asset.toUpperCase() === challenge.quote.asset.toUpperCase()
+            && quoted.network.toLowerCase() === plan.network.toLowerCase()
+            && quoted.network.toLowerCase() === challenge.quote.network.toLowerCase()
+            && quoted.source === challenge.quote.source
+            && quoted.specialist === challenge.quote.specialist
+            && decision.policyDecision.asset.toUpperCase() === AUDD_ASSET
+            && decision.policyDecision.network.toLowerCase() === plan.network.toLowerCase();
+        if (!matchesAuddPlan) {
+            return {
+                allowed: false,
+                reasonCodes: ['budget_policy_malformed'],
+                policyDecision: decision.policyDecision,
+                paymentPlan: plan,
+                auditNotes: ['Denied: buyer budget policy decision did not match the AUDD payment plan quote.'],
+            };
+        }
+        return {
+            allowed: true,
+            reasonCodes: ['audd_payment_plan_allowed'],
+            paymentProofRef: decision.paymentProofRef,
+            policyDecision: decision.policyDecision,
+            paymentPlan: plan,
+            auditNotes: decision.auditNotes,
+        };
+    }
+    const mapped = decision.reasonCodes.includes('budget_policy_malformed')
+        ? 'budget_policy_malformed'
+        : decision.reasonCodes.includes('budget_policy_denied')
+            ? 'budget_policy_denied'
+            : decision.reasonCodes.includes('live_payment_not_approved')
+                ? 'live_payment_not_approved'
+                : decision.reasonCodes.includes('unsupported_payment_rail')
+                    ? 'unsupported_payment_rail'
+                    : 'challenge_malformed';
+    return {
+        allowed: false,
+        reasonCodes: [mapped],
+        policyDecision: decision.policyDecision,
+        paymentPlan: plan,
+        auditNotes: decision.auditNotes,
+    };
+}
+export function evaluateAuddPaymentPlanPreflight(challengeInput, options = {}) {
+    if (!isPaymentChallenge(challengeInput)) {
+        return deny('challenge_malformed', 'Denied: payment challenge is malformed.');
+    }
+    const challenge = challengeInput;
+    const rawPlan = isPlainObject(challenge.policyMetadata)
+        ? challenge.policyMetadata.auddPaymentPlan
+        : undefined;
+    if (rawPlan === undefined) {
+        return deny('missing_audd_payment_plan', 'Denied: AUDD/Solana payment plan metadata is missing.');
+    }
+    if (containsCredentialMaterial(rawPlan)) {
+        return deny('credential_leakage_rejected', 'Denied: AUDD/Solana payment plan includes credential-bearing material.');
+    }
+    const plan = planFromChallenge(challenge);
+    if (!plan) {
+        return deny('payment_plan_malformed', 'Denied: AUDD/Solana payment plan metadata is malformed.');
+    }
+    if (challenge.quote.asset.toUpperCase() !== AUDD_ASSET) {
+        return deny('wrong_asset', 'Denied: challenge quote asset is not AUDD.', { paymentPlan: plan });
+    }
+    if (challenge.quote.amount !== plan.amount || challenge.quote.network !== plan.network || challenge.payTo !== plan.payee) {
+        return deny('quote_payment_plan_mismatch', 'Denied: challenge quote/payee does not match the AUDD payment plan.', { paymentPlan: plan });
+    }
+    if (challenge.mode !== plan.paymentMode) {
+        return deny('quote_payment_plan_mismatch', 'Denied: challenge mode does not match the AUDD payment plan mode.', { paymentPlan: plan });
+    }
+    if (!hasOnlyNonEmptyStrings(options.allowedNetworks)) {
+        return deny('buyer_policy_missing', 'Denied: buyer policy must declare allowed AUDD/Solana networks.', { paymentPlan: plan });
+    }
+    if (!hasOnlyNonEmptyStrings(options.allowedMints)) {
+        return deny('buyer_policy_missing', 'Denied: buyer policy must declare allowed AUDD mints.', { paymentPlan: plan });
+    }
+    if (!hasOnlyNonEmptyStrings(options.allowedPayees)) {
+        return deny('buyer_policy_missing', 'Denied: buyer policy must declare allowed AUDD payees.', { paymentPlan: plan });
+    }
+    if (!hasOnlyNonEmptyStrings(options.allowedSettlementAccounts)) {
+        return deny('buyer_policy_missing', 'Denied: buyer policy must declare allowed AUDD settlement accounts.', { paymentPlan: plan });
+    }
+    if (options.requireEvidence !== true) {
+        return deny('buyer_policy_missing', 'Denied: buyer policy must explicitly require evidence for AUDD payment plans.', { paymentPlan: plan });
+    }
+    if (!options.maxAmount && !options.evaluateBudgetPolicy) {
+        return deny('buyer_policy_missing', 'Denied: buyer policy must declare max AUDD amount or provide a budget evaluator.', { paymentPlan: plan });
+    }
+    if (!options.allowedNetworks.some((network) => normalized(network) === normalized(plan.network))) {
+        return deny('wrong_network', `Denied: ${plan.network} is not an allowed AUDD/Solana network.`, { paymentPlan: plan });
+    }
+    if (!options.allowedMints.some((mint) => normalized(mint) === normalized(plan.mint))) {
+        return deny('wrong_mint', 'Denied: AUDD mint is not allowed by buyer policy.', { paymentPlan: plan });
+    }
+    if (!options.allowedPayees.some((payee) => payee === plan.payee)) {
+        return deny('missing_payee', 'Denied: AUDD payee is not allowed by buyer policy.', { paymentPlan: plan });
+    }
+    if (!options.allowedSettlementAccounts.some((account) => account === plan.settlementAccount)) {
+        return deny('missing_payee', 'Denied: AUDD settlement account is not allowed by buyer policy.', { paymentPlan: plan });
+    }
+    const now = options.now instanceof Date ? options.now : new Date(options.now ?? Date.now());
+    if (Number.isNaN(now.getTime()) || Date.parse(plan.quoteExpiresAt) <= now.getTime()) {
+        return deny('quote_expired', 'Denied: AUDD quote is expired.', { paymentPlan: plan });
+    }
+    if (options.requireEvidence && !plan.evidenceRequired) {
+        return deny('evidence_required', 'Denied: buyer policy requires evidence for AUDD payment plans.', { paymentPlan: plan });
+    }
+    if (options.approvalState !== 'approved') {
+        return deny('operator_approval_required', 'Denied: AUDD/Solana payment plan requires explicit operator approval.', { paymentPlan: plan });
+    }
+    if (challenge.mode === 'live' && !options.approveLivePayment) {
+        return deny('live_payment_not_approved', 'Denied: live AUDD/Solana payment remains disabled without explicit approval.', { paymentPlan: plan });
+    }
+    if (options.maxAmount && !positiveAmount(options.maxAmount)) {
+        return deny('payment_plan_malformed', 'Denied: buyer maximum amount is malformed.', { paymentPlan: plan });
+    }
+    if (options.maxAmount && amountToBigInt(plan.amount) > amountToBigInt(options.maxAmount)) {
+        return deny('amount_exceeds_max', 'Denied: AUDD payment plan amount exceeds buyer maximum.', { paymentPlan: plan });
+    }
+    const buyerDecision = evaluateBuyerPaymentChallenge(challenge, {
+        allowedRails: [{ asset: AUDD_ASSET, network: plan.network }],
+        approveLivePayment: options.approveLivePayment,
+        paymentProofRef: options.paymentProofRef,
+        evaluateBudgetPolicy: options.evaluateBudgetPolicy,
+    });
+    return adaptBuyerDecision(buyerDecision, plan, challenge);
+}

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -8,3 +8,4 @@ export * from './evidence-archive.js';
 export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
+export * from './audd-payment-plan.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -8,3 +8,4 @@ export * from './evidence-archive.js';
 export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
+export * from './audd-payment-plan.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/buyer-seller.d.ts",
       "import": "./dist/buyer-seller.js"
     },
+    "./audd-payment-plan": {
+      "types": "./dist/audd-payment-plan.d.ts",
+      "import": "./dist/audd-payment-plan.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/audd-payment-plan.ts
+++ b/packages/agent-protocol/src/audd-payment-plan.ts
@@ -1,0 +1,414 @@
+import {
+  evaluateBuyerPaymentChallenge,
+  PAYMENT_CHALLENGE_SCHEMA_VERSION,
+  type BudgetPolicyEvaluator,
+  type BuyerPreflightDecision,
+  type PaymentChallenge,
+} from './buyer-seller.js';
+import type { ReddiPolicyApprovalState, ReddiPolicyDecision } from './policy.js';
+
+export const AUDD_PAYMENT_PLAN_SCHEMA_VERSION = 'reddi.audd-payment-plan.v1' as const;
+export const AUDD_ASSET = 'AUDD' as const;
+
+export type AuddSolanaPaymentPlan = {
+  schemaVersion: typeof AUDD_PAYMENT_PLAN_SCHEMA_VERSION;
+  asset: typeof AUDD_ASSET;
+  network: string;
+  mint: string;
+  payee: string;
+  settlementAccount: string;
+  amount: string;
+  quoteExpiresAt: string;
+  failurePolicy: {
+    mode: 'no_charge_on_failure' | 'refund_on_failure' | 'manual_review';
+    description: string;
+  };
+  refundPolicy: {
+    mode: 'none' | 'automatic' | 'manual_review';
+    description: string;
+  };
+  evidenceRequired: boolean;
+  paymentMode: 'dry-run' | 'live';
+};
+
+export type AuddPaymentPlanInput = Omit<AuddSolanaPaymentPlan, 'schemaVersion' | 'asset'> & {
+  asset?: typeof AUDD_ASSET;
+};
+
+export type AuddPaymentPlanPreflightReasonCode =
+  | 'audd_payment_plan_allowed'
+  | 'challenge_malformed'
+  | 'missing_audd_payment_plan'
+  | 'payment_plan_malformed'
+  | 'credential_leakage_rejected'
+  | 'buyer_policy_missing'
+  | 'quote_payment_plan_mismatch'
+  | 'wrong_asset'
+  | 'wrong_network'
+  | 'wrong_mint'
+  | 'missing_payee'
+  | 'quote_expired'
+  | 'evidence_required'
+  | 'operator_approval_required'
+  | 'live_payment_not_approved'
+  | 'amount_exceeds_max'
+  | 'budget_policy_denied'
+  | 'budget_policy_malformed'
+  | 'unsupported_payment_rail';
+
+export type AuddPaymentPlanPreflightDecision = {
+  allowed: boolean;
+  reasonCodes: AuddPaymentPlanPreflightReasonCode[];
+  paymentProofRef?: string;
+  policyDecision?: ReddiPolicyDecision;
+  paymentPlan?: AuddSolanaPaymentPlan;
+  auditNotes: string[];
+};
+
+export type AuddPaymentPlanPreflightOptions = {
+  allowedNetworks?: string[];
+  allowedMints?: string[];
+  allowedPayees?: string[];
+  allowedSettlementAccounts?: string[];
+  maxAmount?: string;
+  requireEvidence?: boolean;
+  approvalState?: ReddiPolicyApprovalState;
+  approveLivePayment?: boolean;
+  paymentProofRef?: string;
+  now?: string | Date;
+  evaluateBudgetPolicy?: BudgetPolicyEvaluator;
+};
+
+const CREDENTIAL_KEYS = new Set([
+  'api_key',
+  'apikey',
+  'access_token',
+  'auth',
+  'authorization',
+  'bearer',
+  'credential',
+  'password',
+  'private_key',
+  'secret',
+  'signature',
+  'sig',
+  'token',
+  'x-amz-signature',
+  'x-goog-signature',
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function positiveAmount(value: unknown): value is string {
+  return typeof value === 'string' && /^[1-9]\d*$/.test(value);
+}
+
+function amountToBigInt(value: string): bigint {
+  return BigInt(value);
+}
+
+function normalized(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function hasOnlyNonEmptyStrings(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length > 0 && value.every(isNonEmptyString);
+}
+
+function containsCredentialMaterial(value: unknown, seen: WeakSet<object> = new WeakSet()): boolean {
+  if (typeof value === 'string') {
+    try {
+      const url = new URL(value);
+      if (url.username || url.password) return true;
+      for (const [key, item] of url.searchParams.entries()) {
+        if (CREDENTIAL_KEYS.has(normalized(key))) return true;
+        if (/bearer\s+[a-z0-9._-]+/i.test(item)) return true;
+      }
+    } catch {
+      if (/bearer\s+[a-z0-9._-]+/i.test(value)) return true;
+    }
+    return false;
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return value.some((item) => containsCredentialMaterial(item, seen));
+  }
+  if (!isPlainObject(value)) return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  return Object.entries(value).some(([key, item]) => (
+    CREDENTIAL_KEYS.has(normalized(key)) || containsCredentialMaterial(item, seen)
+  ));
+}
+
+function containsCircularReference(value: unknown, seen: WeakSet<object> = new WeakSet()): boolean {
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return true;
+    seen.add(value);
+    return value.some((item) => containsCircularReference(item, seen));
+  }
+  if (!isPlainObject(value)) return false;
+  if (seen.has(value)) return true;
+  seen.add(value);
+  return Object.values(value).some((item) => containsCircularReference(item, seen));
+}
+
+function isPaymentChallenge(value: unknown): value is PaymentChallenge {
+  if (!isPlainObject(value)) return false;
+  if (value.schemaVersion !== PAYMENT_CHALLENGE_SCHEMA_VERSION || value.status !== 402) return false;
+  if (!['dry-run', 'fixture', 'live'].includes(String(value.mode))) return false;
+  if (!isPlainObject(value.quote)) return false;
+  return positiveAmount(value.quote.amount)
+    && isNonEmptyString(value.quote.asset)
+    && isNonEmptyString(value.quote.network)
+    && isNonEmptyString(value.quote.source)
+    && isNonEmptyString(value.quote.specialist)
+    && isNonEmptyString(value.payTo)
+    && isNonEmptyString(value.nonce)
+    && isNonEmptyString(value.endpoint);
+}
+
+function validatePolicyText(value: unknown): value is AuddSolanaPaymentPlan['failurePolicy'] {
+  if (!isPlainObject(value)) return false;
+  return ['no_charge_on_failure', 'refund_on_failure', 'manual_review'].includes(String(value.mode))
+    && isNonEmptyString(value.description);
+}
+
+function validateRefundText(value: unknown): value is AuddSolanaPaymentPlan['refundPolicy'] {
+  if (!isPlainObject(value)) return false;
+  return ['none', 'automatic', 'manual_review'].includes(String(value.mode))
+    && isNonEmptyString(value.description);
+}
+
+export function validateAuddSolanaPaymentPlan(value: unknown): value is AuddSolanaPaymentPlan {
+  if (!isPlainObject(value)) return false;
+  if (value.schemaVersion !== AUDD_PAYMENT_PLAN_SCHEMA_VERSION) return false;
+  if (value.asset !== AUDD_ASSET) return false;
+  if (!isNonEmptyString(value.network)) return false;
+  if (!isNonEmptyString(value.mint)) return false;
+  if (!isNonEmptyString(value.payee)) return false;
+  if (!isNonEmptyString(value.settlementAccount)) return false;
+  if (!positiveAmount(value.amount)) return false;
+  if (!isNonEmptyString(value.quoteExpiresAt) || Number.isNaN(Date.parse(value.quoteExpiresAt))) return false;
+  if (!validatePolicyText(value.failurePolicy)) return false;
+  if (!validateRefundText(value.refundPolicy)) return false;
+  if (typeof value.evidenceRequired !== 'boolean') return false;
+  if (!['dry-run', 'live'].includes(String(value.paymentMode))) return false;
+  if (containsCircularReference(value)) return false;
+  return !containsCredentialMaterial(value);
+}
+
+export function createAuddSolanaPaymentPlan(input: AuddPaymentPlanInput): AuddSolanaPaymentPlan {
+  const plan: AuddSolanaPaymentPlan = {
+    schemaVersion: AUDD_PAYMENT_PLAN_SCHEMA_VERSION,
+    asset: AUDD_ASSET,
+    ...input,
+  };
+  if (!validateAuddSolanaPaymentPlan(plan)) throw new Error('invalid_audd_payment_plan');
+  return plan;
+}
+
+export function createAuddPaymentChallenge(
+  input: Omit<PaymentChallenge, 'schemaVersion' | 'status' | 'quote' | 'payTo' | 'policyMetadata'> & {
+    paymentPlan: AuddSolanaPaymentPlan;
+    quote?: Partial<PaymentChallenge['quote']>;
+    payTo?: string;
+    policyMetadata?: Record<string, unknown>;
+  },
+): PaymentChallenge {
+  const { paymentPlan, quote, payTo, policyMetadata, ...rest } = input;
+  if (!validateAuddSolanaPaymentPlan(paymentPlan)) throw new Error('invalid_audd_payment_plan');
+  const challenge: PaymentChallenge = {
+    schemaVersion: PAYMENT_CHALLENGE_SCHEMA_VERSION,
+    status: 402,
+    ...rest,
+    quote: {
+      amount: paymentPlan.amount,
+      asset: AUDD_ASSET,
+      network: paymentPlan.network,
+      source: quote?.source ?? '',
+      specialist: quote?.specialist ?? '',
+    },
+    payTo: payTo ?? paymentPlan.payee,
+    policyMetadata: {
+      ...policyMetadata,
+      auddPaymentPlan: paymentPlan,
+    },
+  };
+  if (!isPaymentChallenge(challenge)) throw new Error('invalid_payment_challenge');
+  return challenge;
+}
+
+function planFromChallenge(challenge: PaymentChallenge): AuddSolanaPaymentPlan | undefined {
+  const plan = isPlainObject(challenge.policyMetadata)
+    ? challenge.policyMetadata.auddPaymentPlan
+    : undefined;
+  return validateAuddSolanaPaymentPlan(plan) ? plan : undefined;
+}
+
+function deny(
+  reasonCode: AuddPaymentPlanPreflightReasonCode,
+  auditNote: string,
+  extras: Partial<AuddPaymentPlanPreflightDecision> = {},
+): AuddPaymentPlanPreflightDecision {
+  return {
+    allowed: false,
+    reasonCodes: [reasonCode],
+    auditNotes: [auditNote],
+    ...extras,
+  };
+}
+
+function adaptBuyerDecision(
+  decision: BuyerPreflightDecision,
+  plan: AuddSolanaPaymentPlan,
+  challenge: PaymentChallenge,
+): AuddPaymentPlanPreflightDecision {
+  if (decision.allowed) {
+    const quoted = decision.policyDecision?.quotedAmount;
+    const matchesAuddPlan = decision.policyDecision?.allowed === true
+      && decision.policyDecision.approvalState === 'approved'
+      && quoted !== null
+      && quoted?.amount === plan.amount
+      && quoted.asset.toUpperCase() === AUDD_ASSET
+      && quoted.asset.toUpperCase() === challenge.quote.asset.toUpperCase()
+      && quoted.network.toLowerCase() === plan.network.toLowerCase()
+      && quoted.network.toLowerCase() === challenge.quote.network.toLowerCase()
+      && quoted.source === challenge.quote.source
+      && quoted.specialist === challenge.quote.specialist
+      && decision.policyDecision.asset.toUpperCase() === AUDD_ASSET
+      && decision.policyDecision.network.toLowerCase() === plan.network.toLowerCase();
+    if (!matchesAuddPlan) {
+      return {
+        allowed: false,
+        reasonCodes: ['budget_policy_malformed'],
+        policyDecision: decision.policyDecision,
+        paymentPlan: plan,
+        auditNotes: ['Denied: buyer budget policy decision did not match the AUDD payment plan quote.'],
+      };
+    }
+    return {
+      allowed: true,
+      reasonCodes: ['audd_payment_plan_allowed'],
+      paymentProofRef: decision.paymentProofRef,
+      policyDecision: decision.policyDecision,
+      paymentPlan: plan,
+      auditNotes: decision.auditNotes,
+    };
+  }
+
+  const mapped = decision.reasonCodes.includes('budget_policy_malformed')
+    ? 'budget_policy_malformed'
+    : decision.reasonCodes.includes('budget_policy_denied')
+      ? 'budget_policy_denied'
+      : decision.reasonCodes.includes('live_payment_not_approved')
+        ? 'live_payment_not_approved'
+        : decision.reasonCodes.includes('unsupported_payment_rail')
+          ? 'unsupported_payment_rail'
+          : 'challenge_malformed';
+  return {
+    allowed: false,
+    reasonCodes: [mapped],
+    policyDecision: decision.policyDecision,
+    paymentPlan: plan,
+    auditNotes: decision.auditNotes,
+  };
+}
+
+export function evaluateAuddPaymentPlanPreflight(
+  challengeInput: unknown,
+  options: AuddPaymentPlanPreflightOptions = {},
+): AuddPaymentPlanPreflightDecision {
+  if (!isPaymentChallenge(challengeInput)) {
+    return deny('challenge_malformed', 'Denied: payment challenge is malformed.');
+  }
+  const challenge = challengeInput;
+  const rawPlan = isPlainObject(challenge.policyMetadata)
+    ? challenge.policyMetadata.auddPaymentPlan
+    : undefined;
+  if (rawPlan === undefined) {
+    return deny('missing_audd_payment_plan', 'Denied: AUDD/Solana payment plan metadata is missing.');
+  }
+  if (containsCredentialMaterial(rawPlan)) {
+    return deny('credential_leakage_rejected', 'Denied: AUDD/Solana payment plan includes credential-bearing material.');
+  }
+  const plan = planFromChallenge(challenge);
+  if (!plan) {
+    return deny('payment_plan_malformed', 'Denied: AUDD/Solana payment plan metadata is malformed.');
+  }
+  if (challenge.quote.asset.toUpperCase() !== AUDD_ASSET) {
+    return deny('wrong_asset', 'Denied: challenge quote asset is not AUDD.', { paymentPlan: plan });
+  }
+  if (challenge.quote.amount !== plan.amount || challenge.quote.network !== plan.network || challenge.payTo !== plan.payee) {
+    return deny('quote_payment_plan_mismatch', 'Denied: challenge quote/payee does not match the AUDD payment plan.', { paymentPlan: plan });
+  }
+  if (challenge.mode !== plan.paymentMode) {
+    return deny('quote_payment_plan_mismatch', 'Denied: challenge mode does not match the AUDD payment plan mode.', { paymentPlan: plan });
+  }
+  if (!hasOnlyNonEmptyStrings(options.allowedNetworks)) {
+    return deny('buyer_policy_missing', 'Denied: buyer policy must declare allowed AUDD/Solana networks.', { paymentPlan: plan });
+  }
+  if (!hasOnlyNonEmptyStrings(options.allowedMints)) {
+    return deny('buyer_policy_missing', 'Denied: buyer policy must declare allowed AUDD mints.', { paymentPlan: plan });
+  }
+  if (!hasOnlyNonEmptyStrings(options.allowedPayees)) {
+    return deny('buyer_policy_missing', 'Denied: buyer policy must declare allowed AUDD payees.', { paymentPlan: plan });
+  }
+  if (!hasOnlyNonEmptyStrings(options.allowedSettlementAccounts)) {
+    return deny('buyer_policy_missing', 'Denied: buyer policy must declare allowed AUDD settlement accounts.', { paymentPlan: plan });
+  }
+  if (options.requireEvidence !== true) {
+    return deny('buyer_policy_missing', 'Denied: buyer policy must explicitly require evidence for AUDD payment plans.', { paymentPlan: plan });
+  }
+  if (!options.maxAmount && !options.evaluateBudgetPolicy) {
+    return deny('buyer_policy_missing', 'Denied: buyer policy must declare max AUDD amount or provide a budget evaluator.', { paymentPlan: plan });
+  }
+  if (!options.allowedNetworks.some((network) => normalized(network) === normalized(plan.network))) {
+    return deny('wrong_network', `Denied: ${plan.network} is not an allowed AUDD/Solana network.`, { paymentPlan: plan });
+  }
+  if (!options.allowedMints.some((mint) => normalized(mint) === normalized(plan.mint))) {
+    return deny('wrong_mint', 'Denied: AUDD mint is not allowed by buyer policy.', { paymentPlan: plan });
+  }
+  if (!options.allowedPayees.some((payee) => payee === plan.payee)) {
+    return deny('missing_payee', 'Denied: AUDD payee is not allowed by buyer policy.', { paymentPlan: plan });
+  }
+  if (!options.allowedSettlementAccounts.some((account) => account === plan.settlementAccount)) {
+    return deny('missing_payee', 'Denied: AUDD settlement account is not allowed by buyer policy.', { paymentPlan: plan });
+  }
+  const now = options.now instanceof Date ? options.now : new Date(options.now ?? Date.now());
+  if (Number.isNaN(now.getTime()) || Date.parse(plan.quoteExpiresAt) <= now.getTime()) {
+    return deny('quote_expired', 'Denied: AUDD quote is expired.', { paymentPlan: plan });
+  }
+  if (options.requireEvidence && !plan.evidenceRequired) {
+    return deny('evidence_required', 'Denied: buyer policy requires evidence for AUDD payment plans.', { paymentPlan: plan });
+  }
+  if (options.approvalState !== 'approved') {
+    return deny('operator_approval_required', 'Denied: AUDD/Solana payment plan requires explicit operator approval.', { paymentPlan: plan });
+  }
+  if (challenge.mode === 'live' && !options.approveLivePayment) {
+    return deny('live_payment_not_approved', 'Denied: live AUDD/Solana payment remains disabled without explicit approval.', { paymentPlan: plan });
+  }
+  if (options.maxAmount && !positiveAmount(options.maxAmount)) {
+    return deny('payment_plan_malformed', 'Denied: buyer maximum amount is malformed.', { paymentPlan: plan });
+  }
+  if (options.maxAmount && amountToBigInt(plan.amount) > amountToBigInt(options.maxAmount)) {
+    return deny('amount_exceeds_max', 'Denied: AUDD payment plan amount exceeds buyer maximum.', { paymentPlan: plan });
+  }
+
+  const buyerDecision = evaluateBuyerPaymentChallenge(challenge, {
+    allowedRails: [{ asset: AUDD_ASSET, network: plan.network }],
+    approveLivePayment: options.approveLivePayment,
+    paymentProofRef: options.paymentProofRef,
+    evaluateBudgetPolicy: options.evaluateBudgetPolicy,
+  });
+  return adaptBuyerDecision(buyerDecision, plan, challenge);
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -8,3 +8,4 @@ export * from './evidence-archive.js';
 export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
+export * from './audd-payment-plan.js';

--- a/packages/agent-protocol/tests/audd-payment-plan.test.ts
+++ b/packages/agent-protocol/tests/audd-payment-plan.test.ts
@@ -1,0 +1,425 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createAuddPaymentChallenge,
+  createAuddSolanaPaymentPlan,
+  evaluateAuddPaymentPlanPreflight,
+  type BudgetPolicyEvaluator,
+} from '../dist/index.js';
+
+const AUDD_DEVNET_MINT = 'AUDDdev111111111111111111111111111111111111';
+const PAYEE = 'solana:9xQeWvG816bUx9EPjHmaT23yvVM2ZW9qQqz4hK5x9demo';
+
+const plan = createAuddSolanaPaymentPlan({
+  network: 'solana-devnet',
+  mint: AUDD_DEVNET_MINT,
+  payee: PAYEE,
+  settlementAccount: PAYEE,
+  amount: '2500000',
+  quoteExpiresAt: '2026-06-18T15:00:00.000Z',
+  failurePolicy: {
+    mode: 'no_charge_on_failure',
+    description: 'Dry-run jobs do not charge when the specialist fails.',
+  },
+  refundPolicy: {
+    mode: 'manual_review',
+    description: 'Live refunds require operator review before settlement.',
+  },
+  evidenceRequired: true,
+  paymentMode: 'dry-run',
+});
+
+const challenge = createAuddPaymentChallenge({
+  mode: 'dry-run',
+  paymentPlan: plan,
+  quote: {
+    source: 'source:ard-catalog',
+    specialist: 'specialist:listing-writer',
+  },
+  nonce: 'audd-001',
+  endpoint: 'http://localhost:4021/specialist',
+});
+
+const allowBudget: BudgetPolicyEvaluator = (quote) => ({
+  allowed: true,
+  reasonCodes: ['allowed'],
+  quotedAmount: quote,
+  remainingBudget: { perRequest: '10000000' },
+  auditNotes: ['Allowed by local AUDD budget policy.'],
+});
+
+const denyBudget: BudgetPolicyEvaluator = (quote) => ({
+  allowed: false,
+  reasonCodes: ['request_amount_exceeds_limit'],
+  quotedAmount: quote,
+  remainingBudget: { perRequest: '0' },
+  auditNotes: ['Denied by local AUDD budget policy.'],
+});
+
+const baseBuyerPolicy = {
+  allowedNetworks: ['solana-devnet'],
+  allowedMints: [AUDD_DEVNET_MINT],
+  allowedPayees: [PAYEE],
+  allowedSettlementAccounts: [PAYEE],
+  maxAmount: '3000000',
+  requireEvidence: true,
+  approvalState: 'approved' as const,
+  now: '2026-06-18T14:00:00.000Z',
+};
+
+describe('AUDD/Solana payment plan adapter', () => {
+  it('creates AUDD/Solana quote metadata and approves a dry-run buyer preflight', () => {
+    assert.equal(challenge.quote.asset, 'AUDD');
+    assert.equal(challenge.quote.network, 'solana-devnet');
+    assert.equal(challenge.quote.amount, '2500000');
+    assert.equal(challenge.payTo, PAYEE);
+    assert.equal(challenge.policyMetadata?.auddPaymentPlan, plan);
+
+    const decision = evaluateAuddPaymentPlanPreflight(challenge, {
+      ...baseBuyerPolicy,
+      evaluateBudgetPolicy: allowBudget,
+      paymentProofRef: 'dry-run:audd-001',
+    });
+
+    assert.equal(decision.allowed, true);
+    assert.deepEqual(decision.reasonCodes, ['audd_payment_plan_allowed']);
+    assert.equal(decision.paymentProofRef, 'dry-run:audd-001');
+    assert.equal(decision.paymentPlan?.asset, 'AUDD');
+    assert.equal(decision.policyDecision?.quotedAmount?.asset, 'AUDD');
+    assert.equal(decision.policyDecision?.approvalState, 'approved');
+  });
+
+  it('fails closed for wrong network, wrong mint, and missing payee', () => {
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        allowedNetworks: ['solana-mainnet-beta'],
+      }).reasonCodes,
+      ['wrong_network'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        allowedMints: ['not-the-audd-mint'],
+      }).reasonCodes,
+      ['wrong_mint'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        allowedPayees: ['solana:other-payee'],
+      }).reasonCodes,
+      ['missing_payee'],
+    );
+
+    const badPayeeGoodSettlement = createAuddPaymentChallenge({
+      mode: 'dry-run',
+      paymentPlan: createAuddSolanaPaymentPlan({
+        ...plan,
+        payee: 'solana:attacker-payee',
+        settlementAccount: PAYEE,
+      }),
+      quote: {
+        source: 'source:ard-catalog',
+        specialist: 'specialist:listing-writer',
+      },
+      nonce: 'audd-payee-mismatch',
+      endpoint: 'http://localhost:4021/specialist',
+    });
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(badPayeeGoodSettlement, {
+        ...baseBuyerPolicy,
+        allowedPayees: [PAYEE],
+        allowedSettlementAccounts: [PAYEE],
+      }).reasonCodes,
+      ['missing_payee'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        allowedPayees: [PAYEE],
+        allowedSettlementAccounts: ['solana:other-settlement'],
+      }).reasonCodes,
+      ['missing_payee'],
+    );
+  });
+
+  it('fails closed for expired quotes, missing evidence, missing approval, and over-budget plans', () => {
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        now: '2026-06-18T15:00:00.000Z',
+      }).reasonCodes,
+      ['quote_expired'],
+    );
+
+    const noEvidence = createAuddPaymentChallenge({
+      mode: 'dry-run',
+      paymentPlan: createAuddSolanaPaymentPlan({ ...plan, evidenceRequired: false }),
+      quote: {
+        source: 'source:ard-catalog',
+        specialist: 'specialist:listing-writer',
+      },
+      nonce: 'audd-002',
+      endpoint: 'http://localhost:4021/specialist',
+    });
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(noEvidence, {
+        ...baseBuyerPolicy,
+        requireEvidence: true,
+      }).reasonCodes,
+      ['evidence_required'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        approvalState: undefined,
+        now: '2026-06-18T14:00:00.000Z',
+      }).reasonCodes,
+      ['operator_approval_required'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        maxAmount: '2499999',
+      }).reasonCodes,
+      ['amount_exceeds_max'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        maxAmount: 'abc',
+      }).reasonCodes,
+      ['payment_plan_malformed'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        evaluateBudgetPolicy: denyBudget,
+      }).reasonCodes,
+      ['budget_policy_denied'],
+    );
+
+    const nullQuoteBudget = (() => ({
+      allowed: true,
+      reasonCodes: ['allowed'],
+      quotedAmount: null,
+      auditNotes: ['Malformed allowed budget output.'],
+    })) as BudgetPolicyEvaluator;
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        evaluateBudgetPolicy: nullQuoteBudget,
+      }).reasonCodes,
+      ['budget_policy_malformed'],
+    );
+
+    const numericAmountBudget = (() => ({
+      allowed: true,
+      reasonCodes: ['allowed'],
+      quotedAmount: {
+        ...challenge.quote,
+        amount: 2500000,
+      },
+      auditNotes: ['Malformed allowed budget output.'],
+    })) as unknown as BudgetPolicyEvaluator;
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        evaluateBudgetPolicy: numericAmountBudget,
+      }).reasonCodes,
+      ['budget_policy_malformed'],
+    );
+
+    const mismatchedQuoteBudget = (() => ({
+      allowed: true,
+      reasonCodes: ['allowed'],
+      quotedAmount: {
+        ...challenge.quote,
+        amount: '1',
+        network: 'solana-mainnet-beta',
+      },
+      auditNotes: ['Wrong quote should not approve AUDD preflight.'],
+    })) as BudgetPolicyEvaluator;
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        evaluateBudgetPolicy: mismatchedQuoteBudget,
+      }).reasonCodes,
+      ['budget_policy_malformed'],
+    );
+  });
+
+  it('requires explicit buyer policy constraints before approving AUDD preflight', () => {
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        approvalState: 'approved',
+        now: '2026-06-18T14:00:00.000Z',
+      }).reasonCodes,
+      ['buyer_policy_missing'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        maxAmount: undefined,
+        evaluateBudgetPolicy: undefined,
+      }).reasonCodes,
+      ['buyer_policy_missing'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        requireEvidence: false,
+      }).reasonCodes,
+      ['buyer_policy_missing'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        allowedNetworks: [42 as unknown as string],
+      }).reasonCodes,
+      ['buyer_policy_missing'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        allowedMints: [42 as unknown as string],
+      }).reasonCodes,
+      ['buyer_policy_missing'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        allowedPayees: [42 as unknown as string],
+      }).reasonCodes,
+      ['buyer_policy_missing'],
+    );
+
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(challenge, {
+        ...baseBuyerPolicy,
+        allowedSettlementAccounts: [42 as unknown as string],
+      }).reasonCodes,
+      ['buyer_policy_missing'],
+    );
+  });
+
+  it('keeps live AUDD payment fail-closed unless explicitly approved', () => {
+    const liveChallenge = createAuddPaymentChallenge({
+      mode: 'live',
+      paymentPlan: createAuddSolanaPaymentPlan({ ...plan, paymentMode: 'live' }),
+      quote: {
+        source: 'source:ard-catalog',
+        specialist: 'specialist:listing-writer',
+      },
+      nonce: 'audd-live-001',
+      endpoint: 'http://localhost:4021/specialist',
+    });
+
+    const blocked = evaluateAuddPaymentPlanPreflight(liveChallenge, {
+      ...baseBuyerPolicy,
+    });
+    assert.equal(blocked.allowed, false);
+    assert.deepEqual(blocked.reasonCodes, ['live_payment_not_approved']);
+
+    const approved = evaluateAuddPaymentPlanPreflight(liveChallenge, {
+      ...baseBuyerPolicy,
+      approveLivePayment: true,
+    });
+    assert.equal(approved.allowed, true);
+    assert.deepEqual(approved.reasonCodes, ['audd_payment_plan_allowed']);
+  });
+
+  it('rejects malformed, mismatched, and credential-bearing AUDD payment plans', () => {
+    const missingPlan = { ...challenge, policyMetadata: {} };
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(missingPlan, {
+        ...baseBuyerPolicy,
+      }).reasonCodes,
+      ['missing_audd_payment_plan'],
+    );
+
+    const mismatched = {
+      ...challenge,
+      quote: { ...challenge.quote, asset: 'USDC' },
+    };
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(mismatched, {
+        ...baseBuyerPolicy,
+      }).reasonCodes,
+      ['wrong_asset'],
+    );
+
+    const modeMismatch = {
+      ...challenge,
+      policyMetadata: {
+        auddPaymentPlan: createAuddSolanaPaymentPlan({ ...plan, paymentMode: 'live' }),
+      },
+    };
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(modeMismatch, {
+        ...baseBuyerPolicy,
+      }).reasonCodes,
+      ['quote_payment_plan_mismatch'],
+    );
+
+    const badPlan = {
+      ...challenge,
+      policyMetadata: {
+        auddPaymentPlan: {
+          ...plan,
+          payee: 'https://pay.example/settle?api_key=secret',
+        },
+      },
+    };
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(badPlan, {
+        ...baseBuyerPolicy,
+      }).reasonCodes,
+      ['credential_leakage_rejected'],
+    );
+
+    const malformed = {
+      ...challenge,
+      policyMetadata: {
+        auddPaymentPlan: {
+          ...plan,
+          amount: '0',
+        },
+      },
+    };
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(malformed, {
+        ...baseBuyerPolicy,
+      }).reasonCodes,
+      ['payment_plan_malformed'],
+    );
+
+    const circularPlan: Record<string, unknown> = { ...plan };
+    circularPlan.self = circularPlan;
+    const circular = {
+      ...challenge,
+      policyMetadata: {
+        auddPaymentPlan: circularPlan,
+      },
+    };
+    assert.deepEqual(
+      evaluateAuddPaymentPlanPreflight(circular, {
+        ...baseBuyerPolicy,
+      }).reasonCodes,
+      ['payment_plan_malformed'],
+    );
+  });
+});


### PR DESCRIPTION
Closes #391.

## Summary
- Add `reddi.audd-payment-plan.v1` metadata/preflight primitives for AUDD-denominated Solana payment plans.
- Add `createAuddSolanaPaymentPlan`, `createAuddPaymentChallenge`, `validateAuddSolanaPaymentPlan`, and `evaluateAuddPaymentPlanPreflight`.
- Validate AUDD quote metadata: asset, Solana network, mint, payee, settlement account, amount, quote expiry, failure/refund policy, evidence requirement, payment mode, and credential-shaped metadata.
- Buyer preflight checks allowed network, mint, actual payee, optional settlement account, max amount, expiry, evidence requirement, approval state, live-payment approval, and optional #159-compatible budget hook.
- Keep AUDD support off-chain/package-only: no wallet access, RPC, SPL transfer, Quasar program change, hosted registry dependency, or payment settlement.

## Validation
- `npm test -- --runInBand` in `packages/agent-protocol` passed with 67 tests.
- `npm run example:buyer-seller:dry-run` passed and emitted receipt/evidence ids without spend.
- `npm run release:dry-run` in `packages/agent-protocol` passed and packed `dist/audd-payment-plan.*`.
- root `npm run check:rap:naming` passed.
- `git diff --check` passed.
- Scope scan found no network fetch, wallet, signer, SPL transfer, RPC, hosted registry call, or on-chain program code in the new adapter surface.

No UI changes; screenshots/video not required.

