### PR TITLE
Add read-only marketplace public export route for #350

### DIFF
--- a/app/api/manager/marketplace-public-export/route.ts
+++ b/app/api/manager/marketplace-public-export/route.ts
@@ -1,0 +1,31 @@
+import { getFixtureBackedMarketplacePublicExportSnapshot } from "@/lib/manager/marketplace-public-export-fixtures";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  try {
+    const result = getFixtureBackedMarketplacePublicExportSnapshot();
+    return Response.json({
+      ok: true,
+      result,
+      guardrails: {
+        readOnly: true,
+        fixtureBacked: true,
+        livePublication: false,
+        livePayment: false,
+        walletSigning: false,
+        rpcProbe: false,
+        mcpCall: false,
+        providerCall: false,
+        reputationAssignment: false,
+      },
+    });
+  } catch (error) {
+    return Response.json(
+      { ok: false, error: error instanceof Error ? error.message : "Marketplace public export failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/__tests__/manager-marketplace-public-export-route.test.ts
+++ b/lib/__tests__/manager-marketplace-public-export-route.test.ts
@@ -1,0 +1,92 @@
+import { validateAiCatalog } from "@reddi/agent-protocol/ai-catalog";
+
+jest.mock("@/lib/registry/bridge", () => {
+  throw new Error("live registry bridge must not be imported by marketplace public export route");
+});
+
+jest.mock("@solana/web3.js", () => {
+  throw new Error("Solana RPC helpers must not be imported by marketplace public export route");
+});
+
+describe("manager marketplace public export route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("returns a read-only fixture-backed export snapshot", async () => {
+    const { GET } = await import("@/app/api/manager/marketplace-public-export/route");
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      guardrails: {
+        readOnly: true,
+        fixtureBacked: true,
+        livePublication: false,
+        livePayment: false,
+        walletSigning: false,
+        rpcProbe: false,
+        mcpCall: false,
+        providerCall: false,
+        reputationAssignment: false,
+      },
+      result: {
+        schemaVersion: "reddi.marketplace-public-export.v1",
+        exported: expect.any(Array),
+        blocked: expect.any(Array),
+        aiCatalog: {
+          specVersion: "1.0",
+          entries: expect.any(Array),
+        },
+      },
+    });
+    expect(body.result.exported).toHaveLength(1);
+    expect(body.result.blocked).toHaveLength(2);
+    expect(body.result.aiCatalog.entries).toHaveLength(1);
+    const catalogValidation = validateAiCatalog(JSON.parse(JSON.stringify(body.result.aiCatalog)));
+    expect(catalogValidation.ok).toBe(true);
+  });
+
+  it("keeps exported catalog entries non-live and hides blocked records from AI Catalog output", async () => {
+    const { GET } = await import("@/app/api/manager/marketplace-public-export/route");
+
+    const res = await GET();
+    const body = await res.json();
+    const [entry] = body.result.aiCatalog.entries;
+
+    expect(entry.data).toMatchObject({
+      endpoint: {
+        liveUrl: null,
+        healthStatus: "not_probed",
+      },
+      payment: {
+        activation: "disabled",
+        settlement: "dry_run_only",
+      },
+      trust: {
+        rapAttested: false,
+        reputationAssigned: false,
+      },
+    });
+    expect(entry.metadata.rap.boundaries).toMatchObject({
+      livePaymentAllowed: false,
+      walletSigningAllowed: false,
+      rpcProbeAllowed: false,
+      mcpCallAllowed: false,
+      reputationAssignmentAllowed: false,
+      publicationAllowed: true,
+      hostedExportAllowed: true,
+      ardCatalogExportAllowed: true,
+    });
+    expect(body.result.blocked.map((item: { fixtureKey: string }) => item.fixtureKey)).toEqual([
+      "approveReadyDraft",
+      "rejectedMalformedConnector",
+    ]);
+    expect(body.result.aiCatalog.entries.map((item: { identifier: string }) => item.identifier)).toEqual([
+      "urn:reddi:marketplace-listing:approveReadyDraft",
+    ]);
+  });
+});

