### PR TITLE
Implement marketplace approval queue UI for #387

### DIFF
--- a/app/manager/listings/page.tsx
+++ b/app/manager/listings/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { MarketplaceApprovalQueue } from "@/components/manager/listings/MarketplaceApprovalQueue";
+import { getMarketplaceApprovalQueue } from "@/lib/manager/marketplace-listings";
+
+export default function ManagerListingsPage() {
+  const queue = getMarketplaceApprovalQueue();
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <header className="mb-6 space-y-3">
+        <Link href="/manager" className="text-sm text-accent-green hover:text-white">
+          Manager operations
+        </Link>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase text-muted-foreground">Marketplace approval queue</p>
+            <h1 className="mt-2 font-display text-3xl font-bold text-white sm:text-4xl">
+              Imported listing preview queue
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
+              Review fixture-backed imported agent-stack listing states before publication. This is a read-only operator UI; live publish, payment, readiness, attestation, and trust mutations remain deferred.
+            </p>
+          </div>
+          <Link
+            href="/manager/discovery"
+            className="inline-flex min-h-10 items-center rounded-lg border border-border bg-surface/60 px-3 py-2 text-sm font-medium text-muted-foreground hover:text-white focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            Open discovery review
+          </Link>
+        </div>
+      </header>
+
+      <MarketplaceApprovalQueue queue={queue} />
+    </div>
+  );
+}

