### PR TITLE
Add static fixture risk taxonomy

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -72,13 +72,16 @@ console.log(corpus.source.checkedCommit); // 4bbabc7cd1a474c1667fa05a2bfe58e411d
 console.log(corpus.files.some((file) => file.parseStatus === 'malformed')); // true
 console.log(result.status); // partial_success while malformed connector diagnostics block draft readiness
 console.log(solanaKit.draftPayloadReadiness.status); // blocked until hooks, deploy commands, and MCPs are reviewed
+console.log(solanaKit.riskDiagnostics.map((diagnostic) => diagnostic.category)); // static risk taxonomy for operator review
 ```
 
 Agent-stack fixture corpora are public, static inputs for onboarding-analyser parser and diagnostics work. The built-in Anthropic financial-services fixture records source URL, checked commit, license/source notes, authenticity notes, crawl timestamp, local research artifact path, high-level marketplace/plugin/managed-agent/MCP surfaces, and validation warnings. The built-in Solana AI Kit fixture records the same source provenance for a Solana-heavy agent-stack toolkit with plugin metadata, agent definitions, commands, MCP declarations, hooks, rules, skills, installer/update/test scripts, and external submodule declarations.
 
 Fixture ingestion rejects credential-shaped metadata, unsafe source URLs, invalid commit refs, invalid timestamps, oversized corpora, and malformed corpus shapes. Public prompt, skill, command, and recipe text is always labelled as untrusted fixture content.
 
-Static ingestion results are deterministic handoff envelopes for later parser, connector-diagnostics, draft-profile, and operator-review work. They combine fixture source metadata, normalized inventory entries, connector diagnostics, rejected entries, validation warnings, and draft-payload readiness without fetching the network or executing imported code.
+Static ingestion results are deterministic handoff envelopes for later parser, connector-diagnostics, draft-profile, and operator-review work. They combine fixture source metadata, normalized inventory entries, MCP connector diagnostics, non-MCP static risk diagnostics, rejected entries, validation warnings, and draft-payload readiness without fetching the network or executing imported code.
+
+Risk diagnostics normalize executable hooks, installer/update/test scripts, deploy-capable commands, wallet/RPC-capable command metadata, local binary requirements, env-required connector metadata, MCP launcher execution, permission policies, and external submodule declarations into the same static ingestion result. They are review payloads only; connector parsing still belongs to the MCP connector diagnostics lane.
 
 The fixture corpus never installs Claude plugins, executes repo scripts, invokes managed agents, contacts MCP servers, fetches paid/provider data, requires credentials, starts local services, calls wallets/RPC endpoints, or publishes imported surfaces as payable RAP listings. Parser, connector-diagnostics, draft-profile, and operator-review behavior land in later RAP slices.
 

--- a/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
@@ -111,6 +111,18 @@ export type StaticAgentStackConnectorDiagnostic = {
     operatorReviewRequired: boolean;
     message: string;
 };
+export type StaticAgentStackRiskCategory = 'executable_hook' | 'installer_or_update_script' | 'deploy_capable_command' | 'wallet_rpc_capable_metadata' | 'local_binary_requirement' | 'env_required_connector' | 'mcp_launcher_execution' | 'external_submodule' | 'permission_policy';
+export type StaticAgentStackRiskDiagnostic = {
+    path: string;
+    sourceKind: AgentStackFixtureSurfaceKind | 'validation-warning';
+    diagnosticLane: 'static_fixture_risk_taxonomy';
+    category: StaticAgentStackRiskCategory;
+    severity: AgentStackFixtureValidationWarning['severity'];
+    warningCodes: string[];
+    blocksDraftPayload: boolean;
+    operatorReviewRequired: boolean;
+    message: string;
+};
 export type StaticAgentStackRejectedEntry = {
     path: string;
     reasonCode: string;
@@ -129,6 +141,7 @@ export type StaticAgentStackIngestionResult = {
     status: StaticAgentStackIngestionStatus;
     inventory: StaticAgentStackInventoryEntry[];
     connectorDiagnostics: StaticAgentStackConnectorDiagnostic[];
+    riskDiagnostics: StaticAgentStackRiskDiagnostic[];
     rejectedEntries: StaticAgentStackRejectedEntry[];
     warnings: AgentStackFixtureValidationWarning[];
     draftPayloadReadiness: StaticAgentStackDraftPayloadReadiness;

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -18,6 +18,98 @@ const SUPPORTED_SURFACE_KINDS = [
     'validation-warning',
 ];
 const WARNING_SEVERITIES = ['info', 'warning', 'blocked'];
+const STATIC_RISK_CODE_MAP = {
+    deploy_capable_commands: {
+        category: 'deploy_capable_command',
+        severity: 'blocked',
+        blocksDraftPayload: true,
+        message: 'Deploy-capable command metadata must be reviewed before draft publication.',
+    },
+    wallet_rpc_adjacent_commands: {
+        category: 'wallet_rpc_capable_metadata',
+        severity: 'blocked',
+        blocksDraftPayload: true,
+        message: 'Wallet, signing, or RPC-capable command metadata must be reviewed before draft publication.',
+    },
+    npx_mcp_execution: {
+        category: 'mcp_launcher_execution',
+        severity: 'warning',
+        blocksDraftPayload: true,
+        message: 'npx-launched MCP metadata must be reviewed before draft publication.',
+    },
+    env_required_connector: {
+        category: 'env_required_connector',
+        severity: 'warning',
+        blocksDraftPayload: true,
+        message: 'Environment-required connector metadata must be reviewed before draft publication.',
+    },
+    local_binary_required: {
+        category: 'local_binary_requirement',
+        severity: 'warning',
+        blocksDraftPayload: true,
+        message: 'Local-binary connector metadata must be reviewed before draft publication.',
+    },
+    executable_hooks: {
+        category: 'executable_hook',
+        severity: 'blocked',
+        blocksDraftPayload: true,
+        message: 'Executable hook metadata must be reviewed before draft publication.',
+    },
+    mainnet_deploy_guard_required: {
+        category: 'deploy_capable_command',
+        severity: 'blocked',
+        blocksDraftPayload: true,
+        message: 'Mainnet deploy guard metadata must be reviewed before draft publication.',
+    },
+    permission_policy: {
+        category: 'permission_policy',
+        severity: 'warning',
+        blocksDraftPayload: false,
+        message: 'Permission policy metadata requires operator review before enablement.',
+    },
+    private_path_denylist: {
+        category: 'permission_policy',
+        severity: 'warning',
+        blocksDraftPayload: false,
+        message: 'Private-path denylist metadata requires operator review before enablement.',
+    },
+    external_submodules_declared: {
+        category: 'external_submodule',
+        severity: 'blocked',
+        blocksDraftPayload: true,
+        message: 'External submodule declarations must be reviewed before draft publication.',
+    },
+    installer_script_non_executable_fixture: {
+        category: 'installer_or_update_script',
+        severity: 'blocked',
+        blocksDraftPayload: true,
+        message: 'Installer, update, or test script metadata must be reviewed before draft publication.',
+    },
+    mcp_connector_requires_operator_review: {
+        category: 'env_required_connector',
+        severity: 'warning',
+        blocksDraftPayload: true,
+        message: 'Connector metadata that requires credentials, hosted services, or local binaries must be reviewed before draft publication.',
+    },
+    executable_hooks_require_operator_review: {
+        category: 'executable_hook',
+        severity: 'blocked',
+        blocksDraftPayload: true,
+        message: 'Executable hook metadata must be reviewed before draft publication.',
+    },
+    solana_deploy_command_requires_operator_review: {
+        category: 'deploy_capable_command',
+        severity: 'blocked',
+        blocksDraftPayload: true,
+        message: 'Deploy-capable Solana command metadata must be reviewed before draft publication.',
+    },
+    external_submodules_not_initialized: {
+        category: 'external_submodule',
+        severity: 'warning',
+        blocksDraftPayload: true,
+        message: 'External submodule declarations must be reviewed before draft publication.',
+    },
+};
 function error(code, path, message) {
     return { code, path, message };
 }
@@ -313,9 +405,61 @@ function connectorBlocksDraftPayload(diagnostic) {
 function connectorRequiresOperatorReview(file, warning) {
     return file.parseStatus !== 'valid' || (file.warningCodes?.length ?? 0) > 0 || warning !== undefined;
 }
-function readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries) {
+function maxSeverity(left, right) {
+    if (left === 'blocked' || right === 'blocked')
+        return 'blocked';
+    if (left === 'warning' || right === 'warning')
+        return 'warning';
+    return 'info';
+}
+function createRiskDiagnostics(corpus) {
+    const byPathAndCategory = new Map();
+    const addRisk = (path, sourceKind, code, severityOverride) => {
+        const mapped = STATIC_RISK_CODE_MAP[code];
+        if (!mapped)
+            return;
+        const key = `${path}:${mapped.category}`;
+        const severity = severityOverride ? maxSeverity(mapped.severity, severityOverride) : mapped.severity;
+        const existing = byPathAndCategory.get(key);
+        if (existing) {
+            byPathAndCategory.set(key, {
+                ...existing,
+                severity: maxSeverity(existing.severity, severity),
+                warningCodes: existing.warningCodes.includes(code) ? existing.warningCodes : [...existing.warningCodes, code],
+                blocksDraftPayload: existing.blocksDraftPayload || mapped.blocksDraftPayload,
+                operatorReviewRequired: true,
+            });
+            return;
+        }
+        byPathAndCategory.set(key, {
+            path,
+            sourceKind,
+            diagnosticLane: 'static_fixture_risk_taxonomy',
+            category: mapped.category,
+            severity,
+            warningCodes: [code],
+            blocksDraftPayload: mapped.blocksDraftPayload,
+            operatorReviewRequired: true,
+            message: mapped.message,
+        });
+    };
+    for (const file of corpus.files) {
+        for (const code of file.warningCodes ?? []) {
+            addRisk(file.path, file.kind, code);
+        }
+    }
+    for (const warning of corpus.validationWarnings) {
+        addRisk(warning.path, 'validation-warning', warning.code, warning.severity);
+    }
+    return [...byPathAndCategory.values()].sort((left, right) => (left.path.localeCompare(right.path)
+        || left.category.localeCompare(right.category)));
+}
+function readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, rejectedEntries) {
     const blockers = [
         ...rejectedEntries.map((entry) => entry.reasonCode),
+        ...riskDiagnostics
+            .filter((diagnostic) => diagnostic.blocksDraftPayload)
+            .map((diagnostic) => `static_risk:${diagnostic.category}:${diagnostic.path}`),
         ...connectorDiagnostics
             .filter((diagnostic) => diagnostic.parseStatus === 'malformed')
             .map((diagnostic) => `malformed_connector:${diagnostic.path}`),
@@ -326,7 +470,9 @@ function readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries) {
     if (blockers.length > 0) {
         return { status: 'blocked', blockers, payloadRefs: [] };
     }
-    if (corpus.validationWarnings.length > 0 || connectorDiagnostics.some((diagnostic) => diagnostic.parseStatus !== 'valid')) {
+    if (corpus.validationWarnings.length > 0
+        || connectorDiagnostics.some((diagnostic) => diagnostic.parseStatus !== 'valid')
+        || riskDiagnostics.some((diagnostic) => diagnostic.operatorReviewRequired)) {
         return {
             status: 'needs_review',
             blockers: ['operator_review_required'],
@@ -375,6 +521,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
         operatorReviewRequired: true,
         message: 'MCP connector surface has no matching static connector metadata file.',
     })));
+    const riskDiagnostics = createRiskDiagnostics(corpus);
     const rejectedEntries = corpus.validationWarnings
         .filter((warning) => warning.severity === 'blocked')
         .map((warning) => ({
@@ -401,7 +548,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
         writeCapable: surface.writeCapable ?? false,
         contentTrustBoundary: surface.contentTrustBoundary,
     }));
-    const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries);
+    const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, rejectedEntries);
     const status = rejectedEntries.length > 0
         ? 'blocked'
         : draftPayloadReadiness.status !== 'ready'
@@ -415,6 +562,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
         status,
         inventory,
         connectorDiagnostics,
+        riskDiagnostics,
         rejectedEntries,
         warnings: corpus.validationWarnings,
         draftPayloadReadiness,

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -150,6 +150,29 @@ export type StaticAgentStackConnectorDiagnostic = {
   message: string;
 };
 
+export type StaticAgentStackRiskCategory =
+  | 'executable_hook'
+  | 'installer_or_update_script'
+  | 'deploy_capable_command'
+  | 'wallet_rpc_capable_metadata'
+  | 'local_binary_requirement'
+  | 'env_required_connector'
+  | 'mcp_launcher_execution'
+  | 'external_submodule'
+  | 'permission_policy';
+
+export type StaticAgentStackRiskDiagnostic = {
+  path: string;
+  sourceKind: AgentStackFixtureSurfaceKind | 'validation-warning';
+  diagnosticLane: 'static_fixture_risk_taxonomy';
+  category: StaticAgentStackRiskCategory;
+  severity: AgentStackFixtureValidationWarning['severity'];
+  warningCodes: string[];
+  blocksDraftPayload: boolean;
+  operatorReviewRequired: boolean;
+  message: string;
+};
+
 export type StaticAgentStackRejectedEntry = {
   path: string;
   reasonCode: string;
@@ -170,6 +193,7 @@ export type StaticAgentStackIngestionResult = {
   status: StaticAgentStackIngestionStatus;
   inventory: StaticAgentStackInventoryEntry[];
   connectorDiagnostics: StaticAgentStackConnectorDiagnostic[];
+  riskDiagnostics: StaticAgentStackRiskDiagnostic[];
   rejectedEntries: StaticAgentStackRejectedEntry[];
   warnings: AgentStackFixtureValidationWarning[];
   draftPayloadReadiness: StaticAgentStackDraftPayloadReadiness;
@@ -195,6 +219,103 @@ const SUPPORTED_SURFACE_KINDS: readonly AgentStackFixtureSurfaceKind[] = [
   'validation-warning',
 ];
 const WARNING_SEVERITIES: readonly AgentStackFixtureValidationWarning['severity'][] = ['info', 'warning', 'blocked'];
+const STATIC_RISK_CODE_MAP: Record<string, {
+  category: StaticAgentStackRiskCategory;
+  severity: AgentStackFixtureValidationWarning['severity'];
+  blocksDraftPayload: boolean;
+  message: string;
+}> = {
+  deploy_capable_commands: {
+    category: 'deploy_capable_command',
+    severity: 'blocked',
+    blocksDraftPayload: true,
+    message: 'Deploy-capable command metadata must be reviewed before draft publication.',
+  },
+  wallet_rpc_adjacent_commands: {
+    category: 'wallet_rpc_capable_metadata',
+    severity: 'blocked',
+    blocksDraftPayload: true,
+    message: 'Wallet, signing, or RPC-capable command metadata must be reviewed before draft publication.',
+  },
+  npx_mcp_execution: {
+    category: 'mcp_launcher_execution',
+    severity: 'warning',
+    blocksDraftPayload: true,
+    message: 'npx-launched MCP metadata must be reviewed before draft publication.',
+  },
+  env_required_connector: {
+    category: 'env_required_connector',
+    severity: 'warning',
+    blocksDraftPayload: true,
+    message: 'Environment-required connector metadata must be reviewed before draft publication.',
+  },
+  local_binary_required: {
+    category: 'local_binary_requirement',
+    severity: 'warning',
+    blocksDraftPayload: true,
+    message: 'Local-binary connector metadata must be reviewed before draft publication.',
+  },
+  executable_hooks: {
+    category: 'executable_hook',
+    severity: 'blocked',
+    blocksDraftPayload: true,
+    message: 'Executable hook metadata must be reviewed before draft publication.',
+  },
+  mainnet_deploy_guard_required: {
+    category: 'deploy_capable_command',
+    severity: 'blocked',
+    blocksDraftPayload: true,
+    message: 'Mainnet deploy guard metadata must be reviewed before draft publication.',
+  },
+  permission_policy: {
+    category: 'permission_policy',
+    severity: 'warning',
+    blocksDraftPayload: false,
+    message: 'Permission policy metadata requires operator review before enablement.',
+  },
+  private_path_denylist: {
+    category: 'permission_policy',
+    severity: 'warning',
+    blocksDraftPayload: false,
+    message: 'Private-path denylist metadata requires operator review before enablement.',
+  },
+  external_submodules_declared: {
+    category: 'external_submodule',
+    severity: 'blocked',
+    blocksDraftPayload: true,
+    message: 'External submodule declarations must be reviewed before draft publication.',
+  },
+  installer_script_non_executable_fixture: {
+    category: 'installer_or_update_script',
+    severity: 'blocked',
+    blocksDraftPayload: true,
+    message: 'Installer, update, or test script metadata must be reviewed before draft publication.',
+  },
+  mcp_connector_requires_operator_review: {
+    category: 'env_required_connector',
+    severity: 'warning',
+    blocksDraftPayload: true,
+    message: 'Connector metadata that requires credentials, hosted services, or local binaries must be reviewed before draft publication.',
+  },
+  executable_hooks_require_operator_review: {
+    category: 'executable_hook',
+    severity: 'blocked',
+    blocksDraftPayload: true,
+    message: 'Executable hook metadata must be reviewed before draft publication.',
+  },
+  solana_deploy_command_requires_operator_review: {
+    category: 'deploy_capable_command',
+    severity: 'blocked',
+    blocksDraftPayload: true,
+    message: 'Deploy-capable Solana command metadata must be reviewed before draft publication.',
+  },
+  external_submodules_not_initialized: {
+    category: 'external_submodule',
+    severity: 'warning',
+    blocksDraftPayload: true,
+    message: 'External submodule declarations must be reviewed before draft publication.',
+  },
+};
 
 function error(
   code: AgentStackFixtureValidationErrorCode,
@@ -519,13 +640,80 @@ function connectorRequiresOperatorReview(file: AgentStackFixtureFile, warning?: 
   return file.parseStatus !== 'valid' || (file.warningCodes?.length ?? 0) > 0 || warning !== undefined;
 }
 
+function maxSeverity(
+  left: AgentStackFixtureValidationWarning['severity'],
+  right: AgentStackFixtureValidationWarning['severity'],
+): AgentStackFixtureValidationWarning['severity'] {
+  if (left === 'blocked' || right === 'blocked') return 'blocked';
+  if (left === 'warning' || right === 'warning') return 'warning';
+  return 'info';
+}
+
+function createRiskDiagnostics(corpus: AgentStackFixtureCorpus): StaticAgentStackRiskDiagnostic[] {
+  const byPathAndCategory = new Map<string, StaticAgentStackRiskDiagnostic>();
+  const addRisk = (
+    path: string,
+    sourceKind: StaticAgentStackRiskDiagnostic['sourceKind'],
+    code: string,
+    severityOverride?: AgentStackFixtureValidationWarning['severity'],
+  ): void => {
+    const mapped = STATIC_RISK_CODE_MAP[code];
+    if (!mapped) return;
+
+    const key = `${path}:${mapped.category}`;
+    const severity = severityOverride ? maxSeverity(mapped.severity, severityOverride) : mapped.severity;
+    const existing = byPathAndCategory.get(key);
+    if (existing) {
+      byPathAndCategory.set(key, {
+        ...existing,
+        severity: maxSeverity(existing.severity, severity),
+        warningCodes: existing.warningCodes.includes(code) ? existing.warningCodes : [...existing.warningCodes, code],
+        blocksDraftPayload: existing.blocksDraftPayload || mapped.blocksDraftPayload,
+        operatorReviewRequired: true,
+      });
+      return;
+    }
+
+    byPathAndCategory.set(key, {
+      path,
+      sourceKind,
+      diagnosticLane: 'static_fixture_risk_taxonomy',
+      category: mapped.category,
+      severity,
+      warningCodes: [code],
+      blocksDraftPayload: mapped.blocksDraftPayload,
+      operatorReviewRequired: true,
+      message: mapped.message,
+    });
+  };
+
+  for (const file of corpus.files) {
+    for (const code of file.warningCodes ?? []) {
+      addRisk(file.path, file.kind, code);
+    }
+  }
+
+  for (const warning of corpus.validationWarnings) {
+    addRisk(warning.path, 'validation-warning', warning.code, warning.severity);
+  }
+
+  return [...byPathAndCategory.values()].sort((left, right) => (
+    left.path.localeCompare(right.path)
+    || left.category.localeCompare(right.category)
+  ));
+}
+
 function readinessFromCorpus(
   corpus: AgentStackFixtureCorpus,
   connectorDiagnostics: StaticAgentStackConnectorDiagnostic[],
+  riskDiagnostics: StaticAgentStackRiskDiagnostic[],
   rejectedEntries: StaticAgentStackRejectedEntry[],
 ): StaticAgentStackDraftPayloadReadiness {
   const blockers = [
     ...rejectedEntries.map((entry) => entry.reasonCode),
+    ...riskDiagnostics
+      .filter((diagnostic) => diagnostic.blocksDraftPayload)
+      .map((diagnostic) => `static_risk:${diagnostic.category}:${diagnostic.path}`),
     ...connectorDiagnostics
       .filter((diagnostic) => diagnostic.parseStatus === 'malformed')
       .map((diagnostic) => `malformed_connector:${diagnostic.path}`),
@@ -538,7 +726,11 @@ function readinessFromCorpus(
     return { status: 'blocked', blockers, payloadRefs: [] };
   }
 
-  if (corpus.validationWarnings.length > 0 || connectorDiagnostics.some((diagnostic) => diagnostic.parseStatus !== 'valid')) {
+  if (
+    corpus.validationWarnings.length > 0
+    || connectorDiagnostics.some((diagnostic) => diagnostic.parseStatus !== 'valid')
+    || riskDiagnostics.some((diagnostic) => diagnostic.operatorReviewRequired)
+  ) {
     return {
       status: 'needs_review',
       blockers: ['operator_review_required'],
@@ -594,6 +786,7 @@ export function createStaticAgentStackIngestionResult(
         operatorReviewRequired: true,
         message: 'MCP connector surface has no matching static connector metadata file.',
       })));
+  const riskDiagnostics = createRiskDiagnostics(corpus);
   const rejectedEntries = corpus.validationWarnings
     .filter((warning) => warning.severity === 'blocked')
     .map((warning): StaticAgentStackRejectedEntry => ({
@@ -620,7 +813,7 @@ export function createStaticAgentStackIngestionResult(
       writeCapable: surface.writeCapable ?? false,
       contentTrustBoundary: surface.contentTrustBoundary,
     }));
-  const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, rejectedEntries);
+  const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, rejectedEntries);
   const status: StaticAgentStackIngestionStatus = rejectedEntries.length > 0
     ? 'blocked'
     : draftPayloadReadiness.status !== 'ready'
@@ -635,6 +828,7 @@ export function createStaticAgentStackIngestionResult(
     status,
     inventory,
     connectorDiagnostics,
+    riskDiagnostics,
     rejectedEntries,
     warnings: corpus.validationWarnings,
     draftPayloadReadiness,

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -396,9 +396,139 @@ describe('agent-stack fixture corpus', () => {
       result.rejectedEntries.map((entry) => entry.reasonCode).sort(),
       ['executable_hooks_require_operator_review', 'solana_deploy_command_requires_operator_review'],
     );
+    assert.deepEqual(
+      result.riskDiagnostics.map((diagnostic) => [
+        diagnostic.path,
+        diagnostic.sourceKind,
+        diagnostic.diagnosticLane,
+        diagnostic.category,
+        diagnostic.severity,
+        diagnostic.warningCodes,
+        diagnostic.blocksDraftPayload,
+        diagnostic.operatorReviewRequired,
+      ]),
+      [
+        [
+          '.claude/commands/*.md',
+          'command',
+          'static_fixture_risk_taxonomy',
+          'deploy_capable_command',
+          'blocked',
+          ['deploy_capable_commands'],
+          true,
+          true,
+        ],
+        [
+          '.claude/commands/*.md',
+          'command',
+          'static_fixture_risk_taxonomy',
+          'wallet_rpc_capable_metadata',
+          'blocked',
+          ['wallet_rpc_adjacent_commands'],
+          true,
+          true,
+        ],
+        [
+          '.claude/commands/deploy.md',
+          'validation-warning',
+          'static_fixture_risk_taxonomy',
+          'deploy_capable_command',
+          'blocked',
+          ['solana_deploy_command_requires_operator_review'],
+          true,
+          true,
+        ],
+        [
+          '.claude/settings.json',
+          'command',
+          'static_fixture_risk_taxonomy',
+          'permission_policy',
+          'warning',
+          ['permission_policy', 'private_path_denylist'],
+          false,
+          true,
+        ],
+        [
+          '.gitmodules',
+          'skill',
+          'static_fixture_risk_taxonomy',
+          'external_submodule',
+          'blocked',
+          ['external_submodules_declared', 'external_submodules_not_initialized'],
+          true,
+          true,
+        ],
+        [
+          '.mcp.json',
+          'mcp-connector-config',
+          'static_fixture_risk_taxonomy',
+          'env_required_connector',
+          'warning',
+          ['env_required_connector', 'mcp_connector_requires_operator_review'],
+          true,
+          true,
+        ],
+        [
+          '.mcp.json',
+          'mcp-connector-config',
+          'static_fixture_risk_taxonomy',
+          'local_binary_requirement',
+          'warning',
+          ['local_binary_required'],
+          true,
+          true,
+        ],
+        [
+          '.mcp.json',
+          'mcp-connector-config',
+          'static_fixture_risk_taxonomy',
+          'mcp_launcher_execution',
+          'warning',
+          ['npx_mcp_execution'],
+          true,
+          true,
+        ],
+        [
+          'install.sh',
+          'command',
+          'static_fixture_risk_taxonomy',
+          'installer_or_update_script',
+          'blocked',
+          ['installer_script_non_executable_fixture'],
+          true,
+          true,
+        ],
+        [
+          'plugin/hooks/hooks.json',
+          'command',
+          'static_fixture_risk_taxonomy',
+          'deploy_capable_command',
+          'blocked',
+          ['mainnet_deploy_guard_required'],
+          true,
+          true,
+        ],
+        [
+          'plugin/hooks/hooks.json',
+          'command',
+          'static_fixture_risk_taxonomy',
+          'executable_hook',
+          'blocked',
+          ['executable_hooks', 'executable_hooks_require_operator_review'],
+          true,
+          true,
+        ],
+      ],
+    );
     assert.equal(result.draftPayloadReadiness.status, 'blocked');
     assert.ok(result.draftPayloadReadiness.blockers.includes('executable_hooks_require_operator_review'));
     assert.ok(result.draftPayloadReadiness.blockers.includes('solana_deploy_command_requires_operator_review'));
+    assert.ok(result.draftPayloadReadiness.blockers.includes('static_risk:executable_hook:plugin/hooks/hooks.json'));
+    assert.ok(result.draftPayloadReadiness.blockers.includes('static_risk:deploy_capable_command:.claude/commands/*.md'));
+    assert.ok(result.draftPayloadReadiness.blockers.includes('static_risk:wallet_rpc_capable_metadata:.claude/commands/*.md'));
+    assert.ok(result.draftPayloadReadiness.blockers.includes('static_risk:local_binary_requirement:.mcp.json'));
+    assert.ok(result.draftPayloadReadiness.blockers.includes('static_risk:env_required_connector:.mcp.json'));
+    assert.ok(result.draftPayloadReadiness.blockers.includes('static_risk:external_submodule:.gitmodules'));
     assert.deepEqual(result.draftPayloadReadiness.payloadRefs, []);
   });
 
@@ -459,6 +589,7 @@ describe('agent-stack fixture corpus', () => {
       ]],
     );
     assert.equal(readyResult.draftPayloadReadiness.status, 'ready');
+    assert.deepEqual(readyResult.riskDiagnostics, []);
     assert.deepEqual(readyResult.draftPayloadReadiness.payloadRefs, [
       'static-ingestion:agent-stack-fixture:anthropic-financial-services:2026-06-18:draft-profile',
       'static-ingestion:agent-stack-fixture:anthropic-financial-services:2026-06-18:draft-listing',
@@ -535,6 +666,16 @@ describe('agent-stack fixture corpus', () => {
     assert.ok(!diagnostic.warningCodes.includes('executable_hooks'));
     assert.ok(!diagnostic.warningCodes.includes('mainnet_deploy_guard_required'));
     assert.ok(!diagnostic.warningCodes.includes('external_submodules_declared'));
+    assert.deepEqual(
+      connectorRiskResult.riskDiagnostics
+        .filter((item) => item.path === '.mcp.json')
+        .map((item) => item.category),
+      [],
+    );
+    assert.equal(
+      connectorRiskResult.riskDiagnostics.some((item) => item.category === 'executable_hook' && item.path === '.mcp.json'),
+      false,
+    );
     assert.equal(connectorRiskResult.draftPayloadReadiness.blockers.includes('executable_hooks_require_operator_review'), true);
     assert.equal(connectorRiskResult.draftPayloadReadiness.blockers.includes('solana_deploy_command_requires_operator_review'), true);
   });


### PR DESCRIPTION
Closes #421.

## Summary
- Adds riskDiagnostics to the existing static ingestion result envelope instead of creating a separate result shape.
- Normalizes executable hooks, installer/update/test script metadata, deploy-capable commands, wallet/RPC-capable command metadata, local binary requirements, env-required connector metadata, MCP launcher execution, permission policy metadata, and external submodule declarations.
- Feeds blocking risk diagnostics into draftPayloadReadiness while keeping connectorDiagnostics scoped to MCP connector metadata from #404.
- Documents the risk taxonomy handoff in packages/agent-protocol/README.md and updates generated dist.

## Guardrails
- Static metadata only.
- No plugin install, script/hook/command execution, MCP/server contact, Solana RPC or wallet call, local service startup, credential read, payment activation, or marketplace publication.

## Validation
- npm test -- --runInBand in packages/agent-protocol: 92/92 passing.
- npm run release:dry-run in packages/agent-protocol: pass.
- npm run check:rap:naming at repo root: pass.
- git diff --check: pass.

## Notes
- This PR keeps #404 connector diagnostics as the MCP parsing lane.
- #421 owns the static risk taxonomy used by draft readiness and future operator review payloads.