--- a/lib/manager/marketplace-public-export-fixtures.ts
+++ b/lib/manager/marketplace-public-export-fixtures.ts
@@ -1,0 +1,106 @@
+import {
+  applyMarketplaceApprovalAction,
+  type MarketplaceApprovalAction,
+  type MarketplaceApprovalRecord,
+  type MarketplaceApprovalRecordState,
+} from "@/lib/manager/marketplace-approval-actions";
+import {
+  deriveMarketplacePublicExportSnapshot,
+  type MarketplacePublicExportSnapshot,
+} from "@/lib/manager/marketplace-public-export";
+import type { MarketplaceReadinessProofMetadata } from "@/lib/manager/marketplace-readiness-gate";
+import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
+
+const fixtureTimestamp = "2026-06-20T00:00:00Z";
+const fixtureOperatorId = "operator:fixture";
+
+export const fixturePublishReadyProof: MarketplaceReadinessProofMetadata = {
+  endpointBindingRef: "endpoint-binding:anthropic-financial-services:dry-run",
+  paymentPlan: {
+    schemaVersion: "marketplace-payment-plan-proof:v1",
+    planId: "plan:anthropic-financial-services:dry-run",
+    currency: "USD",
+    amount: 0,
+    activation: "disabled",
+    settlement: "dry_run_only",
+    evidenceRef: "evidence:payment-plan:dry-run",
+  },
+  dryRunReceiptRefs: ["receipt:dry-run:approve-ready"],
+  evidenceRefs: ["evidence:static-review:approve-ready"],
+  attestationDraftRef: "attestation-draft:approve-ready",
+  operatorApproval: {
+    approved: true,
+    approvedBy: fixtureOperatorId,
+    approvedAt: fixtureTimestamp,
+    evidenceRef: "evidence:operator-approval:approve-ready",
+  },
+};
+
+export function getFixtureBackedMarketplacePublicExportSnapshot(): MarketplacePublicExportSnapshot {
+  const published = publishedFixtureRecord();
+  const approvedButUnpublished = recordFor("approved", "approveReadyDraft");
+  const unsafeForgedPublished = {
+    ...recordFor("published", "rejectedMalformedConnector", true),
+    auditHistory: [{
+      operatorId: fixtureOperatorId,
+      action: "publish" as const,
+      reason: "Forged publish fixture for blocked export diagnostics.",
+      timestamp: fixtureTimestamp,
+      previousState: "approved" as const,
+      nextState: "published" as const,
+      evidenceRefs: ["evidence:forged:publish"],
+    }],
+  };
+
+  return deriveMarketplacePublicExportSnapshot(
+    [published, approvedButUnpublished, unsafeForgedPublished],
+    {
+      [published.id]: fixturePublishReadyProof,
+      [approvedButUnpublished.id]: fixturePublishReadyProof,
+      [unsafeForgedPublished.id]: fixturePublishReadyProof,
+    },
+    { generatedAt: fixtureTimestamp },
+  );
+}
+
+function action(
+  type: MarketplaceApprovalAction["type"],
+  overrides: Partial<MarketplaceApprovalAction> = {},
+): MarketplaceApprovalAction {
+  return {
+    type,
+    operatorId: fixtureOperatorId,
+    timestamp: fixtureTimestamp,
+    ...overrides,
+  };
+}
+
+function publishedFixtureRecord() {
+  const approve = applyMarketplaceApprovalAction(recordFor("draft", "approveReadyDraft"), action("approve"));
+  if (!approve.ok) throw new Error(approve.reason);
+
+  const publish = applyMarketplaceApprovalAction(approve.record, action("publish", {
+    readinessProof: fixturePublishReadyProof,
+    evidenceRefs: ["evidence:operator-action:publish"],
+  }));
+  if (!publish.ok) throw new Error(publish.reason);
+
+  return publish.record;
+}
+
+function recordFor(
+  state: MarketplaceApprovalRecordState,
+  fixtureKey: string,
+  publicVisible = false,
+): MarketplaceApprovalRecord {
+  const candidate = getStaticAgentStackReviewWorkspace().candidates.find((item) => item.fixtureKey === fixtureKey);
+  if (!candidate) throw new Error(`missing fixture candidate: ${fixtureKey}`);
+  return {
+    id: `${state}:${fixtureKey}`,
+    fixtureKey,
+    candidate,
+    state,
+    publicVisible,
+    auditHistory: [],
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a read-only manager API route for the #350 marketplace public export snapshot.
- Uses a fixture-backed local builder that consumes the #433 derivation and #377/#378 proof/state gates.
- Returns exported and blocked records plus AI Catalog-shaped entries for successful `published && gates.ok` listings.

## Guardrails
- Route is read-only and fixture-backed.
- No live registry write, marketplace publication, payment activation, wallet signing, RPC probe, MCP/provider call, repo fetch, trust upgrade, reputation assignment, or imported command execution.
- Route tests fail if the live registry bridge or Solana RPC helpers are imported.

## Validation
- `npx jest lib/__tests__/manager-marketplace-public-export.test.ts lib/__tests__/manager-marketplace-public-export-route.test.ts --runInBand`
- `npm run build`
- `npm run check:rap:naming`
- `git diff --check`

Refs #350.