### PR TITLE
Add static operator review fixtures for #415

### DIFF
--- a/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.d.ts
@@ -305,6 +305,28 @@ export type StaticAgentStackOperatorReviewPayload = {
     };
     rawSnapshotRefs: string[];
 };
+export type StaticAgentStackOperatorReviewFixtureState = 'approve_ready_draft' | 'request_changes_draft' | 'rejected_draft' | 'suspended_draft';
+export type StaticAgentStackOperatorReviewFixtureViewport = {
+    name: 'mobile' | 'tablet' | 'desktop';
+    width: number;
+    height: number;
+    requiredStates: StaticAgentStackOperatorReviewStateCode[];
+    requiredGroupKinds: AgentStackFixtureSurfaceKind[];
+};
+export type StaticAgentStackOperatorReviewFixture = {
+    fixtureId: string;
+    description: string;
+    fixtureState: StaticAgentStackOperatorReviewFixtureState;
+    queueState: StaticAgentStackOperatorReviewStatus;
+    uiTestRefs: string[];
+    operatorReviewPayload: StaticAgentStackOperatorReviewPayload;
+    requiredReviewItemStates: StaticAgentStackOperatorReviewStateCode[];
+    requiredGroupKinds: AgentStackFixtureSurfaceKind[];
+    requiredRiskCategories: StaticAgentStackRiskCategory[];
+    viewportCoverage: StaticAgentStackOperatorReviewFixtureViewport[];
+    staticOnly: true;
+    guardrails: readonly string[];
+};
 export type StaticAgentStackIngestionResult = {
     schemaVersion: typeof STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION;
     corpusId: string;
@@ -647,3 +669,75 @@ export declare const agentStackFixtureCorpora: {
     };
 };
 export declare const agentStackFixtureCases: Record<string, AgentStackFixtureCase>;
