### PR TITLE
Add marketplace approval action transitions for #378

### DIFF
--- a/lib/__tests__/manager-marketplace-approval-actions.test.ts
+++ b/lib/__tests__/manager-marketplace-approval-actions.test.ts
@@ -1,0 +1,269 @@
+import {
+  applyMarketplaceApprovalAction,
+  getBlockingApprovalReviewItems,
+  type MarketplaceApprovalAction,
+  type MarketplaceApprovalRecord,
+  type MarketplaceApprovalRecordState,
+} from "@/lib/manager/marketplace-approval-actions";
+import type { MarketplaceReadinessProofMetadata } from "@/lib/manager/marketplace-readiness-gate";
+import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
+
+const timestamp = "2026-06-20T00:00:00Z";
+const operatorId = "operator:test";
+
+const publishReadyProof: MarketplaceReadinessProofMetadata = {
+  endpointBindingRef: "endpoint-binding:anthropic-financial-services:dry-run",
+  paymentPlan: {
+    schemaVersion: "marketplace-payment-plan-proof:v1",
+    planId: "plan:anthropic-financial-services:dry-run",
+    currency: "USD",
+    amount: 0,
+    activation: "disabled",
+    settlement: "dry_run_only",
+    evidenceRef: "evidence:payment-plan:dry-run",
+  },
+  dryRunReceiptRefs: ["receipt:dry-run:approve-ready"],
+  evidenceRefs: ["evidence:static-review:approve-ready"],
+  attestationDraftRef: "attestation-draft:approve-ready",
+  operatorApproval: {
+    approved: true,
+    approvedBy: operatorId,
+    approvedAt: timestamp,
+    evidenceRef: "evidence:operator-approval:approve-ready",
+  },
+};
+
+describe("manager marketplace approval actions", () => {
+  it("approves static-safe imported metadata and publishes only with publish-ready proof", () => {
+    const approve = applyMarketplaceApprovalAction(recordFor("draft", "approveReadyDraft"), action("approve"));
+
+    expect(approve.ok).toBe(true);
+    expect(approve.record.state).toBe("approved");
+    expect(approve.record.publicVisible).toBe(false);
+
+    const publish = applyMarketplaceApprovalAction(approve.record, action("publish", {
+      readinessProof: publishReadyProof,
+      evidenceRefs: ["evidence:operator-action:publish"],
+    }));
+
+    expect(publish.ok).toBe(true);
+    expect(publish.record.state).toBe("published");
+    expect(publish.record.publicVisible).toBe(true);
+    expect(publish.readiness?.status).toBe("publish_ready");
+    expect(publish.readiness?.boundaries.publicationAllowed).toBe(true);
+    expect(publish.record.auditHistory).toEqual([
+      expect.objectContaining({
+        operatorId,
+        action: "approve",
+        previousState: "draft",
+        nextState: "approved",
+        timestamp,
+      }),
+      expect.objectContaining({
+        operatorId,
+        action: "publish",
+        previousState: "approved",
+        nextState: "published",
+        evidenceRefs: expect.arrayContaining([
+          "evidence:operator-action:publish",
+          "evidence:operator-approval:approve-ready",
+          "receipt:dry-run:approve-ready",
+        ]),
+      }),
+    ]);
+  });
+
+  it("blocks publish before approval", () => {
+    const result = applyMarketplaceApprovalAction(recordFor("draft", "approveReadyDraft"), action("publish", {
+      readinessProof: publishReadyProof,
+    }));
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("Publish requires approved state; got draft.");
+    expect(result.record.state).toBe("draft");
+    expect(result.record.publicVisible).toBe(false);
+    expect(result.record.auditHistory).toEqual([]);
+  });
+
+  it("keeps approve internal-only even if an input record is unexpectedly public visible", () => {
+    const approve = applyMarketplaceApprovalAction(recordFor("draft", "approveReadyDraft", true), action("approve"));
+
+    expect(approve.ok).toBe(true);
+    expect(approve.record.state).toBe("approved");
+    expect(approve.record.publicVisible).toBe(false);
+    expect(approve.record.auditHistory[0]).toMatchObject({
+      action: "approve",
+      previousState: "draft",
+      nextState: "approved",
+    });
+  });
+
+  it("blocks publish when readiness is blocked", () => {
+    const result = applyMarketplaceApprovalAction(recordFor("approved", "rejectedMalformedConnector"), action("publish", {
+      readinessProof: publishReadyProof,
+    }));
+
+    expect(result.ok).toBe(false);
+    expect(result.readiness?.status).toBe("blocked");
+    expect(result.readiness?.boundaries.publicationAllowed).toBe(false);
+    expect(result.record.state).toBe("approved");
+  });
+
+  it("blocks publish when readiness is only dry-run ready", () => {
+    const { operatorApproval, ...dryRunReadyProof } = publishReadyProof;
+    expect(operatorApproval).toBeDefined();
+
+    const result = applyMarketplaceApprovalAction(recordFor("approved", "approveReadyDraft"), action("publish", {
+      readinessProof: dryRunReadyProof,
+    }));
+
+    expect(result.ok).toBe(false);
+    expect(result.readiness?.status).toBe("dry_run_ready");
+    expect(result.readiness?.boundaries.publicationAllowed).toBe(false);
+    expect(result.record.state).toBe("approved");
+  });
+
+  it.each(["draft", "approve_ready", "blocked"] as MarketplaceApprovalRecordState[])(
+    "requests changes from %s and records the reason",
+    (state) => {
+      const result = applyMarketplaceApprovalAction(recordFor(state, "approveReadyDraft"), action("request_changes", {
+        reason: "Needs local endpoint binding evidence before approval.",
+        evidenceRefs: ["evidence:review-note:1"],
+      }));
+
+      expect(result.ok).toBe(true);
+      expect(result.record.state).toBe("needs_changes");
+      expect(result.record.publicVisible).toBe(false);
+      expect(result.record.auditHistory[0]).toMatchObject({
+        action: "request_changes",
+        reason: "Needs local endpoint binding evidence before approval.",
+        previousState: state,
+        nextState: "needs_changes",
+        evidenceRefs: ["evidence:review-note:1"],
+      });
+    },
+  );
+
+  it("keeps reject terminal until a future explicit reopen lane exists", () => {
+    const rejected = applyMarketplaceApprovalAction(recordFor("draft", "approveReadyDraft"), action("reject", {
+      reason: "Operator rejected this import.",
+    }));
+
+    expect(rejected.ok).toBe(true);
+    expect(rejected.record.state).toBe("rejected");
+    expect(rejected.record.publicVisible).toBe(false);
+
+    const retry = applyMarketplaceApprovalAction(rejected.record, action("approve"));
+
+    expect(retry.ok).toBe(false);
+    expect(retry.reason).toContain("terminal");
+    expect(retry.record.state).toBe("rejected");
+    expect(retry.record.auditHistory).toHaveLength(1);
+  });
+
+  it("suspends approved, published, internal, and already suspended records with public visibility forced false", () => {
+    for (const state of ["approved", "published", "internal", "suspended"] as MarketplaceApprovalRecordState[]) {
+      const result = applyMarketplaceApprovalAction(recordFor(state, "approveReadyDraft", true), action("suspend"));
+
+      expect(result.ok).toBe(true);
+      expect(result.record.state).toBe("suspended");
+      expect(result.record.publicVisible).toBe(false);
+      expect(result.record.auditHistory[0]).toMatchObject({
+        action: "suspend",
+        previousState: state,
+        nextState: "suspended",
+      });
+    }
+  });
+
+  it("unpublishes idempotently and forces public visibility false", () => {
+    const fromPublished = applyMarketplaceApprovalAction(recordFor("published", "approveReadyDraft", true), action("unpublish"));
+    const fromApproved = applyMarketplaceApprovalAction(recordFor("approved", "approveReadyDraft", false), action("unpublish"));
+
+    expect(fromPublished.ok).toBe(true);
+    expect(fromPublished.record.state).toBe("approved");
+    expect(fromPublished.record.publicVisible).toBe(false);
+    expect(fromApproved.ok).toBe(true);
+    expect(fromApproved.record.state).toBe("approved");
+    expect(fromApproved.record.publicVisible).toBe(false);
+  });
+
+  it.each([
+    "rejectedMalformedConnector",
+    "suspendedUnsafeMetadata",
+    "solanaAiKitBlocked",
+  ])("does not approve unsafe, malformed, or static-risk imported metadata from %s", (fixtureKey) => {
+    const record = recordFor("draft", fixtureKey);
+
+    expect(getBlockingApprovalReviewItems(record.candidate).length).toBeGreaterThan(0);
+
+    const result = applyMarketplaceApprovalAction(record, action("approve"));
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("Imported metadata cannot be approved");
+    expect(result.record.state).toBe("draft");
+    expect(result.record.auditHistory).toEqual([]);
+  });
+
+  it("blocks unsafe metadata approval even when the static review item is informational", () => {
+    const record = recordFor("draft", "approveReadyDraft");
+    const warningOnlyRecord: MarketplaceApprovalRecord = {
+      ...record,
+      candidate: {
+        ...record.candidate,
+        reviewItems: [
+          ...record.candidate.reviewItems,
+          {
+            id: "review:unsafe-info-only",
+            state: "unsafe_metadata_warning",
+            severity: "info",
+            path: "plugins/",
+            source: "validation_warning",
+            reasonCodes: ["unsafe_metadata_warning"],
+            message: "Informational unsafe metadata still requires operator review before approval.",
+            blocksPublication: false,
+            recommendedAction: "review_unsafe_metadata",
+          },
+        ],
+      },
+    };
+
+    expect(getBlockingApprovalReviewItems(warningOnlyRecord.candidate)).toHaveLength(1);
+
+    const result = applyMarketplaceApprovalAction(warningOnlyRecord, action("approve"));
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("unsafe_metadata_warning");
+    expect(result.record.state).toBe("draft");
+    expect(result.record.auditHistory).toEqual([]);
+  });
+});
+
+function action(
+  type: MarketplaceApprovalAction["type"],
+  overrides: Partial<MarketplaceApprovalAction> = {},
+): MarketplaceApprovalAction {
+  return {
+    type,
+    operatorId,
+    timestamp,
+    ...overrides,
+  };
+}
+
+function recordFor(
+  state: MarketplaceApprovalRecordState,
+  fixtureKey: string,
+  publicVisible = false,
+): MarketplaceApprovalRecord {
+  const candidate = getStaticAgentStackReviewWorkspace().candidates.find((item) => item.fixtureKey === fixtureKey);
+  if (!candidate) throw new Error(`missing fixture candidate: ${fixtureKey}`);
+  return {
+    id: `${state}:${fixtureKey}`,
+    fixtureKey,
+    candidate,
+    state,
+    publicVisible,
+    auditHistory: [],
+  };
+}

