### PR TITLE
Add marketplace public export read model for #350

### DIFF
--- a/lib/__tests__/manager-marketplace-public-export.test.ts
+++ b/lib/__tests__/manager-marketplace-public-export.test.ts
@@ -1,0 +1,272 @@
+import {
+  applyMarketplaceApprovalAction,
+  type MarketplaceApprovalAction,
+  type MarketplaceApprovalRecord,
+  type MarketplaceApprovalRecordState,
+} from "@/lib/manager/marketplace-approval-actions";
+import {
+  deriveMarketplacePublicExportItem,
+  deriveMarketplacePublicExportSnapshot,
+} from "@/lib/manager/marketplace-public-export";
+import type { MarketplaceReadinessProofMetadata } from "@/lib/manager/marketplace-readiness-gate";
+import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
+import { validateAiCatalog } from "@reddi/agent-protocol/ai-catalog";
+
+const timestamp = "2026-06-20T00:00:00Z";
+const operatorId = "operator:test";
+
+const publishReadyProof: MarketplaceReadinessProofMetadata = {
+  endpointBindingRef: "endpoint-binding:anthropic-financial-services:dry-run",
+  paymentPlan: {
+    schemaVersion: "marketplace-payment-plan-proof:v1",
+    planId: "plan:anthropic-financial-services:dry-run",
+    currency: "USD",
+    amount: 0,
+    activation: "disabled",
+    settlement: "dry_run_only",
+    evidenceRef: "evidence:payment-plan:dry-run",
+  },
+  dryRunReceiptRefs: ["receipt:dry-run:approve-ready"],
+  evidenceRefs: ["evidence:static-review:approve-ready"],
+  attestationDraftRef: "attestation-draft:approve-ready",
+  operatorApproval: {
+    approved: true,
+    approvedBy: operatorId,
+    approvedAt: timestamp,
+    evidenceRef: "evidence:operator-approval:approve-ready",
+  },
+};
+
+describe("manager marketplace public export", () => {
+  it("exports a published listing into hosted and ARD-compatible catalog snapshots", () => {
+    const published = publishedRecord();
+    const result = deriveMarketplacePublicExportItem(published, publishReadyProof);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reasons.join(","));
+
+    expect(result.listing).toMatchObject({
+      schemaVersion: "reddi.marketplace-public-export.v1",
+      listingId: published.id,
+      fixtureKey: "approveReadyDraft",
+      source: {
+        imported: true,
+        staticOnly: true,
+        untrusted: true,
+      },
+      endpoint: {
+        bindingRef: publishReadyProof.endpointBindingRef,
+        liveUrl: null,
+        healthStatus: "not_probed",
+      },
+      payment: {
+        planId: publishReadyProof.paymentPlan?.planId,
+        activation: "disabled",
+        settlement: "dry_run_only",
+      },
+      trust: {
+        rapAttested: false,
+        reputationAssigned: false,
+        operatorApprovalEvidenceRef: publishReadyProof.operatorApproval?.evidenceRef,
+      },
+    });
+    expect(result.listing.evidenceRefs).toEqual(expect.arrayContaining([
+      "evidence:operator-action:publish",
+      "evidence:operator-approval:approve-ready",
+      "receipt:dry-run:approve-ready",
+    ]));
+    expect(result.boundaries).toMatchObject({
+      livePaymentAllowed: false,
+      walletSigningAllowed: false,
+      rpcProbeAllowed: false,
+      mcpCallAllowed: false,
+      reputationAssignmentAllowed: false,
+      publicationAllowed: true,
+      hostedExportAllowed: true,
+      ardCatalogExportAllowed: true,
+    });
+    expect(result.catalogResource).toMatchObject({
+      identifier: "urn:reddi:marketplace-listing:approveReadyDraft",
+      mediaType: "application/vnd.reddi.marketplace-listing+json",
+      data: result.listing,
+      metadata: {
+        rap: {
+          readinessStatus: "publish_ready",
+          boundaries: result.boundaries,
+        },
+      },
+    });
+  });
+
+  it("builds a catalog snapshot with only eligible exported entries", () => {
+    const published = publishedRecord();
+    const blocked = recordFor("approved", "approveReadyDraft");
+    const snapshot = deriveMarketplacePublicExportSnapshot(
+      [published, blocked],
+      { [published.id]: publishReadyProof, [blocked.id]: publishReadyProof },
+      { generatedAt: timestamp },
+    );
+
+    expect(snapshot.schemaVersion).toBe("reddi.marketplace-public-export.v1");
+    expect(snapshot.generatedAt).toBe(timestamp);
+    expect(snapshot.exported).toHaveLength(1);
+    expect(snapshot.blocked).toHaveLength(1);
+    expect(snapshot.aiCatalog).toMatchObject({
+      specVersion: "1.0",
+      entries: [snapshot.exported[0].catalogResource],
+    });
+    expect(validateAiCatalog(snapshot.aiCatalog).ok).toBe(true);
+  });
+
+  it.each(["draft", "needs_changes", "approved", "rejected", "suspended", "internal"] as MarketplaceApprovalRecordState[])(
+    "blocks export from %s state",
+    (state) => {
+      const result = deriveMarketplacePublicExportItem(recordFor(state, "approveReadyDraft"), publishReadyProof);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected blocked export");
+      expect(result.reasons).toContain(`record_state_not_published:${state}`);
+      expect(result.boundaries.hostedExportAllowed).toBe(false);
+      expect(result.boundaries.ardCatalogExportAllowed).toBe(false);
+    },
+  );
+
+  it("blocks export when a published record is not public visible", () => {
+    const result = deriveMarketplacePublicExportItem(
+      { ...publishedRecord(), publicVisible: false },
+      publishReadyProof,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked export");
+    expect(result.reasons).toContain("public_visibility_false");
+  });
+
+  it("blocks export when readiness is only dry-run ready", () => {
+    const { operatorApproval, ...dryRunReadyProof } = publishReadyProof;
+    expect(operatorApproval).toBeDefined();
+    const result = deriveMarketplacePublicExportItem(publishedRecord(), dryRunReadyProof);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked export");
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      "readiness_not_publish_ready:dry_run_ready",
+      "publication_not_allowed",
+      "operator_approval_missing",
+      "operator_approval_evidence_missing",
+    ]));
+    expect(result.readinessStatus).toBe("dry_run_ready");
+  });
+
+  it("blocks export when readiness is blocked", () => {
+    const result = deriveMarketplacePublicExportItem(publishedRecord(), {});
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked export");
+    expect(result.reasons).toContain("readiness_not_publish_ready:blocked");
+    expect(result.reasons).toContain("publication_not_allowed");
+    expect(result.readinessStatus).toBe("blocked");
+  });
+
+  it("blocks export when operator approval proof lacks evidence", () => {
+    const result = deriveMarketplacePublicExportItem(publishedRecord(), {
+      ...publishReadyProof,
+      operatorApproval: undefined,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked export");
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      "readiness_not_publish_ready:dry_run_ready",
+      "operator_approval_missing",
+      "operator_approval_evidence_missing",
+    ]));
+  });
+
+  it("blocks export when publish audit evidence is missing", () => {
+    const publishedWithoutAuditEvidence: MarketplaceApprovalRecord = {
+      ...publishedRecord(),
+      auditHistory: [
+        {
+          operatorId,
+          action: "publish",
+          reason: "Manual fixture with missing evidence.",
+          timestamp,
+          previousState: "approved",
+          nextState: "published",
+          evidenceRefs: [],
+        },
+      ],
+    };
+
+    const result = deriveMarketplacePublicExportItem(publishedWithoutAuditEvidence, publishReadyProof);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked export");
+    expect(result.reasons).toContain("publish_audit_missing");
+  });
+
+  it("does not export unsafe imported metadata even with forged published state and proof", () => {
+    const forgedUnsafeRecord: MarketplaceApprovalRecord = {
+      ...recordFor("published", "rejectedMalformedConnector", true),
+      auditHistory: [{
+        operatorId,
+        action: "publish",
+        reason: "Forged publish evidence.",
+        timestamp,
+        previousState: "approved",
+        nextState: "published",
+        evidenceRefs: ["evidence:forged:publish"],
+      }],
+    };
+
+    const result = deriveMarketplacePublicExportItem(forgedUnsafeRecord, publishReadyProof);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked export");
+    expect(result.readinessStatus).toBe("blocked");
+    expect(result.blockReasons.join(" ")).toContain("Safe metadata");
+  });
+});
+
+function action(
+  type: MarketplaceApprovalAction["type"],
+  overrides: Partial<MarketplaceApprovalAction> = {},
+): MarketplaceApprovalAction {
+  return {
+    type,
+    operatorId,
+    timestamp,
+    ...overrides,
+  };
+}
+
+function publishedRecord() {
+  const approve = applyMarketplaceApprovalAction(recordFor("draft", "approveReadyDraft"), action("approve"));
+  if (!approve.ok) throw new Error(approve.reason);
+
+  const publish = applyMarketplaceApprovalAction(approve.record, action("publish", {
+    readinessProof: publishReadyProof,
+    evidenceRefs: ["evidence:operator-action:publish"],
+  }));
+  if (!publish.ok) throw new Error(publish.reason);
+
+  return publish.record;
+}
+
+function recordFor(
+  state: MarketplaceApprovalRecordState,
+  fixtureKey: string,
+  publicVisible = false,
+): MarketplaceApprovalRecord {
+  const candidate = getStaticAgentStackReviewWorkspace().candidates.find((item) => item.fixtureKey === fixtureKey);
+  if (!candidate) throw new Error(`missing fixture candidate: ${fixtureKey}`);
+  return {
+    id: `${state}:${fixtureKey}`,
+    fixtureKey,
+    candidate,
+    state,
+    publicVisible,
+    auditHistory: [],
+  };
+}