+export declare const agentStackOperatorReviewFixtureStates: {
+    readonly approveReadyDraft: {
+        readonly fixtureId: "agent-stack-operator-review-fixture:approve-ready-draft";
+        readonly description: "Approve-ready draft review frame for imported repo and plugin groups; publication and payment stay disabled.";
+        readonly fixtureState: "approve_ready_draft";
+        readonly queueState: StaticAgentStackOperatorReviewStatus;
+        readonly uiTestRefs: ["storybook:agent-stack/operator-review/approve-ready-draft", "playwright:agent-stack-operator-review-approve-ready-draft"];
+        readonly operatorReviewPayload: StaticAgentStackOperatorReviewPayload;
+        readonly requiredReviewItemStates: ["approve_ready_draft"];
+        readonly requiredGroupKinds: ["repo-marketplace-metadata", "claude-plugin"];
+        readonly requiredRiskCategories: [];
+        readonly viewportCoverage: StaticAgentStackOperatorReviewFixtureViewport[];
+        readonly staticOnly: true;
+        readonly guardrails: readonly ["Static fixture only: do not execute imported hooks, commands, skills, installers, tests, or agent instructions.", "Do not fetch repositories, submodules, MCP servers, RPC endpoints, wallets, paid providers, or payment rails.", "Do not store secrets, private operational metadata, credential-shaped values, wallet keys, or provider tokens.", "Do not activate live payment, publication, provider trust, reputation, registry listing, or endpoint binding from this fixture."];
+    };
+    readonly requestChangesMissingPayment: {
+        readonly fixtureId: "agent-stack-operator-review-fixture:request-changes-missing-payment";
+        readonly description: "Request-changes draft review frame for missing payment and endpoint setup.";
+        readonly fixtureState: "request_changes_draft";
+        readonly queueState: StaticAgentStackOperatorReviewStatus;
+        readonly uiTestRefs: ["storybook:agent-stack/operator-review/request-changes-missing-payment", "playwright:agent-stack-operator-review-request-changes-missing-payment"];
+        readonly operatorReviewPayload: StaticAgentStackOperatorReviewPayload;
+        readonly requiredReviewItemStates: ["request_changes_missing_payment"];
+        readonly requiredGroupKinds: ["repo-marketplace-metadata", "claude-plugin"];
+        readonly requiredRiskCategories: [];
+        readonly viewportCoverage: StaticAgentStackOperatorReviewFixtureViewport[];
+        readonly staticOnly: true;
+        readonly guardrails: readonly ["Static fixture only: do not execute imported hooks, commands, skills, installers, tests, or agent instructions.", "Do not fetch repositories, submodules, MCP servers, RPC endpoints, wallets, paid providers, or payment rails.", "Do not store secrets, private operational metadata, credential-shaped values, wallet keys, or provider tokens.", "Do not activate live payment, publication, provider trust, reputation, registry listing, or endpoint binding from this fixture."];
+    };
+    readonly rejectedMalformedConnector: {
+        readonly fixtureId: "agent-stack-operator-review-fixture:rejected-malformed-connector";
+        readonly description: "Rejected draft review frame for malformed connector and unsafe metadata warnings.";
+        readonly fixtureState: "rejected_draft";
+        readonly queueState: StaticAgentStackOperatorReviewStatus;
+        readonly uiTestRefs: ["storybook:agent-stack/operator-review/rejected-malformed-connector", "playwright:agent-stack-operator-review-rejected-malformed-connector"];
+        readonly operatorReviewPayload: StaticAgentStackOperatorReviewPayload;
+        readonly requiredReviewItemStates: ["rejected_malformed_connector", "unsafe_metadata_warning", "request_changes_missing_payment"];
+        readonly requiredGroupKinds: ["repo-marketplace-metadata", "claude-plugin", "mcp-connector-config"];
+        readonly requiredRiskCategories: [];
+        readonly viewportCoverage: StaticAgentStackOperatorReviewFixtureViewport[];
+        readonly staticOnly: true;
+        readonly guardrails: readonly ["Static fixture only: do not execute imported hooks, commands, skills, installers, tests, or agent instructions.", "Do not fetch repositories, submodules, MCP servers, RPC endpoints, wallets, paid providers, or payment rails.", "Do not store secrets, private operational metadata, credential-shaped values, wallet keys, or provider tokens.", "Do not activate live payment, publication, provider trust, reputation, registry listing, or endpoint binding from this fixture."];
+    };
+    readonly suspendedUnsafeMetadata: {
+        readonly fixtureId: "agent-stack-operator-review-fixture:suspended-unsafe-metadata";
+        readonly description: "Suspended draft review frame for blocked unsafe imported metadata.";
+        readonly fixtureState: "suspended_draft";
+        readonly queueState: StaticAgentStackOperatorReviewStatus;
+        readonly uiTestRefs: ["storybook:agent-stack/operator-review/suspended-unsafe-metadata", "playwright:agent-stack-operator-review-suspended-unsafe-metadata"];
+        readonly operatorReviewPayload: StaticAgentStackOperatorReviewPayload;
+        readonly requiredReviewItemStates: ["suspended_imported_listing", "unsafe_metadata_warning"];
+        readonly requiredGroupKinds: ["repo-marketplace-metadata", "claude-plugin", "mcp-connector-config"];
+        readonly requiredRiskCategories: [];
+        readonly viewportCoverage: StaticAgentStackOperatorReviewFixtureViewport[];
+        readonly staticOnly: true;
+        readonly guardrails: readonly ["Static fixture only: do not execute imported hooks, commands, skills, installers, tests, or agent instructions.", "Do not fetch repositories, submodules, MCP servers, RPC endpoints, wallets, paid providers, or payment rails.", "Do not store secrets, private operational metadata, credential-shaped values, wallet keys, or provider tokens.", "Do not activate live payment, publication, provider trust, reputation, registry listing, or endpoint binding from this fixture."];
+    };
+    readonly solanaAiKitBlocked: {
+        readonly fixtureId: "agent-stack-operator-review-fixture:solana-ai-kit-blocked";
+        readonly description: "Solana AI Kit blocked review frame for hooks, deploy commands, env-required MCPs, local binaries, and submodules.";
+        readonly fixtureState: "suspended_draft";
+        readonly queueState: StaticAgentStackOperatorReviewStatus;
+        readonly uiTestRefs: ["storybook:agent-stack/operator-review/solana-ai-kit-blocked", "playwright:agent-stack-operator-review-solana-ai-kit-blocked"];
+        readonly operatorReviewPayload: StaticAgentStackOperatorReviewPayload;
+        readonly requiredReviewItemStates: ["static_risk_blocker", "suspended_imported_listing"];
+        readonly requiredGroupKinds: ["repo-marketplace-metadata", "claude-plugin", "command", "mcp-connector-config", "skill"];
+        readonly requiredRiskCategories: ["executable_hook", "deploy_capable_command", "env_required_connector", "local_binary_requirement", "external_submodule"];
+        readonly viewportCoverage: StaticAgentStackOperatorReviewFixtureViewport[];
+        readonly staticOnly: true;
+        readonly guardrails: readonly ["Static fixture only: do not execute imported hooks, commands, skills, installers, tests, or agent instructions.", "Do not fetch repositories, submodules, MCP servers, RPC endpoints, wallets, paid providers, or payment rails.", "Do not store secrets, private operational metadata, credential-shaped values, wallet keys, or provider tokens.", "Do not activate live payment, publication, provider trust, reputation, registry listing, or endpoint binding from this fixture."];
+    };
+};

--- a/packages/agent-protocol/dist/agent-stack-fixtures.js
+++ b/packages/agent-protocol/dist/agent-stack-fixtures.js
@@ -1398,3 +1398,157 @@ export const agentStackFixtureCases = {
         expectedErrorCodes: ['credential_leakage_rejected'],
     },
 };