--- a/app/manager/page.tsx
+++ b/app/manager/page.tsx
@@ -79,12 +79,20 @@ export default function ManagerPage() {
         <p className="max-w-3xl text-sm text-muted-foreground">
           One human-facing launchpad for the four roles: Specialist, Attestor, Consumer, and Agent Manager. Use it to clear setup blockers before demos or live marketplace use.
         </p>
-        <Link
-          href="/manager/discovery"
-          className="inline-flex rounded-lg border border-[#14F195]/40 bg-[#14F195]/10 px-3 py-2 text-sm font-medium text-[#14F195] hover:border-[#14F195]/70 hover:text-emerald-100"
-        >
-          Open static discovery review
-        </Link>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href="/manager/discovery"
+            className="inline-flex min-h-10 items-center rounded-lg border border-[#14F195]/40 bg-[#14F195]/10 px-3 py-2 text-sm font-medium text-[#14F195] hover:border-[#14F195]/70 hover:text-emerald-100"
+          >
+            Open static discovery review
+          </Link>
+          <Link
+            href="/manager/listings"
+            className="inline-flex min-h-10 items-center rounded-lg border border-[#9945FF]/40 bg-[#9945FF]/10 px-3 py-2 text-sm font-medium text-violet-200 hover:border-[#9945FF]/70 hover:text-white"
+          >
+            Open listing approval queue
+          </Link>
+        </div>
       </header>
 
       {error && (
@@ -195,5 +203,5 @@ const fallbackRoles: ManagerRole[] = [
   { id: "specialist", label: "Specialist", href: "/onboarding", count: 0, status: "action_needed", nextAction: "Register and verify the first specialist.", signals: ["runtime", "endpoint", "x402"] },
   { id: "attestor", label: "Attestor", href: "/attestation", count: 0, status: "action_needed", nextAction: "Configure attestation operator and submit first attestation.", signals: ["operator", "audit", "release gate"] },
   { id: "consumer", label: "Consumer", href: "/consumer", count: 0, status: "action_needed", nextAction: "Register a consumer profile and run paid invocation.", signals: ["policy", "payment", "feedback"] },
-  { id: "manager", label: "Agent Manager", href: "/manager", count: 1, status: "action_needed", nextAction: "Clear role blockers and generate evidence.", signals: ["readiness", "recovery", "BDD"] },
+  { id: "manager", label: "Agent Manager", href: "/manager/listings", count: 1, status: "action_needed", nextAction: "Clear role blockers, review imported listings, and generate evidence.", signals: ["readiness", "listing queue", "BDD"] },
 ];

--- a/components/manager/listings/MarketplaceApprovalQueue.tsx
+++ b/components/manager/listings/MarketplaceApprovalQueue.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import type React from "react";
+import { useMemo, useState } from "react";
+import {
+  Ban,
+  CheckCircle2,
+  CircleSlash,
+  CreditCard,
+  FileSearch,
+  Lock,
+  PauseCircle,
+  Rocket,
+  Send,
+  ShieldAlert,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type {
+  MarketplaceApprovalQueueItem,
+  MarketplaceApprovalQueueState,
+  MarketplaceApprovalQueueView,
+} from "@/lib/manager/marketplace-listings";
+import { cn } from "@/lib/utils";
+
+const stateOrder: MarketplaceApprovalQueueState[] = [
+  "draft",
+  "needs_changes",
+  "approve_ready",
+  "published_placeholder",
+  "rejected",
+  "blocked",
+  "suspended",
+];
+
+export function MarketplaceApprovalQueue({ queue }: { queue: MarketplaceApprovalQueueView }) {
+  const [selectedState, setSelectedState] = useState<MarketplaceApprovalQueueState>("draft");
+  const selected = useMemo(
+    () => queue.items.find((item) => item.state === selectedState) ?? queue.items[0] ?? null,
+    [queue.items, selectedState],
+  );
+
+  if (!selected) {
+    return (
+      <section className="rounded-lg border border-dashed border-border bg-surface/30 p-6" data-testid="marketplace-approval-empty">
+        <h2 className="font-display text-lg font-semibold">{queue.emptyState.title}</h2>
+        <p className="mt-2 text-sm text-muted-foreground">{queue.emptyState.message}</p>
+      </section>
+    );
+  }
+
+  return (
+    <div className="space-y-5" data-testid="marketplace-approval-queue">
+      <section className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase text-amber-100">Static boundary</p>
+            <p className="mt-1 max-w-3xl text-sm text-amber-50">
+              Imported agent stacks remain untrusted static metadata until later RAP wrapping, readiness, attestation, payment, and publication gates ship.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2" aria-label="Static listing boundary labels">
+            {queue.boundaryLabels.map((label) => (
+              <Badge key={label} variant="outline" className="border-amber-300/40 bg-black/20 text-amber-50">
+                {label}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-5 xl:grid-cols-[360px_minmax(0,1fr)]">
+        <section className="space-y-3" aria-label="Marketplace approval queue states">
+          {stateOrder.map((state) => {
+            const item = queue.items.find((candidate) => candidate.state === state);
+            if (!item) return null;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                data-testid={`marketplace-queue-state-${item.state}`}
+                onClick={() => setSelectedState(item.state)}
+                className={cn(
+                  "w-full rounded-lg border p-4 text-left transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                  selected.state === item.state
+                    ? "border-accent-purple bg-accent-purple/10"
+                    : "border-border bg-surface/50 hover:border-muted-foreground/50",
+                )}
+                aria-pressed={selected.state === item.state}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="font-semibold text-white">{item.label}</p>
+                    <p className="mt-1 break-all font-mono text-xs text-muted-foreground">{item.fixtureKey}</p>
+                  </div>
+                  <StateBadge state={item.state} />
+                </div>
+                <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">{item.listingPreview.statusCopy}</p>
+                <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+                  <MiniStat label="items" value={item.candidate.resourceCounts.reviewItems} />
+                  <MiniStat label="warnings" value={item.candidate.resourceCounts.warnings} />
+                  <MiniStat label="blockers" value={item.candidate.resourceCounts.blockers} />
+                </div>
+              </button>
+            );
+          })}
+        </section>
+
+        <ListingPreview item={selected} boundaryLabels={queue.boundaryLabels} />
+      </div>
+    </div>
+  );
+}
+
+function ListingPreview({
+  item,
+  boundaryLabels,
+}: {
+  item: MarketplaceApprovalQueueItem;
+  boundaryLabels: string[];
+}) {
+  return (
+    <article className="space-y-5" data-testid="marketplace-listing-preview">
+      <section className="overflow-hidden rounded-lg border border-border bg-surface/60">
+        <div className="relative min-h-40 bg-gradient-to-br from-indigo-500/30 via-sky-500/15 to-emerald-500/20 p-5">
+          <div className="absolute inset-0 bg-page/55" />
+          <div className="relative flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap gap-2">
+                {boundaryLabels.map((label) => (
+                  <Badge key={label} variant={label === "untrusted" ? "destructive" : "outline"} className="bg-black/25">
+                    {label}
+                  </Badge>
+                ))}
+              </div>
+              <h2 className="mt-4 font-display text-2xl font-semibold text-white">{item.listingPreview.name}</h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-200">{item.listingPreview.tagline}</p>
+              <p className="mt-3 max-w-3xl rounded-lg border border-white/10 bg-black/25 p-3 text-sm text-white">
+                {item.listingPreview.statusCopy}
+              </p>
+            </div>
+            <StateBadge state={item.state} />
+          </div>
+        </div>
+
+        <div className="grid gap-4 p-5 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="space-y-4">
+            <div>
+              <p className="text-xs font-semibold uppercase text-muted-foreground">Marketplace card language</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {item.listingPreview.capabilities.length ? item.listingPreview.capabilities.map((capability) => (
+                  <Badge key={capability} variant="outline" className="border-white/10 bg-white/5 text-gray-300">
+                    {capability}
+                  </Badge>
+                )) : (
+                  <Badge variant="outline" className="border-white/10 bg-white/5 text-gray-300">
+                    static capability refs only
+                  </Badge>
+                )}
+              </div>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              <KeyValue label="Model/source" value={item.listingPreview.model} />
+              <KeyValue label="Source snapshot" value={`${item.candidate.checkedRef} @ ${item.candidate.checkedCommit}`} />
+              <KeyValue label="Publication" value={item.listingPreview.publicationCopy} />
+              <KeyValue label="Payment readiness" value={item.listingPreview.paymentCopy} />
+              <KeyValue label="Publication readiness" value={item.listingPreview.readinessCopy} />
+              <KeyValue label="Fixture state" value={item.candidate.fixtureState} />
+            </div>
+
+            <section className="rounded-lg border border-border bg-page/50 p-4">
+              <h3 className="font-display text-base font-semibold">Operator review evidence</h3>
+              <ul className="mt-3 grid gap-2 md:grid-cols-2">
+                {item.candidate.reviewItems.slice(0, 6).map((reviewItem, index) => (
+                  <li key={`${reviewItem.id}:${index}`} className="rounded-lg border border-border bg-surface/60 p-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant={reviewItem.blocksPublication ? "destructive" : "outline"}>
+                        {reviewItem.severity}
+                      </Badge>
+                      <span className="font-mono text-xs text-muted-foreground">{reviewItem.state}</span>
+                    </div>
+                    <p className="mt-2 text-sm text-white">{reviewItem.message}</p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+
+          <aside className="space-y-4">
+            <section className="rounded-lg border border-border bg-page/50 p-4">
+              <h3 className="font-display text-base font-semibold">Non-live actions</h3>
+              <div className="mt-3 grid grid-cols-2 gap-2" data-testid="marketplace-placeholder-actions">
+                <PlaceholderAction icon={<CheckCircle2 />} label="Approve" />
+                <PlaceholderAction icon={<Ban />} label="Reject" />
+                <PlaceholderAction icon={<Send />} label="Request changes" />
+                <PlaceholderAction icon={<Rocket />} label="Publish" />
+                <PlaceholderAction icon={<CircleSlash />} label="Unpublish" />
+                <PlaceholderAction icon={<PauseCircle />} label="Suspend" />
+                <PlaceholderAction icon={<CreditCard />} label="Payment readiness" />
+                <PlaceholderAction icon={<FileSearch />} label="Publication readiness" />
+              </div>
+              <p className="mt-3 text-xs leading-5 text-muted-foreground">
+                Placeholder only. This queue performs no API mutation, live marketplace publication, payment activation, wallet signing, RPC probe, MCP call, repo fetch, provider trust upgrade, reputation assignment, or imported command execution.
+              </p>
+            </section>
+
+            <section className="rounded-lg border border-border bg-page/50 p-4">
+              <h3 className="flex items-center gap-2 font-display text-base font-semibold">
+                <ShieldAlert className="size-4 text-accent-green" aria-hidden="true" />
+                Static guardrails
+              </h3>
+              <ul className="mt-3 space-y-2">
+                {item.candidate.secretGuardrails.slice(0, 4).map((guardrail) => (
+                  <li key={guardrail} className="rounded-lg border border-border bg-surface/60 p-3 text-sm text-muted-foreground">
+                    {guardrail}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </aside>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-dashed border-border bg-surface/30 p-4" data-testid="marketplace-static-boundary-note">
+        <h3 className="flex items-center gap-2 font-display text-base font-semibold">
+          <Lock className="size-4 text-accent-green" aria-hidden="true" />
+          RAP marketplace boundary
+        </h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          RAP is not a generic agent builder. These imported stacks are static, untrusted listing candidates until later gates create real wrappers, attestations, readiness checks, and publication records.
+        </p>
+      </section>
+    </article>
+  );
+}
+
+function StateBadge({ state }: { state: MarketplaceApprovalQueueState }) {
+  const label = state.replaceAll("_", " ");
+  const className =
+    state === "approve_ready"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+      : state === "published_placeholder"
+        ? "border-sky-500/30 bg-sky-500/10 text-sky-200"
+        : state === "needs_changes"
+          ? "border-amber-500/30 bg-amber-500/10 text-amber-200"
+          : state === "rejected" || state === "blocked" || state === "suspended"
+            ? "border-red-500/30 bg-red-500/10 text-red-200"
+            : "border-white/10 bg-white/5 text-gray-300";
+
+  return (
+    <Badge variant="outline" className={cn("shrink-0", className)}>
+      {label}
+    </Badge>
+  );
+}
+
+function MiniStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-border bg-page/50 px-2 py-2">
+      <p className="font-mono text-base text-white">{value}</p>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-page/50 p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 break-words text-sm text-white">{value}</p>
+    </div>
+  );
+}
+
+function PlaceholderAction({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <Button type="button" variant="outline" size="sm" disabled title={`${label} is a non-live placeholder`}>
+      <span className="[&_svg]:size-3.5" aria-hidden="true">{icon}</span>
+      {label}
+    </Button>
+  );
+}

--- a/e2e/manager-listings.spec.ts
+++ b/e2e/manager-listings.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from '@playwright/test'
+
+const queueStates = [
+  'draft',
+  'needs_changes',
+  'approve_ready',
+  'published_placeholder',
+  'rejected',
+  'blocked',
+  'suspended',
+]
+
+const actionLabels = [
+  'Approve',
+  'Reject',
+  'Request changes',
+  'Publish',
+  'Unpublish',
+  'Suspend',
+  'Payment readiness',
+  'Publication readiness',
+]
+
+test.describe('/manager/listings', () => {
+  test('renders every static approval queue state with visible marketplace boundaries', async ({ page }) => {
+    await page.goto('/manager/listings')
+
+    await expect(page.getByRole('heading', { name: /imported listing preview queue/i })).toBeVisible()
+    await expect(page.getByText(/Imported agent stacks remain untrusted static metadata/i)).toBeVisible()
+
+    for (const state of queueStates) {
+      await expect(page.getByTestId(`marketplace-queue-state-${state}`)).toBeVisible()
+    }
+
+    const preview = page.getByTestId('marketplace-listing-preview')
+    for (const label of ['imported metadata', 'external source', 'untrusted', 'not RAP-attested', 'not published', 'static-only']) {
+      await expect(preview.getByText(label).first()).toBeVisible()
+    }
+    await expect(preview.getByText(/Placeholder only/i)).toBeVisible()
+    await expect(page.getByTestId('marketplace-static-boundary-note')).toContainText(/not a generic agent builder/i)
+  })
+
+  test('keeps approve, reject, publish, payment, and readiness actions disabled', async ({ page }) => {
+    await page.goto('/manager/listings')
+
+    const actions = page.getByTestId('marketplace-placeholder-actions')
+    for (const label of actionLabels) {
+      await expect(actions.getByRole('button', { name: new RegExp(`^${label}$`, 'i') })).toBeDisabled()
+    }
+
+    await expect(page.getByText(/no API mutation, live marketplace publication, payment activation, wallet signing, RPC probe, MCP call, repo fetch/i)).toBeVisible()
+  })
+
+  test('records preview to approval placeholder to request changes to publish and suspend placeholder path', async ({ page }) => {
+    await page.goto('/manager/listings')
+
+    await page.getByTestId('marketplace-queue-state-draft').click()
+    await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Draft listing generated/i)
+
+    await page.getByTestId('marketplace-queue-state-approve_ready').click()
+    await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Approve-ready fixture state only/i)
+    await expect(page.getByRole('button', { name: /^Approve$/i })).toBeDisabled()
+
+    await page.getByTestId('marketplace-queue-state-needs_changes').click()
+    await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Needs changes before approval/i)
+    await expect(page.getByRole('button', { name: /^Request changes$/i })).toBeDisabled()
+
+    await page.getByTestId('marketplace-queue-state-published_placeholder').click()
+    await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Published state is represented only as a UI placeholder/i)
+    await expect(page.getByRole('button', { name: /^Publish$/i })).toBeDisabled()
+
+    await page.getByTestId('marketplace-queue-state-suspended').click()
+    await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Suspended imported listing fixture/i)
+    await expect(page.getByRole('button', { name: /^Suspend$/i })).toBeDisabled()
+  })
+
+  for (const viewport of [
+    { name: 'mobile', width: 390, height: 844 },
+    { name: 'tablet', width: 834, height: 1112 },
+    { name: 'desktop', width: 1440, height: 900 },
+  ]) {
+    for (const state of queueStates) {
+      test(`captures ${state} at ${viewport.name} ${viewport.width}x${viewport.height}`, async ({ page }) => {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height })
+        await page.goto('/manager/listings')
+        await page.getByTestId(`marketplace-queue-state-${state}`).click()
+
+        await expect(page.getByTestId('marketplace-listing-preview')).toBeVisible()
+        await expect(page.getByText(/not RAP-attested/i).first()).toBeVisible()
+        await expect(page.getByText(/not published/i).first()).toBeVisible()
+        await page.screenshot({
+          path: `artifacts/manager-listings/${viewport.name}-${state}-${viewport.width}x${viewport.height}.png`,
+          fullPage: true,
+        })
+      })
+    }
+  }
+})

--- a/lib/manager/marketplace-listings.ts
+++ b/lib/manager/marketplace-listings.ts
@@ -1,0 +1,151 @@
+import type { OperatorDiscoveryCandidateView } from "@/lib/manager/static-agent-stack-review";
+import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
+
+export type MarketplaceApprovalQueueState =
+  | "draft"
+  | "needs_changes"
+  | "approve_ready"
+  | "published_placeholder"
+  | "rejected"
+  | "blocked"
+  | "suspended";
+
+export type MarketplaceApprovalQueueItem = {
+  id: string;
+  state: MarketplaceApprovalQueueState;
+  label: string;
+  fixtureKey: string;
+  candidate: OperatorDiscoveryCandidateView;
+  listingPreview: {
+    name: string;
+    model: string;
+    tagline: string;
+    capabilities: string[];
+    tools: string[];
+    skills: string[];
+    statusCopy: string;
+    publicationCopy: string;
+    paymentCopy: string;
+    readinessCopy: string;
+  };
+};
+
+export type MarketplaceApprovalQueueView = {
+  items: MarketplaceApprovalQueueItem[];
+  boundaryLabels: string[];
+  emptyState: {
+    title: string;
+    message: string;
+  };
+};
+
+const boundaryLabels = [
+  "imported metadata",
+  "external source",
+  "untrusted",
+  "not RAP-attested",
+  "not published",
+  "static-only",
+];
+
+export function getMarketplaceApprovalQueue(): MarketplaceApprovalQueueView {
+  const workspace = getStaticAgentStackReviewWorkspace();
+  const byKey = Object.fromEntries(workspace.candidates.map((candidate) => [candidate.fixtureKey, candidate]));
+  const approveReady = requireCandidate(byKey, "approveReadyDraft");
+  const requestChanges = requireCandidate(byKey, "requestChangesMissingPayment");
+  const rejected = requireCandidate(byKey, "rejectedMalformedConnector");
+  const suspended = requireCandidate(byKey, "suspendedUnsafeMetadata");
+  const blocked = requireCandidate(byKey, "solanaAiKitBlocked");
+
+  return {
+    boundaryLabels,
+    items: [
+      buildQueueItem("draft", "Draft", approveReady, {
+        statusCopy: "Draft listing generated from static fixture metadata.",
+        publicationCopy: "Not published. Operator approval, readiness, and attestation gates are deferred.",
+        paymentCopy: "Payment readiness is missing and cannot be activated here.",
+        readinessCopy: "Publication readiness check is a disabled placeholder.",
+      }),
+      buildQueueItem("needs_changes", "Needs changes", requestChanges, {
+        statusCopy: "Needs changes before approval because payment and endpoint setup are incomplete.",
+        publicationCopy: "Not published. Request-changes action is display-only.",
+        paymentCopy: "Missing payment setup; activation remains disabled.",
+        readinessCopy: "Readiness is blocked by fixture review items.",
+      }),
+      buildQueueItem("approve_ready", "Approved / approve-ready placeholder", approveReady, {
+        statusCopy: "Approve-ready fixture state only. Approval is not written anywhere.",
+        publicationCopy: "Not published. Approve and publish are disabled placeholders.",
+        paymentCopy: "Payment readiness remains separate from this static preview.",
+        readinessCopy: "Publication readiness will be evaluated by a later gate.",
+      }),
+      buildQueueItem("published_placeholder", "Published placeholder", approveReady, {
+        statusCopy: "Published state is represented only as a UI placeholder for operator review.",
+        publicationCopy: "No live marketplace publication exists from this page.",
+        paymentCopy: "No live payment activation, wallet signing, or settlement setup occurs.",
+        readinessCopy: "Readiness is illustrative until the deferred publication workflow ships.",
+      }),
+      buildQueueItem("rejected", "Rejected", rejected, {
+        statusCopy: "Rejected fixture state with malformed connector evidence.",
+        publicationCopy: "Not published. Rejection is already fixture metadata, not a live mutation.",
+        paymentCopy: "Payment remains inactive for rejected imported metadata.",
+        readinessCopy: "Publication readiness remains unavailable.",
+      }),
+      buildQueueItem("blocked", "Blocked", blocked, {
+        statusCopy: "Blocked by static risk diagnostics and operator guardrails.",
+        publicationCopy: "Not published. Blockers must be cleared outside this read-only UI.",
+        paymentCopy: "Payment activation is disabled while blockers remain.",
+        readinessCopy: "Readiness cannot pass while static risk blockers are present.",
+      }),
+      buildQueueItem("suspended", "Suspended", suspended, {
+        statusCopy: "Suspended imported listing fixture with unsafe metadata warnings.",
+        publicationCopy: "Not published. Suspend/unpublish controls are non-live placeholders.",
+        paymentCopy: "Payment readiness is disabled for suspended metadata.",
+        readinessCopy: "Publication readiness is unavailable for suspended metadata.",
+      }),
+    ],
+    emptyState: {
+      title: "No imported listing states are available",
+      message:
+        "The approval queue is built from package-owned static fixture states and never fetches repositories, contacts MCP servers, activates payments, or publishes listings.",
+    },
+  };
+}
+
+function requireCandidate(
+  byKey: Record<string, OperatorDiscoveryCandidateView>,
+  fixtureKey: string,
+): OperatorDiscoveryCandidateView {
+  const candidate = byKey[fixtureKey];
+  if (!candidate) throw new Error(`missing marketplace approval fixture candidate: ${fixtureKey}`);
+  return candidate;
+}
+
+function buildQueueItem(
+  state: MarketplaceApprovalQueueState,
+  label: string,
+  candidate: OperatorDiscoveryCandidateView,
+  copy: Pick<MarketplaceApprovalQueueItem["listingPreview"], "statusCopy" | "publicationCopy" | "paymentCopy" | "readinessCopy">,
+): MarketplaceApprovalQueueItem {
+  const buyerPreview = candidate.draftPreview.buyerPreview;
+  const capabilityValues = Object.values(buyerPreview)
+    .flatMap((value) => value.split(/[,;]/))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return {
+    id: `${state}:${candidate.fixtureKey}`,
+    state,
+    label,
+    fixtureKey: candidate.fixtureKey,
+    candidate,
+    listingPreview: {
+      name: buyerPreview.displayName ?? candidate.title,
+      model: buyerPreview.model ?? candidate.sourceKindSummary,
+      tagline: buyerPreview.summary ?? candidate.description,
+      capabilities: capabilityValues.slice(0, 5),
+      tools: candidate.groups.flatMap((group) => group.capabilityRefs).slice(0, 4),
+      skills: candidate.requiredGroupKinds.slice(0, 4),
+      ...copy,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `/manager/listings` as a separate read-only marketplace approval queue for imported agent-stack listing states.
- Reuses the existing #383/#415 static review view-model path and `agentStackOperatorReviewFixtureStates` via `getStaticAgentStackReviewWorkspace()`; no fixture JSON is copied into app code.
- Adds draft, needs changes, approve-ready, published placeholder, rejected, blocked, and suspended preview states with visible imported/external/untrusted/not RAP-attested/not published/static-only labels.
- Adds disabled placeholder controls for approve, reject, request changes, publish, unpublish, suspend, payment readiness, and publication readiness.
- Wires `/manager` navigation to the listing approval queue.

## Static guardrails
- No live marketplace publication, payment activation, wallet signing, RPC probes, MCP calls, repo fetches, backend mutations, provider trust upgrades, reputation assignment, or imported command execution.
- Published and approved states are placeholders only; imported stacks remain untrusted static metadata until later RAP gates.

## Validation
- `npx eslint app/manager/listings/page.tsx app/manager/page.tsx components/manager/listings/MarketplaceApprovalQueue.tsx lib/manager/marketplace-listings.ts e2e/manager-listings.spec.ts` ✅
- `npm run build` ✅
  - Existing warnings observed: Next workspace-root inference, Turbopack NFT trace warning through `lib/economic-demo/webpage-live-workflow-evidence-server.ts`, localStorage experimental warnings, and bigint pure JS fallback.
- `npm run test:bdd:index` ✅
- `npm run check:rap:naming` ✅
- `git diff --check` ✅
- `PLAYWRIGHT_BROWSER_CHANNEL=chrome npm run test:e2e -- e2e/manager-listings.spec.ts` ✅ 24 passed
- `npm test --prefix packages/agent-protocol` not run; package code was not touched.

## Evidence
Screenshots generated for every queue state at mobile/tablet/desktop:
- `artifacts/manager-listings/mobile-{draft,needs_changes,approve_ready,published_placeholder,rejected,blocked,suspended}-390x844.png`
- `artifacts/manager-listings/tablet-{draft,needs_changes,approve_ready,published_placeholder,rejected,blocked,suspended}-834x1112.png`
- `artifacts/manager-listings/desktop-{draft,needs_changes,approve_ready,published_placeholder,rejected,blocked,suspended}-1440x900.png`

Video evidence for the preview -> approve/request changes -> publish/suspend placeholder path:
- `test-results/manager-listings--manager--1c562-nd-suspend-placeholder-path-chromium/video.webm`
