### PR TITLE
Add static ingestion result envelope

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -61,17 +61,22 @@ Catalog ingestion never performs network fetches, paid invocations, wallet actio
 import {
   agentStackFixtureCorpora,
   createAgentStackFixtureCorpus,
+  createStaticAgentStackIngestionResult,
 } from '@reddi/agent-protocol/agent-stack-fixtures';
 
 const corpus = createAgentStackFixtureCorpus(agentStackFixtureCorpora.anthropicFinancialServices);
+const result = createStaticAgentStackIngestionResult(corpus);
 
 console.log(corpus.source.checkedCommit); // 4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1
 console.log(corpus.files.some((file) => file.parseStatus === 'malformed')); // true
+console.log(result.status); // blocked until malformed connector diagnostics are handled
 ```
 
 Agent-stack fixture corpora are public, static inputs for onboarding-analyser parser and diagnostics work. The built-in Anthropic financial-services fixture records source URL, checked commit, license/source notes, authenticity notes, crawl timestamp, local research artifact path, high-level marketplace/plugin/managed-agent/MCP surfaces, and validation warnings.
 
 Fixture ingestion rejects credential-shaped metadata, unsafe source URLs, invalid commit refs, invalid timestamps, oversized corpora, and malformed corpus shapes. Public prompt, skill, command, and recipe text is always labelled as untrusted fixture content.
+
+Static ingestion results are deterministic handoff envelopes for later parser, connector-diagnostics, draft-profile, and operator-review work. They combine fixture source metadata, normalized inventory entries, connector diagnostics, rejected entries, validation warnings, and draft-payload readiness without fetching the network or executing imported code.
 
 The fixture corpus never installs Claude plugins, executes repo scripts, invokes managed agents, contacts MCP servers, fetches paid/provider data, requires credentials, or publishes imported surfaces as payable RAP listings. Parser, connector-diagnostics, draft-profile, and operator-review behavior land in later RAP slices.
 

--- a/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
@@ -1,4 +1,5 @@
 export declare const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION: "reddi.agent-stack-fixture-corpus.v1";
+export declare const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION: "reddi.static-agent-stack-ingestion-result.v1";
 export type AgentStackFixtureSurfaceKind = 'repo-marketplace-metadata' | 'claude-plugin' | 'managed-agent-cookbook' | 'mcp-connector-config' | 'skill' | 'command' | 'subagent' | 'partner-plugin' | 'vertical-plugin' | 'validation-warning';
 export type AgentStackFixtureValidationErrorCode = 'malformed_fixture_corpus' | 'invalid_source_reference' | 'credential_leakage_rejected' | 'invalid_commit_ref' | 'invalid_timestamp' | 'unsafe_url' | 'corpus_too_large';
 export type AgentStackFixtureValidationError = {
@@ -79,8 +80,58 @@ export type AgentStackFixtureCase = {
     expectedValid: boolean;
     expectedErrorCodes: AgentStackFixtureValidationErrorCode[];
 };
+export type StaticAgentStackIngestionStatus = 'ready_for_draft' | 'partial_success' | 'blocked';
+export type StaticAgentStackInventoryEntry = {
+    id: string;
+    name: string;
+    kind: AgentStackFixtureSurfaceKind;
+    sourcePath: string;
+    runtimeSurface?: string;
+    category?: string;
+    commands: string[];
+    skills: string[];
+    toolGrants: string[];
+    authDependencies: string[];
+    dataDependencies: string[];
+    safetyHints: string[];
+    humanReviewHints: string[];
+    writeCapable: boolean;
+    contentTrustBoundary: AgentStackFixtureSurface['contentTrustBoundary'];
+};
+export type StaticAgentStackConnectorDiagnostic = {
+    path: string;
+    parseStatus: AgentStackFixtureFile['parseStatus'];
+    severity: AgentStackFixtureValidationWarning['severity'];
+    warningCodes: string[];
+    message: string;
+};
+export type StaticAgentStackRejectedEntry = {
+    path: string;
+    reasonCode: string;
+    message: string;
+};
+export type StaticAgentStackDraftPayloadReadiness = {
+    status: 'ready' | 'needs_review' | 'blocked';
+    blockers: string[];
+    payloadRefs: string[];
+};
+export type StaticAgentStackIngestionResult = {
+    schemaVersion: typeof STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION;
+    corpusId: string;
+    title: string;
+    source: AgentStackFixtureSource;
+    status: StaticAgentStackIngestionStatus;
+    inventory: StaticAgentStackInventoryEntry[];
+    connectorDiagnostics: StaticAgentStackConnectorDiagnostic[];
+    rejectedEntries: StaticAgentStackRejectedEntry[];
+    warnings: AgentStackFixtureValidationWarning[];
+    draftPayloadReadiness: StaticAgentStackDraftPayloadReadiness;
+    staticOnly: true;
+    nonGoals: string[];
+};
 export declare function validateAgentStackFixtureCorpus(input: unknown, options?: AgentStackFixtureValidationOptions): AgentStackFixtureValidationResult;
 export declare function createAgentStackFixtureCorpus(input: unknown, options?: AgentStackFixtureValidationOptions): AgentStackFixtureCorpus;
+export declare function createStaticAgentStackIngestionResult(input: unknown, options?: AgentStackFixtureValidationOptions): StaticAgentStackIngestionResult;
 export declare const agentStackFixtureCorpora: {
     readonly anthropicFinancialServices: {
         readonly schemaVersion: "reddi.agent-stack-fixture-corpus.v1";

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -1,4 +1,5 @@
 export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixture-corpus.v1';
+export const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION = 'reddi.static-agent-stack-ingestion-result.v1';
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
 const RFC3339_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
@@ -289,6 +290,106 @@ export function createAgentStackFixtureCorpus(input, options = {}) {
         throw new Error(`invalid_agent_stack_fixture_corpus:${result.errors.map((item) => item.code).join(',')}`);
     }
     return result.corpus;
+}
+function connectorMessage(file, warning) {
+    if (warning?.message)
+        return warning.message;
+    switch (file.parseStatus) {
+        case 'valid':
+            return 'Connector metadata is statically valid.';
+        case 'malformed':
+            return 'Connector metadata is malformed and must be diagnosed before draft publication.';
+        case 'missing':
+            return 'Connector metadata file is missing.';
+        case 'not_parsed':
+        default:
+            return 'Connector metadata is recorded but not parsed yet.';
+    }
+}
+function readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries) {
+    const blockers = [
+        ...rejectedEntries.map((entry) => entry.reasonCode),
+        ...connectorDiagnostics
+            .filter((diagnostic) => diagnostic.parseStatus === 'malformed')
+            .map((diagnostic) => `malformed_connector:${diagnostic.path}`),
+    ];
+    if (blockers.length > 0) {
+        return { status: 'blocked', blockers, payloadRefs: [] };
+    }
+    if (corpus.validationWarnings.length > 0 || connectorDiagnostics.some((diagnostic) => diagnostic.parseStatus !== 'valid')) {
+        return {
+            status: 'needs_review',
+            blockers: ['operator_review_required'],
+            payloadRefs: [],
+        };
+    }
+    return {
+        status: 'ready',
+        blockers: [],
+        payloadRefs: [`static-ingestion:${corpus.id}:draft-profile`, `static-ingestion:${corpus.id}:draft-listing`],
+    };
+}
+export function createStaticAgentStackIngestionResult(input, options = {}) {
+    const corpus = createAgentStackFixtureCorpus(input, options);
+    const warningByPath = new Map(corpus.validationWarnings.map((warning) => [warning.path, warning]));
+    const connectorDiagnostics = corpus.files
+        .filter((file) => file.kind === 'mcp-connector-config')
+        .map((file) => {
+        const warning = warningByPath.get(file.path);
+        return {
+            path: file.path,
+            parseStatus: file.parseStatus,
+            severity: warning?.severity ?? (file.parseStatus === 'valid' ? 'info' : 'warning'),
+            warningCodes: file.warningCodes ?? [],
+            message: connectorMessage(file, warning),
+        };
+    });
+    const rejectedEntries = corpus.validationWarnings
+        .filter((warning) => warning.severity === 'blocked')
+        .map((warning) => ({
+        path: warning.path,
+        reasonCode: warning.code,
+        message: warning.message,
+    }));
+    const inventory = corpus.surfaces
+        .filter((surface) => surface.kind !== 'validation-warning')
+        .map((surface) => ({
+        id: surface.id,
+        name: surface.name,
+        kind: surface.kind,
+        sourcePath: surface.path,
+        runtimeSurface: surface.runtimeSurface,
+        category: surface.category,
+        commands: surface.commands ?? [],
+        skills: surface.skills ?? [],
+        toolGrants: surface.toolGrants ?? [],
+        authDependencies: surface.authDependencies ?? [],
+        dataDependencies: surface.dataDependencies ?? [],
+        safetyHints: surface.safetyHints ?? [],
+        humanReviewHints: surface.humanReviewHints ?? [],
+        writeCapable: surface.writeCapable ?? false,
+        contentTrustBoundary: surface.contentTrustBoundary,
+    }));
+    const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries);
+    const status = rejectedEntries.length > 0
+        ? 'blocked'
+        : draftPayloadReadiness.status !== 'ready'
+            ? 'partial_success'
+            : 'ready_for_draft';
+    return {
+        schemaVersion: STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION,
+        corpusId: corpus.id,
+        title: corpus.title,
+        source: corpus.source,
+        status,
+        inventory,
+        connectorDiagnostics,
+        rejectedEntries,
+        warnings: corpus.validationWarnings,
+        draftPayloadReadiness,
+        staticOnly: true,
+        nonGoals: corpus.nonGoals,
+    };
 }
 export const agentStackFixtureCorpora = {
     anthropicFinancialServices: {

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -312,6 +312,9 @@ function readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries) {
         ...connectorDiagnostics
             .filter((diagnostic) => diagnostic.parseStatus === 'malformed')
             .map((diagnostic) => `malformed_connector:${diagnostic.path}`),
+        ...connectorDiagnostics
+            .filter((diagnostic) => diagnostic.parseStatus === 'missing')
+            .map((diagnostic) => `missing_connector:${diagnostic.path}`),
     ];
     if (blockers.length > 0) {
         return { status: 'blocked', blockers, payloadRefs: [] };
@@ -332,6 +335,9 @@ function readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries) {
 export function createStaticAgentStackIngestionResult(input, options = {}) {
     const corpus = createAgentStackFixtureCorpus(input, options);
     const warningByPath = new Map(corpus.validationWarnings.map((warning) => [warning.path, warning]));
+    const connectorFilesByPath = new Map(corpus.files
+        .filter((file) => file.kind === 'mcp-connector-config')
+        .map((file) => [file.path, file]));
     const connectorDiagnostics = corpus.files
         .filter((file) => file.kind === 'mcp-connector-config')
         .map((file) => {
@@ -343,7 +349,16 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
             warningCodes: file.warningCodes ?? [],
             message: connectorMessage(file, warning),
         };
-    });
+    })
+        .concat(corpus.surfaces
+        .filter((surface) => surface.kind === 'mcp-connector-config' && !connectorFilesByPath.has(surface.path))
+        .map((surface) => ({
+        path: surface.path,
+        parseStatus: 'missing',
+        severity: 'blocked',
+        warningCodes: ['missing_mcp_connector_config'],
+        message: 'MCP connector surface has no matching static connector metadata file.',
+    })));
     const rejectedEntries = corpus.validationWarnings
         .filter((warning) => warning.severity === 'blocked')
         .map((warning) => ({

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -1,4 +1,5 @@
 export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixture-corpus.v1' as const;
+export const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION = 'reddi.static-agent-stack-ingestion-result.v1' as const;
 
 export type AgentStackFixtureSurfaceKind =
   | 'repo-marketplace-metadata'
@@ -110,6 +111,64 @@ export type AgentStackFixtureCase = {
   corpus: unknown;
   expectedValid: boolean;
   expectedErrorCodes: AgentStackFixtureValidationErrorCode[];
+};
+
+export type StaticAgentStackIngestionStatus =
+  | 'ready_for_draft'
+  | 'partial_success'
+  | 'blocked';
+
+export type StaticAgentStackInventoryEntry = {
+  id: string;
+  name: string;
+  kind: AgentStackFixtureSurfaceKind;
+  sourcePath: string;
+  runtimeSurface?: string;
+  category?: string;
+  commands: string[];
+  skills: string[];
+  toolGrants: string[];
+  authDependencies: string[];
+  dataDependencies: string[];
+  safetyHints: string[];
+  humanReviewHints: string[];
+  writeCapable: boolean;
+  contentTrustBoundary: AgentStackFixtureSurface['contentTrustBoundary'];
+};
+
+export type StaticAgentStackConnectorDiagnostic = {
+  path: string;
+  parseStatus: AgentStackFixtureFile['parseStatus'];
+  severity: AgentStackFixtureValidationWarning['severity'];
+  warningCodes: string[];
+  message: string;
+};
+
+export type StaticAgentStackRejectedEntry = {
+  path: string;
+  reasonCode: string;
+  message: string;
+};
+
+export type StaticAgentStackDraftPayloadReadiness = {
+  status: 'ready' | 'needs_review' | 'blocked';
+  blockers: string[];
+  payloadRefs: string[];
+};
+
+export type StaticAgentStackIngestionResult = {
+  schemaVersion: typeof STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION;
+  corpusId: string;
+  title: string;
+  source: AgentStackFixtureSource;
+  status: StaticAgentStackIngestionStatus;
+  inventory: StaticAgentStackInventoryEntry[];
+  connectorDiagnostics: StaticAgentStackConnectorDiagnostic[];
+  rejectedEntries: StaticAgentStackRejectedEntry[];
+  warnings: AgentStackFixtureValidationWarning[];
+  draftPayloadReadiness: StaticAgentStackDraftPayloadReadiness;
+  staticOnly: true;
+  nonGoals: string[];
 };
 
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
@@ -428,6 +487,119 @@ export function createAgentStackFixtureCorpus(input: unknown, options: AgentStac
     throw new Error(`invalid_agent_stack_fixture_corpus:${result.errors.map((item) => item.code).join(',')}`);
   }
   return result.corpus;
+}
+
+function connectorMessage(file: AgentStackFixtureFile, warning?: AgentStackFixtureValidationWarning): string {
+  if (warning?.message) return warning.message;
+  switch (file.parseStatus) {
+    case 'valid':
+      return 'Connector metadata is statically valid.';
+    case 'malformed':
+      return 'Connector metadata is malformed and must be diagnosed before draft publication.';
+    case 'missing':
+      return 'Connector metadata file is missing.';
+    case 'not_parsed':
+    default:
+      return 'Connector metadata is recorded but not parsed yet.';
+  }
+}
+
+function readinessFromCorpus(
+  corpus: AgentStackFixtureCorpus,
+  connectorDiagnostics: StaticAgentStackConnectorDiagnostic[],
+  rejectedEntries: StaticAgentStackRejectedEntry[],
+): StaticAgentStackDraftPayloadReadiness {
+  const blockers = [
+    ...rejectedEntries.map((entry) => entry.reasonCode),
+    ...connectorDiagnostics
+      .filter((diagnostic) => diagnostic.parseStatus === 'malformed')
+      .map((diagnostic) => `malformed_connector:${diagnostic.path}`),
+  ];
+
+  if (blockers.length > 0) {
+    return { status: 'blocked', blockers, payloadRefs: [] };
+  }
+
+  if (corpus.validationWarnings.length > 0 || connectorDiagnostics.some((diagnostic) => diagnostic.parseStatus !== 'valid')) {
+    return {
+      status: 'needs_review',
+      blockers: ['operator_review_required'],
+      payloadRefs: [],
+    };
+  }
+
+  return {
+    status: 'ready',
+    blockers: [],
+    payloadRefs: [`static-ingestion:${corpus.id}:draft-profile`, `static-ingestion:${corpus.id}:draft-listing`],
+  };
+}
+
+export function createStaticAgentStackIngestionResult(
+  input: unknown,
+  options: AgentStackFixtureValidationOptions = {},
+): StaticAgentStackIngestionResult {
+  const corpus = createAgentStackFixtureCorpus(input, options);
+  const warningByPath = new Map(corpus.validationWarnings.map((warning) => [warning.path, warning]));
+  const connectorDiagnostics = corpus.files
+    .filter((file) => file.kind === 'mcp-connector-config')
+    .map((file): StaticAgentStackConnectorDiagnostic => {
+      const warning = warningByPath.get(file.path);
+      return {
+        path: file.path,
+        parseStatus: file.parseStatus,
+        severity: warning?.severity ?? (file.parseStatus === 'valid' ? 'info' : 'warning'),
+        warningCodes: file.warningCodes ?? [],
+        message: connectorMessage(file, warning),
+      };
+    });
+  const rejectedEntries = corpus.validationWarnings
+    .filter((warning) => warning.severity === 'blocked')
+    .map((warning): StaticAgentStackRejectedEntry => ({
+      path: warning.path,
+      reasonCode: warning.code,
+      message: warning.message,
+    }));
+  const inventory = corpus.surfaces
+    .filter((surface) => surface.kind !== 'validation-warning')
+    .map((surface): StaticAgentStackInventoryEntry => ({
+      id: surface.id,
+      name: surface.name,
+      kind: surface.kind,
+      sourcePath: surface.path,
+      runtimeSurface: surface.runtimeSurface,
+      category: surface.category,
+      commands: surface.commands ?? [],
+      skills: surface.skills ?? [],
+      toolGrants: surface.toolGrants ?? [],
+      authDependencies: surface.authDependencies ?? [],
+      dataDependencies: surface.dataDependencies ?? [],
+      safetyHints: surface.safetyHints ?? [],
+      humanReviewHints: surface.humanReviewHints ?? [],
+      writeCapable: surface.writeCapable ?? false,
+      contentTrustBoundary: surface.contentTrustBoundary,
+    }));
+  const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries);
+  const status: StaticAgentStackIngestionStatus = rejectedEntries.length > 0
+    ? 'blocked'
+    : draftPayloadReadiness.status !== 'ready'
+      ? 'partial_success'
+      : 'ready_for_draft';
+
+  return {
+    schemaVersion: STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION,
+    corpusId: corpus.id,
+    title: corpus.title,
+    source: corpus.source,
+    status,
+    inventory,
+    connectorDiagnostics,
+    rejectedEntries,
+    warnings: corpus.validationWarnings,
+    draftPayloadReadiness,
+    staticOnly: true,
+    nonGoals: corpus.nonGoals,
+  };
 }
 
 export const agentStackFixtureCorpora = {

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -514,6 +514,9 @@ function readinessFromCorpus(
     ...connectorDiagnostics
       .filter((diagnostic) => diagnostic.parseStatus === 'malformed')
       .map((diagnostic) => `malformed_connector:${diagnostic.path}`),
+    ...connectorDiagnostics
+      .filter((diagnostic) => diagnostic.parseStatus === 'missing')
+      .map((diagnostic) => `missing_connector:${diagnostic.path}`),
   ];
 
   if (blockers.length > 0) {
@@ -541,6 +544,11 @@ export function createStaticAgentStackIngestionResult(
 ): StaticAgentStackIngestionResult {
   const corpus = createAgentStackFixtureCorpus(input, options);
   const warningByPath = new Map(corpus.validationWarnings.map((warning) => [warning.path, warning]));
+  const connectorFilesByPath = new Map(
+    corpus.files
+      .filter((file) => file.kind === 'mcp-connector-config')
+      .map((file) => [file.path, file]),
+  );
   const connectorDiagnostics = corpus.files
     .filter((file) => file.kind === 'mcp-connector-config')
     .map((file): StaticAgentStackConnectorDiagnostic => {
@@ -552,7 +560,16 @@ export function createStaticAgentStackIngestionResult(
         warningCodes: file.warningCodes ?? [],
         message: connectorMessage(file, warning),
       };
-    });
+    })
+    .concat(corpus.surfaces
+      .filter((surface) => surface.kind === 'mcp-connector-config' && !connectorFilesByPath.has(surface.path))
+      .map((surface): StaticAgentStackConnectorDiagnostic => ({
+        path: surface.path,
+        parseStatus: 'missing',
+        severity: 'blocked',
+        warningCodes: ['missing_mcp_connector_config'],
+        message: 'MCP connector surface has no matching static connector metadata file.',
+      })));
   const rejectedEntries = corpus.validationWarnings
     .filter((warning) => warning.severity === 'blocked')
     .map((warning): StaticAgentStackRejectedEntry => ({

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -327,6 +327,39 @@ describe('agent-stack fixture corpus', () => {
     ]);
   });
 
+  it('blocks draft readiness when an MCP connector surface has no matching connector file diagnostic', () => {
+    const missingConnectorFileResult = createStaticAgentStackIngestionResult({
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      files: agentStackFixtureCorpora.anthropicFinancialServices.files.filter((file) => file.kind !== 'mcp-connector-config'),
+      validationWarnings: [],
+    });
+
+    assert.equal(missingConnectorFileResult.status, 'partial_success');
+    assert.deepEqual(
+      missingConnectorFileResult.connectorDiagnostics.map((diagnostic) => [
+        diagnostic.path,
+        diagnostic.parseStatus,
+        diagnostic.severity,
+        diagnostic.warningCodes,
+      ]),
+      [
+        [
+          'plugins/vertical-plugins/financial-analysis/.mcp.json',
+          'missing',
+          'blocked',
+          ['missing_mcp_connector_config'],
+        ],
+      ],
+    );
+    assert.equal(missingConnectorFileResult.draftPayloadReadiness.status, 'blocked');
+    assert.ok(
+      missingConnectorFileResult.draftPayloadReadiness.blockers.includes(
+        'missing_connector:plugins/vertical-plugins/financial-analysis/.mcp.json',
+      ),
+    );
+    assert.deepEqual(missingConnectorFileResult.draftPayloadReadiness.payloadRefs, []);
+  });
+
   it('does not expose a static ingestion result for invalid or credential-shaped corpora', () => {
     assert.throws(
       () => createStaticAgentStackIngestionResult({

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -4,6 +4,7 @@ import {
   agentStackFixtureCases,
   agentStackFixtureCorpora,
   createAgentStackFixtureCorpus,
+  createStaticAgentStackIngestionResult,
   validateAgentStackFixtureCorpus,
   type AgentStackFixtureValidationErrorCode,
 } from '../dist/index.js';
@@ -258,5 +259,99 @@ describe('agent-stack fixture corpus', () => {
         assert.ok(malformedTimestamp.errors.some((item) => item.path === '$.source.crawlTimestamp'));
       }
     }
+  });
+
+  it('creates a deterministic static ingestion result envelope with partial success diagnostics', () => {
+    const result = createStaticAgentStackIngestionResult(agentStackFixtureCorpora.anthropicFinancialServices);
+
+    assert.equal(result.schemaVersion, 'reddi.static-agent-stack-ingestion-result.v1');
+    assert.equal(result.corpusId, agentStackFixtureCorpora.anthropicFinancialServices.id);
+    assert.equal(result.status, 'partial_success');
+    assert.equal(result.staticOnly, true);
+    assert.equal(result.inventory.some((entry) => entry.kind === 'claude-plugin'), true);
+    assert.equal(result.inventory.some((entry) => entry.kind === 'validation-warning'), false);
+    assert.equal(result.inventory.find((entry) => entry.kind === 'claude-plugin')?.writeCapable, true);
+    assert.deepEqual(
+      result.connectorDiagnostics.map((diagnostic) => [diagnostic.path, diagnostic.parseStatus, diagnostic.warningCodes]),
+      [['plugins/vertical-plugins/financial-analysis/.mcp.json', 'malformed', ['malformed_mcp_json']]],
+    );
+    assert.equal(result.rejectedEntries.length, 0);
+    assert.equal(result.draftPayloadReadiness.status, 'blocked');
+    assert.ok(result.draftPayloadReadiness.blockers.includes('malformed_connector:plugins/vertical-plugins/financial-analysis/.mcp.json'));
+    assert.deepEqual(result.draftPayloadReadiness.payloadRefs, []);
+    assert.doesNotThrow(() => JSON.stringify(result));
+  });
+
+  it('marks blocked validation warnings as rejected entries without losing unrelated inventory', () => {
+    const blockedResult = createStaticAgentStackIngestionResult({
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      validationWarnings: [
+        ...agentStackFixtureCorpora.anthropicFinancialServices.validationWarnings,
+        {
+          code: 'unsafe_metadata',
+          severity: 'blocked',
+          path: 'plugins/partner-plugins/example/plugin.json',
+          message: 'Unsafe imported metadata must not be exposed to draft publication.',
+        },
+      ],
+    });
+
+    assert.equal(blockedResult.status, 'blocked');
+    assert.equal(blockedResult.rejectedEntries.length, 1);
+    assert.deepEqual(blockedResult.rejectedEntries[0], {
+      path: 'plugins/partner-plugins/example/plugin.json',
+      reasonCode: 'unsafe_metadata',
+      message: 'Unsafe imported metadata must not be exposed to draft publication.',
+    });
+    assert.ok(blockedResult.inventory.some((entry) => entry.kind === 'managed-agent-cookbook'));
+  });
+
+  it('creates ready payload references only when the corpus has no warnings or connector blockers', () => {
+    const readyResult = createStaticAgentStackIngestionResult({
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      files: agentStackFixtureCorpora.anthropicFinancialServices.files.map((file) => file.kind === 'mcp-connector-config'
+        ? {
+          ...file,
+          parseStatus: 'valid',
+          warningCodes: [],
+        }
+        : file),
+      validationWarnings: [],
+    });
+
+    assert.equal(readyResult.status, 'ready_for_draft');
+    assert.equal(readyResult.draftPayloadReadiness.status, 'ready');
+    assert.deepEqual(readyResult.draftPayloadReadiness.payloadRefs, [
+      'static-ingestion:agent-stack-fixture:anthropic-financial-services:2026-06-18:draft-profile',
+      'static-ingestion:agent-stack-fixture:anthropic-financial-services:2026-06-18:draft-listing',
+    ]);
+  });
+
+  it('does not expose a static ingestion result for invalid or credential-shaped corpora', () => {
+    assert.throws(
+      () => createStaticAgentStackIngestionResult({
+        ...agentStackFixtureCorpora.anthropicFinancialServices,
+        surfaces: [
+          {
+            ...agentStackFixtureCorpora.anthropicFinancialServices.surfaces[0],
+            apiKey: 'sk-not-real-but-secret-shaped',
+          },
+        ],
+      }),
+      /invalid_agent_stack_fixture_corpus:credential_leakage_rejected/,
+    );
+
+    assert.throws(
+      () => createStaticAgentStackIngestionResult({
+        ...agentStackFixtureCorpora.anthropicFinancialServices,
+        files: [
+          {
+            ...agentStackFixtureCorpora.anthropicFinancialServices.files[0],
+            path: '/tmp/secret',
+          },
+        ],
+      }),
+      /invalid_agent_stack_fixture_corpus:invalid_source_reference/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- closes #414
- adds `reddi.static-agent-stack-ingestion-result.v1` as the deterministic handoff envelope for static agent-stack ingestion
- derives normalized inventory entries, connector diagnostics, rejected entries, warnings, and draft-payload readiness from already validated fixture corpora
- documents the envelope in `@reddi/agent-protocol` README and packs updated dist

## Guardrails
- static fixture metadata only
- no network fetch, plugin install, command execution, managed-agent invocation, MCP server contact, paid/provider call, wallet/RPC/SPL transfer, Quasar/on-chain behavior, payment activation, or marketplace publication
- invalid/credential-shaped/unsafe fixture corpora fail before any typed ingestion result is exposed

## Validation
- `npm test` in `packages/agent-protocol` passed with 86 tests
- `npm run release:dry-run` in `packages/agent-protocol` passed and packed updated `dist/agent-stack-fixtures.*`
- root `npm run check:rap:naming` passed
- `git diff --check` passed

## Notes
- The built-in Anthropic fixture now returns `partial_success` for static ingestion because unrelated inventory is preserved while the known malformed `.mcp.json` blocks draft payload readiness until #404 diagnostics land.
