### PR TITLE
Add Quasar registry compatibility projection for #390

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -233,6 +233,34 @@ Off-chain reputation preview consumes `reddi.receipt-evidence-binding.v1` record
 
 This preview is not Quasar-backed and does not build instruction flows while #390 compatibility is pending. It never performs wallet signing, RPC calls, hosted registry writes, marketplace publication, live payment execution, provider calls, or reputation mutation, and it never allows buyer-facing trust/reputation claims from preview data alone.
 
+## Quasar Registry Compatibility
+
+```typescript
+import {
+  deriveQuasarRegistryCompatibility,
+} from '@reddi/agent-protocol/quasar-registry-compatibility';
+
+const report = deriveQuasarRegistryCompatibility({
+  listingId: 'listing:research-agent',
+  displayName: 'Research Agent',
+  role: { callable: true },
+  model: 'qwen3:8b',
+  registrationIntent: 'metadata_only',
+  offchain: {
+    description: 'Rich listing copy remains off-chain.',
+    ardUrl: 'https://agents.example/.well-known/ai-catalog.json',
+    auddTerms: { asset: 'AUDD', network: 'solana-devnet' },
+  },
+});
+
+console.log(report.registrationStatus); // metadata_only / registerable / blocked
+console.log(report.guardrails.instructionBuilt); // false
+```
+
+Quasar registry compatibility separates compact on-chain `AgentAccount` fields from hosted RAP and ARD listing metadata. The compact projection is limited to owner, agent type, model, native lamport rate, minimum reputation, active state, and decoded read-only reputation/attestation aggregates. Rich descriptions, endpoints, ARD/catalog refs, AUDD/x402/payment-plan terms, EvidenceArchive refs, trust badges, capabilities, tags, health checks, review states, and operator approval evidence remain off-chain.
+
+The mapper is a compatibility report only. It does not build Quasar instructions, sign wallets, call RPC, deploy programs, activate live payments, or publish hosted listings. Imported/static listings without an explicit owner and native SOL lamport rate stay `metadata_only` rather than becoming register instructions.
+
 ## Buyer Client And Seller Middleware
 
 ```typescript

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -12,3 +12,4 @@ export * from './audd-payment-plan.js';
 export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';
+export * from './quasar-registry-compatibility.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -12,3 +12,4 @@ export * from './audd-payment-plan.js';
 export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';
+export * from './quasar-registry-compatibility.js';

--- a/packages/agent-protocol/dist/quasar-registry-compatibility.d.ts
+++ b/packages/agent-protocol/dist/quasar-registry-compatibility.d.ts
@@ -1,0 +1,113 @@
+export declare const QUASAR_REGISTRY_COMPATIBILITY_SCHEMA_VERSION: "reddi.quasar-registry-compatibility.v1";
+export declare const QUASAR_AGENT_ACCOUNT_COMPATIBILITY: {
+    readonly discriminator: readonly [20];
+    readonly dataSize: 153;
+    readonly pdaSeed: "agent";
+    readonly modelMaxBytes: 64;
+    readonly onchainFieldNames: readonly ["owner", "agentType", "model", "rateLamports", "minReputation", "active", "reputationScore", "jobsCompleted", "jobsFailed", "createdAt", "attestationAccuracy"];
+    readonly offchainFieldNames: readonly ["profileId", "listingId", "displayName", "summary", "description", "buyerPreview", "endpoint", "ardUrl", "catalogRefs", "sourceRefs", "authRequirements", "auddTerms", "evidenceRefs", "receiptRefs", "trustBadges", "providerTrustStatus", "capabilities", "tags", "groups", "riskDiagnostics", "reviewStates", "operatorApprovalEvidenceRef"];
+};
+export type QuasarRegistryAgentType = 'Primary' | 'Attestation' | 'Both';
+export type QuasarRegistryRegistrationIntent = 'metadata_only' | 'register' | 'update';
+export type QuasarRegistryRegistrationStatus = 'metadata_only' | 'registerable' | 'blocked';
+export type QuasarRegistryCompatibilityInput = {
+    profileId?: string;
+    listingId: string;
+    displayName: string;
+    summary?: string;
+    description?: string;
+    owner?: string;
+    role?: {
+        callable?: boolean;
+        attestation?: boolean;
+    };
+    model?: string;
+    nativeSolRateLamports?: string | bigint | number;
+    minReputation?: number;
+    registrationIntent?: QuasarRegistryRegistrationIntent;
+    active?: boolean;
+    decodedAggregates?: {
+        reputationScore?: number;
+        jobsCompleted?: string | bigint | number;
+        jobsFailed?: string | bigint | number;
+        createdAt?: string | bigint | number;
+        attestationAccuracy?: number;
+    };
+    offchain: {
+        buyerPreview?: string;
+        endpoint?: {
+            url?: string;
+            bindingRef?: string;
+            healthStatus?: 'not_probed' | 'healthy' | 'unhealthy' | 'unknown';
+        };
+        ardUrl?: string;
+        catalogRefs?: string[];
+        sourceRefs?: string[];
+        authRequirements?: string[];
+        auddTerms?: {
+            asset: string;
+            network: string;
+            amount?: string;
+            paymentPlanRef?: string;
+            quoteRef?: string;
+            settlementAccount?: string;
+            refundPolicy?: string;
+            failurePolicy?: string;
+        };
+        evidenceRefs?: string[];
+        receiptRefs?: string[];
+        trustBadges?: string[];
+        providerTrustStatus?: 'unverified' | 'self_attested' | 'external_attested' | 'reddi_attested' | 'verified';
+        capabilities?: string[];
+        tags?: string[];
+        groups?: string[];
+        riskDiagnostics?: string[];
+        reviewStates?: string[];
+        operatorApprovalEvidenceRef?: string;
+    };
+};
+export type QuasarRegistryCompatibilityReport = {
+    schemaVersion: typeof QUASAR_REGISTRY_COMPATIBILITY_SCHEMA_VERSION;
+    profileId?: string;
+    listingId: string;
+    registrationStatus: QuasarRegistryRegistrationStatus;
+    account: typeof QUASAR_AGENT_ACCOUNT_COMPATIBILITY;
+    onchain: {
+        owner?: string;
+        agentType: QuasarRegistryAgentType;
+        model: string;
+        rateLamports?: string;
+        minReputation: number;
+        active: boolean;
+        aggregates: {
+            source: 'decoded_quasar_account' | 'not_available';
+            reputationScore?: number;
+            jobsCompleted?: string;
+            jobsFailed?: string;
+            createdAt?: string;
+            attestationAccuracy?: number;
+        };
+    };
+    offchain: QuasarRegistryCompatibilityInput['offchain'] & {
+        profileId?: string;
+        listingId: string;
+        displayName: string;
+        summary?: string;
+        description?: string;
+    };
+    blockedReasons: string[];
+    reasonCodes: string[];
+    guardrails: {
+        richMetadataOnchain: false;
+        auddCustodyOnchain: false;
+        endpointOnchain: false;
+        evidencePayloadOnchain: false;
+        trustBadgeOnchain: false;
+        instructionBuilt: false;
+        walletSigning: false;
+        rpcCall: false;
+        programDeploy: false;
+        livePaymentExecuted: false;
+    };
+};
+export declare function deriveQuasarRegistryCompatibility(input: QuasarRegistryCompatibilityInput): QuasarRegistryCompatibilityReport;

--- a/packages/agent-protocol/dist/quasar-registry-compatibility.js
+++ b/packages/agent-protocol/dist/quasar-registry-compatibility.js
@@ -1,0 +1,214 @@
+export const QUASAR_REGISTRY_COMPATIBILITY_SCHEMA_VERSION = 'reddi.quasar-registry-compatibility.v1';
+const U64_MAX = 18446744073709551615n;
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+export const QUASAR_AGENT_ACCOUNT_COMPATIBILITY = {
+    discriminator: [20],
+    dataSize: 153,
+    pdaSeed: 'agent',
+    modelMaxBytes: 64,
+    onchainFieldNames: [
+        'owner',
+        'agentType',
+        'model',
+        'rateLamports',
+        'minReputation',
+        'active',
+        'reputationScore',
+        'jobsCompleted',
+        'jobsFailed',
+        'createdAt',
+        'attestationAccuracy',
+    ],
+    offchainFieldNames: [
+        'profileId',
+        'listingId',
+        'displayName',
+        'summary',
+        'description',
+        'buyerPreview',
+        'endpoint',
+        'ardUrl',
+        'catalogRefs',
+        'sourceRefs',
+        'authRequirements',
+        'auddTerms',
+        'evidenceRefs',
+        'receiptRefs',
+        'trustBadges',
+        'providerTrustStatus',
+        'capabilities',
+        'tags',
+        'groups',
+        'riskDiagnostics',
+        'reviewStates',
+        'operatorApprovalEvidenceRef',
+    ],
+};
+export function deriveQuasarRegistryCompatibility(input) {
+    const registrationIntent = input.registrationIntent ?? 'metadata_only';
+    const model = input.model ?? fallbackModel(input);
+    const onchain = {
+        owner: input.owner,
+        agentType: deriveAgentType(input.role),
+        model,
+        rateLamports: input.nativeSolRateLamports === undefined ? undefined : toUnsignedIntegerString(input.nativeSolRateLamports),
+        minReputation: input.minReputation ?? 0,
+        active: registrationIntent === 'metadata_only' ? false : input.active === true,
+        aggregates: normalizeAggregates(input.decodedAggregates),
+    };
+    const blockedReasons = blockedReasonsFor(input, onchain, registrationIntent);
+    const registrationStatus = blockedReasons.length > 0
+        ? 'blocked'
+        : registrationIntent === 'metadata_only'
+            ? 'metadata_only'
+            : 'registerable';
+    return {
+        schemaVersion: QUASAR_REGISTRY_COMPATIBILITY_SCHEMA_VERSION,
+        profileId: input.profileId,
+        listingId: input.listingId,
+        registrationStatus,
+        account: QUASAR_AGENT_ACCOUNT_COMPATIBILITY,
+        onchain,
+        offchain: {
+            ...input.offchain,
+            profileId: input.profileId,
+            listingId: input.listingId,
+            displayName: input.displayName,
+            summary: input.summary,
+            description: input.description,
+            catalogRefs: input.offchain.catalogRefs ?? [],
+            sourceRefs: input.offchain.sourceRefs ?? [],
+            authRequirements: input.offchain.authRequirements ?? [],
+            evidenceRefs: input.offchain.evidenceRefs ?? [],
+            receiptRefs: input.offchain.receiptRefs ?? [],
+            trustBadges: input.offchain.trustBadges ?? [],
+            capabilities: input.offchain.capabilities ?? [],
+            tags: input.offchain.tags ?? [],
+            groups: input.offchain.groups ?? [],
+            riskDiagnostics: input.offchain.riskDiagnostics ?? [],
+            reviewStates: input.offchain.reviewStates ?? [],
+        },
+        blockedReasons,
+        reasonCodes: reasonCodesFor(input, registrationStatus),
+        guardrails: {
+            richMetadataOnchain: false,
+            auddCustodyOnchain: false,
+            endpointOnchain: false,
+            evidencePayloadOnchain: false,
+            trustBadgeOnchain: false,
+            instructionBuilt: false,
+            walletSigning: false,
+            rpcCall: false,
+            programDeploy: false,
+            livePaymentExecuted: false,
+        },
+    };
+}
+function deriveAgentType(role) {
+    if (role?.callable && role.attestation)
+        return 'Both';
+    if (role?.attestation)
+        return 'Attestation';
+    return 'Primary';
+}
+function fallbackModel(input) {
+    const source = input.displayName || input.listingId || 'static-fixture';
+    const compact = source.toLowerCase().replace(/[^a-z0-9:_-]+/g, '-').replace(/^-+|-+$/g, '');
+    return compact.slice(0, QUASAR_AGENT_ACCOUNT_COMPATIBILITY.modelMaxBytes) || 'static-fixture';
+}
+function normalizeAggregates(input) {
+    if (!input)
+        return { source: 'not_available' };
+    return {
+        source: 'decoded_quasar_account',
+        reputationScore: input.reputationScore,
+        jobsCompleted: input.jobsCompleted === undefined ? undefined : toUnsignedIntegerString(input.jobsCompleted),
+        jobsFailed: input.jobsFailed === undefined ? undefined : toUnsignedIntegerString(input.jobsFailed),
+        createdAt: input.createdAt === undefined ? undefined : toSignedIntegerString(input.createdAt),
+        attestationAccuracy: input.attestationAccuracy,
+    };
+}
+function blockedReasonsFor(input, onchain, registrationIntent) {
+    const reasons = [
+        isNonEmptyString(input.listingId) ? undefined : 'missing_listing_id',
+        utf8ByteLength(onchain.model) <= QUASAR_AGENT_ACCOUNT_COMPATIBILITY.modelMaxBytes ? undefined : 'model_too_long_for_quasar_account',
+        isUint8(onchain.minReputation) ? undefined : 'invalid_min_reputation',
+        onchain.aggregates.reputationScore === undefined || isBasisPointLike(onchain.aggregates.reputationScore) ? undefined : 'invalid_reputation_score',
+        onchain.aggregates.attestationAccuracy === undefined || isBasisPointLike(onchain.aggregates.attestationAccuracy) ? undefined : 'invalid_attestation_accuracy',
+        registrationIntent === 'metadata_only' || isSolanaPublicKey(input.owner) ? undefined : 'missing_or_invalid_owner',
+        registrationIntent === 'metadata_only' || isU64String(onchain.rateLamports) ? undefined : 'missing_native_sol_rate_lamports',
+        isNonEmptyString(input.displayName) ? undefined : 'missing_display_name',
+    ];
+    return reasons.filter(isNonEmptyString);
+}
+function reasonCodesFor(input, registrationStatus) {
+    const reasonCodes = [
+        registrationStatus,
+        'rich_metadata_offchain',
+        'audd_terms_offchain',
+        'no_instruction_built',
+        input.nativeSolRateLamports === undefined ? 'native_lamports_rate_missing' : undefined,
+        input.owner === undefined ? 'owner_missing' : undefined,
+    ];
+    return reasonCodes.filter(isNonEmptyString);
+}
+function toUnsignedIntegerString(value) {
+    if (typeof value === 'bigint')
+        return value >= 0n ? value.toString() : '-1';
+    if (typeof value === 'number')
+        return Number.isSafeInteger(value) && value >= 0 ? String(value) : '-1';
+    return /^[0-9]+$/.test(value) ? value : '-1';
+}
+function toSignedIntegerString(value) {
+    if (typeof value === 'bigint')
+        return value.toString();
+    if (typeof value === 'number')
+        return Number.isSafeInteger(value) ? String(value) : '0';
+    return /^-?[0-9]+$/.test(value) ? value : '0';
+}
+function isU64String(value) {
+    if (typeof value !== 'string' || !/^[0-9]+$/.test(value))
+        return false;
+    return BigInt(value) <= U64_MAX;
+}
+function isUint8(value) {
+    return Number.isInteger(value) && value >= 0 && value <= 255;
+}
+function isBasisPointLike(value) {
+    return Number.isInteger(value) && value >= 0 && value <= 10000;
+}
+function isSolanaPublicKey(value) {
+    return typeof value === 'string' && decodeBase58(value)?.length === 32;
+}
+function decodeBase58(value) {
+    if (value.length === 0)
+        return undefined;
+    const bytes = [0];
+    for (const char of value) {
+        const alphabetIndex = BASE58_ALPHABET.indexOf(char);
+        if (alphabetIndex === -1)
+            return undefined;
+        let carry = alphabetIndex;
+        for (let byteIndex = 0; byteIndex < bytes.length; byteIndex += 1) {
+            carry += bytes[byteIndex] * 58;
+            bytes[byteIndex] = carry & 0xff;
+            carry >>= 8;
+        }
+        while (carry > 0) {
+            bytes.push(carry & 0xff);
+            carry >>= 8;
+        }
+    }
+    for (const char of value) {
+        if (char !== '1')
+            break;
+        bytes.push(0);
+    }
+    return Uint8Array.from(bytes.reverse());
+}
+function utf8ByteLength(value) {
+    return new TextEncoder().encode(value).length;
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -66,6 +66,10 @@
       "types": "./dist/offchain-reputation-preview.d.ts",
       "import": "./dist/offchain-reputation-preview.js"
     },
+    "./quasar-registry-compatibility": {
+      "types": "./dist/quasar-registry-compatibility.d.ts",
+      "import": "./dist/quasar-registry-compatibility.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -12,3 +12,4 @@ export * from './audd-payment-plan.js';
 export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';
+export * from './quasar-registry-compatibility.js';

--- a/packages/agent-protocol/src/quasar-registry-compatibility.ts
+++ b/packages/agent-protocol/src/quasar-registry-compatibility.ts
@@ -1,0 +1,337 @@
+export const QUASAR_REGISTRY_COMPATIBILITY_SCHEMA_VERSION = 'reddi.quasar-registry-compatibility.v1' as const;
+const U64_MAX = 18_446_744_073_709_551_615n;
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+export const QUASAR_AGENT_ACCOUNT_COMPATIBILITY = {
+  discriminator: [20],
+  dataSize: 153,
+  pdaSeed: 'agent',
+  modelMaxBytes: 64,
+  onchainFieldNames: [
+    'owner',
+    'agentType',
+    'model',
+    'rateLamports',
+    'minReputation',
+    'active',
+    'reputationScore',
+    'jobsCompleted',
+    'jobsFailed',
+    'createdAt',
+    'attestationAccuracy',
+  ],
+  offchainFieldNames: [
+    'profileId',
+    'listingId',
+    'displayName',
+    'summary',
+    'description',
+    'buyerPreview',
+    'endpoint',
+    'ardUrl',
+    'catalogRefs',
+    'sourceRefs',
+    'authRequirements',
+    'auddTerms',
+    'evidenceRefs',
+    'receiptRefs',
+    'trustBadges',
+    'providerTrustStatus',
+    'capabilities',
+    'tags',
+    'groups',
+    'riskDiagnostics',
+    'reviewStates',
+    'operatorApprovalEvidenceRef',
+  ],
+} as const;
+
+export type QuasarRegistryAgentType = 'Primary' | 'Attestation' | 'Both';
+export type QuasarRegistryRegistrationIntent = 'metadata_only' | 'register' | 'update';
+export type QuasarRegistryRegistrationStatus = 'metadata_only' | 'registerable' | 'blocked';
+
+export type QuasarRegistryCompatibilityInput = {
+  profileId?: string;
+  listingId: string;
+  displayName: string;
+  summary?: string;
+  description?: string;
+  owner?: string;
+  role?: {
+    callable?: boolean;
+    attestation?: boolean;
+  };
+  model?: string;
+  nativeSolRateLamports?: string | bigint | number;
+  minReputation?: number;
+  registrationIntent?: QuasarRegistryRegistrationIntent;
+  active?: boolean;
+  decodedAggregates?: {
+    reputationScore?: number;
+    jobsCompleted?: string | bigint | number;
+    jobsFailed?: string | bigint | number;
+    createdAt?: string | bigint | number;
+    attestationAccuracy?: number;
+  };
+  offchain: {
+    buyerPreview?: string;
+    endpoint?: {
+      url?: string;
+      bindingRef?: string;
+      healthStatus?: 'not_probed' | 'healthy' | 'unhealthy' | 'unknown';
+    };
+    ardUrl?: string;
+    catalogRefs?: string[];
+    sourceRefs?: string[];
+    authRequirements?: string[];
+    auddTerms?: {
+      asset: string;
+      network: string;
+      amount?: string;
+      paymentPlanRef?: string;
+      quoteRef?: string;
+      settlementAccount?: string;
+      refundPolicy?: string;
+      failurePolicy?: string;
+    };
+    evidenceRefs?: string[];
+    receiptRefs?: string[];
+    trustBadges?: string[];
+    providerTrustStatus?: 'unverified' | 'self_attested' | 'external_attested' | 'reddi_attested' | 'verified';
+    capabilities?: string[];
+    tags?: string[];
+    groups?: string[];
+    riskDiagnostics?: string[];
+    reviewStates?: string[];
+    operatorApprovalEvidenceRef?: string;
+  };
+};
+
+export type QuasarRegistryCompatibilityReport = {
+  schemaVersion: typeof QUASAR_REGISTRY_COMPATIBILITY_SCHEMA_VERSION;
+  profileId?: string;
+  listingId: string;
+  registrationStatus: QuasarRegistryRegistrationStatus;
+  account: typeof QUASAR_AGENT_ACCOUNT_COMPATIBILITY;
+  onchain: {
+    owner?: string;
+    agentType: QuasarRegistryAgentType;
+    model: string;
+    rateLamports?: string;
+    minReputation: number;
+    active: boolean;
+    aggregates: {
+      source: 'decoded_quasar_account' | 'not_available';
+      reputationScore?: number;
+      jobsCompleted?: string;
+      jobsFailed?: string;
+      createdAt?: string;
+      attestationAccuracy?: number;
+    };
+  };
+  offchain: QuasarRegistryCompatibilityInput['offchain'] & {
+    profileId?: string;
+    listingId: string;
+    displayName: string;
+    summary?: string;
+    description?: string;
+  };
+  blockedReasons: string[];
+  reasonCodes: string[];
+  guardrails: {
+    richMetadataOnchain: false;
+    auddCustodyOnchain: false;
+    endpointOnchain: false;
+    evidencePayloadOnchain: false;
+    trustBadgeOnchain: false;
+    instructionBuilt: false;
+    walletSigning: false;
+    rpcCall: false;
+    programDeploy: false;
+    livePaymentExecuted: false;
+  };
+};
+
+export function deriveQuasarRegistryCompatibility(
+  input: QuasarRegistryCompatibilityInput,
+): QuasarRegistryCompatibilityReport {
+  const registrationIntent = input.registrationIntent ?? 'metadata_only';
+  const model = input.model ?? fallbackModel(input);
+  const onchain = {
+    owner: input.owner,
+    agentType: deriveAgentType(input.role),
+    model,
+    rateLamports: input.nativeSolRateLamports === undefined ? undefined : toUnsignedIntegerString(input.nativeSolRateLamports),
+    minReputation: input.minReputation ?? 0,
+    active: registrationIntent === 'metadata_only' ? false : input.active === true,
+    aggregates: normalizeAggregates(input.decodedAggregates),
+  };
+  const blockedReasons = blockedReasonsFor(input, onchain, registrationIntent);
+  const registrationStatus: QuasarRegistryRegistrationStatus = blockedReasons.length > 0
+    ? 'blocked'
+    : registrationIntent === 'metadata_only'
+      ? 'metadata_only'
+      : 'registerable';
+
+  return {
+    schemaVersion: QUASAR_REGISTRY_COMPATIBILITY_SCHEMA_VERSION,
+    profileId: input.profileId,
+    listingId: input.listingId,
+    registrationStatus,
+    account: QUASAR_AGENT_ACCOUNT_COMPATIBILITY,
+    onchain,
+    offchain: {
+      ...input.offchain,
+      profileId: input.profileId,
+      listingId: input.listingId,
+      displayName: input.displayName,
+      summary: input.summary,
+      description: input.description,
+      catalogRefs: input.offchain.catalogRefs ?? [],
+      sourceRefs: input.offchain.sourceRefs ?? [],
+      authRequirements: input.offchain.authRequirements ?? [],
+      evidenceRefs: input.offchain.evidenceRefs ?? [],
+      receiptRefs: input.offchain.receiptRefs ?? [],
+      trustBadges: input.offchain.trustBadges ?? [],
+      capabilities: input.offchain.capabilities ?? [],
+      tags: input.offchain.tags ?? [],
+      groups: input.offchain.groups ?? [],
+      riskDiagnostics: input.offchain.riskDiagnostics ?? [],
+      reviewStates: input.offchain.reviewStates ?? [],
+    },
+    blockedReasons,
+    reasonCodes: reasonCodesFor(input, registrationStatus),
+    guardrails: {
+      richMetadataOnchain: false,
+      auddCustodyOnchain: false,
+      endpointOnchain: false,
+      evidencePayloadOnchain: false,
+      trustBadgeOnchain: false,
+      instructionBuilt: false,
+      walletSigning: false,
+      rpcCall: false,
+      programDeploy: false,
+      livePaymentExecuted: false,
+    },
+  };
+}
+
+function deriveAgentType(role: QuasarRegistryCompatibilityInput['role']): QuasarRegistryAgentType {
+  if (role?.callable && role.attestation) return 'Both';
+  if (role?.attestation) return 'Attestation';
+  return 'Primary';
+}
+
+function fallbackModel(input: QuasarRegistryCompatibilityInput): string {
+  const source = input.displayName || input.listingId || 'static-fixture';
+  const compact = source.toLowerCase().replace(/[^a-z0-9:_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return compact.slice(0, QUASAR_AGENT_ACCOUNT_COMPATIBILITY.modelMaxBytes) || 'static-fixture';
+}
+
+function normalizeAggregates(input: QuasarRegistryCompatibilityInput['decodedAggregates']): QuasarRegistryCompatibilityReport['onchain']['aggregates'] {
+  if (!input) return { source: 'not_available' };
+  return {
+    source: 'decoded_quasar_account',
+    reputationScore: input.reputationScore,
+    jobsCompleted: input.jobsCompleted === undefined ? undefined : toUnsignedIntegerString(input.jobsCompleted),
+    jobsFailed: input.jobsFailed === undefined ? undefined : toUnsignedIntegerString(input.jobsFailed),
+    createdAt: input.createdAt === undefined ? undefined : toSignedIntegerString(input.createdAt),
+    attestationAccuracy: input.attestationAccuracy,
+  };
+}
+
+function blockedReasonsFor(
+  input: QuasarRegistryCompatibilityInput,
+  onchain: QuasarRegistryCompatibilityReport['onchain'],
+  registrationIntent: QuasarRegistryRegistrationIntent,
+): string[] {
+  const reasons = [
+    isNonEmptyString(input.listingId) ? undefined : 'missing_listing_id',
+    utf8ByteLength(onchain.model) <= QUASAR_AGENT_ACCOUNT_COMPATIBILITY.modelMaxBytes ? undefined : 'model_too_long_for_quasar_account',
+    isUint8(onchain.minReputation) ? undefined : 'invalid_min_reputation',
+    onchain.aggregates.reputationScore === undefined || isBasisPointLike(onchain.aggregates.reputationScore) ? undefined : 'invalid_reputation_score',
+    onchain.aggregates.attestationAccuracy === undefined || isBasisPointLike(onchain.aggregates.attestationAccuracy) ? undefined : 'invalid_attestation_accuracy',
+    registrationIntent === 'metadata_only' || isSolanaPublicKey(input.owner) ? undefined : 'missing_or_invalid_owner',
+    registrationIntent === 'metadata_only' || isU64String(onchain.rateLamports) ? undefined : 'missing_native_sol_rate_lamports',
+    isNonEmptyString(input.displayName) ? undefined : 'missing_display_name',
+  ];
+  return reasons.filter(isNonEmptyString);
+}
+
+function reasonCodesFor(
+  input: QuasarRegistryCompatibilityInput,
+  registrationStatus: QuasarRegistryRegistrationStatus,
+): string[] {
+  const reasonCodes = [
+    registrationStatus,
+    'rich_metadata_offchain',
+    'audd_terms_offchain',
+    'no_instruction_built',
+    input.nativeSolRateLamports === undefined ? 'native_lamports_rate_missing' : undefined,
+    input.owner === undefined ? 'owner_missing' : undefined,
+  ];
+  return reasonCodes.filter(isNonEmptyString);
+}
+
+function toUnsignedIntegerString(value: string | bigint | number): string {
+  if (typeof value === 'bigint') return value >= 0n ? value.toString() : '-1';
+  if (typeof value === 'number') return Number.isSafeInteger(value) && value >= 0 ? String(value) : '-1';
+  return /^[0-9]+$/.test(value) ? value : '-1';
+}
+
+function toSignedIntegerString(value: string | bigint | number): string {
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'number') return Number.isSafeInteger(value) ? String(value) : '0';
+  return /^-?[0-9]+$/.test(value) ? value : '0';
+}
+
+function isU64String(value: string | undefined): value is string {
+  if (typeof value !== 'string' || !/^[0-9]+$/.test(value)) return false;
+  return BigInt(value) <= U64_MAX;
+}
+
+function isUint8(value: number): boolean {
+  return Number.isInteger(value) && value >= 0 && value <= 255;
+}
+
+function isBasisPointLike(value: number): boolean {
+  return Number.isInteger(value) && value >= 0 && value <= 10000;
+}
+
+function isSolanaPublicKey(value: string | undefined): value is string {
+  return typeof value === 'string' && decodeBase58(value)?.length === 32;
+}
+
+function decodeBase58(value: string): Uint8Array | undefined {
+  if (value.length === 0) return undefined;
+  const bytes = [0];
+  for (const char of value) {
+    const alphabetIndex = BASE58_ALPHABET.indexOf(char);
+    if (alphabetIndex === -1) return undefined;
+    let carry = alphabetIndex;
+    for (let byteIndex = 0; byteIndex < bytes.length; byteIndex += 1) {
+      carry += bytes[byteIndex] * 58;
+      bytes[byteIndex] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  for (const char of value) {
+    if (char !== '1') break;
+    bytes.push(0);
+  }
+
+  return Uint8Array.from(bytes.reverse());
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/packages/agent-protocol/tests/quasar-registry-compatibility.test.ts
+++ b/packages/agent-protocol/tests/quasar-registry-compatibility.test.ts
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  deriveQuasarRegistryCompatibility,
+  QUASAR_AGENT_ACCOUNT_COMPATIBILITY,
+  type QuasarRegistryCompatibilityInput,
+} from '../dist/index.js';
+
+function importedProfile(overrides: Partial<QuasarRegistryCompatibilityInput> = {}): QuasarRegistryCompatibilityInput {
+  return {
+    profileId: 'profile:static:research-agent',
+    listingId: 'listing:hosted-rap:research-agent',
+    displayName: 'Research Agent',
+    summary: 'Imported research specialist metadata.',
+    description: 'Rich buyer-facing listing copy belongs off-chain.',
+    role: { callable: true },
+    model: 'qwen3:8b',
+    registrationIntent: 'metadata_only',
+    minReputation: 0,
+    offchain: {
+      buyerPreview: 'Detailed buyer copy and operator caveats.',
+      endpoint: { url: 'https://agents.example/research', bindingRef: 'endpoint-binding:research', healthStatus: 'not_probed' },
+      ardUrl: 'https://agents.example/.well-known/ai-catalog.json',
+      catalogRefs: ['/.well-known/ai-catalog.json'],
+      sourceRefs: ['https://github.com/example/research-agent#abc123'],
+      authRequirements: ['operator-approved-token'],
+      auddTerms: {
+        asset: 'AUDD',
+        network: 'solana-devnet',
+        amount: '2500000',
+        paymentPlanRef: 'payment-plan:research-agent',
+        quoteRef: 'quote:research-agent',
+        settlementAccount: 'solana:settlementFixture1111111111111111111111',
+        refundPolicy: 'manual_review',
+        failurePolicy: 'no_charge_on_failure',
+      },
+      evidenceRefs: ['evidence:dry-run:research-agent'],
+      receiptRefs: ['receipt:dry-run:research-agent'],
+      trustBadges: ['offchain-preview-only'],
+      providerTrustStatus: 'unverified',
+      capabilities: ['research', 'summarization'],
+      tags: ['hosted-rap', 'external'],
+      groups: ['tools', 'skills'],
+      riskDiagnostics: ['static_only_untrusted_import'],
+      reviewStates: ['operator_review_required'],
+      operatorApprovalEvidenceRef: 'operator-approval:research-agent',
+    },
+    ...overrides,
+  };
+}
+
+describe('Quasar registry compatibility projection', () => {
+  it('keeps imported rich profile metadata off-chain and metadata-only', () => {
+    const report = deriveQuasarRegistryCompatibility(importedProfile());
+
+    assert.equal(report.schemaVersion, 'reddi.quasar-registry-compatibility.v1');
+    assert.equal(report.registrationStatus, 'metadata_only');
+    assert.equal(report.onchain.agentType, 'Primary');
+    assert.equal(report.onchain.active, false);
+    assert.equal(report.onchain.rateLamports, undefined);
+    assert.equal(report.offchain.auddTerms?.asset, 'AUDD');
+    assert.equal(report.offchain.endpoint?.healthStatus, 'not_probed');
+    assert.deepEqual(report.account.discriminator, [20]);
+    assert.equal(report.account.dataSize, 153);
+    assert.equal(report.account.modelMaxBytes, 64);
+    assert.ok(!report.account.onchainFieldNames.includes('endpoint' as never));
+    assert.ok(!report.account.onchainFieldNames.includes('auddTerms' as never));
+    assert.ok(report.account.offchainFieldNames.includes('evidenceRefs'));
+    assert.deepEqual(report.guardrails, {
+      richMetadataOnchain: false,
+      auddCustodyOnchain: false,
+      endpointOnchain: false,
+      evidencePayloadOnchain: false,
+      trustBadgeOnchain: false,
+      instructionBuilt: false,
+      walletSigning: false,
+      rpcCall: false,
+      programDeploy: false,
+      livePaymentExecuted: false,
+    });
+  });
+
+  it('marks explicit native-SOL registry profiles as registerable without building instructions', () => {
+    const report = deriveQuasarRegistryCompatibility(importedProfile({
+      owner: '11111111111111111111111111111112',
+      nativeSolRateLamports: 1_250_000n,
+      minReputation: 7,
+      active: true,
+      registrationIntent: 'register',
+      role: { callable: true, attestation: true },
+    }));
+
+    assert.equal(report.registrationStatus, 'registerable');
+    assert.deepEqual(report.blockedReasons, []);
+    assert.equal(report.onchain.agentType, 'Both');
+    assert.equal(report.onchain.rateLamports, '1250000');
+    assert.equal(report.onchain.minReputation, 7);
+    assert.equal(report.onchain.active, true);
+    assert.equal(report.guardrails.instructionBuilt, false);
+    assert.equal(report.guardrails.walletSigning, false);
+    assert.equal(report.guardrails.rpcCall, false);
+  });
+
+  it('derives compact agent type from explicit capability intent', () => {
+    assert.equal(deriveQuasarRegistryCompatibility(importedProfile({ role: { callable: true } })).onchain.agentType, 'Primary');
+    assert.equal(deriveQuasarRegistryCompatibility(importedProfile({ role: { attestation: true } })).onchain.agentType, 'Attestation');
+    assert.equal(deriveQuasarRegistryCompatibility(importedProfile({ role: { callable: true, attestation: true } })).onchain.agentType, 'Both');
+  });
+
+  it('fails closed for overlong models and invalid compact u8 thresholds', () => {
+    const report = deriveQuasarRegistryCompatibility(importedProfile({
+      model: 'x'.repeat(65),
+      minReputation: 300,
+      registrationIntent: 'register',
+      owner: '11111111111111111111111111111112',
+      nativeSolRateLamports: '1000',
+    }));
+
+    assert.equal(report.registrationStatus, 'blocked');
+    assert.deepEqual(report.blockedReasons, [
+      'model_too_long_for_quasar_account',
+      'invalid_min_reputation',
+    ]);
+    assert.equal(report.guardrails.programDeploy, false);
+    assert.equal(report.offchain.description, 'Rich buyer-facing listing copy belongs off-chain.');
+  });
+
+  it('fails closed for owners that match base58 shape but are not Solana public keys', () => {
+    const report = deriveQuasarRegistryCompatibility(importedProfile({
+      owner: 'z'.repeat(44),
+      nativeSolRateLamports: '1000',
+      registrationIntent: 'register',
+    }));
+
+    assert.equal(report.registrationStatus, 'blocked');
+    assert.deepEqual(report.blockedReasons, ['missing_or_invalid_owner']);
+    assert.equal(report.guardrails.instructionBuilt, false);
+    assert.equal(report.guardrails.rpcCall, false);
+  });
+
+  it('fails closed for native SOL lamport rates outside Quasar u64 storage', () => {
+    const report = deriveQuasarRegistryCompatibility(importedProfile({
+      owner: '11111111111111111111111111111112',
+      nativeSolRateLamports: '18446744073709551616',
+      registrationIntent: 'register',
+    }));
+
+    assert.equal(report.registrationStatus, 'blocked');
+    assert.deepEqual(report.blockedReasons, ['missing_native_sol_rate_lamports']);
+    assert.equal(report.onchain.rateLamports, '18446744073709551616');
+    assert.equal(report.guardrails.walletSigning, false);
+  });
+
+  it('keeps Quasar aggregates read-only and sourced only from decoded accounts', () => {
+    const report = deriveQuasarRegistryCompatibility(importedProfile({
+      decodedAggregates: {
+        reputationScore: 8800,
+        jobsCompleted: 42n,
+        jobsFailed: '3',
+        createdAt: 1_720_000_000,
+        attestationAccuracy: 9300,
+      },
+    }));
+
+    assert.equal(report.onchain.aggregates.source, 'decoded_quasar_account');
+    assert.equal(report.onchain.aggregates.reputationScore, 8800);
+    assert.equal(report.onchain.aggregates.jobsCompleted, '42');
+    assert.equal(report.onchain.aggregates.jobsFailed, '3');
+    assert.equal(report.onchain.aggregates.createdAt, '1720000000');
+    assert.equal(report.onchain.aggregates.attestationAccuracy, 9300);
+    assert.equal(QUASAR_AGENT_ACCOUNT_COMPATIBILITY.pdaSeed, 'agent');
+  });
+
+  it('does not convert AUDD terms into lamports for metadata-only listings', () => {
+    const report = deriveQuasarRegistryCompatibility(importedProfile({
+      offchain: {
+        ...importedProfile().offchain,
+        auddTerms: {
+          asset: 'AUDD',
+          network: 'solana-devnet',
+          amount: '999999999',
+        },
+      },
+    }));
+
+    assert.equal(report.registrationStatus, 'metadata_only');
+    assert.equal(report.onchain.rateLamports, undefined);
+    assert.equal(report.offchain.auddTerms?.amount, '999999999');
+    assert.ok(report.reasonCodes.includes('audd_terms_offchain'));
+    assert.ok(report.reasonCodes.includes('native_lamports_rate_missing'));
+  });
+});


### PR DESCRIPTION
## Summary
- Add package-level `reddi.quasar-registry-compatibility.v1` projection.
- Separate compact Quasar AgentAccount fields from rich RAP/ARD hosted listing metadata.
- Add package subpath export `@reddi/agent-protocol/quasar-registry-compatibility`, README docs, generated dist, and package tests.

## Behavior
- On-chain projection is limited to owner, agent type, compact model, native SOL lamport rate, min reputation, active flag, and decoded read-only aggregates.
- ARD URL/catalog refs, endpoints, auth, AUDD terms, evidence/receipt refs, trust badges, capabilities, tags, risk/review state, and operator approval evidence stay off-chain.
- Imported/static listings without explicit owner/native lamports rate stay `metadata_only`, not register instructions.
- Explicit native-SOL registry profiles can be marked `registerable`, but the mapper still builds no instruction.
- AUDD terms are never converted to lamports.

## Safety / Scope
- Package/read-model only.
- No Quasar instruction builder usage from the mapper.
- No wallet signing, RPC reads/probes, devnet/mainnet access, Surfpool start, program deploy, SPL/AUDD custody, live payment, hosted registry write, marketplace publication, provider/MCP call, or repo fetch.

## Validation
- `npm test` in `packages/agent-protocol` passed 121/121.
- `npm run release:dry-run` in `packages/agent-protocol` passed and includes the new dist files.
- Focused root Jest passed: `lib/__tests__/quasar-agent-account-decoder.test.ts` and `lib/__tests__/quasar-instructions.test.ts` (2 suites, 6 tests).
- `git diff --check` passed.
- `npm run check:rap:naming` passed.
- Scoped forbidden-import scan found no live Solana/RPC/Quasar instruction imports in the new package source/test; matches were only the helper name `isLikelyBase58PublicKey`.

Refs #390