+const operatorReviewFixtureGuardrails = [
+    'Static fixture only: do not execute imported hooks, commands, skills, installers, tests, or agent instructions.',
+    'Do not fetch repositories, submodules, MCP servers, RPC endpoints, wallets, paid providers, or payment rails.',
+    'Do not store secrets, private operational metadata, credential-shaped values, wallet keys, or provider tokens.',
+    'Do not activate live payment, publication, provider trust, reputation, registry listing, or endpoint binding from this fixture.',
+];
+const operatorReviewViewportCoverage = (requiredStates, requiredGroupKinds) => [
+    {
+        name: 'mobile',
+        width: 390,
+        height: 844,
+        requiredStates,
+        requiredGroupKinds,
+    },
+    {
+        name: 'tablet',
+        width: 834,
+        height: 1112,
+        requiredStates,
+        requiredGroupKinds,
+    },
+    {
+        name: 'desktop',
+        width: 1440,
+        height: 900,
+        requiredStates,
+        requiredGroupKinds,
+    },
+];
+const createReadyAnthropicOperatorReviewPayload = () => (createStaticAgentStackIngestionResult({
+    ...agentStackFixtureCorpora.anthropicFinancialServices,
+    files: agentStackFixtureCorpora.anthropicFinancialServices.files.map((file) => file.kind === 'mcp-connector-config'
+        ? {
+            ...file,
+            parseStatus: 'valid',
+            parseErrorLocation: undefined,
+            warningCodes: [],
+        }
+        : file),
+    validationWarnings: [],
+}).operatorReviewPayload);
+const createSuspendedAnthropicOperatorReviewPayload = () => (createStaticAgentStackIngestionResult({
+    ...agentStackFixtureCorpora.anthropicFinancialServices,
+    validationWarnings: [
+        ...agentStackFixtureCorpora.anthropicFinancialServices.validationWarnings,
+        {
+            code: 'unsafe_metadata',
+            severity: 'blocked',
+            path: 'plugins/partner-plugins/example/plugin.json',
+            message: 'Unsafe imported metadata must stay suspended until operator review replaces or removes it.',
+        },
+    ],
+}).operatorReviewPayload);
+const approveReadyDraftPayload = createReadyAnthropicOperatorReviewPayload();
+const rejectedDraftPayload = createStaticAgentStackIngestionResult(agentStackFixtureCorpora.anthropicFinancialServices).operatorReviewPayload;
+const suspendedDraftPayload = createSuspendedAnthropicOperatorReviewPayload();
+const solanaBlockedPayload = createStaticAgentStackIngestionResult(agentStackFixtureCorpora.solanaAiKit).operatorReviewPayload;
+export const agentStackOperatorReviewFixtureStates = {
+    approveReadyDraft: {
+        fixtureId: 'agent-stack-operator-review-fixture:approve-ready-draft',
+        description: 'Approve-ready draft review frame for imported repo and plugin groups; publication and payment stay disabled.',
+        fixtureState: 'approve_ready_draft',
+        queueState: approveReadyDraftPayload.status,
+        uiTestRefs: [
+            'storybook:agent-stack/operator-review/approve-ready-draft',
+            'playwright:agent-stack-operator-review-approve-ready-draft',
+        ],
+        operatorReviewPayload: approveReadyDraftPayload,
+        requiredReviewItemStates: ['approve_ready_draft'],
+        requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin'],
+        requiredRiskCategories: [],
+        viewportCoverage: operatorReviewViewportCoverage(['approve_ready_draft'], ['repo-marketplace-metadata', 'claude-plugin']),
+        staticOnly: true,
+        guardrails: operatorReviewFixtureGuardrails,
+    },
+    requestChangesMissingPayment: {
+        fixtureId: 'agent-stack-operator-review-fixture:request-changes-missing-payment',
+        description: 'Request-changes draft review frame for missing payment and endpoint setup.',
+        fixtureState: 'request_changes_draft',
+        queueState: approveReadyDraftPayload.status,
+        uiTestRefs: [
+            'storybook:agent-stack/operator-review/request-changes-missing-payment',
+            'playwright:agent-stack-operator-review-request-changes-missing-payment',
+        ],
+        operatorReviewPayload: approveReadyDraftPayload,
+        requiredReviewItemStates: ['request_changes_missing_payment'],
+        requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin'],
+        requiredRiskCategories: [],
+        viewportCoverage: operatorReviewViewportCoverage(['request_changes_missing_payment'], ['repo-marketplace-metadata', 'claude-plugin']),
+        staticOnly: true,
+        guardrails: operatorReviewFixtureGuardrails,
+    },
+    rejectedMalformedConnector: {
+        fixtureId: 'agent-stack-operator-review-fixture:rejected-malformed-connector',
+        description: 'Rejected draft review frame for malformed connector and unsafe metadata warnings.',
+        fixtureState: 'rejected_draft',
+        queueState: rejectedDraftPayload.status,
+        uiTestRefs: [
+            'storybook:agent-stack/operator-review/rejected-malformed-connector',
+            'playwright:agent-stack-operator-review-rejected-malformed-connector',
+        ],
+        operatorReviewPayload: rejectedDraftPayload,
+        requiredReviewItemStates: [
+            'rejected_malformed_connector',
+            'unsafe_metadata_warning',
+            'request_changes_missing_payment',
+        ],
+        requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin', 'mcp-connector-config'],
+        requiredRiskCategories: [],
+        viewportCoverage: operatorReviewViewportCoverage(['rejected_malformed_connector', 'unsafe_metadata_warning', 'request_changes_missing_payment'], ['repo-marketplace-metadata', 'claude-plugin', 'mcp-connector-config']),
+        staticOnly: true,
+        guardrails: operatorReviewFixtureGuardrails,
+    },
+    suspendedUnsafeMetadata: {
+        fixtureId: 'agent-stack-operator-review-fixture:suspended-unsafe-metadata',
+        description: 'Suspended draft review frame for blocked unsafe imported metadata.',
+        fixtureState: 'suspended_draft',
+        queueState: suspendedDraftPayload.status,
+        uiTestRefs: [
+            'storybook:agent-stack/operator-review/suspended-unsafe-metadata',
+            'playwright:agent-stack-operator-review-suspended-unsafe-metadata',
+        ],
+        operatorReviewPayload: suspendedDraftPayload,
+        requiredReviewItemStates: ['suspended_imported_listing', 'unsafe_metadata_warning'],
+        requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin', 'mcp-connector-config'],
+        requiredRiskCategories: [],
+        viewportCoverage: operatorReviewViewportCoverage(['suspended_imported_listing', 'unsafe_metadata_warning'], ['repo-marketplace-metadata', 'claude-plugin', 'mcp-connector-config']),
+        staticOnly: true,
+        guardrails: operatorReviewFixtureGuardrails,
+    },
+    solanaAiKitBlocked: {
+        fixtureId: 'agent-stack-operator-review-fixture:solana-ai-kit-blocked',
+        description: 'Solana AI Kit blocked review frame for hooks, deploy commands, env-required MCPs, local binaries, and submodules.',
+        fixtureState: 'suspended_draft',
+        queueState: solanaBlockedPayload.status,
+        uiTestRefs: [
+            'storybook:agent-stack/operator-review/solana-ai-kit-blocked',
+            'playwright:agent-stack-operator-review-solana-ai-kit-blocked',
+        ],
+        operatorReviewPayload: solanaBlockedPayload,
+        requiredReviewItemStates: ['static_risk_blocker', 'suspended_imported_listing'],
+        requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin', 'command', 'mcp-connector-config', 'skill'],
+        requiredRiskCategories: [
+            'executable_hook',
+            'deploy_capable_command',
+            'env_required_connector',
+            'local_binary_requirement',
+            'external_submodule',
+        ],
+        viewportCoverage: operatorReviewViewportCoverage(['static_risk_blocker', 'suspended_imported_listing'], ['repo-marketplace-metadata', 'claude-plugin', 'command', 'mcp-connector-config', 'skill']),
+        staticOnly: true,
+        guardrails: operatorReviewFixtureGuardrails,
+    },
+};