--- a/lib/manager/marketplace-public-export.ts
+++ b/lib/manager/marketplace-public-export.ts
@@ -1,0 +1,337 @@
+import type {
+  MarketplaceApprovalAuditEntry,
+  MarketplaceApprovalRecord,
+} from "@/lib/manager/marketplace-approval-actions";
+import {
+  evaluateMarketplaceReadiness,
+  type MarketplaceReadinessBoundary,
+  type MarketplaceReadinessProofMetadata,
+  type MarketplaceReadinessResult,
+} from "@/lib/manager/marketplace-readiness-gate";
+
+export const MARKETPLACE_PUBLIC_EXPORT_SCHEMA_VERSION = "reddi.marketplace-public-export.v1" as const;
+
+export type MarketplacePublicExportBoundary = MarketplaceReadinessBoundary & {
+  hostedExportAllowed: boolean;
+  ardCatalogExportAllowed: boolean;
+};
+
+export type MarketplacePublicListingSnapshot = {
+  schemaVersion: typeof MARKETPLACE_PUBLIC_EXPORT_SCHEMA_VERSION;
+  listingId: string;
+  fixtureKey: string;
+  displayName: string;
+  summary: string;
+  source: {
+    sourceUrl: string;
+    checkedCommit?: string;
+    imported: true;
+    staticOnly: true;
+    untrusted: true;
+  };
+  endpoint: {
+    bindingRef: string;
+    liveUrl: null;
+    healthStatus: "not_probed";
+  };
+  capabilities: {
+    tags: string[];
+    capabilityRefs: string[];
+    groupKinds: string[];
+  };
+  payment: {
+    planId: string;
+    currency: string;
+    amount: number;
+    activation: "disabled";
+    settlement: "dry_run_only";
+    evidenceRef: string;
+  };
+  trust: {
+    rapAttested: false;
+    reputationAssigned: false;
+    operatorApprovalEvidenceRef: string;
+    attestationDraftRef: string;
+  };
+  evidenceRefs: string[];
+  disclosureLabels: string[];
+};
+
+export type MarketplacePublicCatalogResource = {
+  identifier: string;
+  mediaType: "application/vnd.reddi.marketplace-listing+json";
+  displayName: string;
+  description: string;
+  data: MarketplacePublicListingSnapshot;
+  metadata: {
+    rap: {
+      listingId: string;
+      fixtureKey: string;
+      readinessStatus: "publish_ready";
+      payment: MarketplacePublicListingSnapshot["payment"];
+      boundaries: MarketplacePublicExportBoundary;
+    };
+    capabilities: string[];
+  };
+};
+
+export type MarketplacePublicAiCatalog = {
+  specVersion: "1.0";
+  host: {
+    identifier: string;
+    displayName: string;
+  };
+  entries: MarketplacePublicCatalogResource[];
+};
+
+export type MarketplacePublicExportSuccess = {
+  ok: true;
+  listing: MarketplacePublicListingSnapshot;
+  catalogResource: MarketplacePublicCatalogResource;
+  readiness: MarketplaceReadinessResult;
+  publishAudit: MarketplaceApprovalAuditEntry;
+  boundaries: MarketplacePublicExportBoundary;
+};
+
+export type MarketplacePublicExportBlock = {
+  ok: false;
+  listingId: string;
+  fixtureKey: string;
+  recordState: MarketplaceApprovalRecord["state"];
+  readinessStatus: MarketplaceReadinessResult["status"];
+  reasons: string[];
+  blockReasons: string[];
+  boundaries: MarketplacePublicExportBoundary;
+};
+
+export type MarketplacePublicExportItem = MarketplacePublicExportSuccess | MarketplacePublicExportBlock;
+
+export type MarketplacePublicExportSnapshot = {
+  schemaVersion: typeof MARKETPLACE_PUBLIC_EXPORT_SCHEMA_VERSION;
+  generatedAt: string;
+  host: MarketplacePublicAiCatalog["host"];
+  exported: MarketplacePublicExportSuccess[];
+  blocked: MarketplacePublicExportBlock[];
+  aiCatalog: MarketplacePublicAiCatalog;
+};
+
+export type MarketplacePublicExportOptions = {
+  generatedAt?: string;
+  host?: MarketplacePublicAiCatalog["host"];
+};
+
+const defaultHost = {
+  identifier: "urn:reddi:marketplace:hosted-imported-agent-stacks",
+  displayName: "Reddi hosted imported agent listings",
+} as const;
+
+const disclosureLabels = [
+  "imported metadata",
+  "external source",
+  "untrusted",
+  "static-only",
+  "operator approved",
+  "not RAP-attested",
+  "dry-run payment proof only",
+  "no live endpoint probe",
+  "no reputation assignment",
+];
+
+export function deriveMarketplacePublicExportItem(
+  record: MarketplaceApprovalRecord,
+  proof: MarketplaceReadinessProofMetadata = {},
+): MarketplacePublicExportItem {
+  const readiness = evaluateMarketplaceReadiness(record.id, record.fixtureKey, record.candidate, proof);
+  const boundaries = publicExportBoundaries(readiness.boundaries, false);
+  const reasons = publicExportBlockReasons(record, proof, readiness);
+  if (reasons.length > 0) {
+    return {
+      ok: false,
+      listingId: record.id,
+      fixtureKey: record.fixtureKey,
+      recordState: record.state,
+      readinessStatus: readiness.status,
+      reasons,
+      blockReasons: readiness.blockReasons,
+      boundaries,
+    };
+  }
+
+  const publishAudit = latestPublishAudit(record);
+  if (!publishAudit) {
+    throw new Error("invariant: public export requires publish audit evidence");
+  }
+
+  const listing = buildListing(record, proof, readiness, publishAudit);
+  const allowedBoundaries = publicExportBoundaries(readiness.boundaries, true);
+  return {
+    ok: true,
+    listing,
+    catalogResource: buildCatalogResource(listing, allowedBoundaries),
+    readiness,
+    publishAudit,
+    boundaries: allowedBoundaries,
+  };
+}
+
+export function deriveMarketplacePublicExportSnapshot(
+  records: MarketplaceApprovalRecord[],
+  proofByListingId: Record<string, MarketplaceReadinessProofMetadata> = {},
+  options: MarketplacePublicExportOptions = {},
+): MarketplacePublicExportSnapshot {
+  const items = records.map((record) => deriveMarketplacePublicExportItem(record, proofByListingId[record.id] ?? {}));
+  const exported = items.filter((item): item is MarketplacePublicExportSuccess => item.ok);
+  const blocked = items.filter((item): item is MarketplacePublicExportBlock => !item.ok);
+  const host = options.host ?? defaultHost;
+
+  return {
+    schemaVersion: MARKETPLACE_PUBLIC_EXPORT_SCHEMA_VERSION,
+    generatedAt: options.generatedAt ?? new Date(0).toISOString(),
+    host,
+    exported,
+    blocked,
+    aiCatalog: {
+      specVersion: "1.0",
+      host,
+      entries: exported.map((item) => item.catalogResource),
+    },
+  };
+}
+
+function publicExportBlockReasons(
+  record: MarketplaceApprovalRecord,
+  proof: MarketplaceReadinessProofMetadata,
+  readiness: MarketplaceReadinessResult,
+) {
+  const reasons = [
+    record.state === "published" ? undefined : `record_state_not_published:${record.state}`,
+    record.publicVisible === true ? undefined : "public_visibility_false",
+    readiness.status === "publish_ready" ? undefined : `readiness_not_publish_ready:${readiness.status}`,
+    readiness.boundaries.publicationAllowed === true ? undefined : "publication_not_allowed",
+    proof.operatorApproval?.approved === true ? undefined : "operator_approval_missing",
+    isNonEmptyString(proof.operatorApproval?.evidenceRef) ? undefined : "operator_approval_evidence_missing",
+    latestPublishAudit(record) ? undefined : "publish_audit_missing",
+  ];
+
+  return reasons.filter(isNonEmptyString);
+}
+
+function buildListing(
+  record: MarketplaceApprovalRecord,
+  proof: MarketplaceReadinessProofMetadata,
+  readiness: MarketplaceReadinessResult,
+  publishAudit: MarketplaceApprovalAuditEntry,
+): MarketplacePublicListingSnapshot {
+  const buyerPreview = record.candidate.draftPreview.buyerPreview;
+  const paymentPlan = proof.paymentPlan;
+  if (!paymentPlan || !proof.endpointBindingRef || !proof.operatorApproval || !proof.attestationDraftRef) {
+    throw new Error("invariant: publish-ready public export requires proof metadata");
+  }
+
+  return {
+    schemaVersion: MARKETPLACE_PUBLIC_EXPORT_SCHEMA_VERSION,
+    listingId: record.id,
+    fixtureKey: record.fixtureKey,
+    displayName: buyerPreview.displayName ?? record.candidate.title,
+    summary: buyerPreview.summary ?? record.candidate.description,
+    source: {
+      sourceUrl: record.candidate.sourceUrl,
+      checkedCommit: record.candidate.checkedCommit,
+      imported: true,
+      staticOnly: true,
+      untrusted: true,
+    },
+    endpoint: {
+      bindingRef: proof.endpointBindingRef,
+      liveUrl: null,
+      healthStatus: "not_probed",
+    },
+    capabilities: {
+      tags: deriveCapabilityTags(record),
+      capabilityRefs: uniqueRefs(record.candidate.groups.flatMap((group) => group.capabilityRefs)),
+      groupKinds: record.candidate.requiredGroupKinds,
+    },
+    payment: {
+      planId: paymentPlan.planId,
+      currency: paymentPlan.currency,
+      amount: paymentPlan.amount,
+      activation: "disabled",
+      settlement: "dry_run_only",
+      evidenceRef: paymentPlan.evidenceRef,
+    },
+    trust: {
+      rapAttested: false,
+      reputationAssigned: false,
+      operatorApprovalEvidenceRef: proof.operatorApproval.evidenceRef,
+      attestationDraftRef: proof.attestationDraftRef,
+    },
+    evidenceRefs: uniqueRefs([
+      ...publishAudit.evidenceRefs,
+      ...readiness.gates.flatMap((gate) => gate.evidenceRefs),
+    ]),
+    disclosureLabels,
+  };
+}
+
+function buildCatalogResource(
+  listing: MarketplacePublicListingSnapshot,
+  boundaries: MarketplacePublicExportBoundary,
+): MarketplacePublicCatalogResource {
+  return {
+    identifier: `urn:reddi:marketplace-listing:${listing.fixtureKey}`,
+    mediaType: "application/vnd.reddi.marketplace-listing+json",
+    displayName: listing.displayName,
+    description: listing.summary,
+    data: listing,
+    metadata: {
+      rap: {
+        listingId: listing.listingId,
+        fixtureKey: listing.fixtureKey,
+        readinessStatus: "publish_ready",
+        payment: listing.payment,
+        boundaries,
+      },
+      capabilities: listing.capabilities.tags,
+    },
+  };
+}
+
+function latestPublishAudit(record: MarketplaceApprovalRecord) {
+  return [...record.auditHistory]
+    .reverse()
+    .find((entry) =>
+      entry.action === "publish"
+      && entry.nextState === "published"
+      && entry.evidenceRefs.some(isNonEmptyString)
+    );
+}
+
+function publicExportBoundaries(
+  readinessBoundaries: MarketplaceReadinessBoundary,
+  exportAllowed: boolean,
+): MarketplacePublicExportBoundary {
+  return {
+    ...readinessBoundaries,
+    hostedExportAllowed: exportAllowed,
+    ardCatalogExportAllowed: exportAllowed,
+  };
+}
+
+function deriveCapabilityTags(record: MarketplaceApprovalRecord) {
+  const buyerPreview = record.candidate.draftPreview.buyerPreview;
+  return uniqueRefs([
+    ...record.candidate.requiredGroupKinds,
+    ...Object.values(buyerPreview)
+      .flatMap((value) => value.split(/[,;]/))
+      .map((value) => value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_"))
+      .filter(Boolean),
+  ]).slice(0, 12);
+}
+
+function uniqueRefs(refs: string[]) {
+  return Array.from(new Set(refs.filter(isNonEmptyString)));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic marketplace public export read model for #350.
- Derives hosted/public listing snapshots and AI Catalog-shaped entries only from local approval records plus #377 readiness proof.
- Returns explicit blocked export reasons for non-published, non-visible, dry-run/blocked readiness, missing operator proof, missing publish audit evidence, and unsafe imported metadata.

## Guardrails
- Backend/test only: no route, UI, public registry write, live marketplace publication, payment activation, wallet signing, RPC probe, MCP/provider call, repo fetch, trust upgrade, reputation assignment, or imported command execution.
- Export requires `published`, `publicVisible === true`, #377 `publish_ready`, `publicationAllowed === true`, operator approval evidence, and publish audit evidence.
- Exported metadata keeps live payment/wallet/RPC/MCP/reputation boundaries false and marks endpoint health as not probed.

## Validation
- `npx jest lib/__tests__/manager-marketplace-readiness-gate.test.ts lib/__tests__/manager-marketplace-approval-actions.test.ts lib/__tests__/manager-marketplace-public-export.test.ts --runInBand`
- `npm run check:rap:naming`
- `git diff --check`

Refs #350. This is the first read-model/export slice; follow-up can wire a route or hosted surface after this derivation is reviewed.