### PR TITLE
Add static fixture draft payloads

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -74,6 +74,7 @@ console.log(result.status); // partial_success while malformed connector diagnos
 console.log(solanaKit.draftPayloadReadiness.status); // blocked until hooks, deploy commands, and MCPs are reviewed
 console.log(solanaKit.riskDiagnostics.map((diagnostic) => diagnostic.category)); // static risk taxonomy for operator review
 console.log(solanaKit.capabilityInventory.entries.map((entry) => entry.runtimeSurface)); // parsed static inventory handoff
+console.log(solanaKit.draftPayloads.listing.publicationDisabled); // true until payment, endpoint, review, and readiness gates pass
 ```
 
 Agent-stack fixture corpora are public, static inputs for onboarding-analyser parser and diagnostics work. The built-in Anthropic financial-services fixture records source URL, checked commit, license/source notes, authenticity notes, crawl timestamp, local research artifact path, high-level marketplace/plugin/managed-agent/MCP surfaces, and validation warnings. The built-in Solana AI Kit fixture records the same source provenance for a Solana-heavy agent-stack toolkit with plugin metadata, agent definitions, commands, MCP declarations, hooks, rules, skills, installer/update/test scripts, and external submodule declarations.
@@ -85,6 +86,8 @@ Static ingestion results are deterministic handoff envelopes for later parser, c
 The capability inventory bundle is the static #371/#403 handoff. It maps fixture surfaces into source paths, runtime surfaces, commands, skills, tool grants, auth/data dependencies, safety hints, human-review hints, write-capable flags, side-effect risk, content-trust boundaries, parser diagnostics, and fixture provenance. It does not parse or execute imported prompt/skill/command text; those remain untrusted metadata for later operator review.
 
 Risk diagnostics normalize executable hooks, installer/update/test scripts, deploy-capable commands, wallet/RPC-capable command metadata, local binary requirements, env-required connector metadata, MCP launcher execution, permission policies, and external submodule declarations into the same static ingestion result. They are review payloads only; connector parsing still belongs to the MCP connector diagnostics lane.
+
+Draft payloads produce a RAP agent profile draft, AI Catalog fragment, and registry/listing draft from static fixture metadata. They carry missing-payment, missing-endpoint, malformed-connector, rejected-entry, unsafe-metadata, and static-risk states forward while keeping publication disabled, payment activation disabled, provider trust unverified, and imported content untrusted until later operator and readiness gates pass.
 
 The fixture corpus never installs Claude plugins, executes repo scripts, invokes managed agents, contacts MCP servers, fetches paid/provider data, requires credentials, starts local services, calls wallets/RPC endpoints, or publishes imported surfaces as payable RAP listings. Parser, connector-diagnostics, draft-profile, and operator-review behavior land in later RAP slices.
 

--- a/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
@@ -1,6 +1,7 @@
 export declare const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION: "reddi.agent-stack-fixture-corpus.v1";
 export declare const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION: "reddi.static-agent-stack-ingestion-result.v1";
 export declare const STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION: "reddi.static-agent-stack-capability-inventory.v1";
+export declare const STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION: "reddi.static-agent-stack-draft-payloads.v1";
 export type AgentStackFixtureSurfaceKind = 'repo-marketplace-metadata' | 'claude-plugin' | 'managed-agent-cookbook' | 'mcp-connector-config' | 'skill' | 'command' | 'subagent' | 'partner-plugin' | 'vertical-plugin' | 'validation-warning';
 export type AgentStackFixtureValidationErrorCode = 'malformed_fixture_corpus' | 'invalid_source_reference' | 'credential_leakage_rejected' | 'invalid_commit_ref' | 'invalid_timestamp' | 'unsafe_url' | 'corpus_too_large';
 export type AgentStackFixtureValidationError = {
@@ -174,6 +175,76 @@ export type StaticAgentStackDraftPayloadReadiness = {
     blockers: string[];
     payloadRefs: string[];
 };
+export type StaticAgentStackDraftStateCode = 'listing_draft' | 'missing_payment' | 'missing_endpoint' | 'malformed_connector' | 'missing_connector' | 'static_risk_review_required' | 'rejected_entry' | 'unsafe_metadata_warning';
+export type StaticAgentStackDraftState = {
+    code: StaticAgentStackDraftStateCode;
+    severity: AgentStackFixtureValidationWarning['severity'];
+    path?: string;
+    message: string;
+};
+export type StaticAgentStackDraftProfile = {
+    schemaVersion: 'reddi.agent-profile.draft.v1';
+    profileId: string;
+    displayName: string;
+    sourceType: 'static-agent-stack-fixture';
+    source: AgentStackFixtureSource;
+    capabilities: StaticAgentStackCapabilityInventoryEntry[];
+    invocation: {
+        endpointType: 'static-fixture-only';
+        endpointUrl?: string;
+        missingEndpoint: boolean;
+    };
+    payment: {
+        status: 'missing_payment_setup';
+        activation: 'disabled';
+    };
+    trust: {
+        sourceAuthenticity: 'verified_source_snapshot';
+        contentTrust: 'untrusted_imported_content';
+        verifiedProviderTrust: false;
+    };
+    policyRequirements: string[];
+    evidenceExpectations: string[];
+    rawSnapshotRefs: string[];
+};
+export type StaticAgentStackAiCatalogFragment = {
+    specVersion: '1.0';
+    resources: Array<{
+        id: string;
+        type: 'agent-stack-draft';
+        mediaType: 'application/vnd.reddi.agent-profile+json';
+        name: string;
+        description: string;
+        capabilities: string[];
+        source: {
+            url: string;
+            checkedCommit: string;
+            checkedRef?: string;
+        };
+        trust: {
+            status: 'unverified';
+            note: string;
+        };
+        payment: {
+            status: 'missing_payment_setup';
+        };
+    }>;
+};
+export type StaticAgentStackListingPayload = {
+    schemaVersion: 'reddi.registry-listing.draft.v1';
+    listingId: string;
+    status: 'draft' | 'needs_review' | 'blocked';
+    profileRef: string;
+    publicationDisabled: true;
+    operatorReviewRequired: true;
+    states: StaticAgentStackDraftState[];
+};
+export type StaticAgentStackDraftPayloads = {
+    schemaVersion: typeof STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION;
+    profile: StaticAgentStackDraftProfile;
+    aiCatalogFragment: StaticAgentStackAiCatalogFragment;
+    listing: StaticAgentStackListingPayload;
+};
 export type StaticAgentStackIngestionResult = {
     schemaVersion: typeof STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION;
     corpusId: string;
@@ -187,6 +258,7 @@ export type StaticAgentStackIngestionResult = {
     rejectedEntries: StaticAgentStackRejectedEntry[];
     warnings: AgentStackFixtureValidationWarning[];
     draftPayloadReadiness: StaticAgentStackDraftPayloadReadiness;
+    draftPayloads: StaticAgentStackDraftPayloads;
     staticOnly: true;
     nonGoals: string[];
 };
@@ -223,8 +295,8 @@ export declare const agentStackFixtureCorpora: {
             readonly kind: "claude-plugin";
             readonly path: "plugins/";
             readonly runtimeSurface: "claude-code-plugin";
-            readonly commands: ["statically discovered command metadata pending #403 parser"];
-            readonly skills: ["statically discovered skill metadata pending #403 parser"];
+            readonly commands: ["statically discovered command metadata"];
+            readonly skills: ["statically discovered skill metadata"];
             readonly toolGrants: ["read", "write-capable grants must be parsed and reviewed before publication"];
             readonly safetyHints: ["Treat plugin prompts and skills as untrusted public text."];
             readonly humanReviewHints: ["Review write-capable commands before draft RAP listing publication."];
@@ -333,8 +405,8 @@ export declare const agentStackFixtureCorpora: {
             readonly kind: "claude-plugin";
             readonly path: "plugin/.claude-plugin/plugin.json";
             readonly runtimeSurface: "claude-code-plugin";
-            readonly commands: ["solana-ai-kit namespaced commands pending #403 parser"];
-            readonly skills: ["plugin skill hub pending #403 parser"];
+            readonly commands: ["solana-ai-kit namespaced commands"];
+            readonly skills: ["plugin skill hub"];
             readonly toolGrants: ["plugin exposes MCP and hooks that require operator review before draft listing"];
             readonly safetyHints: ["Treat plugin manifest and plugin-distributed commands as untrusted public metadata."];
             readonly humanReviewHints: ["Review plugin metadata before generating RAP listing copy."];
@@ -433,7 +505,7 @@ export declare const agentStackFixtureCorpora: {
             readonly present: true;
             readonly parseStatus: "not_parsed";
             readonly mediaType: "text/markdown";
-            readonly summary: "Fifteen Solana-focused agent definitions; parser support belongs to #403.";
+            readonly summary: "Fifteen Solana-focused agent definitions represented as untrusted static metadata.";
         }, {
             readonly path: ".claude/commands/*.md";
             readonly kind: "command";

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -1,6 +1,7 @@
 export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixture-corpus.v1';
 export const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION = 'reddi.static-agent-stack-ingestion-result.v1';
 export const STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION = 'reddi.static-agent-stack-capability-inventory.v1';
+export const STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION = 'reddi.static-agent-stack-draft-payloads.v1';
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
 const RFC3339_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
@@ -567,6 +568,142 @@ function readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, reje
         payloadRefs: [`static-ingestion:${corpus.id}:draft-profile`, `static-ingestion:${corpus.id}:draft-listing`],
     };
 }
+function draftStateSeverityFromReadiness(status) {
+    if (status === 'blocked')
+        return 'blocked';
+    if (status === 'needs_review')
+        return 'needs_review';
+    return 'draft';
+}
+function rawSnapshotRefsForCorpus(corpus) {
+    return [
+        `source:${corpus.source.sourceUrl}#${corpus.source.checkedCommit}`,
+        ...(corpus.source.localResearchArtifactPath ? [`local:${corpus.source.localResearchArtifactPath}`] : []),
+    ];
+}
+function createDraftPayloads(corpus, capabilityInventory, connectorDiagnostics, riskDiagnostics, rejectedEntries, warnings, draftPayloadReadiness) {
+    const draftStates = [
+        {
+            code: 'listing_draft',
+            severity: 'info',
+            message: 'Imported static fixture is a draft only until operator approval and readiness gates pass.',
+        },
+        {
+            code: 'missing_payment',
+            severity: 'warning',
+            message: 'Imported static fixture has no payment setup; payment activation is disabled.',
+        },
+        {
+            code: 'missing_endpoint',
+            severity: 'warning',
+            message: 'Imported static fixture has no invocation endpoint; endpoint binding must be supplied before publication.',
+        },
+        ...connectorDiagnostics
+            .filter((diagnostic) => diagnostic.parseStatus === 'malformed' || diagnostic.parseStatus === 'missing')
+            .map((diagnostic) => ({
+            code: diagnostic.parseStatus === 'missing' ? 'missing_connector' : 'malformed_connector',
+            severity: 'blocked',
+            path: diagnostic.path,
+            message: diagnostic.message,
+        })),
+        ...riskDiagnostics
+            .filter((diagnostic) => diagnostic.operatorReviewRequired)
+            .map((diagnostic) => ({
+            code: 'static_risk_review_required',
+            severity: diagnostic.blocksDraftPayload ? 'blocked' : diagnostic.severity,
+            path: diagnostic.path,
+            message: diagnostic.message,
+        })),
+        ...rejectedEntries.map((entry) => ({
+            code: 'rejected_entry',
+            severity: 'blocked',
+            path: entry.path,
+            message: entry.message,
+        })),
+        ...warnings
+            .filter((warning) => warning.severity !== 'blocked')
+            .map((warning) => ({
+            code: 'unsafe_metadata_warning',
+            severity: warning.severity,
+            path: warning.path,
+            message: warning.message,
+        })),
+    ];
+    const profileId = `draft-profile:${corpus.id}`;
+    const listingId = `draft-listing:${corpus.id}`;
+    const capabilityLabels = capabilityInventory.entries.flatMap((entry) => [
+        entry.capabilityName,
+        ...entry.commands,
+        ...entry.skills,
+    ]);
+    return {
+        schemaVersion: STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION,
+        profile: {
+            schemaVersion: 'reddi.agent-profile.draft.v1',
+            profileId,
+            displayName: corpus.title,
+            sourceType: 'static-agent-stack-fixture',
+            source: corpus.source,
+            capabilities: capabilityInventory.entries,
+            invocation: {
+                endpointType: 'static-fixture-only',
+                missingEndpoint: true,
+            },
+            payment: {
+                status: 'missing_payment_setup',
+                activation: 'disabled',
+            },
+            trust: {
+                sourceAuthenticity: 'verified_source_snapshot',
+                contentTrust: 'untrusted_imported_content',
+                verifiedProviderTrust: false,
+            },
+            policyRequirements: [
+                'operator_review_required',
+                'payment_setup_required',
+                'endpoint_binding_required',
+            ],
+            evidenceExpectations: [
+                'source_snapshot_reference',
+                'operator_review_record',
+                'readiness_gate_result',
+            ],
+            rawSnapshotRefs: rawSnapshotRefsForCorpus(corpus),
+        },
+        aiCatalogFragment: {
+            specVersion: '1.0',
+            resources: [{
+                    id: `urn:reddi:agent-stack-draft:${corpus.id}`,
+                    type: 'agent-stack-draft',
+                    mediaType: 'application/vnd.reddi.agent-profile+json',
+                    name: corpus.title,
+                    description: 'Draft RAP profile generated from an untrusted static agent-stack fixture.',
+                    capabilities: [...new Set(capabilityLabels)].sort(),
+                    source: {
+                        url: corpus.source.sourceUrl,
+                        checkedCommit: corpus.source.checkedCommit,
+                        checkedRef: corpus.source.checkedRef,
+                    },
+                    trust: {
+                        status: 'unverified',
+                        note: 'Source snapshot is recorded, but imported content and provider trust are unverified until RAP review.',
+                    },
+                    payment: {
+                        status: 'missing_payment_setup',
+                    },
+                }],
+        },
+        listing: {
+            schemaVersion: 'reddi.registry-listing.draft.v1',
+            listingId,
+            status: draftStateSeverityFromReadiness(draftPayloadReadiness.status),
+            profileRef: profileId,
+            publicationDisabled: true,
+            operatorReviewRequired: true,
+            states: draftStates,
+        },
+    };
+}
 export function createStaticAgentStackIngestionResult(input, options = {}) {
     const corpus = createAgentStackFixtureCorpus(input, options);
     const warningByPath = new Map(corpus.validationWarnings.map((warning) => [warning.path, warning]));
@@ -632,6 +769,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
     }));
     const capabilityInventory = createCapabilityInventoryBundle(corpus, inventory, rejectedEntries);
     const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, rejectedEntries);