--- a/packages/agent-protocol/src/agent-stack-fixtures.ts
+++ b/packages/agent-protocol/src/agent-stack-fixtures.ts
@@ -401,6 +401,35 @@ export type StaticAgentStackOperatorReviewPayload = {
   rawSnapshotRefs: string[];
 };
 
+export type StaticAgentStackOperatorReviewFixtureState =
+  | 'approve_ready_draft'
+  | 'request_changes_draft'
+  | 'rejected_draft'
+  | 'suspended_draft';
+
+export type StaticAgentStackOperatorReviewFixtureViewport = {
+  name: 'mobile' | 'tablet' | 'desktop';
+  width: number;
+  height: number;
+  requiredStates: StaticAgentStackOperatorReviewStateCode[];
+  requiredGroupKinds: AgentStackFixtureSurfaceKind[];
+};
+
+export type StaticAgentStackOperatorReviewFixture = {
+  fixtureId: string;
+  description: string;
+  fixtureState: StaticAgentStackOperatorReviewFixtureState;
+  queueState: StaticAgentStackOperatorReviewStatus;
+  uiTestRefs: string[];
+  operatorReviewPayload: StaticAgentStackOperatorReviewPayload;
+  requiredReviewItemStates: StaticAgentStackOperatorReviewStateCode[];
+  requiredGroupKinds: AgentStackFixtureSurfaceKind[];
+  requiredRiskCategories: StaticAgentStackRiskCategory[];
+  viewportCoverage: StaticAgentStackOperatorReviewFixtureViewport[];
+  staticOnly: true;
+  guardrails: readonly string[];
+};
+
 export type StaticAgentStackIngestionResult = {
   schemaVersion: typeof STATIC_AGENT_STACK_INGESTION_RESULT_SCHEMA_VERSION;
   corpusId: string;
@@ -1929,3 +1958,185 @@ export const agentStackFixtureCases: Record<string, AgentStackFixtureCase> = {
     expectedErrorCodes: ['credential_leakage_rejected'],
   },
 };
