### PR TITLE
Add static capability inventory bundle

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -73,13 +73,16 @@ console.log(corpus.files.some((file) => file.parseStatus === 'malformed')); // t
 console.log(result.status); // partial_success while malformed connector diagnostics block draft readiness
 console.log(solanaKit.draftPayloadReadiness.status); // blocked until hooks, deploy commands, and MCPs are reviewed
 console.log(solanaKit.riskDiagnostics.map((diagnostic) => diagnostic.category)); // static risk taxonomy for operator review
+console.log(solanaKit.capabilityInventory.entries.map((entry) => entry.runtimeSurface)); // parsed static inventory handoff
 ```
 
 Agent-stack fixture corpora are public, static inputs for onboarding-analyser parser and diagnostics work. The built-in Anthropic financial-services fixture records source URL, checked commit, license/source notes, authenticity notes, crawl timestamp, local research artifact path, high-level marketplace/plugin/managed-agent/MCP surfaces, and validation warnings. The built-in Solana AI Kit fixture records the same source provenance for a Solana-heavy agent-stack toolkit with plugin metadata, agent definitions, commands, MCP declarations, hooks, rules, skills, installer/update/test scripts, and external submodule declarations.
 
 Fixture ingestion rejects credential-shaped metadata, unsafe source URLs, invalid commit refs, invalid timestamps, oversized corpora, and malformed corpus shapes. Public prompt, skill, command, and recipe text is always labelled as untrusted fixture content.
 
-Static ingestion results are deterministic handoff envelopes for later parser, connector-diagnostics, draft-profile, and operator-review work. They combine fixture source metadata, normalized inventory entries, MCP connector diagnostics, non-MCP static risk diagnostics, rejected entries, validation warnings, and draft-payload readiness without fetching the network or executing imported code.
+Static ingestion results are deterministic handoff envelopes for later parser, connector-diagnostics, draft-profile, and operator-review work. They combine fixture source metadata, normalized inventory entries, a parsed capability inventory bundle, MCP connector diagnostics, non-MCP static risk diagnostics, rejected entries, validation warnings, and draft-payload readiness without fetching the network or executing imported code.
+
+The capability inventory bundle is the static #371/#403 handoff. It maps fixture surfaces into source paths, runtime surfaces, commands, skills, tool grants, auth/data dependencies, safety hints, human-review hints, write-capable flags, side-effect risk, content-trust boundaries, parser diagnostics, and fixture provenance. It does not parse or execute imported prompt/skill/command text; those remain untrusted metadata for later operator review.
 
 Risk diagnostics normalize executable hooks, installer/update/test scripts, deploy-capable commands, wallet/RPC-capable command metadata, local binary requirements, env-required connector metadata, MCP launcher execution, permission policies, and external submodule declarations into the same static ingestion result. They are review payloads only; connector parsing still belongs to the MCP connector diagnostics lane.
 

--- a/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
@@ -1,5 +1,6 @@
 export declare const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION: "reddi.agent-stack-fixture-corpus.v1";
 export declare const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION: "reddi.static-agent-stack-ingestion-result.v1";
+export declare const STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION: "reddi.static-agent-stack-capability-inventory.v1";
 export type AgentStackFixtureSurfaceKind = 'repo-marketplace-metadata' | 'claude-plugin' | 'managed-agent-cookbook' | 'mcp-connector-config' | 'skill' | 'command' | 'subagent' | 'partner-plugin' | 'vertical-plugin' | 'validation-warning';
 export type AgentStackFixtureValidationErrorCode = 'malformed_fixture_corpus' | 'invalid_source_reference' | 'credential_leakage_rejected' | 'invalid_commit_ref' | 'invalid_timestamp' | 'unsafe_url' | 'corpus_too_large';
 export type AgentStackFixtureValidationError = {
@@ -99,6 +100,46 @@ export type StaticAgentStackInventoryEntry = {
     writeCapable: boolean;
     contentTrustBoundary: AgentStackFixtureSurface['contentTrustBoundary'];
 };
+export type StaticAgentStackCapabilityInventoryEntry = {
+    capabilityId: string;
+    capabilityName: string;
+    sourceKind: AgentStackFixtureSurfaceKind;
+    sourcePath: string;
+    runtimeSurface?: string;
+    category?: string;
+    commands: string[];
+    skills: string[];
+    toolGrants: string[];
+    authDependencies: string[];
+    dataDependencies: string[];
+    safetyHints: string[];
+    humanReviewHints: string[];
+    writeCapable: boolean;
+    sideEffectRisk: 'none' | 'read' | 'write' | 'execute';
+    contentTrustBoundary: AgentStackFixtureSurface['contentTrustBoundary'];
+    provenance: {
+        corpusId: string;
+        sourceUrl: string;
+        checkedCommit: string;
+        checkedRef?: string;
+        license?: string;
+    };
+};
+export type StaticAgentStackParserDiagnostic = {
+    path: string;
+    sourceKind: AgentStackFixtureSurfaceKind | 'validation-warning';
+    severity: AgentStackFixtureValidationWarning['severity'];
+    code: string;
+    message: string;
+};
+export type StaticAgentStackCapabilityInventoryBundle = {
+    schemaVersion: typeof STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION;
+    corpusId: string;
+    source: AgentStackFixtureSource;
+    entries: StaticAgentStackCapabilityInventoryEntry[];
+    parserDiagnostics: StaticAgentStackParserDiagnostic[];
+    rejectedEntries: StaticAgentStackRejectedEntry[];
+};
 export type StaticAgentStackConnectorDiagnostic = {
     path: string;
     sourceKind: 'mcp-connector-config';
@@ -140,6 +181,7 @@ export type StaticAgentStackIngestionResult = {
     source: AgentStackFixtureSource;
     status: StaticAgentStackIngestionStatus;
     inventory: StaticAgentStackInventoryEntry[];
+    capabilityInventory: StaticAgentStackCapabilityInventoryBundle;
     connectorDiagnostics: StaticAgentStackConnectorDiagnostic[];
     riskDiagnostics: StaticAgentStackRiskDiagnostic[];
     rejectedEntries: StaticAgentStackRejectedEntry[];

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -1,5 +1,6 @@
 export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixture-corpus.v1';
 export const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION = 'reddi.static-agent-stack-ingestion-result.v1';
+export const STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION = 'reddi.static-agent-stack-capability-inventory.v1';
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
 const RFC3339_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
@@ -454,6 +455,87 @@ function createRiskDiagnostics(corpus) {
     return [...byPathAndCategory.values()].sort((left, right) => (left.path.localeCompare(right.path)
         || left.category.localeCompare(right.category)));
 }
+function sideEffectRiskFromSurface(surface) {
+    const combinedHints = [
+        ...(surface.commands ?? []),
+        ...(surface.toolGrants ?? []),
+        ...(surface.safetyHints ?? []),
+        surface.runtimeSurface ?? '',
+    ].join(' ').toLowerCase();
+    if (combinedHints.includes('hook')
+        || combinedHints.includes('bash')
+        || combinedHints.includes('shell')
+        || combinedHints.includes('deploy')
+        || combinedHints.includes('install')
+        || combinedHints.includes('npx')) {
+        return 'execute';
+    }
+    if (surface.writeCapable)
+        return 'write';
+    if (combinedHints.includes('rpc') || combinedHints.includes('browser') || combinedHints.includes('api'))
+        return 'read';
+    return 'none';
+}
+function createCapabilityInventoryBundle(corpus, inventory, rejectedEntries) {
+    const inventoryById = new Map(inventory.map((entry) => [entry.id, entry]));
+    const entries = corpus.surfaces
+        .filter((surface) => surface.kind !== 'validation-warning')
+        .map((surface) => {
+        const inventoryEntry = inventoryById.get(surface.id);
+        return {
+            capabilityId: surface.id,
+            capabilityName: surface.name,
+            sourceKind: surface.kind,
+            sourcePath: surface.path,
+            runtimeSurface: surface.runtimeSurface,
+            category: surface.category,
+            commands: inventoryEntry?.commands ?? [],
+            skills: inventoryEntry?.skills ?? [],
+            toolGrants: inventoryEntry?.toolGrants ?? [],
+            authDependencies: inventoryEntry?.authDependencies ?? [],
+            dataDependencies: inventoryEntry?.dataDependencies ?? [],
+            safetyHints: inventoryEntry?.safetyHints ?? [],
+            humanReviewHints: inventoryEntry?.humanReviewHints ?? [],
+            writeCapable: inventoryEntry?.writeCapable ?? false,
+            sideEffectRisk: sideEffectRiskFromSurface(surface),
+            contentTrustBoundary: surface.contentTrustBoundary,
+            provenance: {
+                corpusId: corpus.id,
+                sourceUrl: corpus.source.sourceUrl,
+                checkedCommit: corpus.source.checkedCommit,
+                checkedRef: corpus.source.checkedRef,
+                license: corpus.source.license,
+            },
+        };
+    });
+    const malformedFileDiagnostics = corpus.files
+        .filter((file) => file.parseStatus === 'malformed')
+        .map((file) => ({
+        path: file.path,
+        sourceKind: file.kind,
+        severity: 'blocked',
+        code: 'malformed_static_metadata',
+        message: file.parseErrorLocation
+            ? `Static metadata is malformed at ${file.parseErrorLocation}.`
+            : 'Static metadata is malformed.',
+    }));
+    const warningDiagnostics = corpus.validationWarnings.map((warning) => ({
+        path: warning.path,
+        sourceKind: 'validation-warning',
+        severity: warning.severity,
+        code: warning.code,
+        message: warning.message,
+    }));
+    return {
+        schemaVersion: STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION,
+        corpusId: corpus.id,
+        source: corpus.source,
+        entries,
+        parserDiagnostics: [...malformedFileDiagnostics, ...warningDiagnostics].sort((left, right) => (left.path.localeCompare(right.path)
+            || left.code.localeCompare(right.code))),
+        rejectedEntries,
+    };
+}
 function readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, rejectedEntries) {
     const blockers = [
         ...rejectedEntries.map((entry) => entry.reasonCode),
@@ -548,6 +630,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
         writeCapable: surface.writeCapable ?? false,
         contentTrustBoundary: surface.contentTrustBoundary,
     }));
+    const capabilityInventory = createCapabilityInventoryBundle(corpus, inventory, rejectedEntries);
     const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, rejectedEntries);
     const status = rejectedEntries.length > 0
         ? 'blocked'
@@ -561,6 +644,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
         source: corpus.source,
         status,
         inventory,
+        capabilityInventory,
         connectorDiagnostics,
         riskDiagnostics,
         rejectedEntries,

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -1,5 +1,6 @@
 export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixture-corpus.v1' as const;
 export const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION = 'reddi.static-agent-stack-ingestion-result.v1' as const;
+export const STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION = 'reddi.static-agent-stack-capability-inventory.v1' as const;
 
 export type AgentStackFixtureSurfaceKind =
   | 'repo-marketplace-metadata'
@@ -137,6 +138,49 @@ export type StaticAgentStackInventoryEntry = {
   contentTrustBoundary: AgentStackFixtureSurface['contentTrustBoundary'];
 };
 
+export type StaticAgentStackCapabilityInventoryEntry = {
+  capabilityId: string;
+  capabilityName: string;
+  sourceKind: AgentStackFixtureSurfaceKind;
+  sourcePath: string;
+  runtimeSurface?: string;
+  category?: string;
+  commands: string[];
+  skills: string[];
+  toolGrants: string[];
+  authDependencies: string[];
+  dataDependencies: string[];
+  safetyHints: string[];
+  humanReviewHints: string[];
+  writeCapable: boolean;
+  sideEffectRisk: 'none' | 'read' | 'write' | 'execute';
+  contentTrustBoundary: AgentStackFixtureSurface['contentTrustBoundary'];
+  provenance: {
+    corpusId: string;
+    sourceUrl: string;
+    checkedCommit: string;
+    checkedRef?: string;
+    license?: string;
+  };
+};
+
+export type StaticAgentStackParserDiagnostic = {
+  path: string;
+  sourceKind: AgentStackFixtureSurfaceKind | 'validation-warning';
+  severity: AgentStackFixtureValidationWarning['severity'];
+  code: string;
+  message: string;
+};
+
+export type StaticAgentStackCapabilityInventoryBundle = {
+  schemaVersion: typeof STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION;
+  corpusId: string;
+  source: AgentStackFixtureSource;
+  entries: StaticAgentStackCapabilityInventoryEntry[];
+  parserDiagnostics: StaticAgentStackParserDiagnostic[];
+  rejectedEntries: StaticAgentStackRejectedEntry[];
+};
+
 export type StaticAgentStackConnectorDiagnostic = {
   path: string;
   sourceKind: 'mcp-connector-config';
@@ -192,6 +236,7 @@ export type StaticAgentStackIngestionResult = {
   source: AgentStackFixtureSource;
   status: StaticAgentStackIngestionStatus;
   inventory: StaticAgentStackInventoryEntry[];
+  capabilityInventory: StaticAgentStackCapabilityInventoryBundle;
   connectorDiagnostics: StaticAgentStackConnectorDiagnostic[];
   riskDiagnostics: StaticAgentStackRiskDiagnostic[];
   rejectedEntries: StaticAgentStackRejectedEntry[];
@@ -703,6 +748,96 @@ function createRiskDiagnostics(corpus: AgentStackFixtureCorpus): StaticAgentStac
   ));
 }
 
+function sideEffectRiskFromSurface(surface: AgentStackFixtureSurface): StaticAgentStackCapabilityInventoryEntry['sideEffectRisk'] {
+  const combinedHints = [
+    ...(surface.commands ?? []),
+    ...(surface.toolGrants ?? []),
+    ...(surface.safetyHints ?? []),
+    surface.runtimeSurface ?? '',
+  ].join(' ').toLowerCase();
+  if (
+    combinedHints.includes('hook')
+    || combinedHints.includes('bash')
+    || combinedHints.includes('shell')
+    || combinedHints.includes('deploy')
+    || combinedHints.includes('install')
+    || combinedHints.includes('npx')
+  ) {
+    return 'execute';
+  }
+  if (surface.writeCapable) return 'write';
+  if (combinedHints.includes('rpc') || combinedHints.includes('browser') || combinedHints.includes('api')) return 'read';
+  return 'none';
+}
+
+function createCapabilityInventoryBundle(
+  corpus: AgentStackFixtureCorpus,
+  inventory: StaticAgentStackInventoryEntry[],
+  rejectedEntries: StaticAgentStackRejectedEntry[],
+): StaticAgentStackCapabilityInventoryBundle {
+  const inventoryById = new Map(inventory.map((entry) => [entry.id, entry]));
+  const entries = corpus.surfaces
+    .filter((surface) => surface.kind !== 'validation-warning')
+    .map((surface): StaticAgentStackCapabilityInventoryEntry => {
+      const inventoryEntry = inventoryById.get(surface.id);
+      return {
+        capabilityId: surface.id,
+        capabilityName: surface.name,
+        sourceKind: surface.kind,
+        sourcePath: surface.path,
+        runtimeSurface: surface.runtimeSurface,
+        category: surface.category,
+        commands: inventoryEntry?.commands ?? [],
+        skills: inventoryEntry?.skills ?? [],
+        toolGrants: inventoryEntry?.toolGrants ?? [],
+        authDependencies: inventoryEntry?.authDependencies ?? [],
+        dataDependencies: inventoryEntry?.dataDependencies ?? [],
+        safetyHints: inventoryEntry?.safetyHints ?? [],
+        humanReviewHints: inventoryEntry?.humanReviewHints ?? [],
+        writeCapable: inventoryEntry?.writeCapable ?? false,
+        sideEffectRisk: sideEffectRiskFromSurface(surface),
+        contentTrustBoundary: surface.contentTrustBoundary,
+        provenance: {
+          corpusId: corpus.id,
+          sourceUrl: corpus.source.sourceUrl,
+          checkedCommit: corpus.source.checkedCommit,
+          checkedRef: corpus.source.checkedRef,
+          license: corpus.source.license,
+        },
+      };
+    });
+  const malformedFileDiagnostics = corpus.files
+    .filter((file) => file.parseStatus === 'malformed')
+    .map((file): StaticAgentStackParserDiagnostic => ({
+      path: file.path,
+      sourceKind: file.kind,
+      severity: 'blocked',
+      code: 'malformed_static_metadata',
+      message: file.parseErrorLocation
+        ? `Static metadata is malformed at ${file.parseErrorLocation}.`
+        : 'Static metadata is malformed.',
+    }));
+  const warningDiagnostics = corpus.validationWarnings.map((warning): StaticAgentStackParserDiagnostic => ({
+    path: warning.path,
+    sourceKind: 'validation-warning',
+    severity: warning.severity,
+    code: warning.code,
+    message: warning.message,
+  }));
+
+  return {
+    schemaVersion: STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION,
+    corpusId: corpus.id,
+    source: corpus.source,
+    entries,
+    parserDiagnostics: [...malformedFileDiagnostics, ...warningDiagnostics].sort((left, right) => (
+      left.path.localeCompare(right.path)
+      || left.code.localeCompare(right.code)
+    )),
+    rejectedEntries,
+  };
+}
+
 function readinessFromCorpus(
   corpus: AgentStackFixtureCorpus,
   connectorDiagnostics: StaticAgentStackConnectorDiagnostic[],
@@ -813,6 +948,7 @@ export function createStaticAgentStackIngestionResult(
       writeCapable: surface.writeCapable ?? false,
       contentTrustBoundary: surface.contentTrustBoundary,
     }));
+  const capabilityInventory = createCapabilityInventoryBundle(corpus, inventory, rejectedEntries);
   const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, rejectedEntries);
   const status: StaticAgentStackIngestionStatus = rejectedEntries.length > 0
     ? 'blocked'
@@ -827,6 +963,7 @@ export function createStaticAgentStackIngestionResult(
     source: corpus.source,
     status,
     inventory,
+    capabilityInventory,
     connectorDiagnostics,
     riskDiagnostics,
     rejectedEntries,

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -327,6 +327,71 @@ describe('agent-stack fixture corpus', () => {
     assert.equal(result.inventory.some((entry) => entry.kind === 'claude-plugin'), true);
     assert.equal(result.inventory.some((entry) => entry.kind === 'validation-warning'), false);
     assert.equal(result.inventory.find((entry) => entry.kind === 'claude-plugin')?.writeCapable, true);
+    assert.equal(result.capabilityInventory.schemaVersion, 'reddi.static-agent-stack-capability-inventory.v1');
+    assert.equal(result.capabilityInventory.corpusId, agentStackFixtureCorpora.anthropicFinancialServices.id);
+    assert.equal(result.capabilityInventory.entries.length, 4);
+    assert.deepEqual(
+      result.capabilityInventory.entries.map((entry) => [
+        entry.capabilityId,
+        entry.sourceKind,
+        entry.sourcePath,
+        entry.runtimeSurface,
+        entry.sideEffectRisk,
+        entry.contentTrustBoundary,
+        entry.provenance.checkedCommit,
+      ]),
+      [
+        [
+          'surface:anthropic-financial-services:marketplace',
+          'repo-marketplace-metadata',
+          '.claude-plugin/marketplace.json',
+          'claude-plugin-marketplace',
+          'none',
+          'metadata_only',
+          '4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1',
+        ],
+        [
+          'surface:anthropic-financial-services:plugins',
+          'claude-plugin',
+          'plugins/',
+          'claude-code-plugin',
+          'write',
+          'untrusted_public_text',
+          '4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1',
+        ],
+        [
+          'surface:anthropic-financial-services:managed-agents',
+          'managed-agent-cookbook',
+          'managed-agents/',
+          'claude-managed-agent',
+          'none',
+          'untrusted_public_text',
+          '4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1',
+        ],
+        [
+          'surface:anthropic-financial-services:mcp-connectors',
+          'mcp-connector-config',
+          'plugins/vertical-plugins/financial-analysis/.mcp.json',
+          'mcp-connector-config',
+          'none',
+          'metadata_only',
+          '4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1',
+        ],
+      ],
+    );
+    assert.deepEqual(
+      result.capabilityInventory.parserDiagnostics.map((diagnostic) => [
+        diagnostic.path,
+        diagnostic.sourceKind,
+        diagnostic.severity,
+        diagnostic.code,
+      ]),
+      [
+        ['plugins/', 'validation-warning', 'info', 'untrusted_prompt_text'],
+        ['plugins/vertical-plugins/financial-analysis/.mcp.json', 'validation-warning', 'warning', 'malformed_mcp_json'],
+        ['plugins/vertical-plugins/financial-analysis/.mcp.json', 'mcp-connector-config', 'blocked', 'malformed_static_metadata'],
+      ],
+    );
     assert.deepEqual(
       result.connectorDiagnostics.map((diagnostic) => [
         diagnostic.path,
@@ -368,6 +433,123 @@ describe('agent-stack fixture corpus', () => {
     assert.ok(inventoryKinds.has('command'));
     assert.ok(inventoryKinds.has('mcp-connector-config'));
     assert.equal(result.inventory.find((entry) => entry.sourcePath === 'plugin/hooks/hooks.json')?.writeCapable, true);
+    assert.equal(result.capabilityInventory.entries.length, 8);
+    assert.deepEqual(
+      result.capabilityInventory.entries.map((entry) => [
+        entry.capabilityId,
+        entry.sourceKind,
+        entry.sourcePath,
+        entry.runtimeSurface,
+        entry.sideEffectRisk,
+        entry.writeCapable,
+        entry.contentTrustBoundary,
+      ]),
+      [
+        [
+          'surface:solana-ai-kit:marketplace',
+          'repo-marketplace-metadata',
+          '.claude-plugin/marketplace.json',
+          'claude-plugin-marketplace',
+          'none',
+          false,
+          'metadata_only',
+        ],
+        [
+          'surface:solana-ai-kit:plugin',
+          'claude-plugin',
+          'plugin/.claude-plugin/plugin.json',
+          'claude-code-plugin',
+          'execute',
+          true,
+          'untrusted_public_text',
+        ],
+        [
+          'surface:solana-ai-kit:agents',
+          'subagent',
+          '.claude/agents/*.md',
+          'claude-subagent',
+          'none',
+          false,
+          'untrusted_public_text',
+        ],
+        [
+          'surface:solana-ai-kit:commands',
+          'command',
+          '.claude/commands/*.md',
+          'claude-code-command',
+          'execute',
+          true,
+          'untrusted_public_text',
+        ],
+        [
+          'surface:solana-ai-kit:mcp',
+          'mcp-connector-config',
+          '.mcp.json',
+          'mcp-connector-config',
+          'execute',
+          false,
+          'metadata_only',
+        ],
+        [
+          'surface:solana-ai-kit:hooks',
+          'command',
+          'plugin/hooks/hooks.json',
+          'claude-code-hooks',
+          'execute',
+          true,
+          'untrusted_public_text',
+        ],
+        [
+          'surface:solana-ai-kit:rules-skills',
+          'skill',
+          '.claude/skills/*.md',
+          'claude-skill',
+          'none',
+          false,
+          'untrusted_public_text',
+        ],
+        [
+          'surface:solana-ai-kit:external-submodules',
+          'skill',
+          '.gitmodules',
+          'git-submodule-declarations',
+          'none',
+          false,
+          'metadata_only',
+        ],
+      ],
+    );
+    assert.deepEqual(
+      result.capabilityInventory.entries.find((entry) => entry.sourcePath === '.claude/commands/*.md')?.commands,
+      ['audit-solana', 'build-program', 'debug-user-tx', 'deploy', 'generate-idl-client', 'profile-cu'],
+    );
+    assert.deepEqual(
+      result.capabilityInventory.entries.find((entry) => entry.sourcePath === '.claude/commands/*.md')?.toolGrants,
+      ['bash', 'git', 'solana-cli', 'anchor', 'cargo', 'npx'],
+    );
+    assert.deepEqual(
+      result.capabilityInventory.entries.find((entry) => entry.sourcePath === '.claude/agents/*.md')?.skills,
+      ['solana architecture', 'anchor', 'pinocchio', 'token-2022', 'qa', 'mobile', 'frontend'],
+    );
+    assert.equal(
+      result.capabilityInventory.entries.every((entry) => entry.provenance.checkedCommit === '4fb9d3d619467e068c1cf3120d3933aa933aeb21'),
+      true,
+    );
+    assert.deepEqual(
+      result.capabilityInventory.parserDiagnostics.map((diagnostic) => [
+        diagnostic.path,
+        diagnostic.sourceKind,
+        diagnostic.severity,
+        diagnostic.code,
+      ]),
+      [
+        ['.claude/agents/*.md', 'validation-warning', 'info', 'untrusted_solana_agent_text'],
+        ['.claude/commands/deploy.md', 'validation-warning', 'blocked', 'solana_deploy_command_requires_operator_review'],
+        ['.gitmodules', 'validation-warning', 'info', 'external_submodules_not_initialized'],
+        ['.mcp.json', 'validation-warning', 'warning', 'mcp_connector_requires_operator_review'],
+        ['plugin/hooks/hooks.json', 'validation-warning', 'blocked', 'executable_hooks_require_operator_review'],
+      ],
+    );
     assert.deepEqual(
       result.connectorDiagnostics.map((diagnostic) => [
         diagnostic.path,


### PR DESCRIPTION
Closes #403.

## Summary
- Adds capabilityInventory to the existing static ingestion result envelope for the #371/#403 static capability inventory handoff.
- Maps validated fixture surfaces into entries with source paths, runtime surfaces, commands, skills, tool grants, auth/data dependencies, safety hints, human-review hints, write-capable flags, side-effect risk, content-trust boundaries, and fixture provenance.
- Adds parser diagnostics from malformed static metadata and fixture validation warnings while keeping imported prompt/skill/command text untrusted.
- Covers both Anthropic financial-services and Solana AI Kit fixture corpora, including Solana agent definitions, commands, hooks, MCP metadata, rules/skills, installer metadata, and external submodule declarations.
- Updates README and generated dist.

## Guardrails
- Static metadata only.
- No network fetch, plugin install, command/hook/script execution, managed-agent invocation, MCP/server contact, Solana RPC/wallet call, payment activation, credential read, local service startup, or marketplace publication.

## Validation
- npm test -- --runInBand in packages/agent-protocol: 92/92 passing.
- npm run release:dry-run in packages/agent-protocol: pass.
- npm run check:rap:naming at repo root: pass.
- git diff --check: pass.

## Notes
- This consumes the #414 static ingestion result envelope and builds on completed #404 connector diagnostics plus #421 static risk taxonomy.
- #405 and #406 can consume this parsed inventory bundle next.