--- a/lib/manager/marketplace-approval-actions.ts
+++ b/lib/manager/marketplace-approval-actions.ts
@@ -1,0 +1,248 @@
+import type { OperatorDiscoveryCandidateView } from "@/lib/manager/static-agent-stack-review";
+import {
+  evaluateMarketplaceReadiness,
+  type MarketplaceReadinessProofMetadata,
+  type MarketplaceReadinessResult,
+} from "@/lib/manager/marketplace-readiness-gate";
+
+export type MarketplaceApprovalRecordState =
+  | "draft"
+  | "needs_changes"
+  | "approve_ready"
+  | "approved"
+  | "published"
+  | "internal"
+  | "blocked"
+  | "rejected"
+  | "suspended";
+
+export type MarketplaceApprovalActionType =
+  | "approve"
+  | "request_changes"
+  | "reject"
+  | "suspend"
+  | "publish"
+  | "unpublish";
+
+export type MarketplaceApprovalAuditEntry = {
+  operatorId: string;
+  action: MarketplaceApprovalActionType;
+  reason: string;
+  timestamp: string;
+  previousState: MarketplaceApprovalRecordState;
+  nextState: MarketplaceApprovalRecordState;
+  evidenceRefs: string[];
+};
+
+export type MarketplaceApprovalRecord = {
+  id: string;
+  fixtureKey: string;
+  candidate: OperatorDiscoveryCandidateView;
+  state: MarketplaceApprovalRecordState;
+  publicVisible: boolean;
+  auditHistory: MarketplaceApprovalAuditEntry[];
+};
+
+export type MarketplaceApprovalAction = {
+  type: MarketplaceApprovalActionType;
+  operatorId: string;
+  timestamp: string;
+  reason?: string;
+  evidenceRefs?: string[];
+  readinessProof?: MarketplaceReadinessProofMetadata;
+};
+
+export type MarketplaceApprovalActionResult =
+  | {
+      ok: true;
+      record: MarketplaceApprovalRecord;
+      readiness?: MarketplaceReadinessResult;
+    }
+  | {
+      ok: false;
+      reason: string;
+      record: MarketplaceApprovalRecord;
+      readiness?: MarketplaceReadinessResult;
+    };
+
+const terminalStates: MarketplaceApprovalRecordState[] = ["rejected"];
+const requestChangesStates: MarketplaceApprovalRecordState[] = ["draft", "approve_ready", "blocked"];
+const suspendStates: MarketplaceApprovalRecordState[] = ["approved", "published", "internal", "suspended"];
+const unsafeApprovalStates = [
+  "unsafe_metadata_warning",
+  "rejected_malformed_connector",
+  "static_risk_blocker",
+  "suspended_imported_listing",
+];
+
+export function applyMarketplaceApprovalAction(
+  record: MarketplaceApprovalRecord,
+  action: MarketplaceApprovalAction,
+): MarketplaceApprovalActionResult {
+  const validationFailure = validateActionInput(action);
+  if (validationFailure) return fail(record, validationFailure);
+  if (terminalStates.includes(record.state) && action.type !== "unpublish") {
+    return fail(record, `Listing state ${record.state} is terminal and cannot transition without an explicit reopen lane.`);
+  }
+
+  switch (action.type) {
+    case "approve":
+      return approve(record, action);
+    case "request_changes":
+      return requestChanges(record, action);
+    case "reject":
+      return transition(record, action, "rejected", false);
+    case "suspend":
+      return suspend(record, action);
+    case "publish":
+      return publish(record, action);
+    case "unpublish":
+      return unpublish(record, action);
+  }
+}
+
+export function getBlockingApprovalReviewItems(candidate: OperatorDiscoveryCandidateView) {
+  return candidate.reviewItems.filter((item) => unsafeApprovalStates.includes(item.state));
+}
+
+function approve(record: MarketplaceApprovalRecord, action: MarketplaceApprovalAction): MarketplaceApprovalActionResult {
+  if (["published", "suspended"].includes(record.state)) {
+    return fail(record, `Listing state ${record.state} cannot be approved by this internal action.`);
+  }
+  const blockers = getBlockingApprovalReviewItems(record.candidate);
+  if (blockers.length > 0) {
+    return fail(
+      record,
+      `Imported metadata cannot be approved while static review blockers remain: ${blockers
+        .map((item) => item.reasonCodes.join(", ") || item.state)
+        .join("; ")}.`,
+    );
+  }
+  if (!record.candidate.staticOnly || !record.candidate.imported || !record.candidate.untrusted) {
+    return fail(record, "Only static imported untrusted candidates can use this internal approval action.");
+  }
+
+  return transition(record, action, "approved", false);
+}
+
+function requestChanges(
+  record: MarketplaceApprovalRecord,
+  action: MarketplaceApprovalAction,
+): MarketplaceApprovalActionResult {
+  if (!requestChangesStates.includes(record.state)) {
+    return fail(record, `Request changes is only allowed from draft, approve_ready, or blocked; got ${record.state}.`);
+  }
+  return transition(record, action, "needs_changes", false);
+}
+
+function suspend(record: MarketplaceApprovalRecord, action: MarketplaceApprovalAction): MarketplaceApprovalActionResult {
+  if (!suspendStates.includes(record.state)) {
+    return fail(record, `Suspend is only allowed from approved, published, or internal; got ${record.state}.`);
+  }
+  if (record.state === "suspended" && record.publicVisible === false) {
+    return transition(record, action, "suspended", false);
+  }
+  return transition(record, action, "suspended", false);
+}
+
+function publish(record: MarketplaceApprovalRecord, action: MarketplaceApprovalAction): MarketplaceApprovalActionResult {
+  if (record.state !== "approved") {
+    return fail(record, `Publish requires approved state; got ${record.state}.`);
+  }
+  const readiness = evaluateMarketplaceReadiness(
+    record.id,
+    record.fixtureKey,
+    record.candidate,
+    action.readinessProof ?? {},
+  );
+  if (readiness.status !== "publish_ready" || readiness.boundaries.publicationAllowed !== true) {
+    return fail(
+      record,
+      `Publish blocked by marketplace readiness: ${readiness.blockReasons.join(" ") || readiness.status}.`,
+      readiness,
+    );
+  }
+  if (!action.readinessProof?.operatorApproval?.approved || !isNonEmptyString(action.readinessProof.operatorApproval.evidenceRef)) {
+    return fail(record, "Publish requires explicit operator approval evidence.", readiness);
+  }
+
+  const evidenceRefs = uniqueRefs([
+    ...(action.evidenceRefs ?? []),
+    ...readiness.gates.flatMap((gate) => gate.evidenceRefs),
+  ]);
+  return transition(record, { ...action, evidenceRefs }, "published", true, readiness);
+}
+
+function unpublish(record: MarketplaceApprovalRecord, action: MarketplaceApprovalAction): MarketplaceApprovalActionResult {
+  const nextState = record.state === "published" ? "approved" : record.state;
+  return transition(record, action, nextState, false);
+}
+
+function transition(
+  record: MarketplaceApprovalRecord,
+  action: MarketplaceApprovalAction,
+  nextState: MarketplaceApprovalRecordState,
+  publicVisible: boolean,
+  readiness?: MarketplaceReadinessResult,
+): MarketplaceApprovalActionResult {
+  const auditEntry: MarketplaceApprovalAuditEntry = {
+    operatorId: action.operatorId,
+    action: action.type,
+    reason: action.reason?.trim() || defaultReasonFor(action.type),
+    timestamp: action.timestamp,
+    previousState: record.state,
+    nextState,
+    evidenceRefs: uniqueRefs(action.evidenceRefs ?? []),
+  };
+
+  return {
+    ok: true,
+    record: {
+      ...record,
+      state: nextState,
+      publicVisible,
+      auditHistory: [...record.auditHistory, auditEntry],
+    },
+    readiness,
+  };
+}
+
+function fail(
+  record: MarketplaceApprovalRecord,
+  reason: string,
+  readiness?: MarketplaceReadinessResult,
+): MarketplaceApprovalActionResult {
+  return { ok: false, reason, record, readiness };
+}
+
+function validateActionInput(action: MarketplaceApprovalAction) {
+  if (!isNonEmptyString(action.operatorId)) return "Operator id is required.";
+  if (!isNonEmptyString(action.timestamp)) return "Action timestamp is required.";
+  if (Number.isNaN(Date.parse(action.timestamp))) return "Action timestamp must be an ISO-compatible date.";
+  return null;
+}
+
+function defaultReasonFor(action: MarketplaceApprovalActionType) {
+  switch (action) {
+    case "approve":
+      return "Operator approved static imported metadata for internal marketplace review.";
+    case "request_changes":
+      return "Operator requested changes before approval.";
+    case "reject":
+      return "Operator rejected imported metadata.";
+    case "suspend":
+      return "Operator suspended the listing and forced public visibility off.";
+    case "publish":
+      return "Operator published after local readiness evidence passed.";
+    case "unpublish":
+      return "Operator forced public visibility off.";
+  }
+}
+
+function uniqueRefs(refs: string[]) {
+  return Array.from(new Set(refs.filter(isNonEmptyString)));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic internal marketplace approval action reducer for imported listing queue records.
- Consumes the #377 `evaluateMarketplaceReadiness` gate before publish can succeed.
- Appends audit history for successful local transitions with operator, action, reason, timestamp, previous/next state, and evidence refs.
- Keeps the scope backend/local only; no UI wiring, public export, registry writes, live payment, wallet/RPC/MCP/provider calls, trust upgrade, or reputation assignment.

## Validation
- `npm exec -- jest lib/__tests__/manager-marketplace-approval-actions.test.ts --runInBand` — 13 passed
- `npm exec -- jest lib/__tests__/manager-marketplace-readiness-gate.test.ts lib/__tests__/manager-marketplace-approval-actions.test.ts --runInBand` — 19 passed
- `npm run build` — passed; existing Next/Turbopack workspace-root/NFT tracing warnings observed
- `npm run check:rap:naming` — passed
- `git diff --check` — passed

## Guardrails
- No public marketplace export or publication write path added.
- No hosted search, ARD publication, payment activation, wallet signing, RPC probe, MCP call, provider call, repo fetch, live x402 retry, Quasar custody, provider trust upgrade, or reputation assignment.
- Imported stacks remain untrusted static metadata unless later explicit gates promote them.

Closes #378.
