### PR TITLE
Add well-known AI Catalog route for #369

### DIFF
--- a/app/.well-known/ai-catalog.json/route.ts
+++ b/app/.well-known/ai-catalog.json/route.ts
@@ -1,0 +1,17 @@
+import { getFixtureBackedMarketplacePublicExportSnapshot } from "@/lib/manager/marketplace-public-export-fixtures";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  try {
+    const snapshot = getFixtureBackedMarketplacePublicExportSnapshot();
+    return Response.json(snapshot.aiCatalog);
+  } catch (error) {
+    return Response.json(
+      { ok: false, error: error instanceof Error ? error.message : "AI Catalog export failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/__tests__/well-known-ai-catalog-route.test.ts
+++ b/lib/__tests__/well-known-ai-catalog-route.test.ts
@@ -1,0 +1,69 @@
+import { validateAiCatalog } from "@reddi/agent-protocol/ai-catalog";
+
+jest.mock("@/lib/registry/bridge", () => {
+  throw new Error("live registry bridge must not be imported by well-known AI Catalog route");
+});
+
+jest.mock("@solana/web3.js", () => {
+  throw new Error("Solana RPC helpers must not be imported by well-known AI Catalog route");
+});
+
+describe("well-known AI Catalog route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("returns the fixture-backed hosted marketplace AI Catalog", async () => {
+    const { GET } = await import("@/app/.well-known/ai-catalog.json/route");
+
+    const res = await GET();
+    const body = await res.json();
+    const catalogValidation = validateAiCatalog(JSON.parse(JSON.stringify(body)));
+
+    expect(res.status).toBe(200);
+    expect(catalogValidation.ok).toBe(true);
+    expect(body).toMatchObject({
+      specVersion: "1.0",
+      host: {
+        identifier: "urn:reddi:marketplace:hosted-imported-agent-stacks",
+      },
+      entries: [
+        expect.objectContaining({
+          identifier: "urn:reddi:marketplace-listing:approveReadyDraft",
+          mediaType: "application/vnd.reddi.marketplace-listing+json",
+        }),
+      ],
+    });
+  });
+
+  it("keeps the well-known catalog non-live", async () => {
+    const { GET } = await import("@/app/.well-known/ai-catalog.json/route");
+
+    const res = await GET();
+    const body = await res.json();
+    const [entry] = body.entries;
+
+    expect(entry.data.endpoint).toMatchObject({
+      liveUrl: null,
+      healthStatus: "not_probed",
+    });
+    expect(entry.data.payment).toMatchObject({
+      activation: "disabled",
+      settlement: "dry_run_only",
+    });
+    expect(entry.data.trust).toMatchObject({
+      rapAttested: false,
+      reputationAssigned: false,
+    });
+    expect(entry.metadata.rap.boundaries).toMatchObject({
+      livePaymentAllowed: false,
+      walletSigningAllowed: false,
+      rpcProbeAllowed: false,
+      mcpCallAllowed: false,
+      reputationAssignmentAllowed: false,
+      publicationAllowed: true,
+      hostedExportAllowed: true,
+      ardCatalogExportAllowed: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a read-only `/.well-known/ai-catalog.json` route backed by the fixture/proof-based marketplace public export snapshot from #434
- return AI Catalog JSON only after the existing #350/#377/#378 gates have derived hosted export entries
- add route tests that validate the catalog shape and fail if live registry/RPC paths are imported

## Guardrails
- no hosted search endpoint yet
- no live registry writes, marketplace publication side effects, payment activation, wallet signing, RPC probes, MCP/provider calls, repo fetches, trust upgrades, reputation assignment, or imported command execution
- route remains deterministic and read-only

## Validation
- `npx jest lib/__tests__/well-known-ai-catalog-route.test.ts lib/__tests__/manager-marketplace-public-export-route.test.ts --runInBand`
- `npm run build`
- `git diff --check`
- `npm run check:rap:naming`

Refs #369