### PR TITLE
Add off-chain reputation preview primitive for #394

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -211,6 +211,28 @@ Attestation v1 records include schema version, evidence reference, evidence hash
 
 Reputation updates are deterministic and local-first. Invalid or incomplete rubrics fail closed and return the previous reputation state unchanged. Failed, disputed, and refunded work produce explicit status and routing-impact reason codes. Self-attested and external-attested records are evidence inputs, not verified claims; `reddi_attested` and `verified` boundaries must come from RAP-side verification or operator-controlled attestations.
 
+## Off-Chain Reputation Preview
+
+```typescript
+import {
+  deriveOffchainReputationPreview,
+} from '@reddi/agent-protocol/offchain-reputation-preview';
+
+const result = deriveOffchainReputationPreview({
+  id: 'preview:listing:planning-001',
+  binding: receiptEvidenceBinding,
+  subject: { id: 'listing:planning-001', type: 'listing' },
+  createdAt: new Date().toISOString(),
+});
+
+console.log(result.preview.status); // preview_ready / insufficient_evidence / blocked
+console.log(result.preview.display.buyerFacingClaimAllowed); // false
+```
+
+Off-chain reputation preview consumes `reddi.receipt-evidence-binding.v1` records and projects an explanatory reputation preview without mutating reputation state. It requires safe binding guardrails, allowed policy/payment preflight metadata, evidence refs, attestation evidence, and matching reputation-event drafts before returning a score preview. Missing attestation or reputation draft data stays `insufficient_evidence`; denied policy/payment, malformed evidence, unsafe live guardrails, failed attestations, or mismatched event ids are blocked.
+
+This preview is not Quasar-backed and does not build instruction flows while #390 compatibility is pending. It never performs wallet signing, RPC calls, hosted registry writes, marketplace publication, live payment execution, provider calls, or reputation mutation, and it never allows buyer-facing trust/reputation claims from preview data alone.
+
 ## Buyer Client And Seller Middleware
 
 ```typescript

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -11,3 +11,4 @@ export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
 export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
+export * from './offchain-reputation-preview.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -11,3 +11,4 @@ export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
 export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
+export * from './offchain-reputation-preview.js';

--- a/packages/agent-protocol/dist/offchain-reputation-preview.d.ts
+++ b/packages/agent-protocol/dist/offchain-reputation-preview.d.ts
@@ -1,0 +1,66 @@
+import type { ReputationEvent } from './attestation-reputation.js';
+import { type ReceiptEvidenceBinding } from './receipt-evidence-binding.js';
+export declare const OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION: "reddi.offchain-reputation-preview.v1";
+export type OffchainReputationPreviewStatus = 'preview_ready' | 'blocked' | 'insufficient_evidence' | 'quasar_compatibility_pending';
+export type OffchainReputationPreviewReasonCode = 'binding_valid' | 'offchain_preview_only' | 'quasar_compatibility_pending' | 'buyer_facing_claim_disabled' | 'missing_binding_id' | 'malformed_binding' | 'unsafe_live_guardrail' | 'missing_source_ref' | 'policy_denied' | 'payment_preflight_denied' | 'missing_payment_proof' | 'missing_evidence_summary' | 'missing_attestation' | 'attestation_not_passed' | 'missing_reputation_draft' | 'reputation_event_mismatch';
+export type OffchainReputationPreview = {
+    schemaVersion: typeof OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION;
+    id: string;
+    subject: {
+        id: string;
+        type: 'specialist' | 'provider' | 'listing';
+    };
+    source: ReceiptEvidenceBinding['source'];
+    status: OffchainReputationPreviewStatus;
+    backing: {
+        reputationKind: 'offchain_preview';
+        attestationKind: 'none' | 'self_attested' | 'external_attested' | 'reddi_attested' | 'verified';
+        quasarBacking: {
+            status: 'not_quasar_backed' | 'compatibility_pending';
+            compatibilityIssue: 390;
+            instructionFlow: 'not_built';
+        };
+        hostedAttestationBacking: 'not_published';
+    };
+    evidenceSummary: {
+        bindingId: string;
+        receiptId: string;
+        evidenceId: string;
+        evidenceHash: string;
+        evidenceRef: string;
+        paymentProofRef: string;
+        attestationId?: string;
+        reputationEventDraftId?: string;
+    };
+    previewEvent?: ReputationEvent;
+    display: {
+        label: 'Off-chain preview' | 'Insufficient evidence' | 'Blocked' | 'Quasar compatibility pending';
+        explanation: string;
+        buyerFacingClaimAllowed: false;
+    };
+    reasonCodes: OffchainReputationPreviewReasonCode[];
+    guardrails: {
+        reputationMutated: false;
+        quasarInstructionBuilt: false;
+        walletSigning: false;
+        rpcCall: false;
+        hostedRegistryWrite: false;
+        marketplacePublished: false;
+        livePaymentExecuted: false;
+    };
+    createdAt: string;
+};
+export type OffchainReputationPreviewInput = {
+    id: string;
+    binding: ReceiptEvidenceBinding;
+    subject?: OffchainReputationPreview['subject'];
+    createdAt: string;
+};
+export type OffchainReputationPreviewResult = {
+    ok: true;
+    preview: OffchainReputationPreview;
+} | {
+    ok: false;
+    preview: OffchainReputationPreview;
+};
+export declare function deriveOffchainReputationPreview(input: OffchainReputationPreviewInput): OffchainReputationPreviewResult;

--- a/packages/agent-protocol/dist/offchain-reputation-preview.js
+++ b/packages/agent-protocol/dist/offchain-reputation-preview.js
@@ -1,0 +1,203 @@
+import { RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION, } from './receipt-evidence-binding.js';
+export const OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION = 'reddi.offchain-reputation-preview.v1';
+const GUARDRAILS = {
+    reputationMutated: false,
+    quasarInstructionBuilt: false,
+    walletSigning: false,
+    rpcCall: false,
+    hostedRegistryWrite: false,
+    marketplacePublished: false,
+    livePaymentExecuted: false,
+};
+export function deriveOffchainReputationPreview(input) {
+    const binding = input.binding;
+    const reasonCodes = [];
+    const evidenceSummary = createEvidenceSummary(input.id, binding);
+    if (!isNonEmptyString(input.id))
+        reasonCodes.push('missing_binding_id');
+    if (!isNonEmptyString(input.createdAt) || Number.isNaN(Date.parse(input.createdAt)))
+        reasonCodes.push('malformed_binding');
+    if (!binding || binding.schemaVersion !== RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION)
+        reasonCodes.push('malformed_binding');
+    if (!bindingHasCoreShape(binding))
+        reasonCodes.push('malformed_binding');
+    if (!hasSourceRef(binding))
+        reasonCodes.push('missing_source_ref');
+    if (!bindingGuardrailsAreSafe(binding))
+        reasonCodes.push('unsafe_live_guardrail');
+    if (binding?.receipt?.policyDecision?.allowed !== true)
+        reasonCodes.push('policy_denied');
+    if (binding?.payment?.preflightAllowed !== true)
+        reasonCodes.push('payment_preflight_denied');
+    if (!isNonEmptyString(binding?.payment?.paymentProofRef) || binding?.payment?.paymentProofRef !== binding?.receipt?.paymentProofRef) {
+        reasonCodes.push('missing_payment_proof');
+    }
+    if (!evidenceSummary)
+        reasonCodes.push('missing_evidence_summary');
+    const hasAttestation = Boolean(binding?.attestation);
+    if (!hasAttestation)
+        reasonCodes.push('missing_attestation');
+    if (binding?.attestation && (binding.attestation.verdict !== 'passed' || binding?.receipt?.attestationStatus !== 'attested')) {
+        reasonCodes.push('attestation_not_passed');
+    }
+    const hasReputationDraft = Boolean(binding?.reputationEventDraft);
+    if (!hasReputationDraft)
+        reasonCodes.push('missing_reputation_draft');
+    if (hasAttestation && hasReputationDraft && !reputationDraftMatchesBinding(binding))
+        reasonCodes.push('reputation_event_mismatch');
+    const blockingReason = reasonCodes.find((code) => [
+        'missing_binding_id',
+        'malformed_binding',
+        'unsafe_live_guardrail',
+        'missing_source_ref',
+        'policy_denied',
+        'payment_preflight_denied',
+        'missing_payment_proof',
+        'missing_evidence_summary',
+        'attestation_not_passed',
+        'reputation_event_mismatch',
+    ].includes(code));
+    const status = blockingReason
+        ? 'blocked'
+        : !hasAttestation || !hasReputationDraft
+            ? 'insufficient_evidence'
+            : 'preview_ready';
+    const normalizedReasonCodes = unique([
+        ...(status === 'preview_ready' ? ['binding_valid'] : []),
+        ...reasonCodes,
+        'offchain_preview_only',
+        'quasar_compatibility_pending',
+        'buyer_facing_claim_disabled',
+    ]);
+    const preview = {
+        schemaVersion: OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION,
+        id: input.id,
+        subject: input.subject ?? inferSubject(binding),
+        source: binding?.source ?? { kind: 'static-fixture', sourceId: 'unknown', fixtureRef: 'unknown' },
+        status,
+        backing: {
+            reputationKind: 'offchain_preview',
+            attestationKind: binding?.attestation?.trustBoundary ?? 'none',
+            quasarBacking: {
+                status: status === 'preview_ready' ? 'compatibility_pending' : 'not_quasar_backed',
+                compatibilityIssue: 390,
+                instructionFlow: 'not_built',
+            },
+            hostedAttestationBacking: 'not_published',
+        },
+        evidenceSummary: evidenceSummary ?? {
+            bindingId: input.id,
+            receiptId: '',
+            evidenceId: '',
+            evidenceHash: '',
+            evidenceRef: '',
+            paymentProofRef: '',
+        },
+        previewEvent: status === 'preview_ready' ? binding.reputationEventDraft : undefined,
+        display: {
+            label: displayLabel(status),
+            explanation: displayExplanation(status),
+            buyerFacingClaimAllowed: false,
+        },
+        reasonCodes: normalizedReasonCodes,
+        guardrails: GUARDRAILS,
+        createdAt: input.createdAt,
+    };
+    return status === 'blocked' ? { ok: false, preview } : { ok: true, preview };
+}
+function createEvidenceSummary(id, binding) {
+    if (!binding)
+        return undefined;
+    if (!isNonEmptyString(id)
+        || !isNonEmptyString(binding.receipt?.id)
+        || !isNonEmptyString(binding.evidence?.id)
+        || !isNonEmptyString(binding.evidence?.evidenceHash)
+        || !isNonEmptyString(binding.receipt?.evidenceRef)
+        || !isNonEmptyString(binding.receipt?.paymentProofRef)) {
+        return undefined;
+    }
+    return {
+        bindingId: binding.id,
+        receiptId: binding.receipt.id,
+        evidenceId: binding.evidence.id,
+        evidenceHash: binding.evidence.evidenceHash,
+        evidenceRef: binding.receipt.evidenceRef,
+        paymentProofRef: binding.receipt.paymentProofRef,
+        attestationId: binding.attestation?.id,
+        reputationEventDraftId: binding.reputationEventDraft?.id,
+    };
+}
+function bindingGuardrailsAreSafe(binding) {
+    if (!binding?.guardrails)
+        return false;
+    return binding.guardrails.rawPromptStored === false
+        && binding.guardrails.rawOutputStored === false
+        && binding.guardrails.livePaymentExecuted === false
+        && binding.guardrails.walletSigning === false
+        && binding.guardrails.rpcCall === false
+        && binding.guardrails.hostedRegistryRequired === false
+        && binding.guardrails.reputationMutated === false;
+}
+function bindingHasCoreShape(binding) {
+    return Boolean(binding?.receipt
+        && binding.evidence
+        && binding.payment
+        && binding.guardrails
+        && typeof binding.receipt === 'object'
+        && typeof binding.evidence === 'object'
+        && typeof binding.payment === 'object'
+        && typeof binding.guardrails === 'object');
+}
+function hasSourceRef(binding) {
+    if (!binding?.source?.sourceId)
+        return false;
+    return [binding.source.catalogRef, binding.source.fixtureRef, binding.source.listingId, binding.source.profileId, binding.source.rawSnapshotRef]
+        .some(isNonEmptyString);
+}
+function reputationDraftMatchesBinding(binding) {
+    if (!binding?.reputationEventDraft || !binding.attestation)
+        return false;
+    return binding.reputationEventDraft.receiptId === binding.receipt?.id
+        && binding.reputationEventDraft.evidenceId === binding.evidence?.id
+        && binding.reputationEventDraft.attestationId === binding.attestation.id
+        && binding.reputationEventDraft.verdict === binding.attestation.verdict
+        && binding.reputationEventDraft.trustBoundary === binding.attestation.trustBoundary;
+}
+function inferSubject(binding) {
+    const draft = binding?.reputationEventDraft;
+    if (draft?.subjectId) {
+        return {
+            id: draft.subjectId,
+            type: binding?.source?.listingId ? 'listing' : 'specialist',
+        };
+    }
+    if (binding?.source?.listingId)
+        return { id: binding.source.listingId, type: 'listing' };
+    if (binding?.source?.profileId)
+        return { id: binding.source.profileId, type: 'specialist' };
+    return { id: 'unknown', type: 'specialist' };
+}
+function displayLabel(status) {
+    if (status === 'blocked')
+        return 'Blocked';
+    if (status === 'insufficient_evidence')
+        return 'Insufficient evidence';
+    if (status === 'quasar_compatibility_pending')
+        return 'Quasar compatibility pending';
+    return 'Off-chain preview';
+}
+function displayExplanation(status) {
+    if (status === 'blocked')
+        return 'The binding cannot produce a reputation preview until the failed gate is corrected.';
+    if (status === 'insufficient_evidence')
+        return 'Evidence exists, but the binding is missing attestation or reputation draft data required for a score preview.';
+    if (status === 'quasar_compatibility_pending')
+        return 'Quasar compatibility is tracked by #390 and no instruction flow is built in this preview.';
+    return 'This is an off-chain reputation preview only; it does not mutate reputation or create a buyer-facing trust claim.';
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function unique(items) {
+    return [...new Set(items)];
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -58,6 +58,14 @@
       "types": "./dist/agent-stack-fixtures.d.ts",
       "import": "./dist/agent-stack-fixtures.js"
     },
+    "./receipt-evidence-binding": {
+      "types": "./dist/receipt-evidence-binding.d.ts",
+      "import": "./dist/receipt-evidence-binding.js"
+    },
+    "./offchain-reputation-preview": {
+      "types": "./dist/offchain-reputation-preview.d.ts",
+      "import": "./dist/offchain-reputation-preview.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -11,3 +11,4 @@ export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
 export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
+export * from './offchain-reputation-preview.js';

--- a/packages/agent-protocol/src/offchain-reputation-preview.ts
+++ b/packages/agent-protocol/src/offchain-reputation-preview.ts
@@ -1,0 +1,298 @@
+import type {
+  ReputationEvent,
+} from './attestation-reputation.js';
+import {
+  RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION,
+  type ReceiptEvidenceBinding,
+} from './receipt-evidence-binding.js';
+
+export const OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION = 'reddi.offchain-reputation-preview.v1' as const;
+
+export type OffchainReputationPreviewStatus =
+  | 'preview_ready'
+  | 'blocked'
+  | 'insufficient_evidence'
+  | 'quasar_compatibility_pending';
+
+export type OffchainReputationPreviewReasonCode =
+  | 'binding_valid'
+  | 'offchain_preview_only'
+  | 'quasar_compatibility_pending'
+  | 'buyer_facing_claim_disabled'
+  | 'missing_binding_id'
+  | 'malformed_binding'
+  | 'unsafe_live_guardrail'
+  | 'missing_source_ref'
+  | 'policy_denied'
+  | 'payment_preflight_denied'
+  | 'missing_payment_proof'
+  | 'missing_evidence_summary'
+  | 'missing_attestation'
+  | 'attestation_not_passed'
+  | 'missing_reputation_draft'
+  | 'reputation_event_mismatch';
+
+export type OffchainReputationPreview = {
+  schemaVersion: typeof OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION;
+  id: string;
+  subject: { id: string; type: 'specialist' | 'provider' | 'listing' };
+  source: ReceiptEvidenceBinding['source'];
+  status: OffchainReputationPreviewStatus;
+  backing: {
+    reputationKind: 'offchain_preview';
+    attestationKind:
+      | 'none'
+      | 'self_attested'
+      | 'external_attested'
+      | 'reddi_attested'
+      | 'verified';
+    quasarBacking: {
+      status: 'not_quasar_backed' | 'compatibility_pending';
+      compatibilityIssue: 390;
+      instructionFlow: 'not_built';
+    };
+    hostedAttestationBacking: 'not_published';
+  };
+  evidenceSummary: {
+    bindingId: string;
+    receiptId: string;
+    evidenceId: string;
+    evidenceHash: string;
+    evidenceRef: string;
+    paymentProofRef: string;
+    attestationId?: string;
+    reputationEventDraftId?: string;
+  };
+  previewEvent?: ReputationEvent;
+  display: {
+    label:
+      | 'Off-chain preview'
+      | 'Insufficient evidence'
+      | 'Blocked'
+      | 'Quasar compatibility pending';
+    explanation: string;
+    buyerFacingClaimAllowed: false;
+  };
+  reasonCodes: OffchainReputationPreviewReasonCode[];
+  guardrails: {
+    reputationMutated: false;
+    quasarInstructionBuilt: false;
+    walletSigning: false;
+    rpcCall: false;
+    hostedRegistryWrite: false;
+    marketplacePublished: false;
+    livePaymentExecuted: false;
+  };
+  createdAt: string;
+};
+
+export type OffchainReputationPreviewInput = {
+  id: string;
+  binding: ReceiptEvidenceBinding;
+  subject?: OffchainReputationPreview['subject'];
+  createdAt: string;
+};
+
+export type OffchainReputationPreviewResult =
+  | { ok: true; preview: OffchainReputationPreview }
+  | { ok: false; preview: OffchainReputationPreview };
+
+const GUARDRAILS: OffchainReputationPreview['guardrails'] = {
+  reputationMutated: false,
+  quasarInstructionBuilt: false,
+  walletSigning: false,
+  rpcCall: false,
+  hostedRegistryWrite: false,
+  marketplacePublished: false,
+  livePaymentExecuted: false,
+};
+
+export function deriveOffchainReputationPreview(input: OffchainReputationPreviewInput): OffchainReputationPreviewResult {
+  const binding = input.binding;
+  const reasonCodes: OffchainReputationPreviewReasonCode[] = [];
+  const evidenceSummary = createEvidenceSummary(input.id, binding);
+
+  if (!isNonEmptyString(input.id)) reasonCodes.push('missing_binding_id');
+  if (!isNonEmptyString(input.createdAt) || Number.isNaN(Date.parse(input.createdAt))) reasonCodes.push('malformed_binding');
+  if (!binding || binding.schemaVersion !== RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION) reasonCodes.push('malformed_binding');
+  if (!bindingHasCoreShape(binding)) reasonCodes.push('malformed_binding');
+  if (!hasSourceRef(binding)) reasonCodes.push('missing_source_ref');
+  if (!bindingGuardrailsAreSafe(binding)) reasonCodes.push('unsafe_live_guardrail');
+  if (binding?.receipt?.policyDecision?.allowed !== true) reasonCodes.push('policy_denied');
+  if (binding?.payment?.preflightAllowed !== true) reasonCodes.push('payment_preflight_denied');
+  if (!isNonEmptyString(binding?.payment?.paymentProofRef) || binding?.payment?.paymentProofRef !== binding?.receipt?.paymentProofRef) {
+    reasonCodes.push('missing_payment_proof');
+  }
+  if (!evidenceSummary) reasonCodes.push('missing_evidence_summary');
+
+  const hasAttestation = Boolean(binding?.attestation);
+  if (!hasAttestation) reasonCodes.push('missing_attestation');
+  if (binding?.attestation && (binding.attestation.verdict !== 'passed' || binding?.receipt?.attestationStatus !== 'attested')) {
+    reasonCodes.push('attestation_not_passed');
+  }
+
+  const hasReputationDraft = Boolean(binding?.reputationEventDraft);
+  if (!hasReputationDraft) reasonCodes.push('missing_reputation_draft');
+  if (hasAttestation && hasReputationDraft && !reputationDraftMatchesBinding(binding)) reasonCodes.push('reputation_event_mismatch');
+
+  const blockingReason = reasonCodes.find((code) => [
+    'missing_binding_id',
+    'malformed_binding',
+    'unsafe_live_guardrail',
+    'missing_source_ref',
+    'policy_denied',
+    'payment_preflight_denied',
+    'missing_payment_proof',
+    'missing_evidence_summary',
+    'attestation_not_passed',
+    'reputation_event_mismatch',
+  ].includes(code));
+
+  const status: OffchainReputationPreviewStatus = blockingReason
+    ? 'blocked'
+    : !hasAttestation || !hasReputationDraft
+      ? 'insufficient_evidence'
+      : 'preview_ready';
+
+  const normalizedReasonCodes = unique([
+    ...(status === 'preview_ready' ? ['binding_valid' as const] : []),
+    ...reasonCodes,
+    'offchain_preview_only' as const,
+    'quasar_compatibility_pending' as const,
+    'buyer_facing_claim_disabled' as const,
+  ]);
+
+  const preview: OffchainReputationPreview = {
+    schemaVersion: OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION,
+    id: input.id,
+    subject: input.subject ?? inferSubject(binding),
+    source: binding?.source ?? { kind: 'static-fixture', sourceId: 'unknown', fixtureRef: 'unknown' },
+    status,
+    backing: {
+      reputationKind: 'offchain_preview',
+      attestationKind: binding?.attestation?.trustBoundary ?? 'none',
+      quasarBacking: {
+        status: status === 'preview_ready' ? 'compatibility_pending' : 'not_quasar_backed',
+        compatibilityIssue: 390,
+        instructionFlow: 'not_built',
+      },
+      hostedAttestationBacking: 'not_published',
+    },
+    evidenceSummary: evidenceSummary ?? {
+      bindingId: input.id,
+      receiptId: '',
+      evidenceId: '',
+      evidenceHash: '',
+      evidenceRef: '',
+      paymentProofRef: '',
+    },
+    previewEvent: status === 'preview_ready' ? binding.reputationEventDraft : undefined,
+    display: {
+      label: displayLabel(status),
+      explanation: displayExplanation(status),
+      buyerFacingClaimAllowed: false,
+    },
+    reasonCodes: normalizedReasonCodes,
+    guardrails: GUARDRAILS,
+    createdAt: input.createdAt,
+  };
+
+  return status === 'blocked' ? { ok: false, preview } : { ok: true, preview };
+}
+
+function createEvidenceSummary(id: string, binding: ReceiptEvidenceBinding | undefined): OffchainReputationPreview['evidenceSummary'] | undefined {
+  if (!binding) return undefined;
+  if (!isNonEmptyString(id)
+    || !isNonEmptyString(binding.receipt?.id)
+    || !isNonEmptyString(binding.evidence?.id)
+    || !isNonEmptyString(binding.evidence?.evidenceHash)
+    || !isNonEmptyString(binding.receipt?.evidenceRef)
+    || !isNonEmptyString(binding.receipt?.paymentProofRef)) {
+    return undefined;
+  }
+
+  return {
+    bindingId: binding.id,
+    receiptId: binding.receipt.id,
+    evidenceId: binding.evidence.id,
+    evidenceHash: binding.evidence.evidenceHash,
+    evidenceRef: binding.receipt.evidenceRef,
+    paymentProofRef: binding.receipt.paymentProofRef,
+    attestationId: binding.attestation?.id,
+    reputationEventDraftId: binding.reputationEventDraft?.id,
+  };
+}
+
+function bindingGuardrailsAreSafe(binding: ReceiptEvidenceBinding | undefined): boolean {
+  if (!binding?.guardrails) return false;
+  return binding.guardrails.rawPromptStored === false
+    && binding.guardrails.rawOutputStored === false
+    && binding.guardrails.livePaymentExecuted === false
+    && binding.guardrails.walletSigning === false
+    && binding.guardrails.rpcCall === false
+    && binding.guardrails.hostedRegistryRequired === false
+    && binding.guardrails.reputationMutated === false;
+}
+
+function bindingHasCoreShape(binding: ReceiptEvidenceBinding | undefined): boolean {
+  return Boolean(
+    binding?.receipt
+    && binding.evidence
+    && binding.payment
+    && binding.guardrails
+    && typeof binding.receipt === 'object'
+    && typeof binding.evidence === 'object'
+    && typeof binding.payment === 'object'
+    && typeof binding.guardrails === 'object',
+  );
+}
+
+function hasSourceRef(binding: ReceiptEvidenceBinding | undefined): boolean {
+  if (!binding?.source?.sourceId) return false;
+  return [binding.source.catalogRef, binding.source.fixtureRef, binding.source.listingId, binding.source.profileId, binding.source.rawSnapshotRef]
+    .some(isNonEmptyString);
+}
+
+function reputationDraftMatchesBinding(binding: ReceiptEvidenceBinding | undefined): boolean {
+  if (!binding?.reputationEventDraft || !binding.attestation) return false;
+  return binding.reputationEventDraft.receiptId === binding.receipt?.id
+    && binding.reputationEventDraft.evidenceId === binding.evidence?.id
+    && binding.reputationEventDraft.attestationId === binding.attestation.id
+    && binding.reputationEventDraft.verdict === binding.attestation.verdict
+    && binding.reputationEventDraft.trustBoundary === binding.attestation.trustBoundary;
+}
+
+function inferSubject(binding: ReceiptEvidenceBinding | undefined): OffchainReputationPreview['subject'] {
+  const draft = binding?.reputationEventDraft;
+  if (draft?.subjectId) {
+    return {
+      id: draft.subjectId,
+      type: binding?.source?.listingId ? 'listing' : 'specialist',
+    };
+  }
+  if (binding?.source?.listingId) return { id: binding.source.listingId, type: 'listing' };
+  if (binding?.source?.profileId) return { id: binding.source.profileId, type: 'specialist' };
+  return { id: 'unknown', type: 'specialist' };
+}
+
+function displayLabel(status: OffchainReputationPreviewStatus): OffchainReputationPreview['display']['label'] {
+  if (status === 'blocked') return 'Blocked';
+  if (status === 'insufficient_evidence') return 'Insufficient evidence';
+  if (status === 'quasar_compatibility_pending') return 'Quasar compatibility pending';
+  return 'Off-chain preview';
+}
+
+function displayExplanation(status: OffchainReputationPreviewStatus): string {
+  if (status === 'blocked') return 'The binding cannot produce a reputation preview until the failed gate is corrected.';
+  if (status === 'insufficient_evidence') return 'Evidence exists, but the binding is missing attestation or reputation draft data required for a score preview.';
+  if (status === 'quasar_compatibility_pending') return 'Quasar compatibility is tracked by #390 and no instruction flow is built in this preview.';
+  return 'This is an off-chain reputation preview only; it does not mutate reputation or create a buyer-facing trust claim.';
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function unique<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}

--- a/packages/agent-protocol/tests/offchain-reputation-preview.test.ts
+++ b/packages/agent-protocol/tests/offchain-reputation-preview.test.ts
@@ -1,0 +1,310 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  applyAttestationToReputation,
+  createAttestationRecord,
+  createEvidenceArchiveRecord,
+  createReceiptEvidenceBinding,
+  createReddiReceipt,
+  deriveOffchainReputationPreview,
+  policyDecisionFromBudgetPolicyDecision,
+  type AuddPaymentPlanPreflightDecision,
+  type ReceiptEvidenceBinding,
+  type ReceiptEvidenceBindingInput,
+} from '../dist/index.js';
+
+const createdAt = '2026-06-20T02:10:00.000Z';
+const requestHash = 'sha256:4f2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15';
+const responseHash = 'sha256:5c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501';
+const sourceId = 'source:hosted-rap:preview-ready';
+const jobId = 'job:ard-onboarded:preview-ready';
+const evidenceId = 'evidence:ard-onboarded:preview-ready';
+const paymentProofRef = 'dry-run:audd-proof:preview-ready';
+
+function validInput(): ReceiptEvidenceBindingInput {
+  const policyDecision = policyDecisionFromBudgetPolicyDecision({
+    allowed: true,
+    reasonCodes: ['allowed'],
+    quotedAmount: {
+      amount: '2500000',
+      asset: 'AUDD',
+      network: 'solana-devnet',
+      source: sourceId,
+      specialist: 'listing:preview-ready',
+    },
+    remainingBudget: { perRequest: '3000000' },
+    auditNotes: ['Allowed by local AUDD dry-run policy.'],
+  });
+
+  const receipt = createReddiReceipt({
+    schemaVersion: 'reddi.receipt.v1',
+    job: { id: jobId, type: 'ard-onboarded-agent-dry-run' },
+    source: {
+      id: sourceId,
+      type: 'hosted-rap-registry',
+      uri: 'urn:reddi:marketplace-listing:previewReady',
+    },
+    payer: { id: 'buyer:fixture' },
+    specialist: { id: 'listing:preview-ready' },
+    protocol: { name: 'Reddi Agent Protocol', version: '0.1.0' },
+    payment: {
+      network: 'solana-devnet',
+      asset: 'AUDD',
+      amount: '2500000',
+      paymentProofRef,
+    },
+    requestHash,
+    responseHash,
+    evidenceRef: 'file://fixtures/evidence/ard-onboarded-preview-ready.json',
+    policyDecision,
+    attestationStatus: 'attested',
+    createdAt,
+  });
+
+  const evidencePayload = {
+    request: { hash: requestHash },
+    response: { hash: responseHash },
+    resultSummary: 'Dry-run workflow completed with redacted request and response hashes only.',
+  };
+
+  const evidence = createEvidenceArchiveRecord({
+    id: evidenceId,
+    receiptId: jobId,
+    sourceId,
+    requestHash,
+    responseHash,
+    evidenceRef: receipt.evidenceRef,
+    createdAt,
+    evidencePayload,
+  });
+
+  const attestation = createAttestationRecord({
+    schemaVersion: 'reddi.attestation.v1',
+    id: 'attestation:ard-onboarded:preview-ready',
+    receiptId: jobId,
+    evidenceId,
+    evidenceRef: evidence.evidenceRef,
+    evidenceHash: evidence.evidenceHash,
+    attestor: { id: 'attestor:local-fixture', type: 'local-fixture' },
+    trustBoundary: 'self_attested',
+    verdict: 'passed',
+    workStatus: 'completed',
+    confidence: 92,
+    rubric: {
+      dimensions: [
+        { id: 'evidence_integrity', score: 95, weight: 1, summary: 'Evidence hashes match.', reasonCodes: ['hashes_match'] },
+        { id: 'policy_compliance', score: 90, weight: 1, summary: 'Policy decision and payment proof are present.', reasonCodes: ['policy_bound'] },
+        { id: 'delivery_quality', score: 90, weight: 1, summary: 'Dry-run output met fixture expectations.', reasonCodes: ['fixture_passed'] },
+      ],
+    },
+    createdAt,
+  });
+
+  const reputation = applyAttestationToReputation(attestation, undefined, {
+    subject: { id: 'listing:preview-ready', type: 'listing' },
+    now: createdAt,
+  });
+  if (!reputation.ok) throw new Error('unexpected reputation fixture failure');
+
+  const paymentPreflight: AuddPaymentPlanPreflightDecision = {
+    allowed: true,
+    reasonCodes: ['audd_payment_plan_allowed'],
+    paymentProofRef,
+    policyDecision,
+    paymentPlan: {
+      schemaVersion: 'reddi.audd-payment-plan.v1',
+      asset: 'AUDD',
+      network: 'solana-devnet',
+      mint: 'AUDDdev111111111111111111111111111111111111',
+      payee: 'solana:payeeFixture111111111111111111111111111111',
+      settlementAccount: 'solana:settlementFixture1111111111111111111111',
+      amount: '2500000',
+      quoteExpiresAt: '2026-06-20T03:00:00.000Z',
+      failurePolicy: { mode: 'no_charge_on_failure', description: 'Dry-run failure does not charge.' },
+      refundPolicy: { mode: 'manual_review', description: 'Refunds require manual review.' },
+      evidenceRequired: true,
+      paymentMode: 'dry-run',
+    },
+    auditNotes: ['Allowed by local AUDD dry-run policy.'],
+  };
+
+  return {
+    id: 'binding:ard-onboarded:preview-ready',
+    source: {
+      kind: 'hosted-rap-registry',
+      sourceId,
+      catalogRef: '/.well-known/ai-catalog.json',
+      listingId: 'previewReady',
+      rawSnapshotRef: 'sha256:hosted-rap-ai-catalog-preview-fixture',
+    },
+    receipt,
+    evidence,
+    evidencePayload,
+    paymentPreflight,
+    attestation,
+    reputationEventDraft: reputation.event,
+    createdAt,
+  };
+}
+
+function validBinding(): ReceiptEvidenceBinding {
+  return createReceiptEvidenceBinding(validInput());
+}
+
+describe('off-chain reputation preview', () => {
+  it('derives a non-mutating preview from a receipt/evidence binding', () => {
+    const result = deriveOffchainReputationPreview({
+      id: 'preview:listing:preview-ready',
+      binding: validBinding(),
+      createdAt,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.preview.schemaVersion, 'reddi.offchain-reputation-preview.v1');
+    assert.equal(result.preview.status, 'preview_ready');
+    assert.equal(result.preview.subject.id, 'listing:preview-ready');
+    assert.equal(result.preview.backing.reputationKind, 'offchain_preview');
+    assert.equal(result.preview.backing.attestationKind, 'self_attested');
+    assert.equal(result.preview.backing.quasarBacking.status, 'compatibility_pending');
+    assert.equal(result.preview.backing.quasarBacking.compatibilityIssue, 390);
+    assert.equal(result.preview.backing.quasarBacking.instructionFlow, 'not_built');
+    assert.equal(result.preview.previewEvent?.id, 'reputation:attestation:ard-onboarded:preview-ready');
+    assert.equal(result.preview.display.buyerFacingClaimAllowed, false);
+    assert.deepEqual(result.preview.guardrails, {
+      reputationMutated: false,
+      quasarInstructionBuilt: false,
+      walletSigning: false,
+      rpcCall: false,
+      hostedRegistryWrite: false,
+      marketplacePublished: false,
+      livePaymentExecuted: false,
+    });
+  });
+
+  it('keeps missing attestation or reputation draft as insufficient evidence', () => {
+    const missingAttestation = deriveOffchainReputationPreview({
+      id: 'preview:missing-attestation',
+      binding: { ...validBinding(), attestation: undefined },
+      createdAt,
+    });
+    assert.equal(missingAttestation.ok, true);
+    assert.equal(missingAttestation.preview.status, 'insufficient_evidence');
+    assert.ok(missingAttestation.preview.reasonCodes.includes('missing_attestation'));
+    assert.equal(missingAttestation.preview.previewEvent, undefined);
+
+    const missingDraft = deriveOffchainReputationPreview({
+      id: 'preview:missing-draft',
+      binding: { ...validBinding(), reputationEventDraft: undefined },
+      createdAt,
+    });
+    assert.equal(missingDraft.ok, true);
+    assert.equal(missingDraft.preview.status, 'insufficient_evidence');
+    assert.ok(missingDraft.preview.reasonCodes.includes('missing_reputation_draft'));
+    assert.equal(missingDraft.preview.display.buyerFacingClaimAllowed, false);
+  });
+
+  it('blocks denied policy and payment preflight evidence', () => {
+    const binding = validBinding();
+    const result = deriveOffchainReputationPreview({
+      id: 'preview:denied-payment',
+      binding: {
+        ...binding,
+        receipt: {
+          ...binding.receipt,
+          policyDecision: { ...binding.receipt.policyDecision, allowed: false },
+        },
+        payment: {
+          ...binding.payment,
+          preflightAllowed: false,
+          reasonCodes: ['buyer_policy_missing'],
+        },
+      },
+      createdAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.preview.status, 'blocked');
+    assert.ok(result.preview.reasonCodes.includes('policy_denied'));
+    assert.ok(result.preview.reasonCodes.includes('payment_preflight_denied'));
+  });
+
+  it('blocks malformed evidence summaries and unsafe live guardrails', () => {
+    const binding = validBinding();
+    const result = deriveOffchainReputationPreview({
+      id: 'preview:unsafe-guardrail',
+      binding: {
+        ...binding,
+        evidence: { ...binding.evidence, evidenceHash: '' },
+        guardrails: { ...binding.guardrails, rpcCall: true },
+      } as unknown as ReceiptEvidenceBinding,
+      createdAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.preview.status, 'blocked');
+    assert.ok(result.preview.reasonCodes.includes('missing_evidence_summary'));
+    assert.ok(result.preview.reasonCodes.includes('unsafe_live_guardrail'));
+  });
+
+  it('fails closed instead of throwing for schema-compatible malformed bindings', () => {
+    const binding = validBinding();
+    const result = deriveOffchainReputationPreview({
+      id: 'preview:malformed-binding',
+      binding: {
+        schemaVersion: binding.schemaVersion,
+        id: binding.id,
+        source: binding.source,
+        attestation: binding.attestation,
+        reputationEventDraft: binding.reputationEventDraft,
+        createdAt: binding.createdAt,
+      } as unknown as ReceiptEvidenceBinding,
+      createdAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.preview.status, 'blocked');
+    assert.ok(result.preview.reasonCodes.includes('malformed_binding'));
+    assert.equal(result.preview.display.buyerFacingClaimAllowed, false);
+  });
+
+  it('blocks failed, disputed, or refunded attestations instead of producing a positive claim', () => {
+    for (const verdict of ['failed', 'disputed', 'refunded'] as const) {
+      const binding = validBinding();
+      const result = deriveOffchainReputationPreview({
+        id: `preview:${verdict}`,
+        binding: {
+          ...binding,
+          receipt: { ...binding.receipt, attestationStatus: 'failed' },
+          attestation: { ...binding.attestation!, verdict },
+        },
+        createdAt,
+      });
+
+      assert.equal(result.ok, false);
+      assert.equal(result.preview.status, 'blocked');
+      assert.equal(result.preview.previewEvent, undefined);
+      assert.ok(result.preview.reasonCodes.includes('attestation_not_passed'));
+      assert.equal(result.preview.display.buyerFacingClaimAllowed, false);
+    }
+  });
+
+  it('fails closed on mismatched reputation event ids', () => {
+    const binding = validBinding();
+    const result = deriveOffchainReputationPreview({
+      id: 'preview:mismatched-event',
+      binding: {
+        ...binding,
+        reputationEventDraft: {
+          ...binding.reputationEventDraft!,
+          evidenceId: 'evidence:other',
+        },
+      },
+      createdAt,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.preview.status, 'blocked');
+    assert.ok(result.preview.reasonCodes.includes('reputation_event_mismatch'));
+    assert.equal(result.preview.display.buyerFacingClaimAllowed, false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `reddi.offchain-reputation-preview.v1` as a package-only/read-only #394 primitive.
- Derive an explanatory off-chain reputation preview from `reddi.receipt-evidence-binding.v1` without mutating reputation state.
- Add package subpath exports for `./receipt-evidence-binding` and `./offchain-reputation-preview`, generated dist files, README docs, and focused tests.

## Safety / Scope
- Preview requires safe #393 binding guardrails, allowed policy/payment preflight metadata, source/evidence/payment refs, passed attestation, and matching reputation-event draft before returning a score preview.
- Missing attestation or reputation draft stays `insufficient_evidence`; denied policy/payment, unsafe guardrails, malformed evidence, failed/disputed/refunded attestations, or mismatched event ids are blocked.
- Buyer-facing reputation/trust claims remain disabled.
- Quasar compatibility is marked pending for #390 and no instruction flow is built.
- No route, UI, marketplace publication, hosted registry write, wallet signing, RPC/Solana/Quasar call, live payment execution, provider/MCP call, or reputation mutation.

## Validation
- `npm test` in `packages/agent-protocol` passed 114/114.
- `npm run release:dry-run` in `packages/agent-protocol` passed and includes the new dist files.
- `git diff --check` passed.
- `npm run check:rap:naming` passed.
- Scoped forbidden-import scan found no live Solana/Quasar/provider imports in the new source/test; only explicit false guardrails and the negative `rpcCall: true` test case.

Refs #394