+    const draftPayloads = createDraftPayloads(corpus, capabilityInventory, connectorDiagnostics, riskDiagnostics, rejectedEntries, corpus.validationWarnings, draftPayloadReadiness);
     const status = rejectedEntries.length > 0
         ? 'blocked'
         : draftPayloadReadiness.status !== 'ready'
@@ -650,6 +788,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
         rejectedEntries,
         warnings: corpus.validationWarnings,
         draftPayloadReadiness,
+        draftPayloads,
         staticOnly: true,
         nonGoals: corpus.nonGoals,
     };
@@ -693,8 +832,8 @@ export const agentStackFixtureCorpora = {
                 kind: 'claude-plugin',
                 path: 'plugins/',
                 runtimeSurface: 'claude-code-plugin',
-                commands: ['statically discovered command metadata pending #403 parser'],
-                skills: ['statically discovered skill metadata pending #403 parser'],
+                commands: ['statically discovered command metadata'],
+                skills: ['statically discovered skill metadata'],
                 toolGrants: ['read', 'write-capable grants must be parsed and reviewed before publication'],
                 safetyHints: ['Treat plugin prompts and skills as untrusted public text.'],
                 humanReviewHints: ['Review write-capable commands before draft RAP listing publication.'],
@@ -829,8 +968,8 @@ export const agentStackFixtureCorpora = {
                 kind: 'claude-plugin',
                 path: 'plugin/.claude-plugin/plugin.json',
                 runtimeSurface: 'claude-code-plugin',
-                commands: ['solana-ai-kit namespaced commands pending #403 parser'],
-                skills: ['plugin skill hub pending #403 parser'],
+                commands: ['solana-ai-kit namespaced commands'],
+                skills: ['plugin skill hub'],
                 toolGrants: ['plugin exposes MCP and hooks that require operator review before draft listing'],
                 safetyHints: ['Treat plugin manifest and plugin-distributed commands as untrusted public metadata.'],
                 humanReviewHints: ['Review plugin metadata before generating RAP listing copy.'],
@@ -940,7 +1079,7 @@ export const agentStackFixtureCorpora = {
                 present: true,
                 parseStatus: 'not_parsed',
                 mediaType: 'text/markdown',
-                summary: 'Fifteen Solana-focused agent definitions; parser support belongs to #403.',
+                summary: 'Fifteen Solana-focused agent definitions represented as untrusted static metadata.',
             },
             {
                 path: '.claude/commands/*.md',

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -1,6 +1,7 @@
 export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixture-corpus.v1' as const;
 export const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION = 'reddi.static-agent-stack-ingestion-result.v1' as const;
 export const STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION = 'reddi.static-agent-stack-capability-inventory.v1' as const;
+export const STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION = 'reddi.static-agent-stack-draft-payloads.v1' as const;
 
 export type AgentStackFixtureSurfaceKind =
   | 'repo-marketplace-metadata'
@@ -229,6 +230,90 @@ export type StaticAgentStackDraftPayloadReadiness = {
   payloadRefs: string[];
 };
 
+export type StaticAgentStackDraftStateCode =
+  | 'listing_draft'
+  | 'missing_payment'
+  | 'missing_endpoint'
+  | 'malformed_connector'
+  | 'missing_connector'
+  | 'static_risk_review_required'
+  | 'rejected_entry'
+  | 'unsafe_metadata_warning';
+
+export type StaticAgentStackDraftState = {
+  code: StaticAgentStackDraftStateCode;
+  severity: AgentStackFixtureValidationWarning['severity'];
+  path?: string;
+  message: string;
+};
+
+export type StaticAgentStackDraftProfile = {
+  schemaVersion: 'reddi.agent-profile.draft.v1';
+  profileId: string;
+  displayName: string;
+  sourceType: 'static-agent-stack-fixture';
+  source: AgentStackFixtureSource;
+  capabilities: StaticAgentStackCapabilityInventoryEntry[];
+  invocation: {
+    endpointType: 'static-fixture-only';
+    endpointUrl?: string;
+    missingEndpoint: boolean;
+  };
+  payment: {
+    status: 'missing_payment_setup';
+    activation: 'disabled';
+  };
+  trust: {
+    sourceAuthenticity: 'verified_source_snapshot';
+    contentTrust: 'untrusted_imported_content';
+    verifiedProviderTrust: false;
+  };
+  policyRequirements: string[];
+  evidenceExpectations: string[];
+  rawSnapshotRefs: string[];
+};
+
+export type StaticAgentStackAiCatalogFragment = {
+  specVersion: '1.0';
+  resources: Array<{
+    id: string;
+    type: 'agent-stack-draft';
+    mediaType: 'application/vnd.reddi.agent-profile+json';
+    name: string;
+    description: string;
+    capabilities: string[];
+    source: {
+      url: string;
+      checkedCommit: string;
+      checkedRef?: string;
+    };
+    trust: {
+      status: 'unverified';
+      note: string;
+    };
+    payment: {
+      status: 'missing_payment_setup';
+    };
+  }>;
+};
+
+export type StaticAgentStackListingPayload = {
+  schemaVersion: 'reddi.registry-listing.draft.v1';
+  listingId: string;
+  status: 'draft' | 'needs_review' | 'blocked';
+  profileRef: string;
+  publicationDisabled: true;
+  operatorReviewRequired: true;
+  states: StaticAgentStackDraftState[];
+};
+
+export type StaticAgentStackDraftPayloads = {
+  schemaVersion: typeof STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION;
+  profile: StaticAgentStackDraftProfile;
+  aiCatalogFragment: StaticAgentStackAiCatalogFragment;
+  listing: StaticAgentStackListingPayload;
+};
+
 export type StaticAgentStackIngestionResult = {
   schemaVersion: typeof STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION;
   corpusId: string;
@@ -242,6 +327,7 @@ export type StaticAgentStackIngestionResult = {
   rejectedEntries: StaticAgentStackRejectedEntry[];
   warnings: AgentStackFixtureValidationWarning[];
   draftPayloadReadiness: StaticAgentStackDraftPayloadReadiness;
+  draftPayloads: StaticAgentStackDraftPayloads;
   staticOnly: true;
   nonGoals: string[];
 };
@@ -880,6 +966,152 @@ function readinessFromCorpus(
   };
 }
 
+function draftStateSeverityFromReadiness(status: StaticAgentStackDraftPayloadReadiness['status']): StaticAgentStackListingPayload['status'] {
+  if (status === 'blocked') return 'blocked';
+  if (status === 'needs_review') return 'needs_review';
+  return 'draft';
+}
+
+function rawSnapshotRefsForCorpus(corpus: AgentStackFixtureCorpus): string[] {
+  return [
+    `source:${corpus.source.sourceUrl}#${corpus.source.checkedCommit}`,
+    ...(corpus.source.localResearchArtifactPath ? [`local:${corpus.source.localResearchArtifactPath}`] : []),
+  ];
+}
+
+function createDraftPayloads(
+  corpus: AgentStackFixtureCorpus,
+  capabilityInventory: StaticAgentStackCapabilityInventoryBundle,
+  connectorDiagnostics: StaticAgentStackConnectorDiagnostic[],
+  riskDiagnostics: StaticAgentStackRiskDiagnostic[],
+  rejectedEntries: StaticAgentStackRejectedEntry[],
+  warnings: AgentStackFixtureValidationWarning[],
+  draftPayloadReadiness: StaticAgentStackDraftPayloadReadiness,
+): StaticAgentStackDraftPayloads {
+  const draftStates: StaticAgentStackDraftState[] = [
+    {
+      code: 'listing_draft',
+      severity: 'info',
+      message: 'Imported static fixture is a draft only until operator approval and readiness gates pass.',
+    },
+    {
+      code: 'missing_payment',
+      severity: 'warning',
+      message: 'Imported static fixture has no payment setup; payment activation is disabled.',
+    },
+    {
+      code: 'missing_endpoint',
+      severity: 'warning',
+      message: 'Imported static fixture has no invocation endpoint; endpoint binding must be supplied before publication.',
+    },
+    ...connectorDiagnostics
+      .filter((diagnostic) => diagnostic.parseStatus === 'malformed' || diagnostic.parseStatus === 'missing')
+      .map((diagnostic): StaticAgentStackDraftState => ({
+        code: diagnostic.parseStatus === 'missing' ? 'missing_connector' : 'malformed_connector',
+        severity: 'blocked',
+        path: diagnostic.path,
+        message: diagnostic.message,
+      })),
+    ...riskDiagnostics
+      .filter((diagnostic) => diagnostic.operatorReviewRequired)
+      .map((diagnostic): StaticAgentStackDraftState => ({
+        code: 'static_risk_review_required',
+        severity: diagnostic.blocksDraftPayload ? 'blocked' : diagnostic.severity,
+        path: diagnostic.path,
+        message: diagnostic.message,
+      })),
+    ...rejectedEntries.map((entry): StaticAgentStackDraftState => ({
+      code: 'rejected_entry',
+      severity: 'blocked',
+      path: entry.path,
+      message: entry.message,
+    })),
+    ...warnings
+      .filter((warning) => warning.severity !== 'blocked')
+      .map((warning): StaticAgentStackDraftState => ({
+        code: 'unsafe_metadata_warning',
+        severity: warning.severity,
+        path: warning.path,
+        message: warning.message,
+      })),
+  ];
+  const profileId = `draft-profile:${corpus.id}`;
+  const listingId = `draft-listing:${corpus.id}`;
+  const capabilityLabels = capabilityInventory.entries.flatMap((entry) => [
+    entry.capabilityName,
+    ...entry.commands,
+    ...entry.skills,
+  ]);
+
+  return {
+    schemaVersion: STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION,
+    profile: {
+      schemaVersion: 'reddi.agent-profile.draft.v1',
+      profileId,
+      displayName: corpus.title,
+      sourceType: 'static-agent-stack-fixture',
+      source: corpus.source,
+      capabilities: capabilityInventory.entries,
+      invocation: {
+        endpointType: 'static-fixture-only',
+        missingEndpoint: true,
+      },
+      payment: {
+        status: 'missing_payment_setup',
+        activation: 'disabled',
+      },
+      trust: {
+        sourceAuthenticity: 'verified_source_snapshot',
+        contentTrust: 'untrusted_imported_content',
+        verifiedProviderTrust: false,
+      },
+      policyRequirements: [
+        'operator_review_required',
+        'payment_setup_required',
+        'endpoint_binding_required',
+      ],
+      evidenceExpectations: [
+        'source_snapshot_reference',
+        'operator_review_record',
+        'readiness_gate_result',
+      ],
+      rawSnapshotRefs: rawSnapshotRefsForCorpus(corpus),
+    },
+    aiCatalogFragment: {
+      specVersion: '1.0',
+      resources: [{
+        id: `urn:reddi:agent-stack-draft:${corpus.id}`,
+        type: 'agent-stack-draft',
+        mediaType: 'application/vnd.reddi.agent-profile+json',
+        name: corpus.title,
+        description: 'Draft RAP profile generated from an untrusted static agent-stack fixture.',
+        capabilities: [...new Set(capabilityLabels)].sort(),
+        source: {
+          url: corpus.source.sourceUrl,
+          checkedCommit: corpus.source.checkedCommit,
+          checkedRef: corpus.source.checkedRef,
+        },
+        trust: {
+          status: 'unverified',
+          note: 'Source snapshot is recorded, but imported content and provider trust are unverified until RAP review.',
+        },
+        payment: {
+          status: 'missing_payment_setup',
+        },
+      }],
+    },
+    listing: {
+      schemaVersion: 'reddi.registry-listing.draft.v1',
+      listingId,
+      status: draftStateSeverityFromReadiness(draftPayloadReadiness.status),
+      profileRef: profileId,
+      publicationDisabled: true,
+      operatorReviewRequired: true,
+      states: draftStates,
+    },
+  };
+}
+
 export function createStaticAgentStackIngestionResult(
   input: unknown,
   options: AgentStackFixtureValidationOptions = {},
@@ -950,6 +1182,15 @@ export function createStaticAgentStackIngestionResult(
     }));
   const capabilityInventory = createCapabilityInventoryBundle(corpus, inventory, rejectedEntries);
   const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, rejectedEntries);
+  const draftPayloads = createDraftPayloads(
+    corpus,
+    capabilityInventory,
+    connectorDiagnostics,
+    riskDiagnostics,
+    rejectedEntries,
+    corpus.validationWarnings,
+    draftPayloadReadiness,
+  );
   const status: StaticAgentStackIngestionStatus = rejectedEntries.length > 0
     ? 'blocked'
     : draftPayloadReadiness.status !== 'ready'
@@ -969,6 +1210,7 @@ export function createStaticAgentStackIngestionResult(
     rejectedEntries,
     warnings: corpus.validationWarnings,
     draftPayloadReadiness,
+    draftPayloads,
     staticOnly: true,
     nonGoals: corpus.nonGoals,
   };
@@ -1013,8 +1255,8 @@ export const agentStackFixtureCorpora = {
         kind: 'claude-plugin',
         path: 'plugins/',
         runtimeSurface: 'claude-code-plugin',
-        commands: ['statically discovered command metadata pending #403 parser'],
-        skills: ['statically discovered skill metadata pending #403 parser'],
+        commands: ['statically discovered command metadata'],
+        skills: ['statically discovered skill metadata'],
         toolGrants: ['read', 'write-capable grants must be parsed and reviewed before publication'],
         safetyHints: ['Treat plugin prompts and skills as untrusted public text.'],
         humanReviewHints: ['Review write-capable commands before draft RAP listing publication.'],
@@ -1149,8 +1391,8 @@ export const agentStackFixtureCorpora = {
         kind: 'claude-plugin',
         path: 'plugin/.claude-plugin/plugin.json',
         runtimeSurface: 'claude-code-plugin',
-        commands: ['solana-ai-kit namespaced commands pending #403 parser'],
-        skills: ['plugin skill hub pending #403 parser'],
+        commands: ['solana-ai-kit namespaced commands'],
+        skills: ['plugin skill hub'],
         toolGrants: ['plugin exposes MCP and hooks that require operator review before draft listing'],
         safetyHints: ['Treat plugin manifest and plugin-distributed commands as untrusted public metadata.'],
         humanReviewHints: ['Review plugin metadata before generating RAP listing copy.'],
@@ -1260,7 +1502,7 @@ export const agentStackFixtureCorpora = {
         present: true,
         parseStatus: 'not_parsed',
         mediaType: 'text/markdown',
-        summary: 'Fifteen Solana-focused agent definitions; parser support belongs to #403.',
+        summary: 'Fifteen Solana-focused agent definitions represented as untrusted static metadata.',
       },
       {
         path: '.claude/commands/*.md',

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -862,6 +862,97 @@ describe('agent-stack fixture corpus', () => {
     assert.equal(connectorRiskResult.draftPayloadReadiness.blockers.includes('solana_deploy_command_requires_operator_review'), true);
   });
 
+  it('generates blocked draft RAP profile and listing payloads for malformed connector fixtures', () => {
+    const result = createStaticAgentStackIngestionResult(agentStackFixtureCorpora.anthropicFinancialServices);
+    const resource = result.draftPayloads.aiCatalogFragment.resources[0];
+
+    assert.equal(result.draftPayloads.schemaVersion, 'reddi.static-agent-stack-draft-payloads.v1');
+    assert.equal(result.draftPayloads.profile.schemaVersion, 'reddi.agent-profile.draft.v1');
+    assert.equal(result.draftPayloads.profile.profileId, 'draft-profile:agent-stack-fixture:anthropic-financial-services:2026-06-18');
+    assert.equal(result.draftPayloads.profile.sourceType, 'static-agent-stack-fixture');
+    assert.equal(result.draftPayloads.profile.capabilities.length, 4);
+    assert.deepEqual(result.draftPayloads.profile.payment, {
+      status: 'missing_payment_setup',
+      activation: 'disabled',
+    });
+    assert.deepEqual(result.draftPayloads.profile.invocation, {
+      endpointType: 'static-fixture-only',
+      missingEndpoint: true,
+    });
+    assert.deepEqual(result.draftPayloads.profile.trust, {
+      sourceAuthenticity: 'verified_source_snapshot',
+      contentTrust: 'untrusted_imported_content',
+      verifiedProviderTrust: false,
+    });
+    assert.deepEqual(result.draftPayloads.profile.rawSnapshotRefs, [
+      'source:https://github.com/anthropics/financial-services#4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1',
+      'local:projects/reddi-agent-protocol/research/ANTHROPIC-FINANCIAL-SERVICES-REPO-ANALYSIS-2026-06-18.md',
+    ]);
+    assert.equal(resource.id, 'urn:reddi:agent-stack-draft:agent-stack-fixture:anthropic-financial-services:2026-06-18');
+    assert.equal(resource.type, 'agent-stack-draft');
+    assert.equal(resource.trust.status, 'unverified');
+    assert.equal(resource.payment.status, 'missing_payment_setup');
+    assert.ok(resource.capabilities.includes('Financial services Claude plugins'));
+    assert.ok(resource.capabilities.includes('statically discovered command metadata'));
+    assert.ok(!resource.capabilities.some((capability) => capability.includes('pending #403 parser')));
+    assert.equal(result.draftPayloads.listing.status, 'blocked');
+    assert.equal(result.draftPayloads.listing.publicationDisabled, true);
+    assert.equal(result.draftPayloads.listing.operatorReviewRequired, true);
+    assert.deepEqual(
+      result.draftPayloads.listing.states.map((state) => [state.code, state.severity, state.path]),
+      [
+        ['listing_draft', 'info', undefined],
+        ['missing_payment', 'warning', undefined],
+        ['missing_endpoint', 'warning', undefined],
+        ['malformed_connector', 'blocked', 'plugins/vertical-plugins/financial-analysis/.mcp.json'],
+        ['unsafe_metadata_warning', 'warning', 'plugins/vertical-plugins/financial-analysis/.mcp.json'],
+        ['unsafe_metadata_warning', 'info', 'plugins/'],
+      ],
+    );
+  });
+
+  it('carries Solana static risk blockers into draft listing states without enabling publication or payment', () => {
+    const result = createStaticAgentStackIngestionResult(agentStackFixtureCorpora.solanaAiKit);
+    const resource = result.draftPayloads.aiCatalogFragment.resources[0];
+    const stateTriples = result.draftPayloads.listing.states.map((state) => [state.code, state.severity, state.path]);
+
+    assert.equal(result.draftPayloads.profile.profileId, 'draft-profile:agent-stack-fixture:solanabr-solana-ai-kit:2026-06-19');
+    assert.equal(result.draftPayloads.profile.payment.activation, 'disabled');
+    assert.equal(result.draftPayloads.profile.invocation.missingEndpoint, true);
+    assert.equal(result.draftPayloads.profile.trust.verifiedProviderTrust, false);
+    assert.equal(result.draftPayloads.profile.capabilities.length, 8);
+    assert.ok(
+      result.draftPayloads.profile.capabilities.every((capability) => (
+        capability.contentTrustBoundary === 'metadata_only' || capability.contentTrustBoundary === 'untrusted_public_text'
+      )),
+    );
+    assert.equal(resource.trust.status, 'unverified');
+    assert.equal(resource.payment.status, 'missing_payment_setup');
+    assert.ok(resource.capabilities.includes('Solana workflow commands'));
+    assert.ok(resource.capabilities.includes('deploy'));
+    assert.ok(resource.capabilities.includes('plugin skill hub'));
+    assert.ok(!resource.capabilities.some((capability) => capability.includes('pending #403 parser')));
+    assert.equal(result.draftPayloads.listing.status, 'blocked');
+    assert.equal(result.draftPayloads.listing.publicationDisabled, true);
+    assert.ok(stateTriples.some((state) => (
+      state[0] === 'static_risk_review_required'
+      && state[1] === 'blocked'
+      && state[2] === 'plugin/hooks/hooks.json'
+    )));
+    assert.ok(stateTriples.some((state) => (
+      state[0] === 'static_risk_review_required'
+      && state[1] === 'blocked'
+      && state[2] === '.mcp.json'
+    )));
+    assert.ok(stateTriples.some((state) => (
+      state[0] === 'rejected_entry'
+      && state[1] === 'blocked'
+      && state[2] === '.claude/commands/deploy.md'
+    )));
+    assert.ok(stateTriples.some((state) => state[0] === 'missing_payment' && state[1] === 'warning'));
+    assert.ok(stateTriples.some((state) => state[0] === 'missing_endpoint' && state[1] === 'warning'));
+  });
+
   it('does not expose a static ingestion result for invalid or credential-shaped corpora', () => {
     assert.throws(
       () => createStaticAgentStackIngestionResult({


### PR DESCRIPTION
Closes #405.

## Summary
- Adds draftPayloads to the existing static ingestion result envelope.
- Generates a draft RAP profile, AI Catalog fragment, and registry/listing draft from static fixture metadata.
- Carries missing-payment, missing-endpoint, malformed-connector, rejected-entry, unsafe-metadata, and static-risk states forward for downstream readiness/operator review.
- Keeps publication disabled, payment activation disabled, imported provider trust unverified, and imported content untrusted.
- Removes stale pending #403 parser labels from fixture metadata now that the parser handoff is merged.
- Updates README, tests, and generated dist.

## Guardrails
- Static metadata only.
- No network fetch, plugin install, command/hook/script execution, managed-agent invocation, MCP/server contact, Solana RPC/wallet call, payment activation, credential read, local service startup, or marketplace publication.

## Validation
- npm test -- --runInBand in packages/agent-protocol: 94/94 passing.
- npm run release:dry-run in packages/agent-protocol: pass.
- npm run check:rap:naming at repo root: pass after rerun. First run raced package clean/build and hit a transient missing dist-tests file.
- git diff --check: pass.

## Notes
- This consumes #403 capabilityInventory, #404 connectorDiagnostics, #421 riskDiagnostics, and the #414 static ingestion result envelope.
- No UI files touched; screenshots/video not applicable.