### PR TITLE
Add receipt evidence binding primitive for #393

### DIFF
--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -10,3 +10,4 @@ export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
 export * from './agent-stack-fixtures.js';
+export * from './receipt-evidence-binding.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -10,3 +10,4 @@ export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
 export * from './agent-stack-fixtures.js';
+export * from './receipt-evidence-binding.js';

--- a/packages/agent-protocol/dist/receipt-evidence-binding.d.ts
+++ b/packages/agent-protocol/dist/receipt-evidence-binding.d.ts
@@ -1,0 +1,92 @@
+import { type AttestationRecord, type ReputationEvent } from './attestation-reputation.js';
+import type { AuddPaymentPlanPreflightDecision } from './audd-payment-plan.js';
+import { type EvidenceArchiveRecord } from './evidence-archive.js';
+import { type ReddiReceipt } from './receipts.js';
+export declare const RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION: "reddi.receipt-evidence-binding.v1";
+export type ReceiptEvidenceSourceKind = 'ai-catalog' | 'ard-registry' | 'hosted-rap-registry' | 'source-adapter' | 'static-fixture';
+export type ReceiptEvidenceSourceRef = {
+    kind: ReceiptEvidenceSourceKind;
+    sourceId: string;
+    catalogRef?: string;
+    fixtureRef?: string;
+    listingId?: string;
+    profileId?: string;
+    rawSnapshotRef?: string;
+};
+export type ReceiptEvidenceBindingInput = {
+    id: string;
+    source: ReceiptEvidenceSourceRef;
+    receipt: ReddiReceipt;
+    evidence: EvidenceArchiveRecord;
+    evidencePayload?: unknown;
+    paymentPreflight: AuddPaymentPlanPreflightDecision;
+    attestation?: AttestationRecord;
+    reputationEventDraft?: ReputationEvent;
+    createdAt: string;
+};
+export type ReceiptEvidenceBinding = {
+    schemaVersion: typeof RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION;
+    id: string;
+    source: ReceiptEvidenceSourceRef;
+    receipt: {
+        id: string;
+        sourceId: string;
+        policyDecision: ReddiReceipt['policyDecision'];
+        paymentProofRef: string;
+        requestHash: string;
+        responseHash: string;
+        evidenceRef: string;
+        attestationStatus: ReddiReceipt['attestationStatus'];
+    };
+    evidence: {
+        id: string;
+        receiptId: string;
+        evidenceRef: string;
+        evidenceHash: string;
+        externalArchivePointer?: EvidenceArchiveRecord['externalArchivePointer'];
+    };
+    payment: {
+        preflightAllowed: boolean;
+        reasonCodes: AuddPaymentPlanPreflightDecision['reasonCodes'];
+        paymentProofRef: string;
+        planRef: {
+            asset: string;
+            network: string;
+            amount: string;
+            paymentMode: 'dry-run' | 'live';
+            evidenceRequired: boolean;
+        };
+    };
+    attestation?: {
+        id: string;
+        status: ReddiReceipt['attestationStatus'];
+        verdict: AttestationRecord['verdict'];
+        trustBoundary: AttestationRecord['trustBoundary'];
+    };
+    reputationEventDraft?: ReputationEvent;
+    guardrails: {
+        rawPromptStored: false;
+        rawOutputStored: false;
+        livePaymentExecuted: false;
+        walletSigning: false;
+        rpcCall: false;
+        hostedRegistryRequired: false;
+        reputationMutated: false;
+    };
+    createdAt: string;
+};
+export type ReceiptEvidenceBindingErrorCode = 'malformed_binding' | 'missing_source_ref' | 'missing_payment_preflight' | 'payment_preflight_denied' | 'payment_proof_mismatch' | 'payment_plan_mismatch' | 'unsupported_network_asset' | 'receipt_invalid' | 'evidence_invalid' | 'evidence_receipt_mismatch' | 'hash_mismatch' | 'attestation_mismatch' | 'reputation_event_mismatch' | 'raw_payload_leakage_rejected' | 'credential_leakage_rejected';
+export type ReceiptEvidenceBindingError = {
+    code: ReceiptEvidenceBindingErrorCode;
+    path: string;
+    message: string;
+};
+export type ReceiptEvidenceBindingResult = {
+    ok: true;
+    binding: ReceiptEvidenceBinding;
+} | {
+    ok: false;
+    errors: ReceiptEvidenceBindingError[];
+};
+export declare function createReceiptEvidenceBinding(input: ReceiptEvidenceBindingInput): ReceiptEvidenceBinding;
+export declare function deriveReceiptEvidenceBinding(input: ReceiptEvidenceBindingInput): ReceiptEvidenceBindingResult;

