### PR TITLE
Add public agent-stack fixture corpus

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -55,6 +55,26 @@ AI Catalog ingestion stores discovery results as untrusted external metadata. Va
 
 Catalog ingestion never performs network fetches, paid invocations, wallet actions, or auto-execution. Buyer policy preflight, quote/payment approval, receipts, evidence, attestations, and reputation remain separate RAP steps after discovery.
 
+## Agent-Stack Fixture Corpora
+
+```typescript
+import {
+  agentStackFixtureCorpora,
+  createAgentStackFixtureCorpus,
+} from '@reddi/agent-protocol/agent-stack-fixtures';
+
+const corpus = createAgentStackFixtureCorpus(agentStackFixtureCorpora.anthropicFinancialServices);
+
+console.log(corpus.source.checkedCommit); // 4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1
+console.log(corpus.files.some((file) => file.parseStatus === 'malformed')); // true
+```
+
+Agent-stack fixture corpora are public, static inputs for onboarding-analyser parser and diagnostics work. The built-in Anthropic financial-services fixture records source URL, checked commit, license/source notes, authenticity notes, crawl timestamp, local research artifact path, high-level marketplace/plugin/managed-agent/MCP surfaces, and validation warnings.
+
+Fixture ingestion rejects credential-shaped metadata, unsafe source URLs, invalid commit refs, invalid timestamps, oversized corpora, and malformed corpus shapes. Public prompt, skill, command, and recipe text is always labelled as untrusted fixture content.
+
+The fixture corpus never installs Claude plugins, executes repo scripts, invokes managed agents, contacts MCP servers, fetches paid/provider data, requires credentials, or publishes imported surfaces as payable RAP listings. Parser, connector-diagnostics, draft-profile, and operator-review behavior land in later RAP slices.
+
 ## Provider Trust Records
 
 ```typescript

--- a/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
@@ -1,0 +1,195 @@
+export declare const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION: "reddi.agent-stack-fixture-corpus.v1";
+export type AgentStackFixtureSurfaceKind = 'repo-marketplace-metadata' | 'claude-plugin' | 'managed-agent-cookbook' | 'mcp-connector-config' | 'skill' | 'command' | 'subagent' | 'partner-plugin' | 'vertical-plugin' | 'validation-warning';
+export type AgentStackFixtureValidationErrorCode = 'malformed_fixture_corpus' | 'invalid_source_reference' | 'credential_leakage_rejected' | 'invalid_commit_ref' | 'invalid_timestamp' | 'unsafe_url' | 'corpus_too_large';
+export type AgentStackFixtureValidationError = {
+    code: AgentStackFixtureValidationErrorCode;
+    path: string;
+    message: string;
+};
+export type AgentStackFixtureSource = {
+    sourceUrl: string;
+    checkedCommit: string;
+    checkedRef?: string;
+    license?: string;
+    sourceNotes: string[];
+    authenticityNotes: string[];
+    crawlTimestamp: string;
+    localResearchArtifactPath?: string;
+};
+export type AgentStackFixtureFile = {
+    path: string;
+    kind: AgentStackFixtureSurfaceKind;
+    present: boolean;
+    parseStatus: 'valid' | 'malformed' | 'not_parsed' | 'missing';
+    mediaType?: string;
+    summary?: string;
+    warningCodes?: string[];
+};
+export type AgentStackFixtureSurface = {
+    id: string;
+    name: string;
+    kind: AgentStackFixtureSurfaceKind;
+    path: string;
+    category?: string;
+    runtimeSurface?: string;
+    commands?: string[];
+    skills?: string[];
+    toolGrants?: string[];
+    authDependencies?: string[];
+    dataDependencies?: string[];
+    safetyHints?: string[];
+    humanReviewHints?: string[];
+    writeCapable?: boolean;
+    contentTrustBoundary: 'untrusted_public_text' | 'metadata_only';
+    notes?: string[];
+};
+export type AgentStackFixtureValidationWarning = {
+    code: string;
+    severity: 'info' | 'warning' | 'blocked';
+    path: string;
+    message: string;
+};
+export type AgentStackFixtureCorpus = {
+    schemaVersion: typeof AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION;
+    id: string;
+    title: string;
+    source: AgentStackFixtureSource;
+    surfaces: AgentStackFixtureSurface[];
+    files: AgentStackFixtureFile[];
+    validationWarnings: AgentStackFixtureValidationWarning[];
+    staticOnly: true;
+    nonGoals: string[];
+};
+export type AgentStackFixtureValidationSuccess = {
+    ok: true;
+    corpus: AgentStackFixtureCorpus;
+    warnings: AgentStackFixtureValidationWarning[];
+};
+export type AgentStackFixtureValidationFailure = {
+    ok: false;
+    errors: AgentStackFixtureValidationError[];
+};
+export type AgentStackFixtureValidationResult = AgentStackFixtureValidationSuccess | AgentStackFixtureValidationFailure;
+export type AgentStackFixtureValidationOptions = {
+    maxBytes?: number;
+};
+export type AgentStackFixtureCase = {
+    description: string;
+    corpus: unknown;
+    expectedValid: boolean;
+    expectedErrorCodes: AgentStackFixtureValidationErrorCode[];
+};
+export declare function validateAgentStackFixtureCorpus(input: unknown, options?: AgentStackFixtureValidationOptions): AgentStackFixtureValidationResult;
+export declare function createAgentStackFixtureCorpus(input: unknown, options?: AgentStackFixtureValidationOptions): AgentStackFixtureCorpus;
+export declare const agentStackFixtureCorpora: {
+    readonly anthropicFinancialServices: {
+        readonly schemaVersion: "reddi.agent-stack-fixture-corpus.v1";
+        readonly id: "agent-stack-fixture:anthropic-financial-services:2026-06-18";
+        readonly title: "Anthropic financial-services agent stack public fixture";
+        readonly source: {
+            readonly sourceUrl: "https://github.com/anthropics/financial-services";
+            readonly checkedCommit: "4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1";
+            readonly checkedRef: "main";
+            readonly license: "Apache-2.0";
+            readonly sourceNotes: ["Public GitHub repository snapshot only; fixture does not install plugins or execute repository commands.", "Fixture records high-level manifest surfaces for onboarding analyser parser and diagnostics tests."];
+            readonly authenticityNotes: ["GitHub organization was verified for anthropic.com during local analysis.", "Anthropic public financial-services announcement linked to the repository during local analysis.", "Latest inspected main commit was GitHub-signature verified in the local analysis artifact."];
+            readonly crawlTimestamp: "2026-06-18T10:50:00.000Z";
+            readonly localResearchArtifactPath: "projects/reddi-agent-protocol/research/ANTHROPIC-FINANCIAL-SERVICES-REPO-ANALYSIS-2026-06-18.md";
+        };
+        readonly surfaces: [{
+            readonly id: "surface:anthropic-financial-services:marketplace";
+            readonly name: "Claude plugin marketplace metadata";
+            readonly kind: "repo-marketplace-metadata";
+            readonly path: ".claude-plugin/marketplace.json";
+            readonly runtimeSurface: "claude-plugin-marketplace";
+            readonly category: "financial-services";
+            readonly contentTrustBoundary: "metadata_only";
+            readonly notes: ["Marketplace metadata is source metadata, not RAP publication approval."];
+        }, {
+            readonly id: "surface:anthropic-financial-services:plugins";
+            readonly name: "Financial services Claude plugins";
+            readonly kind: "claude-plugin";
+            readonly path: "plugins/";
+            readonly runtimeSurface: "claude-code-plugin";
+            readonly commands: ["statically discovered command metadata pending #403 parser"];
+            readonly skills: ["statically discovered skill metadata pending #403 parser"];
+            readonly toolGrants: ["read", "write-capable grants must be parsed and reviewed before publication"];
+            readonly safetyHints: ["Treat plugin prompts and skills as untrusted public text."];
+            readonly humanReviewHints: ["Review write-capable commands before draft RAP listing publication."];
+            readonly writeCapable: true;
+            readonly contentTrustBoundary: "untrusted_public_text";
+        }, {
+            readonly id: "surface:anthropic-financial-services:managed-agents";
+            readonly name: "Claude managed-agent cookbooks";
+            readonly kind: "managed-agent-cookbook";
+            readonly path: "managed-agents/";
+            readonly runtimeSurface: "claude-managed-agent";
+            readonly authDependencies: ["third-party connector credentials may be required by recipes"];
+            readonly dataDependencies: ["financial workspace documents", "Microsoft 365 or partner data sources"];
+            readonly safetyHints: ["Managed-agent YAML is static input only until #403/#405 produce reviewable inventories."];
+            readonly humanReviewHints: ["Operator review is required before imported recipes become payable listings."];
+            readonly contentTrustBoundary: "untrusted_public_text";
+        }, {
+            readonly id: "surface:anthropic-financial-services:mcp-connectors";
+            readonly name: "MCP connector configurations";
+            readonly kind: "mcp-connector-config";
+            readonly path: "plugins/vertical-plugins/financial-analysis/.mcp.json";
+            readonly runtimeSurface: "mcp-connector-config";
+            readonly authDependencies: ["box", "egnyte", "microsoft-365", "partner connectors"];
+            readonly safetyHints: ["Connector config validation is static only and must not contact MCP servers."];
+            readonly humanReviewHints: ["Malformed connector config should block only affected connector readiness, not unrelated metadata ingestion."];
+            readonly contentTrustBoundary: "metadata_only";
+        }, {
+            readonly id: "surface:anthropic-financial-services:known-warning";
+            readonly name: "Known malformed financial-analysis MCP config";
+            readonly kind: "validation-warning";
+            readonly path: "plugins/vertical-plugins/financial-analysis/.mcp.json";
+            readonly safetyHints: ["Known invalid JSON is preserved as a regression fixture for #404."];
+            readonly contentTrustBoundary: "metadata_only";
+        }];
+        readonly files: [{
+            readonly path: ".claude-plugin/marketplace.json";
+            readonly kind: "repo-marketplace-metadata";
+            readonly present: true;
+            readonly parseStatus: "not_parsed";
+            readonly mediaType: "application/json";
+            readonly summary: "Repository-level marketplace metadata for Claude plugin distribution.";
+        }, {
+            readonly path: "plugins/**/plugin.json";
+            readonly kind: "claude-plugin";
+            readonly present: true;
+            readonly parseStatus: "not_parsed";
+            readonly mediaType: "application/json";
+            readonly summary: "Plugin manifests for horizontal, vertical, and partner packages.";
+        }, {
+            readonly path: "managed-agents/**/agent.yaml";
+            readonly kind: "managed-agent-cookbook";
+            readonly present: true;
+            readonly parseStatus: "not_parsed";
+            readonly mediaType: "application/yaml";
+            readonly summary: "Managed-agent cookbook metadata; parser support belongs to #403.";
+        }, {
+            readonly path: "plugins/vertical-plugins/financial-analysis/.mcp.json";
+            readonly kind: "mcp-connector-config";
+            readonly present: true;
+            readonly parseStatus: "malformed";
+            readonly mediaType: "application/json";
+            readonly warningCodes: ["malformed_mcp_json"];
+            readonly summary: "Known malformed connector manifest from local analysis; full diagnostics belong to #404.";
+        }];
+        readonly validationWarnings: [{
+            readonly code: "malformed_mcp_json";
+            readonly severity: "warning";
+            readonly path: "plugins/vertical-plugins/financial-analysis/.mcp.json";
+            readonly message: "Known malformed JSON should fail closed for connector diagnostics while preserving partial static ingestion.";
+        }, {
+            readonly code: "untrusted_prompt_text";
+            readonly severity: "info";
+            readonly path: "plugins/";
+            readonly message: "Public prompt, skill, and command text is untrusted fixture content and cannot alter analyser behavior.";
+        }];
+        readonly staticOnly: true;
+        readonly nonGoals: ["Do not install Claude plugins.", "Do not execute repository scripts, commands, managed agents, or MCP servers.", "Do not fetch paid/provider data or require credentials.", "Do not publish imported surfaces as payable RAP listings without operator review."];
+    };
+};
+export declare const agentStackFixtureCases: Record<string, AgentStackFixtureCase>;

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -107,6 +107,15 @@ function validatePath(value, path, errors) {
         errors.push(error('invalid_source_reference', path, 'path must be a safe static source path'));
         return;
     }
+    if (value.startsWith('/')) {
+        errors.push(error('invalid_source_reference', path, 'path must be relative to the static fixture root'));
+    }
+    if (/^[A-Za-z]:\//.test(value)) {
+        errors.push(error('invalid_source_reference', path, 'path must not use a drive-letter prefix'));
+    }
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)) {
+        errors.push(error('invalid_source_reference', path, 'path must not use a URI scheme'));
+    }
     const segments = value.split(/[/:]+/);
     if (segments.includes('..')) {
         errors.push(error('invalid_source_reference', path, 'path must not include traversal segments'));

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -1,5 +1,6 @@
 export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixture-corpus.v1';
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
+const RFC3339_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
 const SECRET_KEY_PATTERN = /(^|[_-])(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|cookie|password|secret|seed|session[_-]?token|signature|sig|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
 const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
@@ -93,8 +94,14 @@ function validateSafeUrl(value, path, errors) {
     }
 }
 function validateTimestamp(value, path, errors) {
-    if (!isNonEmptyString(value) || Number.isNaN(Date.parse(value))) {
+    if (!isNonEmptyString(value) || !RFC3339_UTC_PATTERN.test(value)) {
         errors.push(error('invalid_timestamp', path, 'crawlTimestamp must be an ISO timestamp'));
+        return;
+    }
+    const parsed = new Date(value);
+    const normalized = value.includes('.') ? value : value.replace('Z', '.000Z');
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== normalized) {
+        errors.push(error('invalid_timestamp', path, 'crawlTimestamp must be a valid ISO timestamp'));
     }
 }
 function validateStringArray(value, path, errors) {

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -3,6 +3,19 @@ const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
 const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
 const SECRET_KEY_PATTERN = /(^|[_-])(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|cookie|password|secret|seed|session[_-]?token|signature|sig|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
 const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
+const SUPPORTED_SURFACE_KINDS = [
+    'repo-marketplace-metadata',
+    'claude-plugin',
+    'managed-agent-cookbook',
+    'mcp-connector-config',
+    'skill',
+    'command',
+    'subagent',
+    'partner-plugin',
+    'vertical-plugin',
+    'validation-warning',
+];
+const WARNING_SEVERITIES = ['info', 'warning', 'blocked'];
 function error(code, path, message) {
     return { code, path, message };
 }
@@ -92,6 +105,11 @@ function validateStringArray(value, path, errors) {
 function validatePath(value, path, errors) {
     if (!isNonEmptyString(value) || !SAFE_PATH_PATTERN.test(value)) {
         errors.push(error('invalid_source_reference', path, 'path must be a safe static source path'));
+        return;
+    }
+    const segments = value.split(/[/:]+/);
+    if (segments.includes('..')) {
+        errors.push(error('invalid_source_reference', path, 'path must not include traversal segments'));
     }
 }
 function validateSurface(value, path, errors) {
@@ -103,6 +121,9 @@ function validateSurface(value, path, errors) {
         if (!isNonEmptyString(value[key])) {
             errors.push(error('malformed_fixture_corpus', `${path}.${key}`, 'surface field must be a non-empty string'));
         }
+    }
+    if (isNonEmptyString(value.kind) && !SUPPORTED_SURFACE_KINDS.includes(value.kind)) {
+        errors.push(error('malformed_fixture_corpus', `${path}.kind`, 'surface kind is unsupported'));
     }
     validatePath(value.path, `${path}.path`, errors);
     if (!['untrusted_public_text', 'metadata_only'].includes(String(value.contentTrustBoundary))) {
@@ -118,11 +139,30 @@ function validateFile(value, path, errors) {
     if (!isNonEmptyString(value.kind)) {
         errors.push(error('malformed_fixture_corpus', `${path}.kind`, 'file kind must be a non-empty string'));
     }
+    else if (!SUPPORTED_SURFACE_KINDS.includes(value.kind)) {
+        errors.push(error('malformed_fixture_corpus', `${path}.kind`, 'file kind is unsupported'));
+    }
     if (typeof value.present !== 'boolean') {
         errors.push(error('malformed_fixture_corpus', `${path}.present`, 'file present must be a boolean'));
     }
     if (!['valid', 'malformed', 'not_parsed', 'missing'].includes(String(value.parseStatus))) {
         errors.push(error('malformed_fixture_corpus', `${path}.parseStatus`, 'file parseStatus is unsupported'));
+    }
+}
+function validateWarning(value, path, errors) {
+    if (!isPlainObject(value)) {
+        errors.push(error('malformed_fixture_corpus', path, 'validation warning must be an object'));
+        return;
+    }
+    if (!isNonEmptyString(value.code)) {
+        errors.push(error('malformed_fixture_corpus', `${path}.code`, 'warning code must be a non-empty string'));
+    }
+    if (!WARNING_SEVERITIES.includes(value.severity)) {
+        errors.push(error('malformed_fixture_corpus', `${path}.severity`, 'warning severity is unsupported'));
+    }
+    validatePath(value.path, `${path}.path`, errors);
+    if (!isNonEmptyString(value.message)) {
+        errors.push(error('malformed_fixture_corpus', `${path}.message`, 'warning message must be a non-empty string'));
     }
 }
 export function validateAgentStackFixtureCorpus(input, options = {}) {
@@ -184,6 +224,9 @@ export function validateAgentStackFixtureCorpus(input, options = {}) {
     }
     if (!Array.isArray(input.validationWarnings)) {
         errors.push(error('malformed_fixture_corpus', '$.validationWarnings', 'validationWarnings must be an array'));
+    }
+    else {
+        input.validationWarnings.forEach((warning, index) => validateWarning(warning, `$.validationWarnings[${index}]`, errors));
     }
     return errors.length === 0
         ? {

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -102,6 +102,21 @@ function validateStringArray(value, path, errors) {
         errors.push(error('malformed_fixture_corpus', path, 'field must be a non-empty string array'));
     }
 }
+function validateOptionalString(value, path, errors) {
+    if (value !== undefined && !isNonEmptyString(value)) {
+        errors.push(error('malformed_fixture_corpus', path, 'field must be a non-empty string when present'));
+    }
+}
+function validateOptionalStringArray(value, path, errors) {
+    if (value !== undefined && (!isStringArray(value) || value.some((item) => !item.trim()))) {
+        errors.push(error('malformed_fixture_corpus', path, 'field must be a string array when present'));
+    }
+}
+function validateOptionalBoolean(value, path, errors) {
+    if (value !== undefined && typeof value !== 'boolean') {
+        errors.push(error('malformed_fixture_corpus', path, 'field must be a boolean when present'));
+    }
+}
 function validatePath(value, path, errors) {
     if (!isNonEmptyString(value) || !SAFE_PATH_PATTERN.test(value)) {
         errors.push(error('invalid_source_reference', path, 'path must be a safe static source path'));
@@ -138,6 +153,17 @@ function validateSurface(value, path, errors) {
     if (!['untrusted_public_text', 'metadata_only'].includes(String(value.contentTrustBoundary))) {
         errors.push(error('malformed_fixture_corpus', `${path}.contentTrustBoundary`, 'surface must declare its content trust boundary'));
     }
+    validateOptionalString(value.category, `${path}.category`, errors);
+    validateOptionalString(value.runtimeSurface, `${path}.runtimeSurface`, errors);
+    validateOptionalStringArray(value.commands, `${path}.commands`, errors);
+    validateOptionalStringArray(value.skills, `${path}.skills`, errors);
+    validateOptionalStringArray(value.toolGrants, `${path}.toolGrants`, errors);
+    validateOptionalStringArray(value.authDependencies, `${path}.authDependencies`, errors);
+    validateOptionalStringArray(value.dataDependencies, `${path}.dataDependencies`, errors);
+    validateOptionalStringArray(value.safetyHints, `${path}.safetyHints`, errors);
+    validateOptionalStringArray(value.humanReviewHints, `${path}.humanReviewHints`, errors);
+    validateOptionalBoolean(value.writeCapable, `${path}.writeCapable`, errors);
+    validateOptionalStringArray(value.notes, `${path}.notes`, errors);
 }
 function validateFile(value, path, errors) {
     if (!isPlainObject(value)) {
@@ -157,6 +183,9 @@ function validateFile(value, path, errors) {
     if (!['valid', 'malformed', 'not_parsed', 'missing'].includes(String(value.parseStatus))) {
         errors.push(error('malformed_fixture_corpus', `${path}.parseStatus`, 'file parseStatus is unsupported'));
     }
+    validateOptionalString(value.mediaType, `${path}.mediaType`, errors);
+    validateOptionalString(value.summary, `${path}.summary`, errors);
+    validateOptionalStringArray(value.warningCodes, `${path}.warningCodes`, errors);
 }
 function validateWarning(value, path, errors) {
     if (!isPlainObject(value)) {
@@ -212,6 +241,8 @@ export function validateAgentStackFixtureCorpus(input, options = {}) {
         if (!isNonEmptyString(input.source.checkedCommit) || !COMMIT_SHA_PATTERN.test(input.source.checkedCommit)) {
             errors.push(error('invalid_commit_ref', '$.source.checkedCommit', 'checkedCommit must be a 40-character commit SHA'));
         }
+        validateOptionalString(input.source.checkedRef, '$.source.checkedRef', errors);
+        validateOptionalString(input.source.license, '$.source.license', errors);
         validateStringArray(input.source.sourceNotes, '$.source.sourceNotes', errors);
         validateStringArray(input.source.authenticityNotes, '$.source.authenticityNotes', errors);
         validateTimestamp(input.source.crawlTimestamp, '$.source.crawlTimestamp', errors);

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -1,0 +1,402 @@
+export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixture-corpus.v1';
+const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
+const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
+const SECRET_KEY_PATTERN = /(^|[_-])(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|cookie|password|secret|seed|session[_-]?token|signature|sig|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
+const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
+function error(code, path, message) {
+    return { code, path, message };
+}
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function isStringArray(value) {
+    return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+function byteLength(value) {
+    try {
+        return new TextEncoder().encode(JSON.stringify(value)).length;
+    }
+    catch {
+        return undefined;
+    }
+}
+function findCredentialMaterial(value, path = '$') {
+    if (typeof value === 'string')
+        return SECRET_VALUE_PATTERN.test(value) ? path : undefined;
+    if (!value || typeof value !== 'object')
+        return undefined;
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index += 1) {
+            const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+            if (found)
+                return found;
+        }
+        return undefined;
+    }
+    for (const [key, child] of Object.entries(value)) {
+        const childPath = `${path}.${key}`;
+        if (SECRET_KEY_PATTERN.test(key))
+            return childPath;
+        const found = findCredentialMaterial(child, childPath);
+        if (found)
+            return found;
+    }
+    return undefined;
+}
+function validateSafeUrl(value, path, errors) {
+    if (!isNonEmptyString(value)) {
+        errors.push(error('invalid_source_reference', path, 'source URL must be a non-empty string'));
+        return;
+    }
+    let parsed;
+    try {
+        parsed = new URL(value);
+    }
+    catch {
+        errors.push(error('invalid_source_reference', path, 'source URL must be a valid URL'));
+        return;
+    }
+    if (parsed.protocol !== 'https:') {
+        errors.push(error('unsafe_url', path, 'source URL must use HTTPS'));
+    }
+    if (parsed.username || parsed.password) {
+        errors.push(error('unsafe_url', path, 'source URL must not embed credentials'));
+    }
+    for (const key of parsed.searchParams.keys()) {
+        if (SECRET_KEY_PATTERN.test(key)) {
+            errors.push(error('credential_leakage_rejected', `${path}.${key}`, 'source URL must not include credential-shaped query keys'));
+        }
+    }
+    for (const queryValue of parsed.searchParams.values()) {
+        if (SECRET_VALUE_PATTERN.test(queryValue)) {
+            errors.push(error('credential_leakage_rejected', path, 'source URL must not include credential-shaped query values'));
+        }
+    }
+}
+function validateTimestamp(value, path, errors) {
+    if (!isNonEmptyString(value) || Number.isNaN(Date.parse(value))) {
+        errors.push(error('invalid_timestamp', path, 'crawlTimestamp must be an ISO timestamp'));
+    }
+}
+function validateStringArray(value, path, errors) {
+    if (!isStringArray(value) || value.length === 0 || value.some((item) => !item.trim())) {
+        errors.push(error('malformed_fixture_corpus', path, 'field must be a non-empty string array'));
+    }
+}
+function validatePath(value, path, errors) {
+    if (!isNonEmptyString(value) || !SAFE_PATH_PATTERN.test(value)) {
+        errors.push(error('invalid_source_reference', path, 'path must be a safe static source path'));
+    }
+}
+function validateSurface(value, path, errors) {
+    if (!isPlainObject(value)) {
+        errors.push(error('malformed_fixture_corpus', path, 'surface must be an object'));
+        return;
+    }
+    for (const key of ['id', 'name', 'kind', 'path']) {
+        if (!isNonEmptyString(value[key])) {
+            errors.push(error('malformed_fixture_corpus', `${path}.${key}`, 'surface field must be a non-empty string'));
+        }
+    }
+    validatePath(value.path, `${path}.path`, errors);
+    if (!['untrusted_public_text', 'metadata_only'].includes(String(value.contentTrustBoundary))) {
+        errors.push(error('malformed_fixture_corpus', `${path}.contentTrustBoundary`, 'surface must declare its content trust boundary'));
+    }
+}
+function validateFile(value, path, errors) {
+    if (!isPlainObject(value)) {
+        errors.push(error('malformed_fixture_corpus', path, 'file entry must be an object'));
+        return;
+    }
+    validatePath(value.path, `${path}.path`, errors);
+    if (!isNonEmptyString(value.kind)) {
+        errors.push(error('malformed_fixture_corpus', `${path}.kind`, 'file kind must be a non-empty string'));
+    }
+    if (typeof value.present !== 'boolean') {
+        errors.push(error('malformed_fixture_corpus', `${path}.present`, 'file present must be a boolean'));
+    }
+    if (!['valid', 'malformed', 'not_parsed', 'missing'].includes(String(value.parseStatus))) {
+        errors.push(error('malformed_fixture_corpus', `${path}.parseStatus`, 'file parseStatus is unsupported'));
+    }
+}
+export function validateAgentStackFixtureCorpus(input, options = {}) {
+    const maxBytes = options.maxBytes ?? 96_000;
+    const errors = [];
+    if (!isPlainObject(input)) {
+        return { ok: false, errors: [error('malformed_fixture_corpus', '$', 'agent-stack fixture corpus must be a plain object')] };
+    }
+    const size = byteLength(input);
+    if (size === undefined) {
+        return { ok: false, errors: [error('malformed_fixture_corpus', '$', 'fixture corpus must be JSON-serializable')] };
+    }
+    if (size > maxBytes) {
+        return { ok: false, errors: [error('corpus_too_large', '$', `fixture corpus exceeds ${maxBytes} bytes`)] };
+    }
+    const credentialPath = findCredentialMaterial(input);
+    if (credentialPath) {
+        return {
+            ok: false,
+            errors: [error('credential_leakage_rejected', credentialPath, 'fixture corpus must not contain credential-shaped material')],
+        };
+    }
+    if (input.schemaVersion !== AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION) {
+        errors.push(error('malformed_fixture_corpus', '$.schemaVersion', `expected ${AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION}`));
+    }
+    if (!isNonEmptyString(input.id))
+        errors.push(error('malformed_fixture_corpus', '$.id', 'id must be a non-empty string'));
+    if (!isNonEmptyString(input.title))
+        errors.push(error('malformed_fixture_corpus', '$.title', 'title must be a non-empty string'));
+    if (input.staticOnly !== true)
+        errors.push(error('malformed_fixture_corpus', '$.staticOnly', 'fixture corpus must be staticOnly=true'));
+    validateStringArray(input.nonGoals, '$.nonGoals', errors);
+    if (!isPlainObject(input.source)) {
+        errors.push(error('malformed_fixture_corpus', '$.source', 'source must be an object'));
+    }
+    else {
+        validateSafeUrl(input.source.sourceUrl, '$.source.sourceUrl', errors);
+        if (!isNonEmptyString(input.source.checkedCommit) || !COMMIT_SHA_PATTERN.test(input.source.checkedCommit)) {
+            errors.push(error('invalid_commit_ref', '$.source.checkedCommit', 'checkedCommit must be a 40-character commit SHA'));
+        }
+        validateStringArray(input.source.sourceNotes, '$.source.sourceNotes', errors);
+        validateStringArray(input.source.authenticityNotes, '$.source.authenticityNotes', errors);
+        validateTimestamp(input.source.crawlTimestamp, '$.source.crawlTimestamp', errors);
+        if (input.source.localResearchArtifactPath !== undefined) {
+            validatePath(input.source.localResearchArtifactPath, '$.source.localResearchArtifactPath', errors);
+        }
+    }
+    if (!Array.isArray(input.surfaces) || input.surfaces.length === 0) {
+        errors.push(error('malformed_fixture_corpus', '$.surfaces', 'surfaces must be a non-empty array'));
+    }
+    else {
+        input.surfaces.forEach((surface, index) => validateSurface(surface, `$.surfaces[${index}]`, errors));
+    }
+    if (!Array.isArray(input.files) || input.files.length === 0) {
+        errors.push(error('malformed_fixture_corpus', '$.files', 'files must be a non-empty array'));
+    }
+    else {
+        input.files.forEach((file, index) => validateFile(file, `$.files[${index}]`, errors));
+    }
+    if (!Array.isArray(input.validationWarnings)) {
+        errors.push(error('malformed_fixture_corpus', '$.validationWarnings', 'validationWarnings must be an array'));
+    }
+    return errors.length === 0
+        ? {
+            ok: true,
+            corpus: input,
+            warnings: input.validationWarnings,
+        }
+        : { ok: false, errors };
+}
+export function createAgentStackFixtureCorpus(input, options = {}) {
+    const result = validateAgentStackFixtureCorpus(input, options);
+    if (!result.ok) {
+        throw new Error(`invalid_agent_stack_fixture_corpus:${result.errors.map((item) => item.code).join(',')}`);
+    }
+    return result.corpus;
+}
+export const agentStackFixtureCorpora = {
+    anthropicFinancialServices: {
+        schemaVersion: AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION,
+        id: 'agent-stack-fixture:anthropic-financial-services:2026-06-18',
+        title: 'Anthropic financial-services agent stack public fixture',
+        source: {
+            sourceUrl: 'https://github.com/anthropics/financial-services',
+            checkedCommit: '4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1',
+            checkedRef: 'main',
+            license: 'Apache-2.0',
+            sourceNotes: [
+                'Public GitHub repository snapshot only; fixture does not install plugins or execute repository commands.',
+                'Fixture records high-level manifest surfaces for onboarding analyser parser and diagnostics tests.',
+            ],
+            authenticityNotes: [
+                'GitHub organization was verified for anthropic.com during local analysis.',
+                'Anthropic public financial-services announcement linked to the repository during local analysis.',
+                'Latest inspected main commit was GitHub-signature verified in the local analysis artifact.',
+            ],
+            crawlTimestamp: '2026-06-18T10:50:00.000Z',
+            localResearchArtifactPath: 'projects/reddi-agent-protocol/research/ANTHROPIC-FINANCIAL-SERVICES-REPO-ANALYSIS-2026-06-18.md',
+        },
+        surfaces: [
+            {
+                id: 'surface:anthropic-financial-services:marketplace',
+                name: 'Claude plugin marketplace metadata',
+                kind: 'repo-marketplace-metadata',
+                path: '.claude-plugin/marketplace.json',
+                runtimeSurface: 'claude-plugin-marketplace',
+                category: 'financial-services',
+                contentTrustBoundary: 'metadata_only',
+                notes: ['Marketplace metadata is source metadata, not RAP publication approval.'],
+            },
+            {
+                id: 'surface:anthropic-financial-services:plugins',
+                name: 'Financial services Claude plugins',
+                kind: 'claude-plugin',
+                path: 'plugins/',
+                runtimeSurface: 'claude-code-plugin',
+                commands: ['statically discovered command metadata pending #403 parser'],
+                skills: ['statically discovered skill metadata pending #403 parser'],
+                toolGrants: ['read', 'write-capable grants must be parsed and reviewed before publication'],
+                safetyHints: ['Treat plugin prompts and skills as untrusted public text.'],
+                humanReviewHints: ['Review write-capable commands before draft RAP listing publication.'],
+                writeCapable: true,
+                contentTrustBoundary: 'untrusted_public_text',
+            },
+            {
+                id: 'surface:anthropic-financial-services:managed-agents',
+                name: 'Claude managed-agent cookbooks',
+                kind: 'managed-agent-cookbook',
+                path: 'managed-agents/',
+                runtimeSurface: 'claude-managed-agent',
+                authDependencies: ['third-party connector credentials may be required by recipes'],
+                dataDependencies: ['financial workspace documents', 'Microsoft 365 or partner data sources'],
+                safetyHints: ['Managed-agent YAML is static input only until #403/#405 produce reviewable inventories.'],
+                humanReviewHints: ['Operator review is required before imported recipes become payable listings.'],
+                contentTrustBoundary: 'untrusted_public_text',
+            },
+            {
+                id: 'surface:anthropic-financial-services:mcp-connectors',
+                name: 'MCP connector configurations',
+                kind: 'mcp-connector-config',
+                path: 'plugins/vertical-plugins/financial-analysis/.mcp.json',
+                runtimeSurface: 'mcp-connector-config',
+                authDependencies: ['box', 'egnyte', 'microsoft-365', 'partner connectors'],
+                safetyHints: ['Connector config validation is static only and must not contact MCP servers.'],
+                humanReviewHints: ['Malformed connector config should block only affected connector readiness, not unrelated metadata ingestion.'],
+                contentTrustBoundary: 'metadata_only',
+            },
+            {
+                id: 'surface:anthropic-financial-services:known-warning',
+                name: 'Known malformed financial-analysis MCP config',
+                kind: 'validation-warning',
+                path: 'plugins/vertical-plugins/financial-analysis/.mcp.json',
+                safetyHints: ['Known invalid JSON is preserved as a regression fixture for #404.'],
+                contentTrustBoundary: 'metadata_only',
+            },
+        ],
+        files: [
+            {
+                path: '.claude-plugin/marketplace.json',
+                kind: 'repo-marketplace-metadata',
+                present: true,
+                parseStatus: 'not_parsed',
+                mediaType: 'application/json',
+                summary: 'Repository-level marketplace metadata for Claude plugin distribution.',
+            },
+            {
+                path: 'plugins/**/plugin.json',
+                kind: 'claude-plugin',
+                present: true,
+                parseStatus: 'not_parsed',
+                mediaType: 'application/json',
+                summary: 'Plugin manifests for horizontal, vertical, and partner packages.',
+            },
+            {
+                path: 'managed-agents/**/agent.yaml',
+                kind: 'managed-agent-cookbook',
+                present: true,
+                parseStatus: 'not_parsed',
+                mediaType: 'application/yaml',
+                summary: 'Managed-agent cookbook metadata; parser support belongs to #403.',
+            },
+            {
+                path: 'plugins/vertical-plugins/financial-analysis/.mcp.json',
+                kind: 'mcp-connector-config',
+                present: true,
+                parseStatus: 'malformed',
+                mediaType: 'application/json',
+                warningCodes: ['malformed_mcp_json'],
+                summary: 'Known malformed connector manifest from local analysis; full diagnostics belong to #404.',
+            },
+        ],
+        validationWarnings: [
+            {
+                code: 'malformed_mcp_json',
+                severity: 'warning',
+                path: 'plugins/vertical-plugins/financial-analysis/.mcp.json',
+                message: 'Known malformed JSON should fail closed for connector diagnostics while preserving partial static ingestion.',
+            },
+            {
+                code: 'untrusted_prompt_text',
+                severity: 'info',
+                path: 'plugins/',
+                message: 'Public prompt, skill, and command text is untrusted fixture content and cannot alter analyser behavior.',
+            },
+        ],
+        staticOnly: true,
+        nonGoals: [
+            'Do not install Claude plugins.',
+            'Do not execute repository scripts, commands, managed agents, or MCP servers.',
+            'Do not fetch paid/provider data or require credentials.',
+            'Do not publish imported surfaces as payable RAP listings without operator review.',
+        ],
+    },
+};
+export const agentStackFixtureCases = {
+    anthropicFinancialServices: {
+        description: 'Valid public Anthropic financial-services agent-stack fixture corpus.',
+        corpus: agentStackFixtureCorpora.anthropicFinancialServices,
+        expectedValid: true,
+        expectedErrorCodes: [],
+    },
+    malformedCorpus: {
+        description: 'Missing source, files, and surfaces fails closed.',
+        corpus: {
+            schemaVersion: AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION,
+            id: 'agent-stack-fixture:malformed',
+            title: 'Malformed fixture',
+            staticOnly: true,
+            nonGoals: ['no execution'],
+        },
+        expectedValid: false,
+        expectedErrorCodes: ['malformed_fixture_corpus'],
+    },
+    invalidCommit: {
+        description: 'Fixture source must include an exact checked commit SHA.',
+        corpus: {
+            ...agentStackFixtureCorpora.anthropicFinancialServices,
+            source: {
+                ...agentStackFixtureCorpora.anthropicFinancialServices.source,
+                checkedCommit: 'main',
+            },
+        },
+        expectedValid: false,
+        expectedErrorCodes: ['invalid_commit_ref'],
+    },
+    unsafeSourceUrl: {
+        description: 'Fixture source URL must be HTTPS without embedded credentials.',
+        corpus: {
+            ...agentStackFixtureCorpora.anthropicFinancialServices,
+            source: {
+                ...agentStackFixtureCorpora.anthropicFinancialServices.source,
+                sourceUrl: 'http://github.com/anthropics/financial-services',
+            },
+        },
+        expectedValid: false,
+        expectedErrorCodes: ['unsafe_url'],
+    },
+    credentialLeakage: {
+        description: 'Credential-shaped metadata is rejected before fixture persistence.',
+        corpus: {
+            ...agentStackFixtureCorpora.anthropicFinancialServices,
+            surfaces: [
+                ...agentStackFixtureCorpora.anthropicFinancialServices.surfaces,
+                {
+                    id: 'surface:leaky',
+                    name: 'Leaky Connector',
+                    kind: 'mcp-connector-config',
+                    path: 'plugins/leaky/.mcp.json',
+                    contentTrustBoundary: 'metadata_only',
+                    notes: ['authorization: bearer should-not-be-stored'],
+                },
+            ],
+        },
+        expectedValid: false,
+        expectedErrorCodes: ['credential_leakage_rejected'],
+    },
+};

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -9,3 +9,4 @@ export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
+export * from './agent-stack-fixtures.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -9,3 +9,4 @@ export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
+export * from './agent-stack-fixtures.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -54,6 +54,10 @@
       "types": "./dist/audd-payment-plan.d.ts",
       "import": "./dist/audd-payment-plan.js"
     },
+    "./agent-stack-fixtures": {
+      "types": "./dist/agent-stack-fixtures.d.ts",
+      "import": "./dist/agent-stack-fixtures.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -116,6 +116,19 @@ const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
 const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
 const SECRET_KEY_PATTERN = /(^|[_-])(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|cookie|password|secret|seed|session[_-]?token|signature|sig|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
 const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
+const SUPPORTED_SURFACE_KINDS: readonly AgentStackFixtureSurfaceKind[] = [
+  'repo-marketplace-metadata',
+  'claude-plugin',
+  'managed-agent-cookbook',
+  'mcp-connector-config',
+  'skill',
+  'command',
+  'subagent',
+  'partner-plugin',
+  'vertical-plugin',
+  'validation-warning',
+];
+const WARNING_SEVERITIES: readonly AgentStackFixtureValidationWarning['severity'][] = ['info', 'warning', 'blocked'];
 
 function error(
   code: AgentStackFixtureValidationErrorCode,
@@ -214,6 +227,12 @@ function validateStringArray(value: unknown, path: string, errors: AgentStackFix
 function validatePath(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
   if (!isNonEmptyString(value) || !SAFE_PATH_PATTERN.test(value)) {
     errors.push(error('invalid_source_reference', path, 'path must be a safe static source path'));
+    return;
+  }
+
+  const segments = value.split(/[/:]+/);
+  if (segments.includes('..')) {
+    errors.push(error('invalid_source_reference', path, 'path must not include traversal segments'));
   }
 }
 
@@ -226,6 +245,9 @@ function validateSurface(value: unknown, path: string, errors: AgentStackFixture
     if (!isNonEmptyString(value[key])) {
       errors.push(error('malformed_fixture_corpus', `${path}.${key}`, 'surface field must be a non-empty string'));
     }
+  }
+  if (isNonEmptyString(value.kind) && !SUPPORTED_SURFACE_KINDS.includes(value.kind as AgentStackFixtureSurfaceKind)) {
+    errors.push(error('malformed_fixture_corpus', `${path}.kind`, 'surface kind is unsupported'));
   }
   validatePath(value.path, `${path}.path`, errors);
   if (!['untrusted_public_text', 'metadata_only'].includes(String(value.contentTrustBoundary))) {
@@ -241,12 +263,31 @@ function validateFile(value: unknown, path: string, errors: AgentStackFixtureVal
   validatePath(value.path, `${path}.path`, errors);
   if (!isNonEmptyString(value.kind)) {
     errors.push(error('malformed_fixture_corpus', `${path}.kind`, 'file kind must be a non-empty string'));
+  } else if (!SUPPORTED_SURFACE_KINDS.includes(value.kind as AgentStackFixtureSurfaceKind)) {
+    errors.push(error('malformed_fixture_corpus', `${path}.kind`, 'file kind is unsupported'));
   }
   if (typeof value.present !== 'boolean') {
     errors.push(error('malformed_fixture_corpus', `${path}.present`, 'file present must be a boolean'));
   }
   if (!['valid', 'malformed', 'not_parsed', 'missing'].includes(String(value.parseStatus))) {
     errors.push(error('malformed_fixture_corpus', `${path}.parseStatus`, 'file parseStatus is unsupported'));
+  }
+}
+
+function validateWarning(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (!isPlainObject(value)) {
+    errors.push(error('malformed_fixture_corpus', path, 'validation warning must be an object'));
+    return;
+  }
+  if (!isNonEmptyString(value.code)) {
+    errors.push(error('malformed_fixture_corpus', `${path}.code`, 'warning code must be a non-empty string'));
+  }
+  if (!WARNING_SEVERITIES.includes(value.severity as AgentStackFixtureValidationWarning['severity'])) {
+    errors.push(error('malformed_fixture_corpus', `${path}.severity`, 'warning severity is unsupported'));
+  }
+  validatePath(value.path, `${path}.path`, errors);
+  if (!isNonEmptyString(value.message)) {
+    errors.push(error('malformed_fixture_corpus', `${path}.message`, 'warning message must be a non-empty string'));
   }
 }
 
@@ -314,6 +355,8 @@ export function validateAgentStackFixtureCorpus(
 
   if (!Array.isArray(input.validationWarnings)) {
     errors.push(error('malformed_fixture_corpus', '$.validationWarnings', 'validationWarnings must be an array'));
+  } else {
+    input.validationWarnings.forEach((warning, index) => validateWarning(warning, `$.validationWarnings[${index}]`, errors));
   }
 
   return errors.length === 0

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -113,6 +113,7 @@ export type AgentStackFixtureCase = {
 };
 
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
+const RFC3339_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
 const SECRET_KEY_PATTERN = /(^|[_-])(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|cookie|password|secret|seed|session[_-]?token|signature|sig|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
 const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
@@ -213,8 +214,15 @@ function validateSafeUrl(value: unknown, path: string, errors: AgentStackFixture
 }
 
 function validateTimestamp(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
-  if (!isNonEmptyString(value) || Number.isNaN(Date.parse(value))) {
+  if (!isNonEmptyString(value) || !RFC3339_UTC_PATTERN.test(value)) {
     errors.push(error('invalid_timestamp', path, 'crawlTimestamp must be an ISO timestamp'));
+    return;
+  }
+
+  const parsed = new Date(value);
+  const normalized = value.includes('.') ? value : value.replace('Z', '.000Z');
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== normalized) {
+    errors.push(error('invalid_timestamp', path, 'crawlTimestamp must be a valid ISO timestamp'));
   }
 }
 

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -230,6 +230,18 @@ function validatePath(value: unknown, path: string, errors: AgentStackFixtureVal
     return;
   }
 
+  if (value.startsWith('/')) {
+    errors.push(error('invalid_source_reference', path, 'path must be relative to the static fixture root'));
+  }
+
+  if (/^[A-Za-z]:\//.test(value)) {
+    errors.push(error('invalid_source_reference', path, 'path must not use a drive-letter prefix'));
+  }
+
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)) {
+    errors.push(error('invalid_source_reference', path, 'path must not use a URI scheme'));
+  }
+
   const segments = value.split(/[/:]+/);
   if (segments.includes('..')) {
     errors.push(error('invalid_source_reference', path, 'path must not include traversal segments'));

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -1,0 +1,536 @@
+export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixture-corpus.v1' as const;
+
+export type AgentStackFixtureSurfaceKind =
+  | 'repo-marketplace-metadata'
+  | 'claude-plugin'
+  | 'managed-agent-cookbook'
+  | 'mcp-connector-config'
+  | 'skill'
+  | 'command'
+  | 'subagent'
+  | 'partner-plugin'
+  | 'vertical-plugin'
+  | 'validation-warning';
+
+export type AgentStackFixtureValidationErrorCode =
+  | 'malformed_fixture_corpus'
+  | 'invalid_source_reference'
+  | 'credential_leakage_rejected'
+  | 'invalid_commit_ref'
+  | 'invalid_timestamp'
+  | 'unsafe_url'
+  | 'corpus_too_large';
+
+export type AgentStackFixtureValidationError = {
+  code: AgentStackFixtureValidationErrorCode;
+  path: string;
+  message: string;
+};
+
+export type AgentStackFixtureSource = {
+  sourceUrl: string;
+  checkedCommit: string;
+  checkedRef?: string;
+  license?: string;
+  sourceNotes: string[];
+  authenticityNotes: string[];
+  crawlTimestamp: string;
+  localResearchArtifactPath?: string;
+};
+
+export type AgentStackFixtureFile = {
+  path: string;
+  kind: AgentStackFixtureSurfaceKind;
+  present: boolean;
+  parseStatus: 'valid' | 'malformed' | 'not_parsed' | 'missing';
+  mediaType?: string;
+  summary?: string;
+  warningCodes?: string[];
+};
+
+export type AgentStackFixtureSurface = {
+  id: string;
+  name: string;
+  kind: AgentStackFixtureSurfaceKind;
+  path: string;
+  category?: string;
+  runtimeSurface?: string;
+  commands?: string[];
+  skills?: string[];
+  toolGrants?: string[];
+  authDependencies?: string[];
+  dataDependencies?: string[];
+  safetyHints?: string[];
+  humanReviewHints?: string[];
+  writeCapable?: boolean;
+  contentTrustBoundary: 'untrusted_public_text' | 'metadata_only';
+  notes?: string[];
+};
+
+export type AgentStackFixtureValidationWarning = {
+  code: string;
+  severity: 'info' | 'warning' | 'blocked';
+  path: string;
+  message: string;
+};
+
+export type AgentStackFixtureCorpus = {
+  schemaVersion: typeof AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION;
+  id: string;
+  title: string;
+  source: AgentStackFixtureSource;
+  surfaces: AgentStackFixtureSurface[];
+  files: AgentStackFixtureFile[];
+  validationWarnings: AgentStackFixtureValidationWarning[];
+  staticOnly: true;
+  nonGoals: string[];
+};
+
+export type AgentStackFixtureValidationSuccess = {
+  ok: true;
+  corpus: AgentStackFixtureCorpus;
+  warnings: AgentStackFixtureValidationWarning[];
+};
+
+export type AgentStackFixtureValidationFailure = {
+  ok: false;
+  errors: AgentStackFixtureValidationError[];
+};
+
+export type AgentStackFixtureValidationResult =
+  | AgentStackFixtureValidationSuccess
+  | AgentStackFixtureValidationFailure;
+
+export type AgentStackFixtureValidationOptions = {
+  maxBytes?: number;
+};
+
+export type AgentStackFixtureCase = {
+  description: string;
+  corpus: unknown;
+  expectedValid: boolean;
+  expectedErrorCodes: AgentStackFixtureValidationErrorCode[];
+};
+
+const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
+const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
+const SECRET_KEY_PATTERN = /(^|[_-])(api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret|authorization|bearer|cookie|password|secret|seed|session[_-]?token|signature|sig|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
+const SECRET_VALUE_PATTERN = /(authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/i;
+
+function error(
+  code: AgentStackFixtureValidationErrorCode,
+  path: string,
+  message: string,
+): AgentStackFixtureValidationError {
+  return { code, path, message };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function byteLength(value: unknown): number | undefined {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).length;
+  } catch {
+    return undefined;
+  }
+}
+
+function findCredentialMaterial(value: unknown, path = '$'): string | undefined {
+  if (typeof value === 'string') return SECRET_VALUE_PATTERN.test(value) ? path : undefined;
+  if (!value || typeof value !== 'object') return undefined;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`;
+    if (SECRET_KEY_PATTERN.test(key)) return childPath;
+    const found = findCredentialMaterial(child, childPath);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function validateSafeUrl(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (!isNonEmptyString(value)) {
+    errors.push(error('invalid_source_reference', path, 'source URL must be a non-empty string'));
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    errors.push(error('invalid_source_reference', path, 'source URL must be a valid URL'));
+    return;
+  }
+
+  if (parsed.protocol !== 'https:') {
+    errors.push(error('unsafe_url', path, 'source URL must use HTTPS'));
+  }
+  if (parsed.username || parsed.password) {
+    errors.push(error('unsafe_url', path, 'source URL must not embed credentials'));
+  }
+  for (const key of parsed.searchParams.keys()) {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      errors.push(error('credential_leakage_rejected', `${path}.${key}`, 'source URL must not include credential-shaped query keys'));
+    }
+  }
+  for (const queryValue of parsed.searchParams.values()) {
+    if (SECRET_VALUE_PATTERN.test(queryValue)) {
+      errors.push(error('credential_leakage_rejected', path, 'source URL must not include credential-shaped query values'));
+    }
+  }
+}
+
+function validateTimestamp(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (!isNonEmptyString(value) || Number.isNaN(Date.parse(value))) {
+    errors.push(error('invalid_timestamp', path, 'crawlTimestamp must be an ISO timestamp'));
+  }
+}
+
+function validateStringArray(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (!isStringArray(value) || value.length === 0 || value.some((item) => !item.trim())) {
+    errors.push(error('malformed_fixture_corpus', path, 'field must be a non-empty string array'));
+  }
+}
+
+function validatePath(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (!isNonEmptyString(value) || !SAFE_PATH_PATTERN.test(value)) {
+    errors.push(error('invalid_source_reference', path, 'path must be a safe static source path'));
+  }
+}
+
+function validateSurface(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (!isPlainObject(value)) {
+    errors.push(error('malformed_fixture_corpus', path, 'surface must be an object'));
+    return;
+  }
+  for (const key of ['id', 'name', 'kind', 'path'] as const) {
+    if (!isNonEmptyString(value[key])) {
+      errors.push(error('malformed_fixture_corpus', `${path}.${key}`, 'surface field must be a non-empty string'));
+    }
+  }
+  validatePath(value.path, `${path}.path`, errors);
+  if (!['untrusted_public_text', 'metadata_only'].includes(String(value.contentTrustBoundary))) {
+    errors.push(error('malformed_fixture_corpus', `${path}.contentTrustBoundary`, 'surface must declare its content trust boundary'));
+  }
+}
+
+function validateFile(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (!isPlainObject(value)) {
+    errors.push(error('malformed_fixture_corpus', path, 'file entry must be an object'));
+    return;
+  }
+  validatePath(value.path, `${path}.path`, errors);
+  if (!isNonEmptyString(value.kind)) {
+    errors.push(error('malformed_fixture_corpus', `${path}.kind`, 'file kind must be a non-empty string'));
+  }
+  if (typeof value.present !== 'boolean') {
+    errors.push(error('malformed_fixture_corpus', `${path}.present`, 'file present must be a boolean'));
+  }
+  if (!['valid', 'malformed', 'not_parsed', 'missing'].includes(String(value.parseStatus))) {
+    errors.push(error('malformed_fixture_corpus', `${path}.parseStatus`, 'file parseStatus is unsupported'));
+  }
+}
+
+export function validateAgentStackFixtureCorpus(
+  input: unknown,
+  options: AgentStackFixtureValidationOptions = {},
+): AgentStackFixtureValidationResult {
+  const maxBytes = options.maxBytes ?? 96_000;
+  const errors: AgentStackFixtureValidationError[] = [];
+
+  if (!isPlainObject(input)) {
+    return { ok: false, errors: [error('malformed_fixture_corpus', '$', 'agent-stack fixture corpus must be a plain object')] };
+  }
+
+  const size = byteLength(input);
+  if (size === undefined) {
+    return { ok: false, errors: [error('malformed_fixture_corpus', '$', 'fixture corpus must be JSON-serializable')] };
+  }
+  if (size > maxBytes) {
+    return { ok: false, errors: [error('corpus_too_large', '$', `fixture corpus exceeds ${maxBytes} bytes`)] };
+  }
+
+  const credentialPath = findCredentialMaterial(input);
+  if (credentialPath) {
+    return {
+      ok: false,
+      errors: [error('credential_leakage_rejected', credentialPath, 'fixture corpus must not contain credential-shaped material')],
+    };
+  }
+
+  if (input.schemaVersion !== AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION) {
+    errors.push(error('malformed_fixture_corpus', '$.schemaVersion', `expected ${AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION}`));
+  }
+  if (!isNonEmptyString(input.id)) errors.push(error('malformed_fixture_corpus', '$.id', 'id must be a non-empty string'));
+  if (!isNonEmptyString(input.title)) errors.push(error('malformed_fixture_corpus', '$.title', 'title must be a non-empty string'));
+  if (input.staticOnly !== true) errors.push(error('malformed_fixture_corpus', '$.staticOnly', 'fixture corpus must be staticOnly=true'));
+  validateStringArray(input.nonGoals, '$.nonGoals', errors);
+
+  if (!isPlainObject(input.source)) {
+    errors.push(error('malformed_fixture_corpus', '$.source', 'source must be an object'));
+  } else {
+    validateSafeUrl(input.source.sourceUrl, '$.source.sourceUrl', errors);
+    if (!isNonEmptyString(input.source.checkedCommit) || !COMMIT_SHA_PATTERN.test(input.source.checkedCommit)) {
+      errors.push(error('invalid_commit_ref', '$.source.checkedCommit', 'checkedCommit must be a 40-character commit SHA'));
+    }
+    validateStringArray(input.source.sourceNotes, '$.source.sourceNotes', errors);
+    validateStringArray(input.source.authenticityNotes, '$.source.authenticityNotes', errors);
+    validateTimestamp(input.source.crawlTimestamp, '$.source.crawlTimestamp', errors);
+    if (input.source.localResearchArtifactPath !== undefined) {
+      validatePath(input.source.localResearchArtifactPath, '$.source.localResearchArtifactPath', errors);
+    }
+  }
+
+  if (!Array.isArray(input.surfaces) || input.surfaces.length === 0) {
+    errors.push(error('malformed_fixture_corpus', '$.surfaces', 'surfaces must be a non-empty array'));
+  } else {
+    input.surfaces.forEach((surface, index) => validateSurface(surface, `$.surfaces[${index}]`, errors));
+  }
+
+  if (!Array.isArray(input.files) || input.files.length === 0) {
+    errors.push(error('malformed_fixture_corpus', '$.files', 'files must be a non-empty array'));
+  } else {
+    input.files.forEach((file, index) => validateFile(file, `$.files[${index}]`, errors));
+  }
+
+  if (!Array.isArray(input.validationWarnings)) {
+    errors.push(error('malformed_fixture_corpus', '$.validationWarnings', 'validationWarnings must be an array'));
+  }
+
+  return errors.length === 0
+    ? {
+      ok: true,
+      corpus: input as AgentStackFixtureCorpus,
+      warnings: (input as AgentStackFixtureCorpus).validationWarnings,
+    }
+    : { ok: false, errors };
+}
+
+export function createAgentStackFixtureCorpus(input: unknown, options: AgentStackFixtureValidationOptions = {}): AgentStackFixtureCorpus {
+  const result = validateAgentStackFixtureCorpus(input, options);
+  if (!result.ok) {
+    throw new Error(`invalid_agent_stack_fixture_corpus:${result.errors.map((item) => item.code).join(',')}`);
+  }
+  return result.corpus;
+}
+
+export const agentStackFixtureCorpora = {
+  anthropicFinancialServices: {
+    schemaVersion: AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION,
+    id: 'agent-stack-fixture:anthropic-financial-services:2026-06-18',
+    title: 'Anthropic financial-services agent stack public fixture',
+    source: {
+      sourceUrl: 'https://github.com/anthropics/financial-services',
+      checkedCommit: '4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1',
+      checkedRef: 'main',
+      license: 'Apache-2.0',
+      sourceNotes: [
+        'Public GitHub repository snapshot only; fixture does not install plugins or execute repository commands.',
+        'Fixture records high-level manifest surfaces for onboarding analyser parser and diagnostics tests.',
+      ],
+      authenticityNotes: [
+        'GitHub organization was verified for anthropic.com during local analysis.',
+        'Anthropic public financial-services announcement linked to the repository during local analysis.',
+        'Latest inspected main commit was GitHub-signature verified in the local analysis artifact.',
+      ],
+      crawlTimestamp: '2026-06-18T10:50:00.000Z',
+      localResearchArtifactPath: 'projects/reddi-agent-protocol/research/ANTHROPIC-FINANCIAL-SERVICES-REPO-ANALYSIS-2026-06-18.md',
+    },
+    surfaces: [
+      {
+        id: 'surface:anthropic-financial-services:marketplace',
+        name: 'Claude plugin marketplace metadata',
+        kind: 'repo-marketplace-metadata',
+        path: '.claude-plugin/marketplace.json',
+        runtimeSurface: 'claude-plugin-marketplace',
+        category: 'financial-services',
+        contentTrustBoundary: 'metadata_only',
+        notes: ['Marketplace metadata is source metadata, not RAP publication approval.'],
+      },
+      {
+        id: 'surface:anthropic-financial-services:plugins',
+        name: 'Financial services Claude plugins',
+        kind: 'claude-plugin',
+        path: 'plugins/',
+        runtimeSurface: 'claude-code-plugin',
+        commands: ['statically discovered command metadata pending #403 parser'],
+        skills: ['statically discovered skill metadata pending #403 parser'],
+        toolGrants: ['read', 'write-capable grants must be parsed and reviewed before publication'],
+        safetyHints: ['Treat plugin prompts and skills as untrusted public text.'],
+        humanReviewHints: ['Review write-capable commands before draft RAP listing publication.'],
+        writeCapable: true,
+        contentTrustBoundary: 'untrusted_public_text',
+      },
+      {
+        id: 'surface:anthropic-financial-services:managed-agents',
+        name: 'Claude managed-agent cookbooks',
+        kind: 'managed-agent-cookbook',
+        path: 'managed-agents/',
+        runtimeSurface: 'claude-managed-agent',
+        authDependencies: ['third-party connector credentials may be required by recipes'],
+        dataDependencies: ['financial workspace documents', 'Microsoft 365 or partner data sources'],
+        safetyHints: ['Managed-agent YAML is static input only until #403/#405 produce reviewable inventories.'],
+        humanReviewHints: ['Operator review is required before imported recipes become payable listings.'],
+        contentTrustBoundary: 'untrusted_public_text',
+      },
+      {
+        id: 'surface:anthropic-financial-services:mcp-connectors',
+        name: 'MCP connector configurations',
+        kind: 'mcp-connector-config',
+        path: 'plugins/vertical-plugins/financial-analysis/.mcp.json',
+        runtimeSurface: 'mcp-connector-config',
+        authDependencies: ['box', 'egnyte', 'microsoft-365', 'partner connectors'],
+        safetyHints: ['Connector config validation is static only and must not contact MCP servers.'],
+        humanReviewHints: ['Malformed connector config should block only affected connector readiness, not unrelated metadata ingestion.'],
+        contentTrustBoundary: 'metadata_only',
+      },
+      {
+        id: 'surface:anthropic-financial-services:known-warning',
+        name: 'Known malformed financial-analysis MCP config',
+        kind: 'validation-warning',
+        path: 'plugins/vertical-plugins/financial-analysis/.mcp.json',
+        safetyHints: ['Known invalid JSON is preserved as a regression fixture for #404.'],
+        contentTrustBoundary: 'metadata_only',
+      },
+    ],
+    files: [
+      {
+        path: '.claude-plugin/marketplace.json',
+        kind: 'repo-marketplace-metadata',
+        present: true,
+        parseStatus: 'not_parsed',
+        mediaType: 'application/json',
+        summary: 'Repository-level marketplace metadata for Claude plugin distribution.',
+      },
+      {
+        path: 'plugins/**/plugin.json',
+        kind: 'claude-plugin',
+        present: true,
+        parseStatus: 'not_parsed',
+        mediaType: 'application/json',
+        summary: 'Plugin manifests for horizontal, vertical, and partner packages.',
+      },
+      {
+        path: 'managed-agents/**/agent.yaml',
+        kind: 'managed-agent-cookbook',
+        present: true,
+        parseStatus: 'not_parsed',
+        mediaType: 'application/yaml',
+        summary: 'Managed-agent cookbook metadata; parser support belongs to #403.',
+      },
+      {
+        path: 'plugins/vertical-plugins/financial-analysis/.mcp.json',
+        kind: 'mcp-connector-config',
+        present: true,
+        parseStatus: 'malformed',
+        mediaType: 'application/json',
+        warningCodes: ['malformed_mcp_json'],
+        summary: 'Known malformed connector manifest from local analysis; full diagnostics belong to #404.',
+      },
+    ],
+    validationWarnings: [
+      {
+        code: 'malformed_mcp_json',
+        severity: 'warning',
+        path: 'plugins/vertical-plugins/financial-analysis/.mcp.json',
+        message: 'Known malformed JSON should fail closed for connector diagnostics while preserving partial static ingestion.',
+      },
+      {
+        code: 'untrusted_prompt_text',
+        severity: 'info',
+        path: 'plugins/',
+        message: 'Public prompt, skill, and command text is untrusted fixture content and cannot alter analyser behavior.',
+      },
+    ],
+    staticOnly: true,
+    nonGoals: [
+      'Do not install Claude plugins.',
+      'Do not execute repository scripts, commands, managed agents, or MCP servers.',
+      'Do not fetch paid/provider data or require credentials.',
+      'Do not publish imported surfaces as payable RAP listings without operator review.',
+    ],
+  },
+} as const satisfies Record<string, AgentStackFixtureCorpus>;
+
+export const agentStackFixtureCases: Record<string, AgentStackFixtureCase> = {
+  anthropicFinancialServices: {
+    description: 'Valid public Anthropic financial-services agent-stack fixture corpus.',
+    corpus: agentStackFixtureCorpora.anthropicFinancialServices,
+    expectedValid: true,
+    expectedErrorCodes: [],
+  },
+  malformedCorpus: {
+    description: 'Missing source, files, and surfaces fails closed.',
+    corpus: {
+      schemaVersion: AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION,
+      id: 'agent-stack-fixture:malformed',
+      title: 'Malformed fixture',
+      staticOnly: true,
+      nonGoals: ['no execution'],
+    },
+    expectedValid: false,
+    expectedErrorCodes: ['malformed_fixture_corpus'],
+  },
+  invalidCommit: {
+    description: 'Fixture source must include an exact checked commit SHA.',
+    corpus: {
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      source: {
+        ...agentStackFixtureCorpora.anthropicFinancialServices.source,
+        checkedCommit: 'main',
+      },
+    },
+    expectedValid: false,
+    expectedErrorCodes: ['invalid_commit_ref'],
+  },
+  unsafeSourceUrl: {
+    description: 'Fixture source URL must be HTTPS without embedded credentials.',
+    corpus: {
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      source: {
+        ...agentStackFixtureCorpora.anthropicFinancialServices.source,
+        sourceUrl: 'http://github.com/anthropics/financial-services',
+      },
+    },
+    expectedValid: false,
+    expectedErrorCodes: ['unsafe_url'],
+  },
+  credentialLeakage: {
+    description: 'Credential-shaped metadata is rejected before fixture persistence.',
+    corpus: {
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      surfaces: [
+        ...agentStackFixtureCorpora.anthropicFinancialServices.surfaces,
+        {
+          id: 'surface:leaky',
+          name: 'Leaky Connector',
+          kind: 'mcp-connector-config',
+          path: 'plugins/leaky/.mcp.json',
+          contentTrustBoundary: 'metadata_only',
+          notes: ['authorization: bearer should-not-be-stored'],
+        },
+      ],
+    },
+    expectedValid: false,
+    expectedErrorCodes: ['credential_leakage_rejected'],
+  },
+};

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -224,6 +224,24 @@ function validateStringArray(value: unknown, path: string, errors: AgentStackFix
   }
 }
 
