### PR TITLE
#383 Operator discovery review workspace

### DIFF
--- a/app/manager/discovery/page.tsx
+++ b/app/manager/discovery/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { OperatorDiscoveryWorkspace } from "@/components/manager/discovery/OperatorDiscoveryWorkspace";
+import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
+
+export default function ManagerDiscoveryPage() {
+  const workspace = getStaticAgentStackReviewWorkspace();
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <header className="mb-6 space-y-3">
+        <Link href="/manager" className="text-sm text-accent-green hover:text-white">
+          Manager operations
+        </Link>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase text-muted-foreground">Operator discovery review</p>
+            <h1 className="mt-2 font-display text-3xl font-bold text-white sm:text-4xl">
+              Static imported catalog workspace
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
+              Inspect imported repo, plugin, connector, command, and skill groups from package-owned fixture states before any marketplace supply path. All controls are read-only placeholders.
+            </p>
+          </div>
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100">
+            External imported content is untrusted, not RAP-attested, and static-only.
+          </div>
+        </div>
+      </header>
+
+      <OperatorDiscoveryWorkspace workspace={workspace} />
+    </div>
+  );
+}

--- a/app/manager/page.tsx
+++ b/app/manager/page.tsx
@@ -79,6 +79,12 @@ export default function ManagerPage() {
         <p className="max-w-3xl text-sm text-muted-foreground">
           One human-facing launchpad for the four roles: Specialist, Attestor, Consumer, and Agent Manager. Use it to clear setup blockers before demos or live marketplace use.
         </p>
+        <Link
+          href="/manager/discovery"
+          className="inline-flex rounded-lg border border-[#14F195]/40 bg-[#14F195]/10 px-3 py-2 text-sm font-medium text-[#14F195] hover:border-[#14F195]/70 hover:text-emerald-100"
+        >
+          Open static discovery review
+        </Link>
       </header>
 
       {error && (

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -32,6 +32,7 @@ const navLinks: { href: string; label: string; badge?: string }[] = [
   { href: "/onboarding", label: "Onboarding Lab" },
   { href: "/dashboard", label: "Dashboards" },
   { href: "/manager", label: "Manager", badge: "New" },
+  { href: "/manager/discovery", label: "Discovery Review", badge: "New" },
   { href: "/specialist", label: "Specialist" },
   { href: "/attestation", label: "Attestation" },
   { href: "/consumer", label: "Consumer" },

--- a/components/manager/discovery/OperatorDiscoveryWorkspace.tsx
+++ b/components/manager/discovery/OperatorDiscoveryWorkspace.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import type React from "react";
+import { useMemo, useState } from "react";
+import {
+  Ban,
+  CheckCircle2,
+  CircleSlash,
+  CreditCard,
+  FileSearch,
+  Lock,
+  PauseCircle,
+  Send,
+  ShieldAlert,
+  WalletCards,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type {
+  OperatorDiscoveryCandidateView,
+  OperatorDiscoveryFilter,
+  OperatorDiscoveryWorkspaceView,
+} from "@/lib/manager/static-agent-stack-review";
+import { cn } from "@/lib/utils";
+
+export function OperatorDiscoveryWorkspace({ workspace }: { workspace: OperatorDiscoveryWorkspaceView }) {
+  const [filter, setFilter] = useState<OperatorDiscoveryFilter>("all");
+  const [selectedId, setSelectedId] = useState(workspace.candidates[0]?.id ?? "");
+
+  const visibleCandidates = useMemo(
+    () => workspace.candidates.filter((candidate) => matchesFilter(candidate, filter)),
+    [filter, workspace.candidates],
+  );
+  const selectedCandidate = visibleCandidates.find((candidate) => candidate.id === selectedId) ?? visibleCandidates[0] ?? null;
+
+  function chooseFilter(nextFilter: OperatorDiscoveryFilter) {
+    const nextCandidates = workspace.candidates.filter((candidate) => matchesFilter(candidate, nextFilter));
+    setFilter(nextFilter);
+    setSelectedId(nextCandidates[0]?.id ?? "");
+  }
+
+  return (
+    <div className="space-y-5" data-testid="operator-discovery-workspace">
+      <section className="rounded-lg border border-border bg-surface/60 p-3">
+        <div className="flex gap-2 overflow-x-auto pb-1" aria-label="Discovery review filters" data-testid="operator-discovery-filters">
+          {workspace.filters.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => chooseFilter(item.id)}
+              className={cn(
+                "h-9 shrink-0 rounded-lg border px-3 text-sm font-medium transition-colors",
+                filter === item.id
+                  ? "border-accent-purple bg-accent-purple/15 text-white"
+                  : "border-border bg-page/60 text-muted-foreground hover:text-white",
+              )}
+              aria-pressed={filter === item.id}
+            >
+              {item.label}
+              <span className="ml-2 text-xs text-muted-foreground">{item.count}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <div className="grid gap-5 xl:grid-cols-[390px_minmax(0,1fr)]">
+        <section className="space-y-3" aria-label="Imported review queue">
+          {visibleCandidates.length > 0 ? visibleCandidates.map((candidate) => (
+            <button
+              key={candidate.id}
+              type="button"
+              data-testid={`operator-discovery-queue-${candidate.fixtureKey}`}
+              onClick={() => setSelectedId(candidate.id)}
+              className={cn(
+                "w-full rounded-lg border p-4 text-left transition-colors",
+                selectedCandidate?.id === candidate.id
+                  ? "border-accent-purple bg-accent-purple/10"
+                  : "border-border bg-surface/50 hover:border-muted-foreground/50",
+              )}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-white">{candidate.title}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{candidate.fixtureState}</p>
+                </div>
+                <StatusBadge candidate={candidate} />
+              </div>
+              <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">{candidate.description}</p>
+              <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+                <MiniStat label="groups" value={candidate.resourceCounts.groups} />
+                <MiniStat label="warnings" value={candidate.resourceCounts.warnings} />
+                <MiniStat label="blockers" value={candidate.resourceCounts.blockers} />
+              </div>
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {candidate.requiredStates.map((state) => (
+                  <Badge key={state} variant="outline" className="h-auto max-w-full whitespace-normal text-[11px]">
+                    {state}
+                  </Badge>
+                ))}
+              </div>
+            </button>
+          )) : (
+            <div className="rounded-lg border border-dashed border-border bg-surface/30 p-6" data-testid="operator-discovery-empty">
+              <h2 className="font-display text-lg font-semibold">{workspace.emptyState.title}</h2>
+              <p className="mt-2 text-sm text-muted-foreground">{workspace.emptyState.message}</p>
+            </div>
+          )}
+        </section>
+
+        {selectedCandidate && <DiscoveryDetail candidate={selectedCandidate} />}
+      </div>
+
+      <section className="rounded-lg border border-dashed border-border bg-surface/30 p-4" data-testid="operator-discovery-supply-empty-state">
+        <h2 className="font-display text-lg font-semibold">Live marketplace supply remains empty</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Imported candidates stay in fixture-backed operator review until a later readiness, payment, attestation, and publication workflow explicitly promotes them.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function DiscoveryDetail({ candidate }: { candidate: OperatorDiscoveryCandidateView }) {
+  return (
+    <article className="space-y-5" data-testid="operator-discovery-detail">
+      <section className="rounded-lg border border-border bg-surface/60 p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="outline">imported</Badge>
+              <Badge variant="outline">external</Badge>
+              <Badge variant="destructive">untrusted</Badge>
+              <Badge variant="outline">not RAP-attested</Badge>
+              <Badge variant="outline">static-only</Badge>
+            </div>
+            <h2 className="mt-3 font-display text-2xl font-semibold">{candidate.title}</h2>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{candidate.description}</p>
+          </div>
+          <StatusBadge candidate={candidate} />
+        </div>
+
+        <dl className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+          <DetailTerm label="Source" value={candidate.sourceUrl} />
+          <DetailTerm label="Source kind" value={candidate.sourceKindSummary} />
+          <DetailTerm label="Snapshot" value={`${candidate.checkedRef} @ ${candidate.checkedCommit}`} />
+          <DetailTerm label="Raw refs" value={candidate.rawSnapshotRefs.join(", ")} />
+          <DetailTerm label="Result refs" value={candidate.resultRefs.join(", ")} />
+        </dl>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <Panel title="Catalog Groups" icon={<FileSearch />}>
+          <div className="space-y-3">
+            {candidate.groups.map((group) => (
+              <div key={group.id} className="rounded-lg border border-border bg-page/50 p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="font-medium text-white">{group.name}</p>
+                    <p className="mt-1 break-all font-mono text-xs text-muted-foreground">{group.sourcePath}</p>
+                  </div>
+                  <Badge variant={group.humanReviewRequired ? "destructive" : "outline"}>
+                    {group.humanReviewRequired ? "review" : "read"}
+                  </Badge>
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">{group.sourceKind} · {group.runtimeSurface}</p>
+                <p className="mt-2 text-xs text-muted-foreground">Resources: {group.capabilityRefs.join(", ")}</p>
+              </div>
+            ))}
+          </div>
+        </Panel>
+
+        <Panel title="Diagnostics" icon={<ShieldAlert />}>
+          <DiagnosticList title="Validation/parser" items={candidate.validationDiagnostics} empty="No validation warnings in this fixture frame." />
+          <DiagnosticList title="Connector" items={candidate.connectorDiagnostics} empty="No malformed connector diagnostics selected." />
+          <DiagnosticList title="Rejected entries" items={candidate.rejectedEntries} empty="No rejected entries selected." />
+        </Panel>
+
+        <Panel title="Risk & Readiness" icon={<Lock />}>
+          <DiagnosticList title="Risk diagnostics" items={candidate.riskDiagnostics} empty="No static risk diagnostics selected." />
+          <KeyValue label="Risk categories" value={candidate.riskCategories.length ? candidate.riskCategories.join(", ") : "none required by fixture"} />
+          <KeyValue label="Payment blocker" value={`${candidate.draftPreview.paymentStatus}; activation ${candidate.draftPreview.paymentActivation}`} />
+          <KeyValue label="Publication" value={candidate.draftPreview.publicationDisabled ? "disabled until separate marketplace approval" : "enabled"} />
+        </Panel>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <Panel title="Marketplace Draft Preview" icon={<CheckCircle2 />}>
+          <div className="grid gap-3 md:grid-cols-2">
+            <KeyValue label="Listing status" value={candidate.draftPreview.listingStatus} />
+            <KeyValue label="Resource count" value={`${candidate.resourceCounts.resources} static capability refs`} />
+            {Object.entries(candidate.draftPreview.buyerPreview).map(([key, value]) => (
+              <KeyValue key={key} label={key} value={value} />
+            ))}
+          </div>
+        </Panel>
+
+        <Panel title="Non-Live Controls" icon={<CircleSlash />}>
+          <div className="grid grid-cols-2 gap-2" data-testid="operator-discovery-placeholder-actions">
+            <PlaceholderAction icon={<CheckCircle2 />} label="Approve" />
+            <PlaceholderAction icon={<Ban />} label="Ignore" />
+            <PlaceholderAction icon={<Send />} label="Request changes" />
+            <PlaceholderAction icon={<PauseCircle />} label="Suspend" />
+            <PlaceholderAction icon={<FileSearch />} label="Publish" />
+            <PlaceholderAction icon={<CreditCard />} label="Payment" />
+            <PlaceholderAction icon={<ShieldAlert />} label="Readiness" />
+            <PlaceholderAction icon={<WalletCards />} label="RAP attestation" />
+          </div>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Placeholder only. This page performs no API mutation, live payment, publication, wallet, RPC, MCP contact, repo fetch, or imported command execution.
+          </p>
+        </Panel>
+      </section>
+
+      <Panel title="Static Guardrails" icon={<Lock />}>
+        <ul className="grid gap-2 md:grid-cols-2">
+          {candidate.secretGuardrails.map((guardrail) => (
+            <li key={guardrail} className="rounded-lg border border-border bg-page/50 p-3 text-sm text-muted-foreground">
+              {guardrail}
+            </li>
+          ))}
+        </ul>
+      </Panel>
+    </article>
+  );
+}
+
+function matchesFilter(candidate: OperatorDiscoveryCandidateView, filter: OperatorDiscoveryFilter) {
+  if (filter === "all") return true;
+  if (filter === "needs-review") return candidate.status !== "approve_ready";
+  if (filter === "blocked") return candidate.resourceCounts.blockers > 0;
+  if (filter === "approve-ready") return candidate.requiredStates.includes("approve_ready_draft");
+  if (filter === "request-changes") return candidate.requiredStates.includes("request_changes_missing_payment");
+  if (filter === "rejected") return candidate.requiredStates.includes("rejected_malformed_connector");
+  if (filter === "suspended") return candidate.requiredStates.includes("suspended_imported_listing");
+  return false;
+}
+
+function StatusBadge({ candidate }: { candidate: OperatorDiscoveryCandidateView }) {
+  const variant = candidate.status === "approve_ready" ? "outline" : candidate.status === "request_changes" ? "secondary" : "destructive";
+  return <Badge variant={variant}>{candidate.status.replaceAll("_", " ")}</Badge>;
+}
+
+function MiniStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-border bg-page/50 px-2 py-2">
+      <p className="font-mono text-base text-white">{value}</p>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function Panel({ title, icon, children }: { title: string; icon: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border border-border bg-surface/60 p-4">
+      <h3 className="mb-3 flex items-center gap-2 font-display text-base font-semibold">
+        <span className="text-accent-green [&_svg]:size-4">{icon}</span>
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function DiagnosticList({
+  title,
+  items,
+  empty,
+}: {
+  title: string;
+  items: OperatorDiscoveryCandidateView["reviewItems"];
+  empty: string;
+}) {
+  return (
+    <div className="mb-4 last:mb-0">
+      <p className="mb-2 text-xs font-semibold uppercase text-muted-foreground">{title}</p>
+      {items.length ? (
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item.id} className="rounded-lg border border-border bg-page/50 p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant={item.severity === "blocked" ? "destructive" : "outline"}>{item.severity}</Badge>
+                <span className="font-mono text-xs text-muted-foreground">{item.state}</span>
+              </div>
+              {item.path && <p className="mt-2 break-all font-mono text-xs text-muted-foreground">{item.path}</p>}
+              <p className="mt-2 text-sm text-white">{item.message}</p>
+              <p className="mt-2 text-xs text-muted-foreground">{item.reasonCodes.join(", ")}</p>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="rounded-lg border border-dashed border-border bg-page/30 p-3 text-sm text-muted-foreground">{empty}</p>
+      )}
+    </div>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-page/50 p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 break-words text-sm text-white">{value}</p>
+    </div>
+  );
+}
+
+function DetailTerm({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-lg border border-border bg-page/50 p-3">
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-1 break-all font-mono text-xs text-white">{value}</dd>
+    </div>
+  );
+}
+
+function PlaceholderAction({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <Button type="button" variant="outline" size="sm" disabled title={`${label} is a non-live placeholder`}>
+      <span className="[&_svg]:size-3.5">{icon}</span>
+      {label}
+    </Button>
+  );
+}

--- a/e2e/manager-discovery.spec.ts
+++ b/e2e/manager-discovery.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/test'
+
+const requiredFixtureKeys = [
+  'approveReadyDraft',
+  'requestChangesMissingPayment',
+  'rejectedMalformedConnector',
+  'suspendedUnsafeMetadata',
+  'solanaAiKitBlocked',
+]
+
+const requiredTabs = [
+  'All',
+  'Needs review',
+  'Blocked',
+  'Approve-ready',
+  'Request changes',
+  'Rejected',
+  'Suspended',
+]
+
+test.describe('/manager/discovery', () => {
+  test('renders static operator discovery review workspace and fixture states', async ({ page }) => {
+    await page.goto('/manager/discovery')
+
+    await expect(page.getByRole('heading', { name: /static imported catalog workspace/i })).toBeVisible()
+    await expect(page.getByText(/External imported content is untrusted, not RAP-attested, and static-only/i)).toBeVisible()
+
+    const filters = page.getByTestId('operator-discovery-filters')
+    for (const tab of requiredTabs) {
+      await expect(filters.getByRole('button', { name: new RegExp(`^${tab}`, 'i') })).toBeVisible()
+    }
+
+    for (const key of requiredFixtureKeys) {
+      await expect(page.getByTestId(`operator-discovery-queue-${key}`)).toBeVisible()
+    }
+
+    await expect(page.getByText(/repo-marketplace-metadata/i).first()).toBeVisible()
+    await expect(page.getByText(/claude-plugin/i).first()).toBeVisible()
+    await expect(page.getByText(/raw refs/i)).toBeVisible()
+    await expect(page.getByText(/storybook:agent-stack\/operator-review/i).first()).toBeVisible()
+    const detail = page.getByTestId('operator-discovery-detail')
+    await expect(detail.getByText(/^not RAP-attested$/i)).toBeVisible()
+    await expect(detail.getByText(/^static-only$/i)).toBeVisible()
+  })
+
+  test('filters review lanes and shows empty state without mutating anything', async ({ page }) => {
+    await page.goto('/manager/discovery')
+
+    const filters = page.getByTestId('operator-discovery-filters')
+
+    await filters.getByRole('button', { name: /^Rejected/i }).click()
+    await expect(page.getByTestId('operator-discovery-queue-rejectedMalformedConnector')).toBeVisible()
+    await expect(page.getByText(/rejected_malformed_connector/i).first()).toBeVisible()
+    await expect(page.getByRole('heading', { name: /^Diagnostics$/i })).toBeVisible()
+
+    await filters.getByRole('button', { name: /^Suspended/i }).click()
+    await expect(page.getByTestId('operator-discovery-queue-suspendedUnsafeMetadata')).toBeVisible()
+    await expect(page.getByTestId('operator-discovery-queue-solanaAiKitBlocked')).toBeVisible()
+    await expect(page.getByText(/suspended_imported_listing/i).first()).toBeVisible()
+
+    await filters.getByRole('button', { name: /^Approve-ready/i }).click()
+    await expect(page.getByTestId('operator-discovery-queue-approveReadyDraft')).toBeVisible()
+    await expect(page.getByText(/no malformed connector diagnostics selected/i)).toBeVisible()
+    await expect(page.getByTestId('operator-discovery-supply-empty-state')).toBeVisible()
+  })
+
+  test('keeps all marketplace, payment, publication, readiness, and attestation actions disabled', async ({ page }) => {
+    await page.goto('/manager/discovery')
+
+    const actions = page.getByTestId('operator-discovery-placeholder-actions')
+    for (const label of ['Approve', 'Ignore', 'Request changes', 'Suspend', 'Publish', 'Payment', 'Readiness', 'RAP attestation']) {
+      await expect(actions.getByRole('button', { name: new RegExp(`^${label}$`, 'i') })).toBeDisabled()
+    }
+
+    await expect(page.getByText(/no API mutation, live payment, publication, wallet, RPC, MCP contact, repo fetch, or imported command execution/i)).toBeVisible()
+    await expect(page.getByText(/Do not store secrets/i)).toBeVisible()
+  })
+
+  for (const viewport of [
+    { name: 'mobile', width: 390, height: 844 },
+    { name: 'tablet', width: 834, height: 1112 },
+    { name: 'desktop', width: 1440, height: 900 },
+  ]) {
+    test(`supports ${viewport.name} ${viewport.width}x${viewport.height} review`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height })
+      await page.goto('/manager/discovery')
+
+      await expect(page.getByTestId('operator-discovery-workspace')).toBeVisible()
+      await expect(page.getByTestId('operator-discovery-detail')).toBeVisible()
+      await expect(page.getByText(/Marketplace Draft Preview/i)).toBeVisible()
+      await expect(page.getByText(/Static Guardrails/i)).toBeVisible()
+      await page.screenshot({ path: `artifacts/manager-discovery/${viewport.name}-${viewport.width}x${viewport.height}.png`, fullPage: true })
+    })
+  }
+})

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -11,6 +11,7 @@ test.describe('Navigation', () => {
       '/customize',
       '/dashboard',
       '/manager',
+      '/manager/discovery',
       '/specialist',
       '/planner',
       '/attestation',

--- a/lib/manager/static-agent-stack-review.ts
+++ b/lib/manager/static-agent-stack-review.ts
@@ -1,0 +1,200 @@
+import {
+  agentStackOperatorReviewFixtureStates,
+  type StaticAgentStackOperatorReviewFixture,
+  type StaticAgentStackOperatorReviewItem,
+  type StaticAgentStackOperatorReviewStateCode,
+  type StaticAgentStackOperatorReviewStatus,
+} from "@reddi/agent-protocol/agent-stack-fixtures";
+
+export type OperatorDiscoveryFilter =
+  | "all"
+  | "needs-review"
+  | "blocked"
+  | "approve-ready"
+  | "request-changes"
+  | "rejected"
+  | "suspended";
+
+export type OperatorDiscoveryGroupView = {
+  id: string;
+  name: string;
+  sourceKind: string;
+  sourcePath: string;
+  runtimeSurface: string;
+  capabilityRefs: string[];
+  rawSnapshotRefs: string[];
+  writeCapable: boolean;
+  humanReviewRequired: boolean;
+};
+
+export type OperatorDiscoveryCandidateView = {
+  id: string;
+  fixtureId: string;
+  fixtureKey: string;
+  title: string;
+  description: string;
+  status: StaticAgentStackOperatorReviewStatus;
+  fixtureState: string;
+  sourceUrl: string;
+  checkedCommit: string;
+  checkedRef: string;
+  sourceKindSummary: string;
+  staticOnly: true;
+  imported: true;
+  external: true;
+  untrusted: true;
+  rapAttested: false;
+  rawSnapshotRefs: string[];
+  resultRefs: string[];
+  resourceCounts: {
+    groups: number;
+    reviewItems: number;
+    warnings: number;
+    rejected: number;
+    blockers: number;
+    resources: number;
+  };
+  groups: OperatorDiscoveryGroupView[];
+  reviewItems: StaticAgentStackOperatorReviewItem[];
+  warnings: StaticAgentStackOperatorReviewItem[];
+  rejectedEntries: StaticAgentStackOperatorReviewItem[];
+  validationDiagnostics: StaticAgentStackOperatorReviewItem[];
+  connectorDiagnostics: StaticAgentStackOperatorReviewItem[];
+  riskDiagnostics: StaticAgentStackOperatorReviewItem[];
+  secretGuardrails: string[];
+  readinessBlockers: string[];
+  riskCategories: string[];
+  draftPreview: {
+    listingStatus: "draft" | "needs_review" | "blocked";
+    publicationDisabled: true;
+    paymentStatus: "missing_payment_setup";
+    paymentActivation: "disabled";
+    buyerPreview: Record<string, string>;
+  };
+  requiredStates: StaticAgentStackOperatorReviewStateCode[];
+  requiredGroupKinds: string[];
+};
+
+export type OperatorDiscoveryWorkspaceView = {
+  filters: Array<{ id: OperatorDiscoveryFilter; label: string; count: number }>;
+  candidates: OperatorDiscoveryCandidateView[];
+  emptyState: {
+    title: string;
+    message: string;
+  };
+};
+
+const fixtureEntries = Object.entries(agentStackOperatorReviewFixtureStates) as Array<
+  [string, StaticAgentStackOperatorReviewFixture]
+>;
+
+export function getStaticAgentStackReviewWorkspace(): OperatorDiscoveryWorkspaceView {
+  const candidates = fixtureEntries.map(([fixtureKey, fixture]) => mapFixture(fixtureKey, fixture));
+
+  return {
+    candidates,
+    filters: [
+      { id: "all", label: "All", count: candidates.length },
+      { id: "needs-review", label: "Needs review", count: candidates.filter((candidate) => candidate.status !== "approve_ready").length },
+      { id: "blocked", label: "Blocked", count: candidates.filter((candidate) => candidate.resourceCounts.blockers > 0).length },
+      { id: "approve-ready", label: "Approve-ready", count: candidates.filter((candidate) => hasRequiredState(candidate, "approve_ready_draft")).length },
+      { id: "request-changes", label: "Request changes", count: candidates.filter((candidate) => hasRequiredState(candidate, "request_changes_missing_payment")).length },
+      { id: "rejected", label: "Rejected", count: candidates.filter((candidate) => hasRequiredState(candidate, "rejected_malformed_connector")).length },
+      { id: "suspended", label: "Suspended", count: candidates.filter((candidate) => hasRequiredState(candidate, "suspended_imported_listing")).length },
+    ],
+    emptyState: {
+      title: "No imported catalog group matches this review lane",
+      message: "This workspace is read-only fixture review. It never creates marketplace supply, payments, wallets, RPC calls, repository fetches, MCP contact, or command execution.",
+    },
+  };
+}
+
+function mapFixture(
+  fixtureKey: string,
+  fixture: StaticAgentStackOperatorReviewFixture,
+): OperatorDiscoveryCandidateView {
+  const payload = fixture.operatorReviewPayload;
+  const warnings = payload.reviewItems.filter((item) => item.severity === "warning" || item.state === "unsafe_metadata_warning");
+  const rejectedEntries = payload.reviewItems.filter((item) => item.source === "rejected_entry");
+  const connectorDiagnostics = payload.reviewItems.filter((item) => item.source === "connector_diagnostic");
+  const riskDiagnostics = payload.reviewItems.filter((item) => item.source === "risk_diagnostic");
+  const validationDiagnostics = payload.reviewItems.filter((item) => item.source === "validation_warning");
+  const readinessBlockers = payload.reviewItems
+    .filter((item) => item.blocksPublication)
+    .map((item) => `${item.reasonCodes.join(", ")}: ${item.message}`);
+
+  return {
+    id: `${payload.reviewId}:${fixtureKey}`,
+    fixtureId: fixture.fixtureId,
+    fixtureKey,
+    title: titleForFixtureKey(fixtureKey),
+    description: fixture.description,
+    status: payload.status,
+    fixtureState: fixture.fixtureState,
+    sourceUrl: payload.source.sourceUrl,
+    checkedCommit: payload.source.checkedCommit,
+    checkedRef: payload.source.checkedRef ?? "unlabeled snapshot",
+    sourceKindSummary: Array.from(new Set(payload.groups.map((group) => group.sourceKind))).join(", "),
+    staticOnly: fixture.staticOnly,
+    imported: true,
+    external: true,
+    untrusted: true,
+    rapAttested: false,
+    rawSnapshotRefs: payload.rawSnapshotRefs,
+    resultRefs: fixture.uiTestRefs,
+    resourceCounts: {
+      groups: payload.groups.length,
+      reviewItems: payload.reviewItems.length,
+      warnings: warnings.length,
+      rejected: rejectedEntries.length,
+      blockers: payload.reviewItems.filter((item) => item.blocksPublication).length,
+      resources: payload.groups.reduce((total, group) => total + group.capabilityRefs.length, 0),
+    },
+    groups: payload.groups.map((group) => ({
+      id: group.groupId,
+      name: group.name,
+      sourceKind: group.sourceKind,
+      sourcePath: group.sourcePath,
+      runtimeSurface: group.runtimeSurface ?? "static import",
+      capabilityRefs: group.capabilityRefs,
+      rawSnapshotRefs: group.rawSnapshotRefs,
+      writeCapable: group.writeCapable,
+      humanReviewRequired: group.humanReviewRequired,
+    })),
+    reviewItems: payload.reviewItems,
+    warnings,
+    rejectedEntries,
+    validationDiagnostics,
+    connectorDiagnostics,
+    riskDiagnostics,
+    secretGuardrails: fixture.guardrails.filter((guardrail) => (
+      guardrail.toLowerCase().includes("secret")
+      || guardrail.toLowerCase().includes("credential")
+      || guardrail.toLowerCase().includes("execute")
+      || guardrail.toLowerCase().includes("fetch")
+      || guardrail.toLowerCase().includes("payment")
+    )),
+    readinessBlockers,
+    riskCategories: fixture.requiredRiskCategories,
+    draftPreview: {
+      listingStatus: payload.status === "approve_ready" ? "draft" : payload.status === "request_changes" ? "needs_review" : "blocked",
+      publicationDisabled: payload.publication.disabled,
+      paymentStatus: payload.payment.status,
+      paymentActivation: payload.payment.activation,
+      buyerPreview: payload.buyerPreview,
+    },
+    requiredStates: fixture.requiredReviewItemStates,
+    requiredGroupKinds: fixture.requiredGroupKinds,
+  };
+}
+
+function hasRequiredState(candidate: OperatorDiscoveryCandidateView, state: StaticAgentStackOperatorReviewStateCode) {
+  return candidate.requiredStates.includes(state);
+}
+
+function titleForFixtureKey(fixtureKey: string) {
+  return fixtureKey
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (value) => value.toUpperCase())
+    .replace("Ai", "AI");
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3010";
 const useExternalBaseURL = Boolean(process.env.PLAYWRIGHT_BASE_URL);
+const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -15,7 +16,15 @@ export default defineConfig({
     screenshot: "on",
     video: "on",
   },
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        ...(browserChannel ? { channel: browserChannel } : {}),
+      },
+    },
+  ],
   webServer: useExternalBaseURL
     ? undefined
     : {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,8 @@
     ],
     "paths": {
       "@/*": ["./*"],
+      "@reddi/agent-protocol": ["./packages/agent-protocol/src/index.ts"],
+      "@reddi/agent-protocol/*": ["./packages/agent-protocol/src/*"],
       "@reddi/x402-solana": ["./packages/x402-solana/src/index.ts"],
       "@reddi/x402-solana/*": ["./packages/x402-solana/src/*"]
     }


### PR DESCRIPTION
## Summary
- Adds `/manager/discovery` as a static/read-only operator discovery review workspace for imported agent-stack catalog candidates.
- Adds `lib/manager/static-agent-stack-review.ts` as a slim adapter over `@reddi/agent-protocol/agent-stack-fixtures` so app code consumes #415 fixture exports instead of copied JSON.
- Adds queue filters, candidate detail, diagnostics/risk/readiness panels, draft preview, explicit imported/external/untrusted/not-RAP-attested/static-only labels, and disabled non-live action placeholders.
- Wires manager/nav entry and focused Playwright coverage, including mobile/tablet/desktop screenshots.

## Guardrails
- Read-only UI only; no API mutations.
- No #387 marketplace approval queue implementation.
- No live payment, publication, wallet, RPC, MCP contact, repo fetch, or imported command execution.
- All approve/ignore/request changes/suspend/publish/payment/readiness/RAP attestation controls are disabled placeholders.

## Validation
- `npm run lint -- app/manager/page.tsx app/manager/discovery/page.tsx components/manager/discovery/OperatorDiscoveryWorkspace.tsx lib/manager/static-agent-stack-review.ts e2e/manager-discovery.spec.ts e2e/navigation.spec.ts playwright.config.ts` ✅
- `npm run build` ✅ (passes with existing Next/Turbopack workspace-root/NFT warnings)
- `npm test --prefix packages/agent-protocol` ✅
- `npm run test:bdd:index` ✅
- `PLAYWRIGHT_BROWSER_CHANNEL=chrome npm run test:e2e -- e2e/manager-discovery.spec.ts --project=chromium` ✅

## Screenshot evidence
- `artifacts/manager-discovery/mobile-390x844.png`
- `artifacts/manager-discovery/tablet-834x1112.png`
- `artifacts/manager-discovery/desktop-1440x900.png`

## Notes
- Full `npm run lint` currently fails on unrelated pre-existing lint issues outside this lane (`app/tour/page.tsx`, legacy tests/packages/dist/scripts). Focused lint for the touched files passes.
- Playwright bundled Chromium install hung locally after download, so the focused run used installed Google Chrome via optional `PLAYWRIGHT_BROWSER_CHANNEL=chrome`; the default Chromium project remains unchanged for environments with the bundled browser installed.