+
+const operatorReviewFixtureGuardrails = [
+  'Static fixture only: do not execute imported hooks, commands, skills, installers, tests, or agent instructions.',
+  'Do not fetch repositories, submodules, MCP servers, RPC endpoints, wallets, paid providers, or payment rails.',
+  'Do not store secrets, private operational metadata, credential-shaped values, wallet keys, or provider tokens.',
+  'Do not activate live payment, publication, provider trust, reputation, registry listing, or endpoint binding from this fixture.',
+] as const;
+
+const operatorReviewViewportCoverage = (
+  requiredStates: StaticAgentStackOperatorReviewStateCode[],
+  requiredGroupKinds: AgentStackFixtureSurfaceKind[],
+): StaticAgentStackOperatorReviewFixtureViewport[] => [
+  {
+    name: 'mobile',
+    width: 390,
+    height: 844,
+    requiredStates,
+    requiredGroupKinds,
+  },
+  {
+    name: 'tablet',
+    width: 834,
+    height: 1112,
+    requiredStates,
+    requiredGroupKinds,
+  },
+  {
+    name: 'desktop',
+    width: 1440,
+    height: 900,
+    requiredStates,
+    requiredGroupKinds,
+  },
+];
+
+const createReadyAnthropicOperatorReviewPayload = (): StaticAgentStackOperatorReviewPayload => (
+  createStaticAgentStackIngestionResult({
+    ...agentStackFixtureCorpora.anthropicFinancialServices,
+    files: agentStackFixtureCorpora.anthropicFinancialServices.files.map((file) => file.kind === 'mcp-connector-config'
+      ? {
+        ...file,
+        parseStatus: 'valid',
+        parseErrorLocation: undefined,
+        warningCodes: [],
+      }
+      : file),
+    validationWarnings: [],
+  }).operatorReviewPayload
+);
+
+const createSuspendedAnthropicOperatorReviewPayload = (): StaticAgentStackOperatorReviewPayload => (
+  createStaticAgentStackIngestionResult({
+    ...agentStackFixtureCorpora.anthropicFinancialServices,
+    validationWarnings: [
+      ...agentStackFixtureCorpora.anthropicFinancialServices.validationWarnings,
+      {
+        code: 'unsafe_metadata',
+        severity: 'blocked',
+        path: 'plugins/partner-plugins/example/plugin.json',
+        message: 'Unsafe imported metadata must stay suspended until operator review replaces or removes it.',
+      },
+    ],
+  }).operatorReviewPayload
+);
+
+const approveReadyDraftPayload = createReadyAnthropicOperatorReviewPayload();
+const rejectedDraftPayload = createStaticAgentStackIngestionResult(agentStackFixtureCorpora.anthropicFinancialServices).operatorReviewPayload;
+const suspendedDraftPayload = createSuspendedAnthropicOperatorReviewPayload();
+const solanaBlockedPayload = createStaticAgentStackIngestionResult(agentStackFixtureCorpora.solanaAiKit).operatorReviewPayload;
+
+export const agentStackOperatorReviewFixtureStates = {
+  approveReadyDraft: {
+    fixtureId: 'agent-stack-operator-review-fixture:approve-ready-draft',
+    description: 'Approve-ready draft review frame for imported repo and plugin groups; publication and payment stay disabled.',
+    fixtureState: 'approve_ready_draft',
+    queueState: approveReadyDraftPayload.status,
+    uiTestRefs: [
+      'storybook:agent-stack/operator-review/approve-ready-draft',
+      'playwright:agent-stack-operator-review-approve-ready-draft',
+    ],
+    operatorReviewPayload: approveReadyDraftPayload,
+    requiredReviewItemStates: ['approve_ready_draft'],
+    requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin'],
+    requiredRiskCategories: [],
+    viewportCoverage: operatorReviewViewportCoverage(
+      ['approve_ready_draft'],
+      ['repo-marketplace-metadata', 'claude-plugin'],
+    ),
+    staticOnly: true,
+    guardrails: operatorReviewFixtureGuardrails,
+  },
+  requestChangesMissingPayment: {
+    fixtureId: 'agent-stack-operator-review-fixture:request-changes-missing-payment',
+    description: 'Request-changes draft review frame for missing payment and endpoint setup.',
+    fixtureState: 'request_changes_draft',
+    queueState: approveReadyDraftPayload.status,
+    uiTestRefs: [
+      'storybook:agent-stack/operator-review/request-changes-missing-payment',
+      'playwright:agent-stack-operator-review-request-changes-missing-payment',
+    ],
+    operatorReviewPayload: approveReadyDraftPayload,
+    requiredReviewItemStates: ['request_changes_missing_payment'],
+    requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin'],
+    requiredRiskCategories: [],
+    viewportCoverage: operatorReviewViewportCoverage(
+      ['request_changes_missing_payment'],
+      ['repo-marketplace-metadata', 'claude-plugin'],
+    ),
+    staticOnly: true,
+    guardrails: operatorReviewFixtureGuardrails,
+  },
+  rejectedMalformedConnector: {
+    fixtureId: 'agent-stack-operator-review-fixture:rejected-malformed-connector',
+    description: 'Rejected draft review frame for malformed connector and unsafe metadata warnings.',
+    fixtureState: 'rejected_draft',
+    queueState: rejectedDraftPayload.status,
+    uiTestRefs: [
+      'storybook:agent-stack/operator-review/rejected-malformed-connector',
+      'playwright:agent-stack-operator-review-rejected-malformed-connector',
+    ],
+    operatorReviewPayload: rejectedDraftPayload,
+    requiredReviewItemStates: [
+      'rejected_malformed_connector',
+      'unsafe_metadata_warning',
+      'request_changes_missing_payment',
+    ],
+    requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin', 'mcp-connector-config'],
+    requiredRiskCategories: [],
+    viewportCoverage: operatorReviewViewportCoverage(
+      ['rejected_malformed_connector', 'unsafe_metadata_warning', 'request_changes_missing_payment'],
+      ['repo-marketplace-metadata', 'claude-plugin', 'mcp-connector-config'],
+    ),
+    staticOnly: true,
+    guardrails: operatorReviewFixtureGuardrails,
+  },
+  suspendedUnsafeMetadata: {
+    fixtureId: 'agent-stack-operator-review-fixture:suspended-unsafe-metadata',
+    description: 'Suspended draft review frame for blocked unsafe imported metadata.',
+    fixtureState: 'suspended_draft',
+    queueState: suspendedDraftPayload.status,
+    uiTestRefs: [
+      'storybook:agent-stack/operator-review/suspended-unsafe-metadata',
+      'playwright:agent-stack-operator-review-suspended-unsafe-metadata',
+    ],
+    operatorReviewPayload: suspendedDraftPayload,
+    requiredReviewItemStates: ['suspended_imported_listing', 'unsafe_metadata_warning'],
+    requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin', 'mcp-connector-config'],
+    requiredRiskCategories: [],
+    viewportCoverage: operatorReviewViewportCoverage(
+      ['suspended_imported_listing', 'unsafe_metadata_warning'],
+      ['repo-marketplace-metadata', 'claude-plugin', 'mcp-connector-config'],
+    ),
+    staticOnly: true,
+    guardrails: operatorReviewFixtureGuardrails,
+  },
+  solanaAiKitBlocked: {
+    fixtureId: 'agent-stack-operator-review-fixture:solana-ai-kit-blocked',
+    description: 'Solana AI Kit blocked review frame for hooks, deploy commands, env-required MCPs, local binaries, and submodules.',
+    fixtureState: 'suspended_draft',
+    queueState: solanaBlockedPayload.status,
+    uiTestRefs: [
+      'storybook:agent-stack/operator-review/solana-ai-kit-blocked',
+      'playwright:agent-stack-operator-review-solana-ai-kit-blocked',
+    ],
+    operatorReviewPayload: solanaBlockedPayload,
+    requiredReviewItemStates: ['static_risk_blocker', 'suspended_imported_listing'],
+    requiredGroupKinds: ['repo-marketplace-metadata', 'claude-plugin', 'command', 'mcp-connector-config', 'skill'],
+    requiredRiskCategories: [
+      'executable_hook',
+      'deploy_capable_command',
+      'env_required_connector',
+      'local_binary_requirement',
+      'external_submodule',
+    ],
+    viewportCoverage: operatorReviewViewportCoverage(
+      ['static_risk_blocker', 'suspended_imported_listing'],
+      ['repo-marketplace-metadata', 'claude-plugin', 'command', 'mcp-connector-config', 'skill'],
+    ),
+    staticOnly: true,
+    guardrails: operatorReviewFixtureGuardrails,
+  },
+} as const satisfies Record<string, StaticAgentStackOperatorReviewFixture>;