+function validateOptionalString(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (value !== undefined && !isNonEmptyString(value)) {
+    errors.push(error('malformed_fixture_corpus', path, 'field must be a non-empty string when present'));
+  }
+}
+
+function validateOptionalStringArray(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (value !== undefined && (!isStringArray(value) || value.some((item) => !item.trim()))) {
+    errors.push(error('malformed_fixture_corpus', path, 'field must be a string array when present'));
+  }
+}
+
+function validateOptionalBoolean(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
+  if (value !== undefined && typeof value !== 'boolean') {
+    errors.push(error('malformed_fixture_corpus', path, 'field must be a boolean when present'));
+  }
+}
+
 function validatePath(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
   if (!isNonEmptyString(value) || !SAFE_PATH_PATTERN.test(value)) {
     errors.push(error('invalid_source_reference', path, 'path must be a safe static source path'));
@@ -265,6 +283,17 @@ function validateSurface(value: unknown, path: string, errors: AgentStackFixture
   if (!['untrusted_public_text', 'metadata_only'].includes(String(value.contentTrustBoundary))) {
     errors.push(error('malformed_fixture_corpus', `${path}.contentTrustBoundary`, 'surface must declare its content trust boundary'));
   }
+  validateOptionalString(value.category, `${path}.category`, errors);
+  validateOptionalString(value.runtimeSurface, `${path}.runtimeSurface`, errors);
+  validateOptionalStringArray(value.commands, `${path}.commands`, errors);
+  validateOptionalStringArray(value.skills, `${path}.skills`, errors);
+  validateOptionalStringArray(value.toolGrants, `${path}.toolGrants`, errors);
+  validateOptionalStringArray(value.authDependencies, `${path}.authDependencies`, errors);
+  validateOptionalStringArray(value.dataDependencies, `${path}.dataDependencies`, errors);
+  validateOptionalStringArray(value.safetyHints, `${path}.safetyHints`, errors);
+  validateOptionalStringArray(value.humanReviewHints, `${path}.humanReviewHints`, errors);
+  validateOptionalBoolean(value.writeCapable, `${path}.writeCapable`, errors);
+  validateOptionalStringArray(value.notes, `${path}.notes`, errors);
 }
 
 function validateFile(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
@@ -284,6 +313,9 @@ function validateFile(value: unknown, path: string, errors: AgentStackFixtureVal
   if (!['valid', 'malformed', 'not_parsed', 'missing'].includes(String(value.parseStatus))) {
     errors.push(error('malformed_fixture_corpus', `${path}.parseStatus`, 'file parseStatus is unsupported'));
   }
+  validateOptionalString(value.mediaType, `${path}.mediaType`, errors);
+  validateOptionalString(value.summary, `${path}.summary`, errors);
+  validateOptionalStringArray(value.warningCodes, `${path}.warningCodes`, errors);
 }
 
 function validateWarning(value: unknown, path: string, errors: AgentStackFixtureValidationError[]): void {
@@ -345,6 +377,8 @@ export function validateAgentStackFixtureCorpus(
     if (!isNonEmptyString(input.source.checkedCommit) || !COMMIT_SHA_PATTERN.test(input.source.checkedCommit)) {
       errors.push(error('invalid_commit_ref', '$.source.checkedCommit', 'checkedCommit must be a 40-character commit SHA'));
     }
+    validateOptionalString(input.source.checkedRef, '$.source.checkedRef', errors);
+    validateOptionalString(input.source.license, '$.source.license', errors);
     validateStringArray(input.source.sourceNotes, '$.source.sourceNotes', errors);
     validateStringArray(input.source.authenticityNotes, '$.source.authenticityNotes', errors);
     validateTimestamp(input.source.crawlTimestamp, '$.source.crawlTimestamp', errors);

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -9,3 +9,4 @@ export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
+export * from './agent-stack-fixtures.js';

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -199,4 +199,47 @@ describe('agent-stack fixture corpus', () => {
       assert.ok(unsafePaths.errors.some((item) => item.path === '$.validationWarnings[0].path'));
     }
   });
+
+  it('rejects malformed optional typed fields before returning a typed corpus', () => {
+    const malformedOptionals = validateAgentStackFixtureCorpus({
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      source: {
+        ...agentStackFixtureCorpora.anthropicFinancialServices.source,
+        checkedRef: 123,
+        license: ['Apache-2.0'],
+      },
+      surfaces: [
+        {
+          ...agentStackFixtureCorpora.anthropicFinancialServices.surfaces[1],
+          commands: [42],
+          writeCapable: 'yes',
+          notes: [false],
+        },
+      ],
+      files: [
+        {
+          ...agentStackFixtureCorpora.anthropicFinancialServices.files[0],
+          mediaType: {},
+          summary: [],
+          warningCodes: [1],
+        },
+      ],
+    });
+
+    assert.equal(malformedOptionals.ok, false);
+    if (!malformedOptionals.ok) {
+      for (const path of [
+        '$.source.checkedRef',
+        '$.source.license',
+        '$.surfaces[0].commands',
+        '$.surfaces[0].writeCapable',
+        '$.surfaces[0].notes',
+        '$.files[0].mediaType',
+        '$.files[0].summary',
+        '$.files[0].warningCodes',
+      ]) {
+        assert.ok(malformedOptionals.errors.some((item) => item.path === path), `${path} should fail validation`);
+      }
+    }
+  });
 });

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -168,4 +168,35 @@ describe('agent-stack fixture corpus', () => {
       assert.ok(malformedWarning.errors.some((item) => item.path === '$.validationWarnings[0].message'));
     }
   });
+
+  it('rejects absolute URI and drive-style fixture paths', () => {
+    const unsafePaths = validateAgentStackFixtureCorpus({
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      surfaces: [
+        {
+          ...agentStackFixtureCorpora.anthropicFinancialServices.surfaces[0],
+          path: '/etc/passwd',
+        },
+      ],
+      files: [
+        {
+          ...agentStackFixtureCorpora.anthropicFinancialServices.files[0],
+          path: 'file:/etc/passwd',
+        },
+      ],
+      validationWarnings: [
+        {
+          ...agentStackFixtureCorpora.anthropicFinancialServices.validationWarnings[0],
+          path: 'C:/Users/loki/secret',
+        },
+      ],
+    });
+
+    assert.equal(unsafePaths.ok, false);
+    if (!unsafePaths.ok) {
+      assert.ok(unsafePaths.errors.some((item) => item.path === '$.surfaces[0].path'));
+      assert.ok(unsafePaths.errors.some((item) => item.path === '$.files[0].path'));
+      assert.ok(unsafePaths.errors.some((item) => item.path === '$.validationWarnings[0].path'));
+    }
+  });
 });

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  agentStackFixtureCases,
+  agentStackFixtureCorpora,
+  createAgentStackFixtureCorpus,
+  validateAgentStackFixtureCorpus,
+  type AgentStackFixtureValidationErrorCode,
+} from '../dist/index.js';
+
+function assertErrorCodes(
+  actual: AgentStackFixtureValidationErrorCode[],
+  expected: AgentStackFixtureValidationErrorCode[],
+): void {
+  for (const code of expected) {
+    assert.ok(actual.includes(code), `expected validation errors to include ${code}`);
+  }
+}
+
+describe('agent-stack fixture corpus', () => {
+  it('validates fixture-backed corpus cases with expected outcomes', () => {
+    const expectedCases = [
+      'anthropicFinancialServices',
+      'malformedCorpus',
+      'invalidCommit',
+      'unsafeSourceUrl',
+      'credentialLeakage',
+    ];
+
+    assert.deepEqual(Object.keys(agentStackFixtureCases).sort(), expectedCases.sort());
+    for (const fixture of Object.values(agentStackFixtureCases)) {
+      const result = validateAgentStackFixtureCorpus(fixture.corpus);
+      assert.equal(result.ok, fixture.expectedValid, fixture.description);
+      if (!result.ok) {
+        assertErrorCodes(result.errors.map((item) => item.code), fixture.expectedErrorCodes);
+      }
+    }
+  });
+
+  it('records public source provenance for the Anthropic financial-services fixture', () => {
+    const result = validateAgentStackFixtureCorpus(agentStackFixtureCorpora.anthropicFinancialServices);
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.corpus.schemaVersion, 'reddi.agent-stack-fixture-corpus.v1');
+      assert.equal(result.corpus.source.sourceUrl, 'https://github.com/anthropics/financial-services');
+      assert.equal(result.corpus.source.checkedCommit, '4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1');
+      assert.equal(
+        result.corpus.source.localResearchArtifactPath,
+        'projects/reddi-agent-protocol/research/ANTHROPIC-FINANCIAL-SERVICES-REPO-ANALYSIS-2026-06-18.md',
+      );
+      assert.equal(result.corpus.source.license, 'Apache-2.0');
+      assert.ok(result.corpus.source.authenticityNotes.some((note) => note.includes('anthropic.com')));
+      assert.equal(result.corpus.staticOnly, true);
+    }
+  });
+
+  it('can represent marketplace, plugin, managed-agent, MCP, and validation warning surfaces', () => {
+    const corpus = createAgentStackFixtureCorpus(agentStackFixtureCorpora.anthropicFinancialServices);
+    const surfaceKinds = new Set(corpus.surfaces.map((surface) => surface.kind));
+    const fileKinds = new Set(corpus.files.map((file) => file.kind));
+
+    assert.ok(surfaceKinds.has('repo-marketplace-metadata'));
+    assert.ok(surfaceKinds.has('claude-plugin'));
+    assert.ok(surfaceKinds.has('managed-agent-cookbook'));
+    assert.ok(surfaceKinds.has('mcp-connector-config'));
+    assert.ok(surfaceKinds.has('validation-warning'));
+    assert.ok(fileKinds.has('repo-marketplace-metadata'));
+    assert.ok(fileKinds.has('claude-plugin'));
+    assert.ok(fileKinds.has('managed-agent-cookbook'));
+    assert.ok(fileKinds.has('mcp-connector-config'));
+  });
+
+  it('preserves the known malformed MCP config as a static warning without blocking unrelated surfaces', () => {
+    const corpus = createAgentStackFixtureCorpus(agentStackFixtureCorpora.anthropicFinancialServices);
+    const malformedFile = corpus.files.find((file) => file.path === 'plugins/vertical-plugins/financial-analysis/.mcp.json');
+    const pluginSurface = corpus.surfaces.find((surface) => surface.kind === 'claude-plugin');
+
+    assert.equal(malformedFile?.parseStatus, 'malformed');
+    assert.deepEqual(malformedFile?.warningCodes, ['malformed_mcp_json']);
+    assert.equal(pluginSurface?.path, 'plugins/');
+    assert.equal(corpus.validationWarnings[0].code, 'malformed_mcp_json');
+  });
+
+  it('marks public prompt, skill, command, and recipe text as untrusted static content', () => {
+    const corpus = createAgentStackFixtureCorpus(agentStackFixtureCorpora.anthropicFinancialServices);
+    const textBearingSurfaces = corpus.surfaces.filter((surface) => (
+      surface.kind === 'claude-plugin' || surface.kind === 'managed-agent-cookbook'
+    ));
+
+    assert.ok(textBearingSurfaces.length >= 2);
+    for (const surface of textBearingSurfaces) {
+      assert.equal(surface.contentTrustBoundary, 'untrusted_public_text');
+    }
+    assert.ok(corpus.validationWarnings.some((warning) => warning.code === 'untrusted_prompt_text'));
+  });
+
+  it('documents static-only non-goals so tests never imply install, execution, paid calls, or credentials', () => {
+    const corpus = createAgentStackFixtureCorpus(agentStackFixtureCorpora.anthropicFinancialServices);
+    const nonGoals = corpus.nonGoals.join(' ');
+
+    assert.match(nonGoals, /Do not install Claude plugins/);
+    assert.match(nonGoals, /Do not execute repository scripts/);
+    assert.match(nonGoals, /Do not fetch paid\/provider data or require credentials/);
+    assert.match(nonGoals, /Do not publish imported surfaces as payable RAP listings/);
+  });
+
+  it('rejects oversized or non-serializable fixture corpora before persistence', () => {
+    const oversized = validateAgentStackFixtureCorpus(agentStackFixtureCorpora.anthropicFinancialServices, { maxBytes: 16 });
+    assert.equal(oversized.ok, false);
+    if (!oversized.ok) {
+      assert.ok(oversized.errors.some((item) => item.code === 'corpus_too_large'));
+    }
+
+    const circular: Record<string, unknown> = {
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+    };
+    circular.self = circular;
+    const nonSerializable = validateAgentStackFixtureCorpus(circular);
+    assert.equal(nonSerializable.ok, false);
+    if (!nonSerializable.ok) {
+      assert.ok(nonSerializable.errors.some((item) => item.code === 'malformed_fixture_corpus'));
+    }
+  });
+});

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -122,4 +122,50 @@ describe('agent-stack fixture corpus', () => {
       assert.ok(nonSerializable.errors.some((item) => item.code === 'malformed_fixture_corpus'));
     }
   });
