### PR TITLE
Add static operator review payloads

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -75,6 +75,7 @@ console.log(solanaKit.draftPayloadReadiness.status); // blocked until hooks, dep
 console.log(solanaKit.riskDiagnostics.map((diagnostic) => diagnostic.category)); // static risk taxonomy for operator review
 console.log(solanaKit.capabilityInventory.entries.map((entry) => entry.runtimeSurface)); // parsed static inventory handoff
 console.log(solanaKit.draftPayloads.listing.publicationDisabled); // true until payment, endpoint, review, and readiness gates pass
+console.log(solanaKit.operatorReviewPayload.publication.disabled); // true until operator approval and readiness gates pass
 ```
 
 Agent-stack fixture corpora are public, static inputs for onboarding-analyser parser and diagnostics work. The built-in Anthropic financial-services fixture records source URL, checked commit, license/source notes, authenticity notes, crawl timestamp, local research artifact path, high-level marketplace/plugin/managed-agent/MCP surfaces, and validation warnings. The built-in Solana AI Kit fixture records the same source provenance for a Solana-heavy agent-stack toolkit with plugin metadata, agent definitions, commands, MCP declarations, hooks, rules, skills, installer/update/test scripts, and external submodule declarations.
@@ -89,7 +90,9 @@ Risk diagnostics normalize executable hooks, installer/update/test scripts, depl
 
 Draft payloads produce a RAP agent profile draft, AI Catalog fragment, and registry/listing draft from static fixture metadata. They carry missing-payment, missing-endpoint, malformed-connector, rejected-entry, unsafe-metadata, and static-risk states forward while keeping publication disabled, payment activation disabled, provider trust unverified, and imported content untrusted until later operator and readiness gates pass.
 
-The fixture corpus never installs Claude plugins, executes repo scripts, invokes managed agents, contacts MCP servers, fetches paid/provider data, requires credentials, starts local services, calls wallets/RPC endpoints, or publishes imported surfaces as payable RAP listings. Parser, connector-diagnostics, draft-profile, and operator-review behavior land in later RAP slices.
+Operator review payloads expose deterministic backend hooks for imported agent-stack review queues. They group parsed repo/plugin surfaces, validation warnings, rejected entries, raw snapshot references, missing payment and endpoint setup, malformed connector states, static risk blockers, and buyer-preview lanes for capability relevance, source authenticity, trust evidence, payment readiness, safety risk, and reputation. They are payloads only: approval, publication, payment activation, provider trust, and reputation remain disabled or unverified until explicit operator approval and #373/#377 readiness gates pass.
+
+The fixture corpus never installs Claude plugins, executes repo scripts, invokes managed agents, contacts MCP servers, fetches paid/provider data, requires credentials, starts local services, calls wallets/RPC endpoints, or publishes imported surfaces as payable RAP listings. Parser, connector-diagnostics, draft-profile, and operator-review behavior are static metadata transformations only.
 
 ## Provider Trust Records
 

--- a/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
@@ -2,6 +2,7 @@ export declare const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION: "reddi.agent-sta
 export declare const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION: "reddi.static-agent-stack-ingestion-result.v1";
 export declare const STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION: "reddi.static-agent-stack-capability-inventory.v1";
 export declare const STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION: "reddi.static-agent-stack-draft-payloads.v1";
+export declare const STATIC_AGENT_STACK_OPERATOR_REVIEW_PAYLOAD_SCHEMA_VERSION: "reddi.static-agent-stack-operator-review-payload.v1";
 export type AgentStackFixtureSurfaceKind = 'repo-marketplace-metadata' | 'claude-plugin' | 'managed-agent-cookbook' | 'mcp-connector-config' | 'skill' | 'command' | 'subagent' | 'partner-plugin' | 'vertical-plugin' | 'validation-warning';
 export type AgentStackFixtureValidationErrorCode = 'malformed_fixture_corpus' | 'invalid_source_reference' | 'credential_leakage_rejected' | 'invalid_commit_ref' | 'invalid_timestamp' | 'unsafe_url' | 'corpus_too_large';
 export type AgentStackFixtureValidationError = {
@@ -245,6 +246,65 @@ export type StaticAgentStackDraftPayloads = {
     aiCatalogFragment: StaticAgentStackAiCatalogFragment;
     listing: StaticAgentStackListingPayload;
 };
+export type StaticAgentStackOperatorReviewStatus = 'approve_ready' | 'request_changes' | 'rejected' | 'suspended';
+export type StaticAgentStackOperatorReviewStateCode = 'approve_ready_draft' | 'rejected_malformed_connector' | 'request_changes_missing_payment' | 'unsafe_metadata_warning' | 'suspended_imported_listing' | 'static_risk_blocker';
+export type StaticAgentStackOperatorReviewItem = {
+    id: string;
+    state: StaticAgentStackOperatorReviewStateCode;
+    severity: AgentStackFixtureValidationWarning['severity'];
+    path?: string;
+    source: 'draft_payload' | 'connector_diagnostic' | 'risk_diagnostic' | 'rejected_entry' | 'validation_warning';
+    reasonCodes: string[];
+    message: string;
+    blocksPublication: boolean;
+    recommendedAction: 'approve_after_readiness_gates' | 'request_payment_setup' | 'request_endpoint_binding' | 'reject_or_fix_malformed_connector' | 'review_static_risk' | 'review_unsafe_metadata' | 'keep_suspended';
+};
+export type StaticAgentStackOperatorReviewGroup = {
+    groupId: string;
+    name: string;
+    sourceKind: AgentStackFixtureSurfaceKind;
+    sourcePath: string;
+    runtimeSurface?: string;
+    capabilityRefs: string[];
+    writeCapable: boolean;
+    humanReviewRequired: boolean;
+    rawSnapshotRefs: string[];
+};
+export type StaticAgentStackOperatorReviewPayload = {
+    schemaVersion: typeof STATIC_AGENT_STACK_OPERATOR_REVIEW_PAYLOAD_SCHEMA_VERSION;
+    reviewId: string;
+    corpusId: string;
+    status: StaticAgentStackOperatorReviewStatus;
+    source: {
+        sourceUrl: string;
+        checkedCommit: string;
+        checkedRef?: string;
+        sourceAuthenticity: 'source_snapshot_recorded';
+        providerTrust: 'unverified';
+        importedContentTrust: 'untrusted';
+    };
+    publication: {
+        disabled: true;
+        requiresOperatorApproval: true;
+        readinessGateRefs: ['#373', '#377'];
+    };
+    payment: {
+        status: 'missing_payment_setup';
+        activation: 'disabled';
+        operatorAction: 'request_payment_setup';
+    };
+    groups: StaticAgentStackOperatorReviewGroup[];
+    reviewItems: StaticAgentStackOperatorReviewItem[];
+    buyerPreview: {
+        capabilityRelevance: 'static_capability_inventory_only';
+        sourceAuthenticity: 'snapshot_recorded_not_provider_trust';
+        trustEvidence: 'unverified_until_operator_review';
+        paymentReadiness: 'missing_payment_setup';
+        safetyRisk: 'operator_review_required';
+        reputation: 'none_for_imported_fixture';
+    };
+    rawSnapshotRefs: string[];
+};
 export type StaticAgentStackIngestionResult = {
     schemaVersion: typeof STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION;
     corpusId: string;
@@ -259,6 +319,7 @@ export type StaticAgentStackIngestionResult = {
     warnings: AgentStackFixtureValidationWarning[];
     draftPayloadReadiness: StaticAgentStackDraftPayloadReadiness;
     draftPayloads: StaticAgentStackDraftPayloads;
+    operatorReviewPayload: StaticAgentStackOperatorReviewPayload;
     staticOnly: true;
     nonGoals: string[];
 };

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -2,6 +2,7 @@ export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixt
 export const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION = 'reddi.static-agent-stack-ingestion-result.v1';
 export const STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION = 'reddi.static-agent-stack-capability-inventory.v1';
 export const STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION = 'reddi.static-agent-stack-draft-payloads.v1';
+export const STATIC_AGENT_STACK_OPERATOR_REVIEW_PAYLOAD_SCHEMA_VERSION = 'reddi.static-agent-stack-operator-review-payload.v1';
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
 const RFC3339_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 const SAFE_PATH_PATTERN = /^[A-Za-z0-9._~@:/+*{}[\], -]+$/;
@@ -704,6 +705,153 @@ function createDraftPayloads(corpus, capabilityInventory, connectorDiagnostics, 
         },
     };
 }
+function reviewItemId(corpusId, state, path) {
+    return `operator-review:${corpusId}:${state}${path ? `:${path}` : ''}`;
+}
+function statusFromReviewItems(reviewItems) {
+    if (reviewItems.some((item) => item.state === 'suspended_imported_listing'))
+        return 'suspended';
+    if (reviewItems.some((item) => item.state === 'rejected_malformed_connector' || item.state === 'static_risk_blocker'))
+        return 'rejected';
+    if (reviewItems.some((item) => item.state === 'request_changes_missing_payment' || item.state === 'unsafe_metadata_warning')) {
+        return 'request_changes';
+    }
+    return 'approve_ready';
+}
+function createOperatorReviewPayload(corpus, capabilityInventory, connectorDiagnostics, riskDiagnostics, rejectedEntries, warnings, draftPayloads) {
+    const rawSnapshotRefs = rawSnapshotRefsForCorpus(corpus);
+    const reviewItems = [
+        {
+            id: reviewItemId(corpus.id, 'approve_ready_draft'),
+            state: 'approve_ready_draft',
+            severity: 'info',
+            source: 'draft_payload',
+            reasonCodes: ['operator_approval_required', 'readiness_gates_required'],
+            message: 'Draft listing cannot become public until operator approval and readiness gates pass.',
+            blocksPublication: true,
+            recommendedAction: 'approve_after_readiness_gates',
+        },
+        {
+            id: reviewItemId(corpus.id, 'request_changes_missing_payment'),
+            state: 'request_changes_missing_payment',
+            severity: 'warning',
+            source: 'draft_payload',
+            reasonCodes: ['missing_payment_setup'],
+            message: 'Payment setup is missing; payment activation remains disabled.',
+            blocksPublication: true,
+            recommendedAction: 'request_payment_setup',
+        },
+        {
+            id: reviewItemId(corpus.id, 'request_changes_missing_payment', 'invocation-endpoint'),
+            state: 'request_changes_missing_payment',
+            severity: 'warning',
+            path: 'invocation-endpoint',
+            source: 'draft_payload',
+            reasonCodes: ['missing_endpoint_binding'],
+            message: 'Invocation endpoint binding is missing and must be supplied before publication.',
+            blocksPublication: true,
+            recommendedAction: 'request_endpoint_binding',
+        },
+        ...connectorDiagnostics
+            .filter((diagnostic) => diagnostic.parseStatus === 'malformed' || diagnostic.parseStatus === 'missing')
+            .map((diagnostic) => ({
+            id: reviewItemId(corpus.id, 'rejected_malformed_connector', diagnostic.path),
+            state: 'rejected_malformed_connector',
+            severity: 'blocked',
+            path: diagnostic.path,
+            source: 'connector_diagnostic',
+            reasonCodes: diagnostic.warningCodes,
+            message: diagnostic.message,
+            blocksPublication: true,
+            recommendedAction: 'reject_or_fix_malformed_connector',
+        })),
+        ...riskDiagnostics
+            .filter((diagnostic) => diagnostic.operatorReviewRequired)
+            .map((diagnostic) => ({
+            id: reviewItemId(corpus.id, 'static_risk_blocker', diagnostic.path),
+            state: 'static_risk_blocker',
+            severity: diagnostic.blocksDraftPayload ? 'blocked' : diagnostic.severity,
+            path: diagnostic.path,
+            source: 'risk_diagnostic',
+            reasonCodes: diagnostic.warningCodes,
+            message: diagnostic.message,
+            blocksPublication: true,
+            recommendedAction: 'review_static_risk',
+        })),
+        ...rejectedEntries.map((entry) => ({
+            id: reviewItemId(corpus.id, 'suspended_imported_listing', entry.path),
+            state: 'suspended_imported_listing',
+            severity: 'blocked',
+            path: entry.path,
+            source: 'rejected_entry',
+            reasonCodes: [entry.reasonCode],
+            message: entry.message,
+            blocksPublication: true,
+            recommendedAction: 'keep_suspended',
+        })),
+        ...warnings
+            .filter((warning) => warning.severity !== 'blocked')
+            .map((warning) => ({
+            id: reviewItemId(corpus.id, 'unsafe_metadata_warning', warning.path),
+            state: 'unsafe_metadata_warning',
+            severity: warning.severity,
+            path: warning.path,
+            source: 'validation_warning',
+            reasonCodes: [warning.code],
+            message: warning.message,
+            blocksPublication: warning.severity === 'warning',
+            recommendedAction: 'review_unsafe_metadata',
+        })),
+    ];
+    return {
+        schemaVersion: STATIC_AGENT_STACK_OPERATOR_REVIEW_PAYLOAD_SCHEMA_VERSION,
+        reviewId: `operator-review:${corpus.id}`,
+        corpusId: corpus.id,
+        status: statusFromReviewItems(reviewItems),
+        source: {
+            sourceUrl: corpus.source.sourceUrl,
+            checkedCommit: corpus.source.checkedCommit,
+            checkedRef: corpus.source.checkedRef,
+            sourceAuthenticity: 'source_snapshot_recorded',
+            providerTrust: 'unverified',
+            importedContentTrust: 'untrusted',
+        },
+        publication: {
+            disabled: true,
+            requiresOperatorApproval: true,
+            readinessGateRefs: ['#373', '#377'],
+        },
+        payment: {
+            status: 'missing_payment_setup',
+            activation: 'disabled',
+            operatorAction: 'request_payment_setup',
+        },
+        groups: capabilityInventory.entries.map((entry) => ({
+            groupId: `operator-review-group:${entry.capabilityId}`,
+            name: entry.capabilityName,
+            sourceKind: entry.sourceKind,
+            sourcePath: entry.sourcePath,
+            runtimeSurface: entry.runtimeSurface,
+            capabilityRefs: [entry.capabilityId, ...entry.commands, ...entry.skills],
+            writeCapable: entry.writeCapable,
+            humanReviewRequired: (entry.humanReviewHints.length > 0
+                || entry.writeCapable
+                || entry.sideEffectRisk === 'write'
+                || entry.sideEffectRisk === 'execute'),
+            rawSnapshotRefs,
+        })),
+        reviewItems,
+        buyerPreview: {
+            capabilityRelevance: 'static_capability_inventory_only',
+            sourceAuthenticity: 'snapshot_recorded_not_provider_trust',
+            trustEvidence: 'unverified_until_operator_review',
+            paymentReadiness: 'missing_payment_setup',
+            safetyRisk: 'operator_review_required',
+            reputation: 'none_for_imported_fixture',
+        },
+        rawSnapshotRefs: draftPayloads.profile.rawSnapshotRefs,
+    };
+}
 export function createStaticAgentStackIngestionResult(input, options = {}) {
     const corpus = createAgentStackFixtureCorpus(input, options);
     const warningByPath = new Map(corpus.validationWarnings.map((warning) => [warning.path, warning]));
@@ -770,6 +918,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
     const capabilityInventory = createCapabilityInventoryBundle(corpus, inventory, rejectedEntries);
     const draftPayloadReadiness = readinessFromCorpus(corpus, connectorDiagnostics, riskDiagnostics, rejectedEntries);
     const draftPayloads = createDraftPayloads(corpus, capabilityInventory, connectorDiagnostics, riskDiagnostics, rejectedEntries, corpus.validationWarnings, draftPayloadReadiness);
+    const operatorReviewPayload = createOperatorReviewPayload(corpus, capabilityInventory, connectorDiagnostics, riskDiagnostics, rejectedEntries, corpus.validationWarnings, draftPayloads);
     const status = rejectedEntries.length > 0
         ? 'blocked'
         : draftPayloadReadiness.status !== 'ready'
@@ -789,6 +938,7 @@ export function createStaticAgentStackIngestionResult(input, options = {}) {
         warnings: corpus.validationWarnings,
         draftPayloadReadiness,
         draftPayloads,
+        operatorReviewPayload,
         staticOnly: true,
         nonGoals: corpus.nonGoals,
     };

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -2,6 +2,7 @@ export const AGENT_STACK_FIXTURE_CORPUS_SCHEMA_VERSION = 'reddi.agent-stack-fixt
 export const STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION = 'reddi.static-agent-stack-ingestion-result.v1' as const;
 export const STATIC_AGENT_STACK_CAPABILITY_INVENTORY_SCHEMA_VERSION = 'reddi.static-agent-stack-capability-inventory.v1' as const;
 export const STATIC_AGENT_STACK_DRAFT_PAYLOADS_SCHEMA_VERSION = 'reddi.static-agent-stack-draft-payloads.v1' as const;
+export const STATIC_AGENT_STACK_OPERATOR_REVIEW_PAYLOAD_SCHEMA_VERSION = 'reddi.static-agent-stack-operator-review-payload.v1' as const;
 
 export type AgentStackFixtureSurfaceKind =
   | 'repo-marketplace-metadata'
@@ -314,6 +315,92 @@ export type StaticAgentStackDraftPayloads = {
   listing: StaticAgentStackListingPayload;
 };
 
+export type StaticAgentStackOperatorReviewStatus =
+  | 'approve_ready'
+  | 'request_changes'
+  | 'rejected'
+  | 'suspended';
+
+export type StaticAgentStackOperatorReviewStateCode =
+  | 'approve_ready_draft'
+  | 'rejected_malformed_connector'
+  | 'request_changes_missing_payment'
+  | 'unsafe_metadata_warning'
+  | 'suspended_imported_listing'
+  | 'static_risk_blocker';
+
+export type StaticAgentStackOperatorReviewItem = {
+  id: string;
+  state: StaticAgentStackOperatorReviewStateCode;
+  severity: AgentStackFixtureValidationWarning['severity'];
+  path?: string;
+  source:
+    | 'draft_payload'
+    | 'connector_diagnostic'
+    | 'risk_diagnostic'
+    | 'rejected_entry'
+    | 'validation_warning';
+  reasonCodes: string[];
+  message: string;
+  blocksPublication: boolean;
+  recommendedAction:
+    | 'approve_after_readiness_gates'
+    | 'request_payment_setup'
+    | 'request_endpoint_binding'
+    | 'reject_or_fix_malformed_connector'
+    | 'review_static_risk'
+    | 'review_unsafe_metadata'
+    | 'keep_suspended';
+};
+
+export type StaticAgentStackOperatorReviewGroup = {
+  groupId: string;
+  name: string;
+  sourceKind: AgentStackFixtureSurfaceKind;
+  sourcePath: string;
+  runtimeSurface?: string;
+  capabilityRefs: string[];
+  writeCapable: boolean;
+  humanReviewRequired: boolean;
+  rawSnapshotRefs: string[];
+};
+
+export type StaticAgentStackOperatorReviewPayload = {
+  schemaVersion: typeof STATIC_AGENT_STACK_OPERATOR_REVIEW_PAYLOAD_SCHEMA_VERSION;
+  reviewId: string;
+  corpusId: string;
+  status: StaticAgentStackOperatorReviewStatus;
+  source: {
+    sourceUrl: string;
+    checkedCommit: string;
+    checkedRef?: string;
+    sourceAuthenticity: 'source_snapshot_recorded';
+    providerTrust: 'unverified';
+    importedContentTrust: 'untrusted';
+  };
+  publication: {
+    disabled: true;
+    requiresOperatorApproval: true;
+    readinessGateRefs: ['#373', '#377'];
+  };
+  payment: {
+    status: 'missing_payment_setup';
+    activation: 'disabled';
+    operatorAction: 'request_payment_setup';
+  };
+  groups: StaticAgentStackOperatorReviewGroup[];
+  reviewItems: StaticAgentStackOperatorReviewItem[];
+  buyerPreview: {
+    capabilityRelevance: 'static_capability_inventory_only';
+    sourceAuthenticity: 'snapshot_recorded_not_provider_trust';
+    trustEvidence: 'unverified_until_operator_review';
+    paymentReadiness: 'missing_payment_setup';
+    safetyRisk: 'operator_review_required';
+    reputation: 'none_for_imported_fixture';
+  };
+  rawSnapshotRefs: string[];
+};
+
 export type StaticAgentStackIngestionResult = {
   schemaVersion: typeof STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION;
   corpusId: string;
@@ -328,6 +415,7 @@ export type StaticAgentStackIngestionResult = {
   warnings: AgentStackFixtureValidationWarning[];
   draftPayloadReadiness: StaticAgentStackDraftPayloadReadiness;
   draftPayloads: StaticAgentStackDraftPayloads;
+  operatorReviewPayload: StaticAgentStackOperatorReviewPayload;
   staticOnly: true;
   nonGoals: string[];
 };
@@ -1112,6 +1200,165 @@ function createDraftPayloads(
   };
 }
 
+function reviewItemId(corpusId: string, state: StaticAgentStackOperatorReviewStateCode, path?: string): string {
+  return `operator-review:${corpusId}:${state}${path ? `:${path}` : ''}`;
+}
+
+function statusFromReviewItems(reviewItems: StaticAgentStackOperatorReviewItem[]): StaticAgentStackOperatorReviewStatus {
+  if (reviewItems.some((item) => item.state === 'suspended_imported_listing')) return 'suspended';
+  if (reviewItems.some((item) => item.state === 'rejected_malformed_connector' || item.state === 'static_risk_blocker')) return 'rejected';
+  if (reviewItems.some((item) => item.state === 'request_changes_missing_payment' || item.state === 'unsafe_metadata_warning')) {
+    return 'request_changes';
+  }
+  return 'approve_ready';
+}
+
+function createOperatorReviewPayload(
+  corpus: AgentStackFixtureCorpus,
+  capabilityInventory: StaticAgentStackCapabilityInventoryBundle,
+  connectorDiagnostics: StaticAgentStackConnectorDiagnostic[],
+  riskDiagnostics: StaticAgentStackRiskDiagnostic[],
+  rejectedEntries: StaticAgentStackRejectedEntry[],
+  warnings: AgentStackFixtureValidationWarning[],
+  draftPayloads: StaticAgentStackDraftPayloads,
+): StaticAgentStackOperatorReviewPayload {
+  const rawSnapshotRefs = rawSnapshotRefsForCorpus(corpus);
+  const reviewItems: StaticAgentStackOperatorReviewItem[] = [
+    {
+      id: reviewItemId(corpus.id, 'approve_ready_draft'),
+      state: 'approve_ready_draft',
+      severity: 'info',
+      source: 'draft_payload',
+      reasonCodes: ['operator_approval_required', 'readiness_gates_required'],
+      message: 'Draft listing cannot become public until operator approval and readiness gates pass.',
+      blocksPublication: true,
+      recommendedAction: 'approve_after_readiness_gates',
+    },
+    {
+      id: reviewItemId(corpus.id, 'request_changes_missing_payment'),
+      state: 'request_changes_missing_payment',
+      severity: 'warning',
+      source: 'draft_payload',
+      reasonCodes: ['missing_payment_setup'],
+      message: 'Payment setup is missing; payment activation remains disabled.',
+      blocksPublication: true,
+      recommendedAction: 'request_payment_setup',
+    },
+    {
+      id: reviewItemId(corpus.id, 'request_changes_missing_payment', 'invocation-endpoint'),
+      state: 'request_changes_missing_payment',
+      severity: 'warning',
+      path: 'invocation-endpoint',
+      source: 'draft_payload',
+      reasonCodes: ['missing_endpoint_binding'],
+      message: 'Invocation endpoint binding is missing and must be supplied before publication.',
+      blocksPublication: true,
+      recommendedAction: 'request_endpoint_binding',
+    },
+    ...connectorDiagnostics
+      .filter((diagnostic) => diagnostic.parseStatus === 'malformed' || diagnostic.parseStatus === 'missing')
+      .map((diagnostic): StaticAgentStackOperatorReviewItem => ({
+        id: reviewItemId(corpus.id, 'rejected_malformed_connector', diagnostic.path),
+        state: 'rejected_malformed_connector',
+        severity: 'blocked',
+        path: diagnostic.path,
+        source: 'connector_diagnostic',
+        reasonCodes: diagnostic.warningCodes,
+        message: diagnostic.message,
+        blocksPublication: true,
+        recommendedAction: 'reject_or_fix_malformed_connector',
+      })),
+    ...riskDiagnostics
+      .filter((diagnostic) => diagnostic.operatorReviewRequired)
+      .map((diagnostic): StaticAgentStackOperatorReviewItem => ({
+        id: reviewItemId(corpus.id, 'static_risk_blocker', diagnostic.path),
+        state: 'static_risk_blocker',
+        severity: diagnostic.blocksDraftPayload ? 'blocked' : diagnostic.severity,
+        path: diagnostic.path,
+        source: 'risk_diagnostic',
+        reasonCodes: diagnostic.warningCodes,
+        message: diagnostic.message,
+        blocksPublication: true,
+        recommendedAction: 'review_static_risk',
+      })),
+    ...rejectedEntries.map((entry): StaticAgentStackOperatorReviewItem => ({
+      id: reviewItemId(corpus.id, 'suspended_imported_listing', entry.path),
+      state: 'suspended_imported_listing',
+      severity: 'blocked',
+      path: entry.path,
+      source: 'rejected_entry',
+      reasonCodes: [entry.reasonCode],
+      message: entry.message,
+      blocksPublication: true,
+      recommendedAction: 'keep_suspended',
+    })),
+    ...warnings
+      .filter((warning) => warning.severity !== 'blocked')
+      .map((warning): StaticAgentStackOperatorReviewItem => ({
+        id: reviewItemId(corpus.id, 'unsafe_metadata_warning', warning.path),
+        state: 'unsafe_metadata_warning',
+        severity: warning.severity,
+        path: warning.path,
+        source: 'validation_warning',
+        reasonCodes: [warning.code],
+        message: warning.message,
+        blocksPublication: warning.severity === 'warning',
+        recommendedAction: 'review_unsafe_metadata',
+      })),
+  ];
+
+  return {
+    schemaVersion: STATIC_AGENT_STACK_OPERATOR_REVIEW_PAYLOAD_SCHEMA_VERSION,
+    reviewId: `operator-review:${corpus.id}`,
+    corpusId: corpus.id,
+    status: statusFromReviewItems(reviewItems),
+    source: {
+      sourceUrl: corpus.source.sourceUrl,
+      checkedCommit: corpus.source.checkedCommit,
+      checkedRef: corpus.source.checkedRef,
+      sourceAuthenticity: 'source_snapshot_recorded',
+      providerTrust: 'unverified',
+      importedContentTrust: 'untrusted',
+    },
+    publication: {
+      disabled: true,
+      requiresOperatorApproval: true,
+      readinessGateRefs: ['#373', '#377'],
+    },
+    payment: {
+      status: 'missing_payment_setup',
+      activation: 'disabled',
+      operatorAction: 'request_payment_setup',
+    },
+    groups: capabilityInventory.entries.map((entry): StaticAgentStackOperatorReviewGroup => ({
+      groupId: `operator-review-group:${entry.capabilityId}`,
+      name: entry.capabilityName,
+      sourceKind: entry.sourceKind,
+      sourcePath: entry.sourcePath,
+      runtimeSurface: entry.runtimeSurface,
+      capabilityRefs: [entry.capabilityId, ...entry.commands, ...entry.skills],
+      writeCapable: entry.writeCapable,
+      humanReviewRequired: (
+        entry.humanReviewHints.length > 0
+        || entry.writeCapable
+        || entry.sideEffectRisk === 'write'
+        || entry.sideEffectRisk === 'execute'
+      ),
+      rawSnapshotRefs,
+    })),
+    reviewItems,
+    buyerPreview: {
+      capabilityRelevance: 'static_capability_inventory_only',
+      sourceAuthenticity: 'snapshot_recorded_not_provider_trust',
+      trustEvidence: 'unverified_until_operator_review',
+      paymentReadiness: 'missing_payment_setup',
+      safetyRisk: 'operator_review_required',
+      reputation: 'none_for_imported_fixture',
+    },
+    rawSnapshotRefs: draftPayloads.profile.rawSnapshotRefs,
+  };
+}
+
 export function createStaticAgentStackIngestionResult(
   input: unknown,
   options: AgentStackFixtureValidationOptions = {},
@@ -1191,6 +1438,15 @@ export function createStaticAgentStackIngestionResult(
     corpus.validationWarnings,
     draftPayloadReadiness,
   );
+  const operatorReviewPayload = createOperatorReviewPayload(
+    corpus,
+    capabilityInventory,
+    connectorDiagnostics,
+    riskDiagnostics,
+    rejectedEntries,
+    corpus.validationWarnings,
+    draftPayloads,
+  );
   const status: StaticAgentStackIngestionStatus = rejectedEntries.length > 0
     ? 'blocked'
     : draftPayloadReadiness.status !== 'ready'
@@ -1211,6 +1467,7 @@ export function createStaticAgentStackIngestionResult(
     warnings: corpus.validationWarnings,
     draftPayloadReadiness,
     draftPayloads,
+    operatorReviewPayload,
     staticOnly: true,
     nonGoals: corpus.nonGoals,
   };

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -953,6 +953,130 @@ describe('agent-stack fixture corpus', () => {
     assert.ok(stateTriples.some((state) => state[0] === 'missing_endpoint' && state[1] === 'warning'));
   });
 
+  it('creates operator review hooks for malformed connectors and missing payment without enabling publication', () => {
+    const result = createStaticAgentStackIngestionResult(agentStackFixtureCorpora.anthropicFinancialServices);
+    const itemStates = result.operatorReviewPayload.reviewItems.map((item) => [item.state, item.severity, item.path]);
+
+    assert.equal(result.operatorReviewPayload.schemaVersion, 'reddi.static-agent-stack-operator-review-payload.v1');
+    assert.equal(result.operatorReviewPayload.reviewId, 'operator-review:agent-stack-fixture:anthropic-financial-services:2026-06-18');
+    assert.equal(result.operatorReviewPayload.status, 'rejected');
+    assert.deepEqual(result.operatorReviewPayload.publication, {
+      disabled: true,
+      requiresOperatorApproval: true,
+      readinessGateRefs: ['#373', '#377'],
+    });
+    assert.deepEqual(result.operatorReviewPayload.payment, {
+      status: 'missing_payment_setup',
+      activation: 'disabled',
+      operatorAction: 'request_payment_setup',
+    });
+    assert.deepEqual(result.operatorReviewPayload.source, {
+      sourceUrl: 'https://github.com/anthropics/financial-services',
+      checkedCommit: '4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1',
+      checkedRef: 'main',
+      sourceAuthenticity: 'source_snapshot_recorded',
+      providerTrust: 'unverified',
+      importedContentTrust: 'untrusted',
+    });
+    assert.deepEqual(result.operatorReviewPayload.buyerPreview, {
+      capabilityRelevance: 'static_capability_inventory_only',
+      sourceAuthenticity: 'snapshot_recorded_not_provider_trust',
+      trustEvidence: 'unverified_until_operator_review',
+      paymentReadiness: 'missing_payment_setup',
+      safetyRisk: 'operator_review_required',
+      reputation: 'none_for_imported_fixture',
+    });
+    assert.ok(result.operatorReviewPayload.groups.some((group) => (
+      group.sourceKind === 'claude-plugin'
+      && group.writeCapable
+      && group.humanReviewRequired
+      && group.rawSnapshotRefs.includes('source:https://github.com/anthropics/financial-services#4bbabc7cd1a474c1667fa05a2bfe58e411dcf9c1')
+    )));
+    assert.ok(itemStates.some((state) => state[0] === 'approve_ready_draft' && state[1] === 'info' && state[2] === undefined));
+    assert.ok(itemStates.some((state) => state[0] === 'request_changes_missing_payment' && state[1] === 'warning' && state[2] === undefined));
+    assert.ok(itemStates.some((state) => state[0] === 'request_changes_missing_payment' && state[2] === 'invocation-endpoint'));
+    assert.ok(itemStates.some((state) => (
+      state[0] === 'rejected_malformed_connector'
+      && state[1] === 'blocked'
+      && state[2] === 'plugins/vertical-plugins/financial-analysis/.mcp.json'
+    )));
+    assert.ok(itemStates.some((state) => (
+      state[0] === 'unsafe_metadata_warning'
+      && state[1] === 'warning'
+      && state[2] === 'plugins/vertical-plugins/financial-analysis/.mcp.json'
+    )));
+    assert.equal(result.operatorReviewPayload.reviewItems.every((item) => item.blocksPublication || item.severity === 'info'), true);
+  });
+
+  it('carries rejected and suspended imported listing states into operator review payloads', () => {
+    const result = createStaticAgentStackIngestionResult({
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      validationWarnings: [
+        ...agentStackFixtureCorpora.anthropicFinancialServices.validationWarnings,
+        {
+          code: 'unsafe_metadata',
+          severity: 'blocked',
+          path: 'plugins/partner-plugins/example/plugin.json',
+          message: 'Unsafe imported metadata must not be exposed to operator approval.',
+        },
+      ],
+    });
+    const suspendedItem = result.operatorReviewPayload.reviewItems.find((item) => (
+      item.state === 'suspended_imported_listing'
+      && item.path === 'plugins/partner-plugins/example/plugin.json'
+    ));
+
+    assert.equal(result.operatorReviewPayload.status, 'suspended');
+    assert.deepEqual(suspendedItem?.reasonCodes, ['unsafe_metadata']);
+    assert.equal(suspendedItem?.recommendedAction, 'keep_suspended');
+    assert.equal(suspendedItem?.blocksPublication, true);
+  });
+
+  it('keeps approve-ready operator review payloads gated on payment, endpoint, and readiness approval', () => {
+    const result = createStaticAgentStackIngestionResult({
+      ...agentStackFixtureCorpora.anthropicFinancialServices,
+      files: agentStackFixtureCorpora.anthropicFinancialServices.files.map((file) => file.kind === 'mcp-connector-config'
+        ? {
+          ...file,
+          parseStatus: 'valid',
+          warningCodes: [],
+        }
+        : file),
+      validationWarnings: [],
+    });
+    const reviewStates = result.operatorReviewPayload.reviewItems.map((item) => item.state);
+
+    assert.equal(result.status, 'ready_for_draft');
+    assert.equal(result.operatorReviewPayload.status, 'request_changes');
+    assert.ok(reviewStates.includes('approve_ready_draft'));
+    assert.ok(reviewStates.includes('request_changes_missing_payment'));
+    assert.ok(!reviewStates.includes('rejected_malformed_connector'));
+    assert.ok(!reviewStates.includes('static_risk_blocker'));
+    assert.equal(result.operatorReviewPayload.publication.disabled, true);
+    assert.equal(result.operatorReviewPayload.payment.activation, 'disabled');
+    assert.equal(result.operatorReviewPayload.source.providerTrust, 'unverified');
+    assert.equal(result.operatorReviewPayload.source.importedContentTrust, 'untrusted');
+  });
+
+  it('exposes Solana static risk blockers as operator review items without executing imported metadata', () => {
+    const result = createStaticAgentStackIngestionResult(agentStackFixtureCorpora.solanaAiKit);
+    const riskItems = result.operatorReviewPayload.reviewItems.filter((item) => item.state === 'static_risk_blocker');
+
+    assert.equal(result.operatorReviewPayload.status, 'suspended');
+    assert.ok(riskItems.some((item) => item.path === 'plugin/hooks/hooks.json' && item.reasonCodes.includes('executable_hooks')));
+    assert.ok(riskItems.some((item) => item.path === '.claude/commands/*.md' && item.reasonCodes.includes('deploy_capable_commands')));
+    assert.ok(riskItems.some((item) => item.path === '.mcp.json' && item.reasonCodes.includes('env_required_connector')));
+    assert.ok(riskItems.some((item) => item.path === '.mcp.json' && item.reasonCodes.includes('local_binary_required')));
+    assert.ok(riskItems.some((item) => item.path === '.gitmodules' && item.reasonCodes.includes('external_submodules_declared')));
+    assert.equal(result.operatorReviewPayload.groups.some((group) => (
+      group.sourcePath === '.claude/commands/*.md'
+      && group.capabilityRefs.includes('deploy')
+      && group.humanReviewRequired
+    )), true);
+    assert.equal(result.operatorReviewPayload.publication.disabled, true);
+    assert.equal(result.operatorReviewPayload.payment.activation, 'disabled');
+  });
+
   it('does not expose a static ingestion result for invalid or credential-shaped corpora', () => {
     assert.throws(
       () => createStaticAgentStackIngestionResult({


### PR DESCRIPTION
## Summary
- Adds `operatorReviewPayload` to the existing static agent-stack ingestion result envelope for #406.
- Exposes deterministic backend review groups, review items, buyer-preview lanes, source/trust/payment/publication gates, and raw snapshot refs from the #403 inventory, #404 connector diagnostics, #405 draft payloads, and #421 risk diagnostics.
- Keeps publication disabled, payment activation disabled, provider trust unverified, imported content untrusted, and reputation absent until explicit operator approval plus #373/#377 readiness gates.

## Guardrails
- Static metadata transformation only.
- No network fetch, plugin install, command/hook/script execution, managed-agent invocation, MCP/server contact, Solana RPC/wallet call, payment activation, credential read, local service startup, or marketplace publication.
- No frontend files touched; screenshot/video evidence is not applicable.

## Validation
- `npm test -- --runInBand` in `packages/agent-protocol` passed with 98 tests.
- `npm run release:dry-run` in `packages/agent-protocol` passed and packed updated dist.
- Root `npm run check:rap:naming` passed.
- `git diff --check` passed.

Closes #406.
