### PR TITLE
Add ARD no-spend workflow demo

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -268,6 +268,16 @@ const decision = evaluateAuddPaymentPlanPreflight(auddChallenge, {
 
 AUDD/Solana payment plans are metadata and policy-preflight helpers for RAP buyer/seller middleware. They represent AUDD quote amount, Solana network, mint, payee/settlement account, expiry, failure/refund policy, and evidence requirements without submitting transactions or requiring hosted RAP infrastructure. Buyer preflight fails closed unless the caller supplies explicit allowed networks, mints, payees, settlement accounts, evidence policy, operator approval, and either a max amount or budget evaluator. Live payment remains fail-closed unless buyer/operator approval is explicit; actual wallet actions, SPL custody, Quasar escrow, and settlement proof verification belong in payment-rail integrations and the Quasar boundary work.
 
+## ARD No-Spend Quickstart
+
+```bash
+npm run example:ard:no-spend
+```
+
+The ARD no-spend example is a deterministic Discover -> Decide -> Prove workflow. It starts from `examples/ard-no-spend-ai-catalog.json`, validates the AI Catalog fixture, creates a discovery candidate, runs source-aware diagnostics, evaluates local policy/trust/payment gates, executes a bounded dry-run specialist function, and emits receipt, evidence, attestation, and reputation output.
+
+The example also prints expected failure states for policy denial, malformed challenge, missing evidence, and unsupported AUDD/Solana network. It does not start a server, fetch an ARD registry, call hosted Reddi infrastructure, use secrets, invoke a paid provider, access a wallet, submit RPC/SPL transfers, or claim AUDD escrow custody.
+
 ## Local Validation
 
 ```bash

--- a/packages/agent-protocol/dist/receipts.js
+++ b/packages/agent-protocol/dist/receipts.js
@@ -1,5 +1,6 @@
 import { isReddiPolicyReasonCode } from './policy.js';
 const SUPPORTED_NETWORK_ASSETS = new Set([
+    'solana-devnet:AUDD',
     'solana-devnet:USDC',
     'solana-devnet:SOL',
     'solana-testnet:USDC',

--- a/packages/agent-protocol/examples/ard-no-spend-ai-catalog.json
+++ b/packages/agent-protocol/examples/ard-no-spend-ai-catalog.json
@@ -1,0 +1,51 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "identifier": "reddi.local",
+    "displayName": "Reddi Local Fixtures",
+    "domain": "reddi.local"
+  },
+  "entries": [
+    {
+      "identifier": "urn:ai:reddi.local:specialists:listing-writer",
+      "mediaType": "application/rap-specialist+json",
+      "displayName": "Listing Writer Specialist",
+      "description": "Turns a short operator brief into a deterministic marketplace listing draft.",
+      "data": {
+        "endpoint": "fixture://specialists/listing-writer",
+        "inputSchema": {
+          "type": "object",
+          "required": ["brief"],
+          "properties": {
+            "brief": { "type": "string" }
+          }
+        }
+      },
+      "capabilities": ["listing_draft", "marketplace_copy", "operator_review"],
+      "payment": {
+        "protocol": "rap",
+        "quoteMode": "preflight",
+        "asset": "AUDD",
+        "network": "solana-devnet",
+        "amount": "2500000"
+      },
+      "trustManifest": {
+        "identity": "urn:ai:reddi.local:specialists:listing-writer",
+        "provenance": ["file://examples/ard-no-spend-ai-catalog.json"],
+        "attestations": ["fixture://attestations/listing-writer-self-test"],
+        "verification": ["fixture://verification/local-demo"]
+      },
+      "metadata": {
+        "rap": {
+          "sourceId": "source:ard-local-catalog",
+          "specialistId": "specialist:listing-writer",
+          "payment": {
+            "protocol": "rap",
+            "quoteMode": "preflight",
+            "assets": [{ "asset": "AUDD", "network": "solana-devnet" }]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/agent-protocol/examples/ard-no-spend-demo.mjs
+++ b/packages/agent-protocol/examples/ard-no-spend-demo.mjs
@@ -1,0 +1,302 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createAiCatalogSnapshot,
+  createAuddPaymentChallenge,
+  createAuddSolanaPaymentPlan,
+  createLocalEvidenceArchive,
+  createPaymentChallenge,
+  evaluateAuddPaymentPlanPreflight,
+  evaluateBuyerPaymentChallenge,
+  handlePaidSpecialistRequest,
+  validateAiCatalog,
+  validateEvidenceArchiveRecord,
+} from '../dist/index.js';
+import {
+  createAiCatalogDiscoveryCandidates,
+  evaluateDiscoveryCandidatePolicyPreflight,
+} from '../dist/discovery-source.js';
+import { createSourceAwareCandidateDiagnostics } from '../dist/source-diagnostics.js';
+import {
+  applyAttestationToReputation,
+  createAttestationRecord,
+  createInitialReputationState,
+} from '../dist/attestation-reputation.js';
+
+const createdAt = '2026-06-19T07:45:00.000Z';
+const nonce = 'ard-no-spend-001';
+const sourceId = 'source:ard-local-catalog';
+const specialistId = 'specialist:listing-writer';
+const auddMint = 'AUDDdev111111111111111111111111111111111111';
+const payee = 'solana:seller-demo';
+const settlementAccount = 'solana:settlement-demo';
+const catalogPath = join(dirname(fileURLToPath(import.meta.url)), 'ard-no-spend-ai-catalog.json');
+const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+
+function hashJson(value) {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}
+
+function assertOk(result, label) {
+  if (!result.ok) {
+    throw new Error(`${label}:${JSON.stringify(result.errors ?? result, null, 2)}`);
+  }
+  return result;
+}
+
+const catalogValidation = assertOk(validateAiCatalog(catalog, {
+  rawSnapshotRef: 'file://examples/ard-no-spend-ai-catalog.json',
+}), 'catalog_validation');
+const snapshot = createAiCatalogSnapshot(catalog, {
+  rawSnapshotRef: 'file://examples/ard-no-spend-ai-catalog.json',
+});
+
+const normalized = assertOk(createAiCatalogDiscoveryCandidates(snapshot, {
+  sourceKind: 'direct-ai-catalog',
+  relevanceScores: {
+    'urn:ai:reddi.local:specialists:listing-writer': 0.93,
+  },
+  trustOptionsByResourceId: {
+    'urn:ai:reddi.local:specialists:listing-writer': {
+      verification: {
+        status: 'verified',
+        verifier: 'rap:local-demo-fixture',
+        checkedAt: createdAt,
+      },
+    },
+  },
+}), 'candidate_normalization');
+
+const paymentPlan = createAuddSolanaPaymentPlan({
+  network: 'solana-devnet',
+  mint: auddMint,
+  payee,
+  settlementAccount,
+  amount: '2500000',
+  quoteExpiresAt: '2026-06-19T08:45:00.000Z',
+  failurePolicy: {
+    mode: 'no_charge_on_failure',
+    description: 'Dry-run fixture jobs do not charge on failure.',
+  },
+  refundPolicy: {
+    mode: 'manual_review',
+    description: 'Live refunds require operator review before settlement.',
+  },
+  evidenceRequired: true,
+  paymentMode: 'dry-run',
+});
+
+const candidate = {
+  ...normalized.candidates[0],
+  quote: {
+    amount: paymentPlan.amount,
+    asset: 'AUDD',
+    network: paymentPlan.network,
+    expiresAt: paymentPlan.quoteExpiresAt,
+    payee,
+  },
+};
+
+const discoveryDecision = evaluateDiscoveryCandidatePolicyPreflight(candidate, {
+  allowedSourceKinds: ['direct-ai-catalog'],
+  requireVerifiedTrust: true,
+  allowedAssets: ['AUDD'],
+  allowedNetworks: ['solana-devnet'],
+  maxQuote: { amount: '3000000', asset: 'AUDD', network: 'solana-devnet' },
+});
+
+const diagnostics = createSourceAwareCandidateDiagnostics(candidate, {
+  policyDecision: discoveryDecision,
+  reputation: { receiptCount: 0, attestationCount: 0 },
+});
+
+const challenge = createAuddPaymentChallenge({
+  mode: 'dry-run',
+  paymentPlan,
+  quote: {
+    source: sourceId,
+    specialist: specialistId,
+  },
+  nonce,
+  endpoint: 'fixture://specialists/listing-writer',
+});
+
+const auddDecision = evaluateAuddPaymentPlanPreflight(challenge, {
+  allowedNetworks: ['solana-devnet'],
+  allowedMints: [auddMint],
+  allowedPayees: [payee],
+  allowedSettlementAccounts: [settlementAccount],
+  maxAmount: '3000000',
+  requireEvidence: true,
+  approvalState: 'approved',
+  paymentProofRef: `dry-run:${nonce}`,
+  now: '2026-06-19T07:45:01.000Z',
+});
+
+const requestBody = {
+  brief: 'Create a public marketplace listing for a local RAP-compatible documentation specialist.',
+};
+const specialistResponse = await handlePaidSpecialistRequest({
+  challenge,
+  request: {
+    body: requestBody,
+    paymentProofRef: auddDecision.paymentProofRef,
+  },
+  policyDecision: auddDecision.policyDecision,
+  createdAt,
+  specialist: async (body) => ({
+    title: 'RAP Documentation Listing Writer',
+    summary: `Local fixture drafted a listing for: ${body.brief}`,
+    reviewRequired: true,
+    noSpend: true,
+  }),
+});
+
+if (specialistResponse.status !== 200) {
+  throw new Error(`specialist_response:${JSON.stringify(specialistResponse, null, 2)}`);
+}
+
+const archive = createLocalEvidenceArchive([specialistResponse.evidence]);
+const attestation = createAttestationRecord({
+  schemaVersion: 'reddi.attestation.v1',
+  id: `attestation:${nonce}`,
+  receiptId: specialistResponse.receipt.job.id,
+  evidenceId: specialistResponse.evidence.id,
+  evidenceRef: specialistResponse.evidence.evidenceRef,
+  evidenceHash: specialistResponse.evidence.evidenceHash,
+  attestor: { id: 'attestor:local-fixture', type: 'local-fixture' },
+  trustBoundary: 'self_attested',
+  verdict: 'passed',
+  workStatus: 'completed',
+  confidence: 82,
+  rubric: {
+    dimensions: [
+      { id: 'evidence_integrity', score: 88, weight: 1, summary: 'Receipt and evidence hashes are present.', reasonCodes: ['evidence_attached'] },
+      { id: 'policy_compliance', score: 92, weight: 1, summary: 'AUDD preflight and discovery policy allowed the dry-run.', reasonCodes: ['policy_allowed'] },
+      { id: 'delivery_quality', score: 84, weight: 1, summary: 'Fixture produced a deterministic listing draft.', reasonCodes: ['specialist_completed'] },
+    ],
+  },
+  createdAt,
+});
+const reputation = applyAttestationToReputation(
+  attestation,
+  createInitialReputationState({ id: specialistId, type: 'specialist' }, createdAt),
+  { now: createdAt },
+);
+
+const unsupportedNetwork = evaluateAuddPaymentPlanPreflight(challenge, {
+  allowedNetworks: ['solana-mainnet-beta'],
+  allowedMints: [auddMint],
+  allowedPayees: [payee],
+  allowedSettlementAccounts: [settlementAccount],
+  maxAmount: '3000000',
+  requireEvidence: true,
+  approvalState: 'approved',
+  now: '2026-06-19T07:45:01.000Z',
+});
+const policyDenial = evaluateDiscoveryCandidatePolicyPreflight(candidate, {
+  allowedSourceKinds: ['direct-ai-catalog'],
+  requireVerifiedTrust: true,
+  allowedAssets: ['AUDD'],
+  allowedNetworks: ['solana-devnet'],
+  maxQuote: { amount: '1000', asset: 'AUDD', network: 'solana-devnet' },
+});
+const malformedChallenge = evaluateBuyerPaymentChallenge({
+  ...createPaymentChallenge({
+    mode: 'dry-run',
+    quote: {
+      amount: '2500000',
+      asset: 'AUDD',
+      network: 'solana-devnet',
+      source: sourceId,
+      specialist: specialistId,
+    },
+    payTo: payee,
+    nonce: 'malformed-demo',
+    endpoint: 'fixture://specialists/listing-writer',
+  }),
+  quote: { amount: 2500000 },
+});
+const missingEvidence = validateEvidenceArchiveRecord(specialistResponse.evidence);
+
+console.log(JSON.stringify({
+  ok: true,
+  mode: 'no-spend',
+  catalog: {
+    valid: catalogValidation.ok,
+    rawSnapshotRef: snapshot.rawSnapshotRef,
+    publisher: snapshot.publisher,
+    resourceCount: snapshot.resources.length,
+  },
+  discovery: {
+    candidate: {
+      identifier: candidate.identifier,
+      name: candidate.name,
+      sourceKind: candidate.sourceKind,
+      publisher: candidate.publisher,
+      trustStatus: candidate.providerTrust?.verification.status,
+      relevanceScore: candidate.relevance?.score,
+    },
+    policyDecision: {
+      allowed: discoveryDecision.allowed,
+      reasonCodes: discoveryDecision.reasonCodes,
+    },
+    diagnostics: {
+      capability: diagnostics.capabilityMatch.summary,
+      publisher: diagnostics.publisherIdentity.summary,
+      trust: diagnostics.trustEvidence.summary,
+      payment: diagnostics.paymentFit.summary,
+    },
+  },
+  payment: {
+    asset: paymentPlan.asset,
+    network: paymentPlan.network,
+    mint: paymentPlan.mint,
+    mode: paymentPlan.paymentMode,
+    allowed: auddDecision.allowed,
+    reasonCodes: auddDecision.reasonCodes,
+    paymentProofRef: auddDecision.paymentProofRef,
+  },
+  execution: {
+    status: specialistResponse.status,
+    result: specialistResponse.result,
+    receiptId: specialistResponse.receipt.job.id,
+    evidenceId: specialistResponse.evidence.id,
+    evidenceRef: specialistResponse.evidence.evidenceRef,
+    requestHash: specialistResponse.receipt.requestHash,
+    responseHash: specialistResponse.receipt.responseHash,
+    archiveHasEvidence: archive.has(specialistResponse.evidence.id),
+  },
+  attestation: {
+    id: attestation.id,
+    verdict: attestation.verdict,
+    trustBoundary: attestation.trustBoundary,
+    reputationScore: reputation.ok ? reputation.state.score : undefined,
+    routingImpact: reputation.ok ? reputation.state.routingImpact : undefined,
+  },
+  failures: {
+    policyDenial: {
+      allowed: policyDenial.allowed,
+      reasonCodes: policyDenial.reasonCodes,
+    },
+    malformedChallenge: {
+      allowed: malformedChallenge.allowed,
+      reasonCodes: malformedChallenge.reasonCodes,
+    },
+    missingEvidence: {
+      ok: missingEvidence.ok,
+      errorCodes: missingEvidence.ok ? [] : missingEvidence.errors.map((item) => item.code),
+    },
+    unsupportedRailNetwork: {
+      allowed: unsupportedNetwork.allowed,
+      reasonCodes: unsupportedNetwork.reasonCodes,
+    },
+  },
+  hashes: {
+    request: hashJson(requestBody),
+    receipt: hashJson(specialistResponse.receipt),
+  },
+}, null, 2));

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -58,6 +58,7 @@
   },
   "files": [
     "dist",
+    "examples",
     "README.md"
   ],
   "sideEffects": false,
@@ -66,6 +67,7 @@
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && tsc -p tsconfig.test.json && node --test dist-tests/*.test.js",
     "example:buyer-seller:dry-run": "npm run build && node examples/buyer-seller-dry-run.mjs",
+    "example:ard:no-spend": "npm run build && node examples/ard-no-spend-demo.mjs",
     "release:dry-run": "npm run clean && npm run build && npm test && npm pack --dry-run"
   },
   "devDependencies": {

--- a/packages/agent-protocol/src/receipts.ts
+++ b/packages/agent-protocol/src/receipts.ts
@@ -62,6 +62,7 @@ export type ReddiReceiptValidationResult =
   | { ok: false; errors: ReddiReceiptValidationError[] };
 
 const SUPPORTED_NETWORK_ASSETS = new Set([
+  'solana-devnet:AUDD',
   'solana-devnet:USDC',
   'solana-devnet:SOL',
   'solana-testnet:USDC',

--- a/packages/agent-protocol/tests/ard-no-spend-demo.test.ts
+++ b/packages/agent-protocol/tests/ard-no-spend-demo.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import {
+  createAiCatalogSnapshot,
+  validateAiCatalog,
+} from '../dist/index.js';
+
+describe('ARD no-spend demo', () => {
+  it('validates the public AI Catalog fixture', () => {
+    const catalog = JSON.parse(readFileSync('examples/ard-no-spend-ai-catalog.json', 'utf8'));
+    const validation = validateAiCatalog(catalog, {
+      rawSnapshotRef: 'file://examples/ard-no-spend-ai-catalog.json',
+    });
+
+    assert.equal(validation.ok, true);
+    const snapshot = createAiCatalogSnapshot(catalog, {
+      rawSnapshotRef: 'file://examples/ard-no-spend-ai-catalog.json',
+    });
+    assert.equal(snapshot.publisher.id, 'reddi.local');
+    assert.equal(snapshot.resources.length, 1);
+    assert.equal(snapshot.resources[0].id, 'urn:ai:reddi.local:specialists:listing-writer');
+    assert.deepEqual(snapshot.resources[0].payment, {
+      protocol: 'rap',
+      quoteMode: 'preflight',
+      asset: 'AUDD',
+      network: 'solana-devnet',
+      amount: '2500000',
+    });
+  });
+
+  it('runs discover decide prove without spend or hosted services', () => {
+    const stdout = execFileSync(process.execPath, ['examples/ard-no-spend-demo.mjs'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+    const output = JSON.parse(stdout);
+
+    assert.equal(output.ok, true);
+    assert.equal(output.mode, 'no-spend');
+    assert.equal(output.catalog.valid, true);
+    assert.equal(output.discovery.candidate.identifier, 'urn:ai:reddi.local:specialists:listing-writer');
+    assert.equal(output.discovery.candidate.trustStatus, 'verified');
+    assert.equal(output.discovery.policyDecision.allowed, true);
+    assert.equal(output.payment.asset, 'AUDD');
+    assert.equal(output.payment.mode, 'dry-run');
+    assert.equal(output.payment.allowed, true);
+    assert.equal(output.payment.paymentProofRef, 'dry-run:ard-no-spend-001');
+    assert.equal(output.execution.status, 200);
+    assert.equal(output.execution.receiptId, 'job:ard-no-spend-001');
+    assert.equal(output.execution.evidenceId, 'evidence:ard-no-spend-001');
+    assert.equal(output.execution.archiveHasEvidence, true);
+    assert.equal(output.attestation.verdict, 'passed');
+    assert.equal(output.failures.policyDenial.allowed, false);
+    assert.ok(output.failures.policyDenial.reasonCodes.includes('over_budget'));
+    assert.equal(output.failures.malformedChallenge.allowed, false);
+    assert.ok(output.failures.malformedChallenge.reasonCodes.includes('challenge_malformed'));
+    assert.equal(output.failures.missingEvidence.ok, false);
+    assert.ok(output.failures.missingEvidence.errorCodes.includes('evidence_missing'));
+    assert.equal(output.failures.unsupportedRailNetwork.allowed, false);
+    assert.ok(output.failures.unsupportedRailNetwork.reasonCodes.includes('wrong_network'));
+  });
+});

--- a/packages/agent-protocol/tests/receipts.test.ts
+++ b/packages/agent-protocol/tests/receipts.test.ts
@@ -117,6 +117,35 @@ describe('Reddi receipt v1', () => {
     }
   });
 
+  it('accepts AUDD receipt proof metadata on Solana networks without implying custody', () => {
+    const result = validateReddiReceipt(receipt({
+      payment: {
+        network: 'solana-devnet',
+        asset: 'AUDD',
+        amount: '2500000',
+        paymentProofRef: 'dry-run:audd-receipt-proof',
+      },
+      policyDecision: {
+        ...reddiReceiptFixtures.happyPath.policyDecision,
+        quotedAmount: {
+          amount: '2500000',
+          asset: 'AUDD',
+          network: 'solana-devnet',
+          source: 'source:planning',
+          specialist: 'specialist:coder',
+        },
+        asset: 'AUDD',
+        network: 'solana-devnet',
+      },
+    }));
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.receipt.payment.asset, 'AUDD');
+      assert.equal(result.receipt.payment.paymentProofRef, 'dry-run:audd-receipt-proof');
+    }
+  });
+
   it('rejects malformed receipt envelopes instead of accepting partial protocol records', () => {
     const result = validateReddiReceipt({ ...reddiReceiptFixtures.happyPath, schemaVersion: 'reddi.receipt.v2', evidenceRef: '' });
     assert.equal(result.ok, false);


### PR DESCRIPTION
## Summary

Closes #368. Advances #357.

Adds a deterministic local ARD-compatible no-spend workflow demo for `@reddi/agent-protocol`.

What it demonstrates:
- Discover: validate a sample `ai-catalog.json` and normalize a discovery candidate
- Decide: run source/trust/policy diagnostics plus AUDD/Solana dry-run preflight
- Prove: execute a bounded dry-run specialist and emit receipt, evidence, attestation, and reputation output
- Failure coverage: policy denial, malformed challenge, missing evidence, and unsupported AUDD/Solana network

## Changes

- Adds `examples/ard-no-spend-ai-catalog.json`
- Adds `examples/ard-no-spend-demo.mjs`
- Adds `npm run example:ard:no-spend`
- Ships examples in the package tarball
- Adds test coverage for the demo and AI Catalog fixture
- Allows `reddi.receipt.v1` to carry AUDD receipt proof metadata on Solana networks without implying custody
- Documents the ARD no-spend quickstart in the package README

## Validation

- `npm test` in `packages/agent-protocol` passed with 70 tests
- `npm run example:ard:no-spend` passed
- `npm run release:dry-run` passed and includes examples in the packed package
- Root `npm run check:rap:naming` passed
- `git diff --check` passed

## Guardrails

- No secrets
- No hosted Reddi service
- No live ARD registry fetch
- No paid provider call
- No wallet/RPC/SPL transfer
- No Quasar/SPL custody claim