+
+  it('rejects unsupported surface and file kinds at runtime', () => {
+    const unsupportedKinds = validateAgentStackFixtureCorpus({
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      surfaces: [
+        {
+          ...agentStackFixtureCorpora.anthropicFinancialServices.surfaces[0],
+          kind: 'wallet-payment-executor',
+        },
+      ],
+      files: [
+        {
+          ...agentStackFixtureCorpora.anthropicFinancialServices.files[0],
+          kind: 'network-installer',
+        },
+      ],
+    });
+
+    assert.equal(unsupportedKinds.ok, false);
+    if (!unsupportedKinds.ok) {
+      assert.ok(unsupportedKinds.errors.some((item) => item.path === '$.surfaces[0].kind'));
+      assert.ok(unsupportedKinds.errors.some((item) => item.path === '$.files[0].kind'));
+    }
+  });
+
+  it('rejects malformed validation warning entries before exposing typed warnings', () => {
+    const malformedWarning = validateAgentStackFixtureCorpus({
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      validationWarnings: [
+        {
+          code: '',
+          severity: 'approved',
+          path: '../escape',
+          message: '',
+        },
+      ],
+    });
+
+    assert.equal(malformedWarning.ok, false);
+    if (!malformedWarning.ok) {
+      assert.ok(malformedWarning.errors.some((item) => item.path === '$.validationWarnings[0].code'));
+      assert.ok(malformedWarning.errors.some((item) => item.path === '$.validationWarnings[0].severity'));
+      assert.ok(malformedWarning.errors.some((item) => item.path === '$.validationWarnings[0].path'));
+      assert.ok(malformedWarning.errors.some((item) => item.path === '$.validationWarnings[0].message'));
+    }
+  });
 });

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -242,4 +242,21 @@ describe('agent-stack fixture corpus', () => {
       }
     }
   });