--- a/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
+++ b/packages/agent-protocol/tests/agent-stack-fixtures.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import {
   agentStackFixtureCases,
   agentStackFixtureCorpora,
+  agentStackOperatorReviewFixtureStates,
   createAgentStackFixtureCorpus,
   createStaticAgentStackIngestionResult,
   validateAgentStackFixtureCorpus,
@@ -1075,6 +1076,146 @@ describe('agent-stack fixture corpus', () => {
     )), true);
     assert.equal(result.operatorReviewPayload.publication.disabled, true);
     assert.equal(result.operatorReviewPayload.payment.activation, 'disabled');
+  });
+
+  it('exports frontend-safe operator review fixture states for deterministic UI tests', () => {
+    const expectedFixtures = [
+      'approveReadyDraft',
+      'rejectedMalformedConnector',
+      'requestChangesMissingPayment',
+      'solanaAiKitBlocked',
+      'suspendedUnsafeMetadata',
+    ];
+
+    assert.deepEqual(Object.keys(agentStackOperatorReviewFixtureStates).sort(), expectedFixtures.sort());
+    for (const fixture of Object.values(agentStackOperatorReviewFixtureStates)) {
+      const payload = fixture.operatorReviewPayload;
+      const itemStates = new Set(payload.reviewItems.map((item) => item.state));
+      const groupKinds = new Set(payload.groups.map((group) => group.sourceKind));
+      const serialized = JSON.stringify(fixture);
+
+      assert.equal(fixture.staticOnly, true);
+      assert.equal(payload.schemaVersion, 'reddi.static-agent-stack-operator-review-payload.v1');
+      assert.equal(payload.publication.disabled, true);
+      assert.equal(payload.publication.requiresOperatorApproval, true);
+      assert.deepEqual(payload.publication.readinessGateRefs, ['#373', '#377']);
+      assert.equal(payload.payment.activation, 'disabled');
+      assert.equal(payload.source.providerTrust, 'unverified');
+      assert.equal(payload.source.importedContentTrust, 'untrusted');
+      assert.equal(payload.buyerPreview.paymentReadiness, 'missing_payment_setup');
+      assert.equal(payload.buyerPreview.safetyRisk, 'operator_review_required');
+      assert.equal(fixture.queueState, payload.status);
+      assert.ok(fixture.uiTestRefs.some((ref) => ref.startsWith('storybook:')));
+      assert.ok(fixture.uiTestRefs.some((ref) => ref.startsWith('playwright:')));
+      assert.ok(fixture.guardrails.some((guardrail) => guardrail.includes('Do not fetch repositories')));
+      assert.ok(fixture.guardrails.some((guardrail) => guardrail.includes('Do not activate live payment')));
+      for (const requiredState of fixture.requiredReviewItemStates) {
+        assert.ok(itemStates.has(requiredState), `${fixture.fixtureId} should expose ${requiredState}`);
+      }
+      for (const requiredKind of fixture.requiredGroupKinds) {
+        assert.ok(groupKinds.has(requiredKind), `${fixture.fixtureId} should expose ${requiredKind}`);
+      }
+      assert.deepEqual(fixture.viewportCoverage.map((viewport) => viewport.name), ['mobile', 'tablet', 'desktop']);
+      for (const viewport of fixture.viewportCoverage) {
+        assert.ok(viewport.width > 0);
+        assert.ok(viewport.height > 0);
+        assert.deepEqual(viewport.requiredStates, fixture.requiredReviewItemStates);
+        assert.deepEqual(viewport.requiredGroupKinds, fixture.requiredGroupKinds);
+      }
+      assert.doesNotMatch(serialized, /sk-[A-Za-z0-9_-]{8,}|authorization:\s*bearer|PRIVATE KEY/i);
+      assert.doesNotMatch(serialized, /live_payment_activation|wallet_private_key|provider_api_key/i);
+    }
+  });
+
+  it('maps operator review fixture scenarios to imported groups and queue states', () => {
+    const fixtures = agentStackOperatorReviewFixtureStates;
+
+    assert.equal(fixtures.approveReadyDraft.fixtureState, 'approve_ready_draft');
+    assert.equal(fixtures.approveReadyDraft.queueState, 'request_changes');
+    assert.ok(fixtures.approveReadyDraft.operatorReviewPayload.groups.some((group) => (
+      group.sourceKind === 'repo-marketplace-metadata'
+      && group.sourcePath === '.claude-plugin/marketplace.json'
+    )));
+    assert.ok(fixtures.approveReadyDraft.operatorReviewPayload.groups.some((group) => (
+      group.sourceKind === 'claude-plugin'
+      && group.runtimeSurface === 'claude-code-plugin'
+    )));
+    assert.ok(fixtures.approveReadyDraft.operatorReviewPayload.reviewItems.some((item) => (
+      item.state === 'approve_ready_draft'
+      && item.recommendedAction === 'approve_after_readiness_gates'
+    )));
+
+    assert.equal(fixtures.requestChangesMissingPayment.fixtureState, 'request_changes_draft');
+    assert.equal(fixtures.requestChangesMissingPayment.queueState, 'request_changes');
+    assert.ok(fixtures.requestChangesMissingPayment.operatorReviewPayload.reviewItems.some((item) => (
+      item.state === 'request_changes_missing_payment'
+      && item.reasonCodes.includes('missing_payment_setup')
+      && item.recommendedAction === 'request_payment_setup'
+    )));
+    assert.ok(fixtures.requestChangesMissingPayment.operatorReviewPayload.reviewItems.some((item) => (
+      item.state === 'request_changes_missing_payment'
+      && item.reasonCodes.includes('missing_endpoint_binding')
+      && item.recommendedAction === 'request_endpoint_binding'
+    )));
+
+    assert.equal(fixtures.rejectedMalformedConnector.fixtureState, 'rejected_draft');
+    assert.equal(fixtures.rejectedMalformedConnector.queueState, 'rejected');
+    assert.ok(fixtures.rejectedMalformedConnector.operatorReviewPayload.reviewItems.some((item) => (
+      item.state === 'rejected_malformed_connector'
+      && item.path === 'plugins/vertical-plugins/financial-analysis/.mcp.json'
+      && item.recommendedAction === 'reject_or_fix_malformed_connector'
+    )));
+    assert.ok(fixtures.rejectedMalformedConnector.operatorReviewPayload.reviewItems.some((item) => (
+      item.state === 'unsafe_metadata_warning'
+      && item.path === 'plugins/vertical-plugins/financial-analysis/.mcp.json'
+    )));
+
+    assert.equal(fixtures.suspendedUnsafeMetadata.fixtureState, 'suspended_draft');
+    assert.equal(fixtures.suspendedUnsafeMetadata.queueState, 'suspended');
+    assert.ok(fixtures.suspendedUnsafeMetadata.operatorReviewPayload.reviewItems.some((item) => (
+      item.state === 'suspended_imported_listing'
+      && item.reasonCodes.includes('unsafe_metadata')
+      && item.recommendedAction === 'keep_suspended'
+    )));
+  });
+
+  it('includes Solana AI Kit blocked operator review fixture coverage for static-only frontend states', () => {
+    const fixture = agentStackOperatorReviewFixtureStates.solanaAiKitBlocked;
+    const payload = fixture.operatorReviewPayload;
+    const riskItems = payload.reviewItems.filter((item) => item.state === 'static_risk_blocker');
+    const riskReasonCodes = new Set(riskItems.flatMap((item) => item.reasonCodes));
+
+    assert.equal(fixture.queueState, 'suspended');
+    assert.deepEqual(fixture.requiredRiskCategories, [
+      'executable_hook',
+      'deploy_capable_command',
+      'env_required_connector',
+      'local_binary_requirement',
+      'external_submodule',
+    ]);
+    assert.ok(riskItems.some((item) => item.path === 'plugin/hooks/hooks.json' && item.reasonCodes.includes('executable_hooks')));
+    assert.ok(riskItems.some((item) => item.path === '.claude/commands/*.md' && item.reasonCodes.includes('deploy_capable_commands')));
+    assert.ok(riskItems.some((item) => item.path === '.mcp.json' && item.reasonCodes.includes('env_required_connector')));
+    assert.ok(riskItems.some((item) => item.path === '.mcp.json' && item.reasonCodes.includes('local_binary_required')));
+    assert.ok(riskItems.some((item) => item.path === '.gitmodules' && item.reasonCodes.includes('external_submodules_declared')));
+    assert.ok(riskReasonCodes.has('executable_hooks_require_operator_review'));
+    assert.ok(riskReasonCodes.has('solana_deploy_command_requires_operator_review'));
+    assert.equal(payload.groups.some((group) => (
+      group.sourceKind === 'command'
+      && group.sourcePath === '.claude/commands/*.md'
+      && group.capabilityRefs.includes('deploy')
+      && group.humanReviewRequired
+    )), true);
+    assert.equal(payload.groups.some((group) => (
+      group.sourceKind === 'mcp-connector-config'
+      && group.sourcePath === '.mcp.json'
+      && group.humanReviewRequired
+    )), true);
+    assert.equal(payload.groups.some((group) => (
+      group.sourceKind === 'skill'
+      && group.sourcePath === '.gitmodules'
+    )), true);
+    assert.ok(fixture.guardrails.every((guardrail) => !guardrail.includes('Helius') && !guardrail.includes('private key')));
   });
 
   it('does not expose a static ingestion result for invalid or credential-shaped corpora', () => {


### PR DESCRIPTION
## Summary
- Adds exported static operator review fixture states for imported agent-stack review queues.
- Covers imported repo/plugin groups, malformed connector, missing payment/endpoint, unsafe metadata, approve-ready/request-changes/rejected/suspended drafts, and Solana AI Kit blockers.
- Includes mobile/tablet/desktop viewport coverage contracts for Storybook, Playwright, and deterministic UI tests.

## Guardrails
- Static-only data: no execution, fetch, MCP/RPC/wallet/payment calls, endpoint binding, publication, or live payment activation.
- No secrets, private operational metadata, credential-shaped values, or executable imported instructions.
- Solana AI Kit blocked cases cover executable hooks, deploy-capable commands, env-required MCP connector metadata, local binary requirements, and external submodule declarations.

## Validation
- npm test --workspace equivalent: `npm test` in `packages/agent-protocol` (101 passing)
- `npm run release:dry-run` in `packages/agent-protocol`
- `npm run check:rap:naming`
- `git diff --check`

Refs #415