### PR TITLE
Add source-aware MCP connector diagnostics

### DIFF
--- a/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
@@ -22,6 +22,7 @@ export type AgentStackFixtureFile = {
     kind: AgentStackFixtureSurfaceKind;
     present: boolean;
     parseStatus: 'valid' | 'malformed' | 'not_parsed' | 'missing';
+    parseErrorLocation?: string;
     mediaType?: string;
     summary?: string;
     warningCodes?: string[];
@@ -100,9 +101,14 @@ export type StaticAgentStackInventoryEntry = {
 };
 export type StaticAgentStackConnectorDiagnostic = {
     path: string;
+    sourceKind: 'mcp-connector-config';
+    diagnosticLane: 'mcp_connector_metadata';
     parseStatus: AgentStackFixtureFile['parseStatus'];
+    parseErrorLocation?: string;
     severity: AgentStackFixtureValidationWarning['severity'];
     warningCodes: string[];
+    blocksDraftPayload: boolean;
+    operatorReviewRequired: boolean;
     message: string;
 };
 export type StaticAgentStackRejectedEntry = {
@@ -224,6 +230,7 @@ export declare const agentStackFixtureCorpora: {
             readonly kind: "mcp-connector-config";
             readonly present: true;
             readonly parseStatus: "malformed";
+            readonly parseErrorLocation: "line 1 column 1";
             readonly mediaType: "application/json";
             readonly warningCodes: ["malformed_mcp_json"];
             readonly summary: "Known malformed connector manifest from local analysis; full diagnostics belong to #404.";

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -311,7 +311,7 @@ function connectorBlocksDraftPayload(diagnostic) {
     return diagnostic.parseStatus === 'malformed' || diagnostic.parseStatus === 'missing';
 }
 function connectorRequiresOperatorReview(file, warning) {
-    return file.parseStatus !== 'valid' || file.warningCodes !== undefined || warning !== undefined;
+    return file.parseStatus !== 'valid' || (file.warningCodes?.length ?? 0) > 0 || warning !== undefined;
 }
 function readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries) {
     const blockers = [
@@ -354,7 +354,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
             sourceKind: 'mcp-connector-config',
             diagnosticLane: 'mcp_connector_metadata',
             parseStatus: file.parseStatus,
-            ...(file.parseErrorLocation ? { parseErrorLocation: file.parseErrorLocation } : {}),
+            ...(file.parseStatus === 'malformed' && file.parseErrorLocation ? { parseErrorLocation: file.parseErrorLocation } : {}),
             severity: warning?.severity ?? (file.parseStatus === 'valid' ? 'info' : 'warning'),
             warningCodes: file.warningCodes ?? [],
             blocksDraftPayload: connectorBlocksDraftPayload(file),

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -191,6 +191,7 @@ function validateFile(value, path, errors) {
     if (!['valid', 'malformed', 'not_parsed', 'missing'].includes(String(value.parseStatus))) {
         errors.push(error('malformed_fixture_corpus', `${path}.parseStatus`, 'file parseStatus is unsupported'));
     }
+    validateOptionalString(value.parseErrorLocation, `${path}.parseErrorLocation`, errors);
     validateOptionalString(value.mediaType, `${path}.mediaType`, errors);
     validateOptionalString(value.summary, `${path}.summary`, errors);
     validateOptionalStringArray(value.warningCodes, `${path}.warningCodes`, errors);
@@ -306,6 +307,12 @@ function connectorMessage(file, warning) {
             return 'Connector metadata is recorded but not parsed yet.';
     }
 }
+function connectorBlocksDraftPayload(diagnostic) {
+    return diagnostic.parseStatus === 'malformed' || diagnostic.parseStatus === 'missing';
+}
+function connectorRequiresOperatorReview(file, warning) {
+    return file.parseStatus !== 'valid' || file.warningCodes !== undefined || warning !== undefined;
+}
 function readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries) {
     const blockers = [
         ...rejectedEntries.map((entry) => entry.reasonCode),
@@ -344,9 +351,14 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
         const warning = warningByPath.get(file.path);
         return {
             path: file.path,
+            sourceKind: 'mcp-connector-config',
+            diagnosticLane: 'mcp_connector_metadata',
             parseStatus: file.parseStatus,
+            ...(file.parseErrorLocation ? { parseErrorLocation: file.parseErrorLocation } : {}),
             severity: warning?.severity ?? (file.parseStatus === 'valid' ? 'info' : 'warning'),
             warningCodes: file.warningCodes ?? [],
+            blocksDraftPayload: connectorBlocksDraftPayload(file),
+            operatorReviewRequired: connectorRequiresOperatorReview(file, warning),
             message: connectorMessage(file, warning),
         };
     })
@@ -354,9 +366,13 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
         .filter((surface) => surface.kind === 'mcp-connector-config' && !connectorFilesByPath.has(surface.path))
         .map((surface) => ({
         path: surface.path,
+        sourceKind: 'mcp-connector-config',
+        diagnosticLane: 'mcp_connector_metadata',
         parseStatus: 'missing',
         severity: 'blocked',
         warningCodes: ['missing_mcp_connector_config'],
+        blocksDraftPayload: true,
+        operatorReviewRequired: true,
         message: 'MCP connector surface has no matching static connector metadata file.',
     })));
     const rejectedEntries = corpus.validationWarnings
@@ -515,6 +531,7 @@ export const agentStackFixtureCorpora = {
                 kind: 'mcp-connector-config',
                 present: true,
                 parseStatus: 'malformed',
+                parseErrorLocation: 'line 1 column 1',
                 mediaType: 'application/json',
                 warningCodes: ['malformed_mcp_json'],
                 summary: 'Known malformed connector manifest from local analysis; full diagnostics belong to #404.',

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -516,7 +516,7 @@ function connectorBlocksDraftPayload(diagnostic: Pick<StaticAgentStackConnectorD
 }
 
 function connectorRequiresOperatorReview(file: AgentStackFixtureFile, warning?: AgentStackFixtureValidationWarning): boolean {
-  return file.parseStatus !== 'valid' || file.warningCodes !== undefined || warning !== undefined;
+  return file.parseStatus !== 'valid' || (file.warningCodes?.length ?? 0) > 0 || warning !== undefined;
 }
 
 function readinessFromCorpus(
@@ -573,7 +573,7 @@ export function createStaticAgentStackIngestionResult(
         sourceKind: 'mcp-connector-config',
         diagnosticLane: 'mcp_connector_metadata',
         parseStatus: file.parseStatus,
-        ...(file.parseErrorLocation ? { parseErrorLocation: file.parseErrorLocation } : {}),
+        ...(file.parseStatus === 'malformed' && file.parseErrorLocation ? { parseErrorLocation: file.parseErrorLocation } : {}),
         severity: warning?.severity ?? (file.parseStatus === 'valid' ? 'info' : 'warning'),
         warningCodes: file.warningCodes ?? [],
         blocksDraftPayload: connectorBlocksDraftPayload(file),

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -44,6 +44,7 @@ export type AgentStackFixtureFile = {
   kind: AgentStackFixtureSurfaceKind;
   present: boolean;
   parseStatus: 'valid' | 'malformed' | 'not_parsed' | 'missing';
+  parseErrorLocation?: string;
   mediaType?: string;
   summary?: string;
   warningCodes?: string[];
@@ -138,9 +139,14 @@ export type StaticAgentStackInventoryEntry = {
 
 export type StaticAgentStackConnectorDiagnostic = {
   path: string;
+  sourceKind: 'mcp-connector-config';
+  diagnosticLane: 'mcp_connector_metadata';
   parseStatus: AgentStackFixtureFile['parseStatus'];
+  parseErrorLocation?: string;
   severity: AgentStackFixtureValidationWarning['severity'];
   warningCodes: string[];
+  blocksDraftPayload: boolean;
+  operatorReviewRequired: boolean;
   message: string;
 };
 
@@ -380,6 +386,7 @@ function validateFile(value: unknown, path: string, errors: AgentStackFixtureVal
   if (!['valid', 'malformed', 'not_parsed', 'missing'].includes(String(value.parseStatus))) {
     errors.push(error('malformed_fixture_corpus', `${path}.parseStatus`, 'file parseStatus is unsupported'));
   }
+  validateOptionalString(value.parseErrorLocation, `${path}.parseErrorLocation`, errors);
   validateOptionalString(value.mediaType, `${path}.mediaType`, errors);
   validateOptionalString(value.summary, `${path}.summary`, errors);
   validateOptionalStringArray(value.warningCodes, `${path}.warningCodes`, errors);
@@ -504,6 +511,14 @@ function connectorMessage(file: AgentStackFixtureFile, warning?: AgentStackFixtu
   }
 }
 
+function connectorBlocksDraftPayload(diagnostic: Pick<StaticAgentStackConnectorDiagnostic, 'parseStatus'>): boolean {
+  return diagnostic.parseStatus === 'malformed' || diagnostic.parseStatus === 'missing';
+}
+
+function connectorRequiresOperatorReview(file: AgentStackFixtureFile, warning?: AgentStackFixtureValidationWarning): boolean {
+  return file.parseStatus !== 'valid' || file.warningCodes !== undefined || warning !== undefined;
+}
+
 function readinessFromCorpus(
   corpus: AgentStackFixtureCorpus,
   connectorDiagnostics: StaticAgentStackConnectorDiagnostic[],
@@ -555,9 +570,14 @@ export function createStaticAgentStackIngestionResult(
       const warning = warningByPath.get(file.path);
       return {
         path: file.path,
+        sourceKind: 'mcp-connector-config',
+        diagnosticLane: 'mcp_connector_metadata',
         parseStatus: file.parseStatus,
+        ...(file.parseErrorLocation ? { parseErrorLocation: file.parseErrorLocation } : {}),
         severity: warning?.severity ?? (file.parseStatus === 'valid' ? 'info' : 'warning'),
         warningCodes: file.warningCodes ?? [],
+        blocksDraftPayload: connectorBlocksDraftPayload(file),
+        operatorReviewRequired: connectorRequiresOperatorReview(file, warning),
         message: connectorMessage(file, warning),
       };
     })
@@ -565,9 +585,13 @@ export function createStaticAgentStackIngestionResult(
       .filter((surface) => surface.kind === 'mcp-connector-config' && !connectorFilesByPath.has(surface.path))
       .map((surface): StaticAgentStackConnectorDiagnostic => ({
         path: surface.path,
+        sourceKind: 'mcp-connector-config',
+        diagnosticLane: 'mcp_connector_metadata',
         parseStatus: 'missing',
         severity: 'blocked',
         warningCodes: ['missing_mcp_connector_config'],
+        blocksDraftPayload: true,
+        operatorReviewRequired: true,
         message: 'MCP connector surface has no matching static connector metadata file.',
       })));
   const rejectedEntries = corpus.validationWarnings
@@ -728,6 +752,7 @@ export const agentStackFixtureCorpora = {
         kind: 'mcp-connector-config',
         present: true,
         parseStatus: 'malformed',
+        parseErrorLocation: 'line 1 column 1',
         mediaType: 'application/json',
         warningCodes: ['malformed_mcp_json'],
         summary: 'Known malformed connector manifest from local analysis; full diagnostics belong to #404.',

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -122,6 +122,7 @@ describe('agent-stack fixture corpus', () => {
     const pluginSurface = corpus.surfaces.find((surface) => surface.kind === 'claude-plugin');
 
     assert.equal(malformedFile?.parseStatus, 'malformed');
+    assert.equal(malformedFile?.parseErrorLocation, 'line 1 column 1');
     assert.deepEqual(malformedFile?.warningCodes, ['malformed_mcp_json']);
     assert.equal(pluginSurface?.path, 'plugins/');
     assert.equal(corpus.validationWarnings[0].code, 'malformed_mcp_json');
@@ -327,8 +328,26 @@ describe('agent-stack fixture corpus', () => {
     assert.equal(result.inventory.some((entry) => entry.kind === 'validation-warning'), false);
     assert.equal(result.inventory.find((entry) => entry.kind === 'claude-plugin')?.writeCapable, true);
     assert.deepEqual(
-      result.connectorDiagnostics.map((diagnostic) => [diagnostic.path, diagnostic.parseStatus, diagnostic.warningCodes]),
-      [['plugins/vertical-plugins/financial-analysis/.mcp.json', 'malformed', ['malformed_mcp_json']]],
+      result.connectorDiagnostics.map((diagnostic) => [
+        diagnostic.path,
+        diagnostic.sourceKind,
+        diagnostic.diagnosticLane,
+        diagnostic.parseStatus,
+        diagnostic.parseErrorLocation,
+        diagnostic.warningCodes,
+        diagnostic.blocksDraftPayload,
+        diagnostic.operatorReviewRequired,
+      ]),
+      [[
+        'plugins/vertical-plugins/financial-analysis/.mcp.json',
+        'mcp-connector-config',
+        'mcp_connector_metadata',
+        'malformed',
+        'line 1 column 1',
+        ['malformed_mcp_json'],
+        true,
+        true,
+      ]],
     );
     assert.equal(result.rejectedEntries.length, 0);
     assert.equal(result.draftPayloadReadiness.status, 'blocked');
@@ -352,16 +371,24 @@ describe('agent-stack fixture corpus', () => {
     assert.deepEqual(
       result.connectorDiagnostics.map((diagnostic) => [
         diagnostic.path,
+        diagnostic.sourceKind,
+        diagnostic.diagnosticLane,
         diagnostic.parseStatus,
         diagnostic.severity,
         diagnostic.warningCodes,
+        diagnostic.blocksDraftPayload,
+        diagnostic.operatorReviewRequired,
       ]),
       [
         [
           '.mcp.json',
+          'mcp-connector-config',
+          'mcp_connector_metadata',
           'valid',
           'warning',
           ['npx_mcp_execution', 'env_required_connector', 'local_binary_required'],
+          false,
+          true,
         ],
       ],
     );
@@ -431,16 +458,24 @@ describe('agent-stack fixture corpus', () => {
     assert.deepEqual(
       missingConnectorFileResult.connectorDiagnostics.map((diagnostic) => [
         diagnostic.path,
+        diagnostic.sourceKind,
+        diagnostic.diagnosticLane,
         diagnostic.parseStatus,
         diagnostic.severity,
         diagnostic.warningCodes,
+        diagnostic.blocksDraftPayload,
+        diagnostic.operatorReviewRequired,
       ]),
       [
         [
           'plugins/vertical-plugins/financial-analysis/.mcp.json',
+          'mcp-connector-config',
+          'mcp_connector_metadata',
           'missing',
           'blocked',
           ['missing_mcp_connector_config'],
+          true,
+          true,
         ],
       ],
     );
@@ -451,6 +486,39 @@ describe('agent-stack fixture corpus', () => {
       ),
     );
     assert.deepEqual(missingConnectorFileResult.draftPayloadReadiness.payloadRefs, []);
+  });
+
+  it('keeps #404 diagnostics scoped to MCP connector metadata and leaves non-MCP risk taxonomy to #421', () => {
+    const connectorRiskResult = createStaticAgentStackIngestionResult({
+      ...agentStackFixtureCorpora.solanaAiKit,
+      files: agentStackFixtureCorpora.solanaAiKit.files.map((file) => file.path === '.mcp.json'
+        ? {
+          ...file,
+          warningCodes: ['unsafe_connector_url', 'credential_shaped_connector_value', 'write_capable_connector_claim'],
+        }
+        : file),
+      validationWarnings: agentStackFixtureCorpora.solanaAiKit.validationWarnings.filter((warning) => (
+        warning.path !== '.mcp.json'
+      )),
+    });
+    const diagnostic = connectorRiskResult.connectorDiagnostics.find((item) => item.path === '.mcp.json');
+
+    assert.deepEqual(diagnostic, {
+      path: '.mcp.json',
+      sourceKind: 'mcp-connector-config',
+      diagnosticLane: 'mcp_connector_metadata',
+      parseStatus: 'valid',
+      severity: 'info',
+      warningCodes: ['unsafe_connector_url', 'credential_shaped_connector_value', 'write_capable_connector_claim'],
+      blocksDraftPayload: false,
+      operatorReviewRequired: true,
+      message: 'Connector metadata is statically valid.',
+    });
+    assert.ok(!diagnostic.warningCodes.includes('executable_hooks'));
+    assert.ok(!diagnostic.warningCodes.includes('mainnet_deploy_guard_required'));
+    assert.ok(!diagnostic.warningCodes.includes('external_submodules_declared'));
+    assert.equal(connectorRiskResult.draftPayloadReadiness.blockers.includes('executable_hooks_require_operator_review'), true);
+    assert.equal(connectorRiskResult.draftPayloadReadiness.blockers.includes('solana_deploy_command_requires_operator_review'), true);
   });
 
   it('does not expose a static ingestion result for invalid or credential-shaped corpora', () => {

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -440,6 +440,24 @@ describe('agent-stack fixture corpus', () => {
     });
 
     assert.equal(readyResult.status, 'ready_for_draft');
+    assert.deepEqual(
+      readyResult.connectorDiagnostics.map((diagnostic) => [
+        diagnostic.path,
+        diagnostic.parseStatus,
+        diagnostic.parseErrorLocation,
+        diagnostic.warningCodes,
+        diagnostic.blocksDraftPayload,
+        diagnostic.operatorReviewRequired,
+      ]),
+      [[
+        'plugins/vertical-plugins/financial-analysis/.mcp.json',
+        'valid',
+        undefined,
+        [],
+        false,
+        false,
+      ]],
+    );
     assert.equal(readyResult.draftPayloadReadiness.status, 'ready');
     assert.deepEqual(readyResult.draftPayloadReadiness.payloadRefs, [
       'static-ingestion:agent-stack-fixture:anthropic-financial-services:2026-06-18:draft-profile',


### PR DESCRIPTION
## Summary\n- Adds explicit MCP connector diagnostic metadata to static agent-stack ingestion results: source kind, diagnostic lane, optional parse location, draft-blocking flag, and operator-review flag.\n- Preserves the #404/#421 boundary: #404 owns MCP connector metadata diagnostics; #421 owns non-MCP hook/script/deploy/wallet/local-binary/external-submodule taxonomy.\n- Records parse location for the known malformed Anthropic MCP fixture and expands tests over Anthropic and Solana AI Kit fixture diagnostics.\n\nCloses #404.\n\n## Validation\n- npm install in packages/agent-protocol for the fresh worktree\n- npm test in packages/agent-protocol: 92/92 passing\n- npm run release:dry-run in packages/agent-protocol\n- npm run check:rap:naming\n- git diff --check\n\n## Guardrails\n- Static metadata only.\n- No plugin install, hook/script/command execution, MCP contact, Solana RPC/wallet call, paid provider call, credential read, payment activation, or marketplace publication.\n- Non-MCP execution/deploy/wallet risk taxonomy remains in #421.