--- a/packages/agent-protocol/dist/receipt-evidence-binding.js
+++ b/packages/agent-protocol/dist/receipt-evidence-binding.js
@@ -1,0 +1,271 @@
+import { validateAttestationRecord, } from './attestation-reputation.js';
+import { validateEvidenceArchiveRecord, } from './evidence-archive.js';
+import { validateReddiReceipt, } from './receipts.js';
+export const RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION = 'reddi.receipt-evidence-binding.v1';
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|signature|sig|signed|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+const RAW_PAYLOAD_KEY_PATTERN = /(^|[_-])(raw[_-]?prompt|prompt|completion|raw[_-]?output|output|transcript)($|[_-])/i;
+export function createReceiptEvidenceBinding(input) {
+    const result = deriveReceiptEvidenceBinding(input);
+    if (!result.ok) {
+        throw new Error(`invalid_receipt_evidence_binding:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+    }
+    return result.binding;
+}
+export function deriveReceiptEvidenceBinding(input) {
+    const errors = [];
+    if (!isNonEmptyString(input.id)) {
+        errors.push(error('malformed_binding', '$.id', 'binding id is required'));
+    }
+    if (!isNonEmptyString(input.createdAt) || Number.isNaN(Date.parse(input.createdAt))) {
+        errors.push(error('malformed_binding', '$.createdAt', 'createdAt must be an ISO timestamp'));
+    }
+    validateSource(input.source, errors);
+    const receiptValidation = validateReddiReceipt(input.receipt);
+    if (!receiptValidation.ok) {
+        errors.push(...receiptValidation.errors.map((item) => error(mapReceiptError(item.code), `$.receipt${item.path.slice(1)}`, item.message)));
+    }
+    const evidenceValidation = validateEvidenceArchiveRecord(input.evidence, input.evidencePayload);
+    if (!evidenceValidation.ok) {
+        errors.push(...evidenceValidation.errors.map((item) => error(mapEvidenceError(item.code), `$.evidence${item.path.slice(1)}`, item.message)));
+    }
+    if (containsRawPayload(input.evidencePayload)) {
+        errors.push(error('raw_payload_leakage_rejected', '$.evidencePayload', 'raw prompt/output payloads must be replaced by hashes or references before binding'));
+    }
+    if (containsCredentialMaterial(input.source)) {
+        errors.push(error('credential_leakage_rejected', '$.source', 'source refs must not contain credential-shaped material'));
+    }
+    validatePaymentPreflight(input, errors);
+    validateRecordLinks(input, errors);
+    validateAttestation(input, errors);
+    validateReputationEvent(input, errors);
+    if (errors.length > 0)
+        return { ok: false, errors };
+    const plan = input.paymentPreflight.paymentPlan;
+    if (!plan || !input.paymentPreflight.paymentProofRef) {
+        return {
+            ok: false,
+            errors: [error('missing_payment_preflight', '$.paymentPreflight', 'payment preflight proof is required')],
+        };
+    }
+    return {
+        ok: true,
+        binding: {
+            schemaVersion: RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION,
+            id: input.id,
+            source: input.source,
+            receipt: {
+                id: input.receipt.job.id,
+                sourceId: input.receipt.source.id,
+                policyDecision: input.receipt.policyDecision,
+                paymentProofRef: input.receipt.payment.paymentProofRef,
+                requestHash: input.receipt.requestHash,
+                responseHash: input.receipt.responseHash,
+                evidenceRef: input.receipt.evidenceRef,
+                attestationStatus: input.receipt.attestationStatus,
+            },
+            evidence: {
+                id: input.evidence.id,
+                receiptId: input.evidence.receiptId,
+                evidenceRef: input.evidence.evidenceRef,
+                evidenceHash: input.evidence.evidenceHash,
+                externalArchivePointer: input.evidence.externalArchivePointer,
+            },
+            payment: {
+                preflightAllowed: input.paymentPreflight.allowed,
+                reasonCodes: input.paymentPreflight.reasonCodes,
+                paymentProofRef: input.paymentPreflight.paymentProofRef,
+                planRef: {
+                    asset: plan.asset,
+                    network: plan.network,
+                    amount: plan.amount,
+                    paymentMode: plan.paymentMode,
+                    evidenceRequired: plan.evidenceRequired,
+                },
+            },
+            attestation: input.attestation
+                ? {
+                    id: input.attestation.id,
+                    status: input.receipt.attestationStatus,
+                    verdict: input.attestation.verdict,
+                    trustBoundary: input.attestation.trustBoundary,
+                }
+                : undefined,
+            reputationEventDraft: input.reputationEventDraft,
+            guardrails: {
+                rawPromptStored: false,
+                rawOutputStored: false,
+                livePaymentExecuted: false,
+                walletSigning: false,
+                rpcCall: false,
+                hostedRegistryRequired: false,
+                reputationMutated: false,
+            },
+            createdAt: input.createdAt,
+        },
+    };
+}
+function validateSource(source, errors) {
+    if (!source || !['ai-catalog', 'ard-registry', 'hosted-rap-registry', 'source-adapter', 'static-fixture'].includes(String(source.kind))) {
+        errors.push(error('missing_source_ref', '$.source.kind', 'source kind is required'));
+    }
+    if (!isNonEmptyString(source?.sourceId)) {
+        errors.push(error('missing_source_ref', '$.source.sourceId', 'source id is required'));
+    }
+    if (![source?.catalogRef, source?.fixtureRef, source?.listingId, source?.profileId, source?.rawSnapshotRef].some(isNonEmptyString)) {
+        errors.push(error('missing_source_ref', '$.source', 'source must include catalog, fixture, listing, profile, or raw snapshot ref'));
+    }
+}
+function validatePaymentPreflight(input, errors) {
+    const proof = input.paymentPreflight;
+    if (!proof || typeof proof.allowed !== 'boolean') {
+        errors.push(error('missing_payment_preflight', '$.paymentPreflight', 'AUDD payment plan preflight proof is required'));
+        return;
+    }
+    if (!proof.allowed) {
+        errors.push(error('payment_preflight_denied', '$.paymentPreflight.allowed', 'payment preflight must be allowed before binding'));
+    }
+    if (!isNonEmptyString(proof.paymentProofRef)) {
+        errors.push(error('missing_payment_preflight', '$.paymentPreflight.paymentProofRef', 'payment proof ref is required'));
+    }
+    else if (proof.paymentProofRef !== input.receipt.payment.paymentProofRef) {
+        errors.push(error('payment_proof_mismatch', '$.paymentPreflight.paymentProofRef', 'payment preflight proof must match receipt payment proof'));
+    }
+    if (!proof.paymentPlan) {
+        errors.push(error('missing_payment_preflight', '$.paymentPreflight.paymentPlan', 'payment plan metadata is required'));
+        return;
+    }
+    if (proof.paymentPlan.asset !== input.receipt.payment.asset
+        || proof.paymentPlan.network !== input.receipt.payment.network
+        || proof.paymentPlan.amount !== input.receipt.payment.amount) {
+        errors.push(error('payment_plan_mismatch', '$.paymentPreflight.paymentPlan', 'payment plan asset/network/amount must match receipt payment'));
+    }
+    if (proof.policyDecision && proof.policyDecision !== input.receipt.policyDecision) {
+        const policy = proof.policyDecision;
+        if (policy.allowed !== input.receipt.policyDecision.allowed
+            || policy.asset !== input.receipt.policyDecision.asset
+            || policy.network !== input.receipt.policyDecision.network
+            || policy.approvalState !== input.receipt.policyDecision.approvalState) {
+            errors.push(error('payment_plan_mismatch', '$.paymentPreflight.policyDecision', 'payment preflight policy decision must match receipt policy decision'));
+        }
+    }
+}
+function validateRecordLinks(input, errors) {
+    if (input.receipt.source.id !== input.source.sourceId) {
+        errors.push(error('evidence_receipt_mismatch', '$.receipt.source.id', 'receipt source must match binding source'));
+    }
+    if (input.evidence.sourceId !== input.source.sourceId) {
+        errors.push(error('evidence_receipt_mismatch', '$.evidence.sourceId', 'evidence source must match binding source'));
+    }
+    if (input.evidence.receiptId !== input.receipt.job.id) {
+        errors.push(error('evidence_receipt_mismatch', '$.evidence.receiptId', 'evidence receipt id must match receipt job id'));
+    }
+    if (input.evidence.requestHash !== input.receipt.requestHash) {
+        errors.push(error('hash_mismatch', '$.evidence.requestHash', 'evidence request hash must match receipt request hash'));
+    }
+    if (input.evidence.responseHash !== input.receipt.responseHash) {
+        errors.push(error('hash_mismatch', '$.evidence.responseHash', 'evidence response hash must match receipt response hash'));
+    }
+    if (input.evidence.evidenceRef !== input.receipt.evidenceRef) {
+        errors.push(error('evidence_receipt_mismatch', '$.evidence.evidenceRef', 'evidence ref must match receipt evidence ref'));
+    }
+}
+function validateAttestation(input, errors) {
+    if (!input.attestation)
+        return;
+    const attestation = validateAttestationRecord(input.attestation);
+    if (!attestation.ok) {
+        errors.push(...attestation.errors.map((item) => error(mapAttestationError(item.code), `$.attestation${item.path.slice(1)}`, item.message)));
+        return;
+    }
+    if (input.attestation.receiptId !== input.receipt.job.id) {
+        errors.push(error('attestation_mismatch', '$.attestation.receiptId', 'attestation receipt id must match receipt job id'));
+    }
+    if (input.attestation.evidenceId !== input.evidence.id || input.attestation.evidenceHash !== input.evidence.evidenceHash) {
+        errors.push(error('attestation_mismatch', '$.attestation.evidenceId', 'attestation evidence id/hash must match evidence archive record'));
+    }
+    if (input.receipt.attestationStatus === 'attested' && input.attestation.verdict !== 'passed') {
+        errors.push(error('attestation_mismatch', '$.receipt.attestationStatus', 'attested receipts require a passed attestation draft'));
+    }
+}
+function validateReputationEvent(input, errors) {
+    if (!input.reputationEventDraft)
+        return;
+    if (!input.attestation) {
+        errors.push(error('reputation_event_mismatch', '$.reputationEventDraft', 'reputation event draft requires attestation evidence'));
+        return;
+    }
+    if (input.reputationEventDraft.receiptId !== input.receipt.job.id
+        || input.reputationEventDraft.attestationId !== input.attestation.id
+        || input.reputationEventDraft.evidenceId !== input.evidence.id) {
+        errors.push(error('reputation_event_mismatch', '$.reputationEventDraft', 'reputation event draft must match receipt, attestation, and evidence ids'));
+    }
+}
+function mapReceiptError(code) {
+    return code === 'credential_leakage_rejected'
+        ? 'credential_leakage_rejected'
+        : code === 'payment_proof_missing'
+            ? 'missing_payment_preflight'
+            : code === 'unsupported_network_asset'
+                ? 'unsupported_network_asset'
+                : 'receipt_invalid';
+}
+function mapEvidenceError(code) {
+    return code === 'credential_leakage_rejected'
+        ? 'credential_leakage_rejected'
+        : code === 'hash_mismatch'
+            ? 'hash_mismatch'
+            : code === 'evidence_missing'
+                ? 'evidence_invalid'
+                : 'evidence_invalid';
+}
+function mapAttestationError(code) {
+    return code === 'credential_leakage_rejected' ? 'credential_leakage_rejected' : 'attestation_mismatch';
+}
+function containsRawPayload(value, path = '$') {
+    if (!value || typeof value !== 'object')
+        return false;
+    if (Array.isArray(value))
+        return value.some((item, index) => containsRawPayload(item, `${path}[${index}]`));
+    for (const [key, nested] of Object.entries(value)) {
+        if (RAW_PAYLOAD_KEY_PATTERN.test(key))
+            return true;
+        if (containsRawPayload(nested, `${path}.${key}`))
+            return true;
+    }
+    return false;
+}
+function containsCredentialMaterial(value) {
+    if (typeof value === 'string') {
+        if (SENSITIVE_VALUE_PATTERN.test(value))
+            return true;
+        try {
+            const parsed = new URL(value);
+            if (parsed.username || parsed.password)
+                return true;
+            for (const key of parsed.searchParams.keys()) {
+                if (SENSITIVE_KEY_PATTERN.test(key))
+                    return true;
+            }
+            for (const queryValue of parsed.searchParams.values()) {
+                if (SENSITIVE_VALUE_PATTERN.test(queryValue))
+                    return true;
+            }
+        }
+        catch {
+            // Non-URL strings are checked by value pattern above.
+        }
+        return false;
+    }
+    if (!value || typeof value !== 'object')
+        return false;
+    if (Array.isArray(value))
+        return value.some(containsCredentialMaterial);
+    return Object.entries(value).some(([key, nested]) => SENSITIVE_KEY_PATTERN.test(key) || containsCredentialMaterial(nested));
+}
+function error(code, path, message) {
+    return { code, path, message };
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -10,3 +10,4 @@ export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
 export * from './agent-stack-fixtures.js';
+export * from './receipt-evidence-binding.js';

--- a/packages/agent-protocol/src/receipt-evidence-binding.ts
+++ b/packages/agent-protocol/src/receipt-evidence-binding.ts
@@ -1,0 +1,406 @@
+import {
+  validateAttestationRecord,
+  type AttestationRecord,
+  type ReputationEvent,
+} from './attestation-reputation.js';
+import type { AuddPaymentPlanPreflightDecision } from './audd-payment-plan.js';
+import {
+  validateEvidenceArchiveRecord,
+  type EvidenceArchiveRecord,
+} from './evidence-archive.js';
+import {
+  validateReddiReceipt,
+  type ReddiReceipt,
+} from './receipts.js';
+
+export const RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION = 'reddi.receipt-evidence-binding.v1' as const;
+
+export type ReceiptEvidenceSourceKind =
+  | 'ai-catalog'
+  | 'ard-registry'
+  | 'hosted-rap-registry'
+  | 'source-adapter'
+  | 'static-fixture';
+
+export type ReceiptEvidenceSourceRef = {
+  kind: ReceiptEvidenceSourceKind;
+  sourceId: string;
+  catalogRef?: string;
+  fixtureRef?: string;
+  listingId?: string;
+  profileId?: string;
+  rawSnapshotRef?: string;
+};
+
+export type ReceiptEvidenceBindingInput = {
+  id: string;
+  source: ReceiptEvidenceSourceRef;
+  receipt: ReddiReceipt;
+  evidence: EvidenceArchiveRecord;
+  evidencePayload?: unknown;
+  paymentPreflight: AuddPaymentPlanPreflightDecision;
+  attestation?: AttestationRecord;
+  reputationEventDraft?: ReputationEvent;
+  createdAt: string;
+};
+
+export type ReceiptEvidenceBinding = {
+  schemaVersion: typeof RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION;
+  id: string;
+  source: ReceiptEvidenceSourceRef;
+  receipt: {
+    id: string;
+    sourceId: string;
+    policyDecision: ReddiReceipt['policyDecision'];
+    paymentProofRef: string;
+    requestHash: string;
+    responseHash: string;
+    evidenceRef: string;
+    attestationStatus: ReddiReceipt['attestationStatus'];
+  };
+  evidence: {
+    id: string;
+    receiptId: string;
+    evidenceRef: string;
+    evidenceHash: string;
+    externalArchivePointer?: EvidenceArchiveRecord['externalArchivePointer'];
+  };
+  payment: {
+    preflightAllowed: boolean;
+    reasonCodes: AuddPaymentPlanPreflightDecision['reasonCodes'];
+    paymentProofRef: string;
+    planRef: {
+      asset: string;
+      network: string;
+      amount: string;
+      paymentMode: 'dry-run' | 'live';
+      evidenceRequired: boolean;
+    };
+  };
+  attestation?: {
+    id: string;
+    status: ReddiReceipt['attestationStatus'];
+    verdict: AttestationRecord['verdict'];
+    trustBoundary: AttestationRecord['trustBoundary'];
+  };
+  reputationEventDraft?: ReputationEvent;
+  guardrails: {
+    rawPromptStored: false;
+    rawOutputStored: false;
+    livePaymentExecuted: false;
+    walletSigning: false;
+    rpcCall: false;
+    hostedRegistryRequired: false;
+    reputationMutated: false;
+  };
+  createdAt: string;
+};
+
+export type ReceiptEvidenceBindingErrorCode =
+  | 'malformed_binding'
+  | 'missing_source_ref'
+  | 'missing_payment_preflight'
+  | 'payment_preflight_denied'
+  | 'payment_proof_mismatch'
+  | 'payment_plan_mismatch'
+  | 'unsupported_network_asset'
+  | 'receipt_invalid'
+  | 'evidence_invalid'
+  | 'evidence_receipt_mismatch'
+  | 'hash_mismatch'
+  | 'attestation_mismatch'
+  | 'reputation_event_mismatch'
+  | 'raw_payload_leakage_rejected'
+  | 'credential_leakage_rejected';
+
+export type ReceiptEvidenceBindingError = {
+  code: ReceiptEvidenceBindingErrorCode;
+  path: string;
+  message: string;
+};
+
+export type ReceiptEvidenceBindingResult =
+  | { ok: true; binding: ReceiptEvidenceBinding }
+  | { ok: false; errors: ReceiptEvidenceBindingError[] };
+
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|signature|sig|signed|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+const RAW_PAYLOAD_KEY_PATTERN = /(^|[_-])(raw[_-]?prompt|prompt|completion|raw[_-]?output|output|transcript)($|[_-])/i;
+
+export function createReceiptEvidenceBinding(input: ReceiptEvidenceBindingInput): ReceiptEvidenceBinding {
+  const result = deriveReceiptEvidenceBinding(input);
+  if (!result.ok) {
+    throw new Error(`invalid_receipt_evidence_binding:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+  }
+  return result.binding;
+}
+
+export function deriveReceiptEvidenceBinding(input: ReceiptEvidenceBindingInput): ReceiptEvidenceBindingResult {
+  const errors: ReceiptEvidenceBindingError[] = [];
+  if (!isNonEmptyString(input.id)) {
+    errors.push(error('malformed_binding', '$.id', 'binding id is required'));
+  }
+  if (!isNonEmptyString(input.createdAt) || Number.isNaN(Date.parse(input.createdAt))) {
+    errors.push(error('malformed_binding', '$.createdAt', 'createdAt must be an ISO timestamp'));
+  }
+
+  validateSource(input.source, errors);
+
+  const receiptValidation = validateReddiReceipt(input.receipt);
+  if (!receiptValidation.ok) {
+    errors.push(...receiptValidation.errors.map((item) => error(mapReceiptError(item.code), `$.receipt${item.path.slice(1)}`, item.message)));
+  }
+
+  const evidenceValidation = validateEvidenceArchiveRecord(input.evidence, input.evidencePayload);
+  if (!evidenceValidation.ok) {
+    errors.push(...evidenceValidation.errors.map((item) => error(mapEvidenceError(item.code), `$.evidence${item.path.slice(1)}`, item.message)));
+  }
+
+  if (containsRawPayload(input.evidencePayload)) {
+    errors.push(error('raw_payload_leakage_rejected', '$.evidencePayload', 'raw prompt/output payloads must be replaced by hashes or references before binding'));
+  }
+
+  if (containsCredentialMaterial(input.source)) {
+    errors.push(error('credential_leakage_rejected', '$.source', 'source refs must not contain credential-shaped material'));
+  }
+
+  validatePaymentPreflight(input, errors);
+  validateRecordLinks(input, errors);
+  validateAttestation(input, errors);
+  validateReputationEvent(input, errors);
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  const plan = input.paymentPreflight.paymentPlan;
+  if (!plan || !input.paymentPreflight.paymentProofRef) {
+    return {
+      ok: false,
+      errors: [error('missing_payment_preflight', '$.paymentPreflight', 'payment preflight proof is required')],
+    };
+  }
+
+  return {
+    ok: true,
+    binding: {
+      schemaVersion: RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION,
+      id: input.id,
+      source: input.source,
+      receipt: {
+        id: input.receipt.job.id,
+        sourceId: input.receipt.source.id,
+        policyDecision: input.receipt.policyDecision,
+        paymentProofRef: input.receipt.payment.paymentProofRef,
+        requestHash: input.receipt.requestHash,
+        responseHash: input.receipt.responseHash,
+        evidenceRef: input.receipt.evidenceRef,
+        attestationStatus: input.receipt.attestationStatus,
+      },
+      evidence: {
+        id: input.evidence.id,
+        receiptId: input.evidence.receiptId,
+        evidenceRef: input.evidence.evidenceRef,
+        evidenceHash: input.evidence.evidenceHash,
+        externalArchivePointer: input.evidence.externalArchivePointer,
+      },
+      payment: {
+        preflightAllowed: input.paymentPreflight.allowed,
+        reasonCodes: input.paymentPreflight.reasonCodes,
+        paymentProofRef: input.paymentPreflight.paymentProofRef,
+        planRef: {
+          asset: plan.asset,
+          network: plan.network,
+          amount: plan.amount,
+          paymentMode: plan.paymentMode,
+          evidenceRequired: plan.evidenceRequired,
+        },
+      },
+      attestation: input.attestation
+        ? {
+            id: input.attestation.id,
+            status: input.receipt.attestationStatus,
+            verdict: input.attestation.verdict,
+            trustBoundary: input.attestation.trustBoundary,
+          }
+        : undefined,
+      reputationEventDraft: input.reputationEventDraft,
+      guardrails: {
+        rawPromptStored: false,
+        rawOutputStored: false,
+        livePaymentExecuted: false,
+        walletSigning: false,
+        rpcCall: false,
+        hostedRegistryRequired: false,
+        reputationMutated: false,
+      },
+      createdAt: input.createdAt,
+    },
+  };
+}
+
+function validateSource(source: ReceiptEvidenceSourceRef, errors: ReceiptEvidenceBindingError[]) {
+  if (!source || !['ai-catalog', 'ard-registry', 'hosted-rap-registry', 'source-adapter', 'static-fixture'].includes(String(source.kind))) {
+    errors.push(error('missing_source_ref', '$.source.kind', 'source kind is required'));
+  }
+  if (!isNonEmptyString(source?.sourceId)) {
+    errors.push(error('missing_source_ref', '$.source.sourceId', 'source id is required'));
+  }
+  if (![source?.catalogRef, source?.fixtureRef, source?.listingId, source?.profileId, source?.rawSnapshotRef].some(isNonEmptyString)) {
+    errors.push(error('missing_source_ref', '$.source', 'source must include catalog, fixture, listing, profile, or raw snapshot ref'));
+  }
+}
+
+function validatePaymentPreflight(input: ReceiptEvidenceBindingInput, errors: ReceiptEvidenceBindingError[]) {
+  const proof = input.paymentPreflight;
+  if (!proof || typeof proof.allowed !== 'boolean') {
+    errors.push(error('missing_payment_preflight', '$.paymentPreflight', 'AUDD payment plan preflight proof is required'));
+    return;
+  }
+  if (!proof.allowed) {
+    errors.push(error('payment_preflight_denied', '$.paymentPreflight.allowed', 'payment preflight must be allowed before binding'));
+  }
+  if (!isNonEmptyString(proof.paymentProofRef)) {
+    errors.push(error('missing_payment_preflight', '$.paymentPreflight.paymentProofRef', 'payment proof ref is required'));
+  } else if (proof.paymentProofRef !== input.receipt.payment.paymentProofRef) {
+    errors.push(error('payment_proof_mismatch', '$.paymentPreflight.paymentProofRef', 'payment preflight proof must match receipt payment proof'));
+  }
+  if (!proof.paymentPlan) {
+    errors.push(error('missing_payment_preflight', '$.paymentPreflight.paymentPlan', 'payment plan metadata is required'));
+    return;
+  }
+  if (
+    proof.paymentPlan.asset !== input.receipt.payment.asset
+    || proof.paymentPlan.network !== input.receipt.payment.network
+    || proof.paymentPlan.amount !== input.receipt.payment.amount
+  ) {
+    errors.push(error('payment_plan_mismatch', '$.paymentPreflight.paymentPlan', 'payment plan asset/network/amount must match receipt payment'));
+  }
+  if (proof.policyDecision && proof.policyDecision !== input.receipt.policyDecision) {
+    const policy = proof.policyDecision;
+    if (
+      policy.allowed !== input.receipt.policyDecision.allowed
+      || policy.asset !== input.receipt.policyDecision.asset
+      || policy.network !== input.receipt.policyDecision.network
+      || policy.approvalState !== input.receipt.policyDecision.approvalState
+    ) {
+      errors.push(error('payment_plan_mismatch', '$.paymentPreflight.policyDecision', 'payment preflight policy decision must match receipt policy decision'));
+    }
+  }
+}
+
+function validateRecordLinks(input: ReceiptEvidenceBindingInput, errors: ReceiptEvidenceBindingError[]) {
+  if (input.receipt.source.id !== input.source.sourceId) {
+    errors.push(error('evidence_receipt_mismatch', '$.receipt.source.id', 'receipt source must match binding source'));
+  }
+  if (input.evidence.sourceId !== input.source.sourceId) {
+    errors.push(error('evidence_receipt_mismatch', '$.evidence.sourceId', 'evidence source must match binding source'));
+  }
+  if (input.evidence.receiptId !== input.receipt.job.id) {
+    errors.push(error('evidence_receipt_mismatch', '$.evidence.receiptId', 'evidence receipt id must match receipt job id'));
+  }
+  if (input.evidence.requestHash !== input.receipt.requestHash) {
+    errors.push(error('hash_mismatch', '$.evidence.requestHash', 'evidence request hash must match receipt request hash'));
+  }
+  if (input.evidence.responseHash !== input.receipt.responseHash) {
+    errors.push(error('hash_mismatch', '$.evidence.responseHash', 'evidence response hash must match receipt response hash'));
+  }
+  if (input.evidence.evidenceRef !== input.receipt.evidenceRef) {
+    errors.push(error('evidence_receipt_mismatch', '$.evidence.evidenceRef', 'evidence ref must match receipt evidence ref'));
+  }
+}
+
+function validateAttestation(input: ReceiptEvidenceBindingInput, errors: ReceiptEvidenceBindingError[]) {
+  if (!input.attestation) return;
+  const attestation = validateAttestationRecord(input.attestation);
+  if (!attestation.ok) {
+    errors.push(...attestation.errors.map((item) => error(mapAttestationError(item.code), `$.attestation${item.path.slice(1)}`, item.message)));
+    return;
+  }
+  if (input.attestation.receiptId !== input.receipt.job.id) {
+    errors.push(error('attestation_mismatch', '$.attestation.receiptId', 'attestation receipt id must match receipt job id'));
+  }
+  if (input.attestation.evidenceId !== input.evidence.id || input.attestation.evidenceHash !== input.evidence.evidenceHash) {
+    errors.push(error('attestation_mismatch', '$.attestation.evidenceId', 'attestation evidence id/hash must match evidence archive record'));
+  }
+  if (input.receipt.attestationStatus === 'attested' && input.attestation.verdict !== 'passed') {
+    errors.push(error('attestation_mismatch', '$.receipt.attestationStatus', 'attested receipts require a passed attestation draft'));
+  }
+}
+
+function validateReputationEvent(input: ReceiptEvidenceBindingInput, errors: ReceiptEvidenceBindingError[]) {
+  if (!input.reputationEventDraft) return;
+  if (!input.attestation) {
+    errors.push(error('reputation_event_mismatch', '$.reputationEventDraft', 'reputation event draft requires attestation evidence'));
+    return;
+  }
+  if (
+    input.reputationEventDraft.receiptId !== input.receipt.job.id
+    || input.reputationEventDraft.attestationId !== input.attestation.id
+    || input.reputationEventDraft.evidenceId !== input.evidence.id
+  ) {
+    errors.push(error('reputation_event_mismatch', '$.reputationEventDraft', 'reputation event draft must match receipt, attestation, and evidence ids'));
+  }
+}
+
+function mapReceiptError(code: string): ReceiptEvidenceBindingErrorCode {
+  return code === 'credential_leakage_rejected'
+    ? 'credential_leakage_rejected'
+    : code === 'payment_proof_missing'
+      ? 'missing_payment_preflight'
+      : code === 'unsupported_network_asset'
+        ? 'unsupported_network_asset'
+        : 'receipt_invalid';
+}
+
+function mapEvidenceError(code: string): ReceiptEvidenceBindingErrorCode {
+  return code === 'credential_leakage_rejected'
+    ? 'credential_leakage_rejected'
+    : code === 'hash_mismatch'
+      ? 'hash_mismatch'
+      : code === 'evidence_missing'
+        ? 'evidence_invalid'
+        : 'evidence_invalid';
+}
+
+function mapAttestationError(code: string): ReceiptEvidenceBindingErrorCode {
+  return code === 'credential_leakage_rejected' ? 'credential_leakage_rejected' : 'attestation_mismatch';
+}
+
+function containsRawPayload(value: unknown, path = '$'): boolean {
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some((item, index) => containsRawPayload(item, `${path}[${index}]`));
+  for (const [key, nested] of Object.entries(value)) {
+    if (RAW_PAYLOAD_KEY_PATTERN.test(key)) return true;
+    if (containsRawPayload(nested, `${path}.${key}`)) return true;
+  }
+  return false;
+}
+
+function containsCredentialMaterial(value: unknown): boolean {
+  if (typeof value === 'string') {
+    if (SENSITIVE_VALUE_PATTERN.test(value)) return true;
+    try {
+      const parsed = new URL(value);
+      if (parsed.username || parsed.password) return true;
+      for (const key of parsed.searchParams.keys()) {
+        if (SENSITIVE_KEY_PATTERN.test(key)) return true;
+      }
+      for (const queryValue of parsed.searchParams.values()) {
+        if (SENSITIVE_VALUE_PATTERN.test(queryValue)) return true;
+      }
+    } catch {
+      // Non-URL strings are checked by value pattern above.
+    }
+    return false;
+  }
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some(containsCredentialMaterial);
+  return Object.entries(value).some(([key, nested]) => SENSITIVE_KEY_PATTERN.test(key) || containsCredentialMaterial(nested));
+}
+
+function error(code: ReceiptEvidenceBindingErrorCode, path: string, message: string): ReceiptEvidenceBindingError {
+  return { code, path, message };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/packages/agent-protocol/tests/receipt-evidence-binding.test.ts
+++ b/packages/agent-protocol/tests/receipt-evidence-binding.test.ts
@@ -1,0 +1,269 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  applyAttestationToReputation,
+  createAttestationRecord,
+  createEvidenceArchiveRecord,
+  createReceiptEvidenceBinding,
+  createReddiReceipt,
+  deriveReceiptEvidenceBinding,
+  policyDecisionFromBudgetPolicyDecision,
+  type AuddPaymentPlanPreflightDecision,
+  type ReceiptEvidenceBindingInput,
+} from '../dist/index.js';
+
+const createdAt = '2026-06-20T01:00:00.000Z';
+const requestHash = 'sha256:7b2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15';
+const responseHash = 'sha256:8c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501';
+const sourceId = 'source:hosted-rap:approve-ready-draft';
+const jobId = 'job:ard-onboarded:approve-ready-draft';
+const evidenceId = 'evidence:ard-onboarded:approve-ready-draft';
+const paymentProofRef = 'dry-run:audd-proof:approve-ready-draft';
+
+function validInput(): ReceiptEvidenceBindingInput {
+  const policyDecision = policyDecisionFromBudgetPolicyDecision({
+    allowed: true,
+    reasonCodes: ['allowed'],
+    quotedAmount: {
+      amount: '2500000',
+      asset: 'AUDD',
+      network: 'solana-devnet',
+      source: sourceId,
+      specialist: 'listing:approve-ready-draft',
+    },
+    remainingBudget: { perRequest: '3000000' },
+    auditNotes: ['Allowed by local AUDD dry-run policy.'],
+  });
+
+  const receipt = createReddiReceipt({
+    schemaVersion: 'reddi.receipt.v1',
+    job: { id: jobId, type: 'ard-onboarded-agent-dry-run' },
+    source: {
+      id: sourceId,
+      type: 'hosted-rap-registry',
+      uri: 'urn:reddi:marketplace-listing:approveReadyDraft',
+    },
+    payer: { id: 'buyer:fixture' },
+    specialist: { id: 'listing:approve-ready-draft' },
+    protocol: { name: 'Reddi Agent Protocol', version: '0.1.0' },
+    payment: {
+      network: 'solana-devnet',
+      asset: 'AUDD',
+      amount: '2500000',
+      paymentProofRef,
+    },
+    requestHash,
+    responseHash,
+    evidenceRef: 'file://fixtures/evidence/ard-onboarded-approve-ready.json',
+    policyDecision,
+    attestationStatus: 'attested',
+    createdAt,
+    metadata: {
+      sourceCatalogRef: '/.well-known/ai-catalog.json',
+      listingId: 'approveReadyDraft',
+    },
+  });
+
+  const evidencePayload = {
+    request: { hash: requestHash },
+    response: { hash: responseHash },
+    resultSummary: 'Dry-run workflow completed with redacted request and response hashes only.',
+    source: { catalogRef: '/.well-known/ai-catalog.json', listingId: 'approveReadyDraft' },
+  };
+
+  const evidence = createEvidenceArchiveRecord({
+    id: evidenceId,
+    receiptId: jobId,
+    sourceId,
+    requestHash,
+    responseHash,
+    evidenceRef: receipt.evidenceRef,
+    createdAt,
+    evidencePayload,
+  });
+
+  const attestation = createAttestationRecord({
+    schemaVersion: 'reddi.attestation.v1',
+    id: 'attestation:ard-onboarded:approve-ready-draft',
+    receiptId: jobId,
+    evidenceId,
+    evidenceRef: evidence.evidenceRef,
+    evidenceHash: evidence.evidenceHash,
+    attestor: { id: 'attestor:local-fixture', type: 'local-fixture' },
+    trustBoundary: 'self_attested',
+    verdict: 'passed',
+    workStatus: 'completed',
+    confidence: 92,
+    rubric: {
+      dimensions: [
+        { id: 'evidence_integrity', score: 95, weight: 1, summary: 'Evidence hashes match.', reasonCodes: ['hashes_match'] },
+        { id: 'policy_compliance', score: 90, weight: 1, summary: 'Policy decision and payment proof are present.', reasonCodes: ['policy_bound'] },
+        { id: 'delivery_quality', score: 90, weight: 1, summary: 'Dry-run output met fixture expectations.', reasonCodes: ['fixture_passed'] },
+      ],
+    },
+    createdAt,
+  });
+
+  const reputation = applyAttestationToReputation(attestation, undefined, {
+    subject: { id: 'listing:approve-ready-draft', type: 'listing' },
+    now: createdAt,
+  });
+  if (!reputation.ok) throw new Error('unexpected reputation fixture failure');
+
+  const paymentPreflight: AuddPaymentPlanPreflightDecision = {
+    allowed: true,
+    reasonCodes: ['audd_payment_plan_allowed'],
+    paymentProofRef,
+    policyDecision,
+    paymentPlan: {
+      schemaVersion: 'reddi.audd-payment-plan.v1',
+      asset: 'AUDD',
+      network: 'solana-devnet',
+      mint: 'AUDDdev111111111111111111111111111111111111',
+      payee: 'solana:payeeFixture111111111111111111111111111111',
+      settlementAccount: 'solana:settlementFixture1111111111111111111111',
+      amount: '2500000',
+      quoteExpiresAt: '2026-06-20T02:00:00.000Z',
+      failurePolicy: { mode: 'no_charge_on_failure', description: 'Dry-run failure does not charge.' },
+      refundPolicy: { mode: 'manual_review', description: 'Refunds require manual review.' },
+      evidenceRequired: true,
+      paymentMode: 'dry-run',
+    },
+    auditNotes: ['Allowed by local AUDD dry-run policy.'],
+  };
+
+  return {
+    id: 'binding:ard-onboarded:approve-ready-draft',
+    source: {
+      kind: 'hosted-rap-registry',
+      sourceId,
+      catalogRef: '/.well-known/ai-catalog.json',
+      listingId: 'approveReadyDraft',
+      rawSnapshotRef: 'sha256:hosted-rap-ai-catalog-fixture',
+    },
+    receipt,
+    evidence,
+    evidencePayload,
+    paymentPreflight,
+    attestation,
+    reputationEventDraft: reputation.event,
+    createdAt,
+  };
+}
+
+describe('receipt/evidence binding for ARD-onboarded agents', () => {
+  it('binds receipt, evidence, payment proof, attestation, and reputation draft without live side effects', () => {
+    const binding = createReceiptEvidenceBinding(validInput());
+
+    assert.equal(binding.schemaVersion, 'reddi.receipt-evidence-binding.v1');
+    assert.equal(binding.source.kind, 'hosted-rap-registry');
+    assert.equal(binding.receipt.paymentProofRef, paymentProofRef);
+    assert.equal(binding.evidence.id, evidenceId);
+    assert.equal(binding.payment.preflightAllowed, true);
+    assert.equal(binding.attestation?.verdict, 'passed');
+    assert.equal(binding.reputationEventDraft?.schemaVersion, 'reddi.reputation-event.v1');
+    assert.deepEqual(binding.guardrails, {
+      rawPromptStored: false,
+      rawOutputStored: false,
+      livePaymentExecuted: false,
+      walletSigning: false,
+      rpcCall: false,
+      hostedRegistryRequired: false,
+      reputationMutated: false,
+    });
+  });
+
+  it('fails closed when evidence payload or external pointer is missing', () => {
+    const input = validInput();
+    const result = deriveReceiptEvidenceBinding({ ...input, evidencePayload: undefined });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.errors.some((item) => item.code === 'evidence_invalid' && item.path === '$.evidence.evidencePayload'));
+    }
+  });
+
+  it('fails closed when payment preflight proof is missing or denied', () => {
+    const input = validInput();
+    const result = deriveReceiptEvidenceBinding({
+      ...input,
+      paymentPreflight: {
+        ...input.paymentPreflight,
+        allowed: false,
+        paymentProofRef: undefined,
+        reasonCodes: ['buyer_policy_missing'],
+      },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.errors.some((item) => item.code === 'payment_preflight_denied'));
+      assert.ok(result.errors.some((item) => item.code === 'missing_payment_preflight'));
+    }
+  });
+
+  it('fails closed when the source reference is missing', () => {
+    const input = validInput();
+    const result = deriveReceiptEvidenceBinding({
+      ...input,
+      source: { kind: 'static-fixture', sourceId },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.errors.some((item) => item.code === 'missing_source_ref' && item.path === '$.source'));
+    }
+  });
+
+  it('fails closed for unsupported receipt payment network and asset', () => {
+    const input = validInput();
+    const result = deriveReceiptEvidenceBinding({
+      ...input,
+      receipt: {
+        ...input.receipt,
+        payment: {
+          ...input.receipt.payment,
+          network: 'base-mainnet',
+          asset: 'USDG',
+        },
+      },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.errors.some((item) => item.code === 'unsupported_network_asset'));
+    }
+  });
+
+  it('fails closed for credential-bearing source or evidence metadata', () => {
+    const input = validInput();
+    const result = deriveReceiptEvidenceBinding({
+      ...input,
+      source: {
+        ...input.source,
+        catalogRef: 'https://registry.example/.well-known/ai-catalog.json?api_key=secret',
+      },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.errors.some((item) => item.code === 'credential_leakage_rejected'));
+    }
+  });
+
+  it('rejects raw prompt or output payload leakage by default', () => {
+    const input = validInput();
+    const result = deriveReceiptEvidenceBinding({
+      ...input,
+      evidencePayload: {
+        ...(input.evidencePayload as Record<string, unknown>),
+        rawPrompt: 'Write a private customer report.',
+      },
+    });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.errors.some((item) => item.code === 'raw_payload_leakage_rejected'));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add package-level `reddi.receipt-evidence-binding.v1` primitive for ARD/onboarded agent workflows
- bind existing Reddi receipts, EvidenceArchive records, AUDD payment-plan preflight proof, optional attestation, and optional reputation event drafts to a single source ref
- fail closed for missing source refs, missing evidence, denied/missing payment preflight, payment proof mismatch, unsupported receipt payment network/asset, credential leakage, attestation/reputation mismatches, and raw prompt/output payload leakage
- export the primitive from `@reddi/agent-protocol` and include generated dist artifacts

## Guardrails
- package/off-chain only
- no routes, UI, live payment, wallet signing, RPC/SPL/Quasar calls, network fetch, hosted registry dependency, provider/MCP calls, publication, or reputation mutation
- reputation event remains a draft bound to evidence; no on-chain or hosted mutation path is introduced

## Validation
- `npm test` in `packages/agent-protocol` passed 108/108
- `npm run release:dry-run` in `packages/agent-protocol` passed and packed the new binding dist files
- `git diff --check`
- `npm run check:rap:naming`

Refs #393