+
+  it('rejects loose or normalized-invalid crawl timestamps', () => {
+    for (const crawlTimestamp of ['June 18, 2026 10:50', '2026', '2026-02-30T00:00:00Z']) {
+      const malformedTimestamp = validateAgentStackFixtureCorpus({
+        ...agentStackFixtureCorpora.anthropicFinancialServices,
+        source: {
+          ...agentStackFixtureCorpora.anthropicFinancialServices.source,
+          crawlTimestamp,
+        },
+      });
+
+      assert.equal(malformedTimestamp.ok, false, `${crawlTimestamp} should fail`);
+      if (!malformedTimestamp.ok) {
+        assert.ok(malformedTimestamp.errors.some((item) => item.path === '$.source.crawlTimestamp'));
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `reddi.agent-stack-fixture-corpus.v1` types, validation, fixtures, and `@reddi/agent-protocol/agent-stack-fixtures` export.
- Adds the Anthropic financial-services public fixture corpus with source URL, checked commit `4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1`, license/source notes, authenticity notes, crawl timestamp, local research artifact path, static surfaces, file entries, and validation warnings.
- Documents that fixture corpora are static inputs only and do not install plugins, execute repo scripts, invoke managed agents, contact MCP servers, fetch paid/provider data, require credentials, or publish payable listings.

## Validation
- `npm test` in `packages/agent-protocol` passed with 77 tests.
- `npm run release:dry-run` in `packages/agent-protocol` passed and packed `dist/agent-stack-fixtures.*`.
- Root `npm run check:rap:naming` passed.
- `git diff --check` passed.

## Guardrails
- No network fetch, plugin install, repo command execution, managed-agent invocation, MCP server contact, paid provider call, wallet/RPC/SPL transfer, or Quasar/on-chain behavior.
- Public prompt/skill/command/recipe content is labelled as untrusted fixture text.
- Known malformed `.mcp.json` is preserved as a static warning for #404 rather than parsed or executed.

Closes #402.