### PR TITLE
feat(agent-protocol): add hosted attestation claim contract

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -233,6 +233,42 @@ Off-chain reputation preview consumes `reddi.receipt-evidence-binding.v1` record
 
 This preview is not Quasar-backed and does not build instruction flows while #390 compatibility is pending. It never performs wallet signing, RPC calls, hosted registry writes, marketplace publication, live payment execution, provider calls, or reputation mutation, and it never allows buyer-facing trust/reputation claims from preview data alone.
 
+## Hosted Attestation Claim
+
+```typescript
+import {
+  deriveHostedAttestationClaim,
+} from '@reddi/agent-protocol/hosted-attestation-claim';
+
+const result = deriveHostedAttestationClaim({
+  id: 'hosted-claim:listing:research-agent',
+  binding,
+  preview,
+  hostedAttestationProof: {
+    sourceProofRef: 'source-proof:research-agent',
+    attestationProofRef: 'hosted-attestation-proof:research-agent',
+    hostedBy: 'reddi',
+  },
+  operatorApproval: {
+    approved: true,
+    evidenceRef: 'operator-approval:research-agent',
+  },
+  publicationGate: {
+    issue: 395,
+    state: 'claim_contract_ready',
+    evidenceRef: 'publication-gate:research-agent',
+  },
+  createdAt: new Date().toISOString(),
+});
+
+console.log(result.claim.status); // hosted_attestation_ready / publication_gate_pending / insufficient_evidence / blocked
+console.log(result.claim.display.buyerFacingClaimAllowed); // false
+```
+
+Hosted attestation claims consume `reddi.receipt-evidence-binding.v1` records plus `reddi.offchain-reputation-preview.v1` previews. A hosted-backed claim requires matching evidence, passed attestation, preview-ready reputation draft, explicit hosted source/attestation proof refs, operator approval evidence, and #395 publication-gate metadata. Missing hosted proof, operator approval, or publication-gate metadata remains `publication_gate_pending`; malformed, failed, disputed, refunded, mismatched, unsafe, or blocked evidence fails closed.
+
+This is a claim contract for downstream publication gates, not marketplace publication itself. It does not mutate reputation, build Quasar instructions, sign wallets, call RPC, write hosted registries, execute live payments, call providers, or permit buyer-facing trust/reputation claims. Quasar-backed instruction fixtures remain separate work after the Surfpool/devnet promotion checklist.
+
 ## Quasar Registry Compatibility
 
 ```typescript

--- a/packages/agent-protocol/dist/hosted-attestation-claim.d.ts
+++ b/packages/agent-protocol/dist/hosted-attestation-claim.d.ts
@@ -1,0 +1,90 @@
+import { type OffchainReputationPreview } from './offchain-reputation-preview.js';
+import { type ReceiptEvidenceBinding } from './receipt-evidence-binding.js';
+export declare const HOSTED_ATTESTATION_CLAIM_SCHEMA_VERSION: "reddi.hosted-attestation-claim.v1";
+export type HostedAttestationClaimStatus = 'hosted_attestation_ready' | 'publication_gate_pending' | 'insufficient_evidence' | 'blocked';
+export type HostedAttestationPublicationGate = {
+    issue: 395;
+    state: 'claim_contract_ready' | 'pending' | 'blocked';
+    evidenceRef?: string;
+    reviewedAt?: string;
+};
+export type HostedAttestationOperatorApproval = {
+    approved: boolean;
+    evidenceRef: string;
+    approvedAt?: string;
+};
+export type HostedAttestationProofRef = {
+    sourceProofRef: string;
+    attestationProofRef: string;
+    hostedBy: 'reddi';
+    reviewedAt?: string;
+};
+export type HostedAttestationClaimReasonCode = 'binding_valid' | 'preview_ready' | 'hosted_attestation_evidence_present' | 'operator_approval_present' | 'publication_gate_present' | 'buyer_facing_claim_disabled' | 'not_quasar_backed' | 'missing_claim_id' | 'malformed_claim' | 'malformed_binding' | 'malformed_preview' | 'preview_not_ready' | 'insufficient_evidence' | 'unsafe_live_guardrail' | 'source_not_hosted' | 'attestation_not_hosted_backed' | 'missing_source_proof' | 'missing_hosted_attestation_proof' | 'missing_attestation' | 'attestation_not_passed' | 'source_mismatch' | 'evidence_mismatch' | 'missing_operator_approval' | 'publication_gate_missing' | 'publication_gate_blocked';
+export type HostedAttestationClaim = {
+    schemaVersion: typeof HOSTED_ATTESTATION_CLAIM_SCHEMA_VERSION;
+    id: string;
+    status: HostedAttestationClaimStatus;
+    subject: OffchainReputationPreview['subject'];
+    source: ReceiptEvidenceBinding['source'];
+    backing: {
+        claimKind: 'hosted_attestation_backed';
+        attestationKind: NonNullable<ReceiptEvidenceBinding['attestation']>['trustBoundary'] | 'none';
+        reputationKind: 'offchain_preview';
+        quasarBacking: {
+            status: 'not_quasar_backed';
+            instructionFlow: 'not_built';
+            promotionChecklistIssue: 441;
+        };
+        hostedAttestationBacking: {
+            status: 'ready' | 'pending' | 'blocked';
+            sourceProofRef?: string;
+            attestationProofRef?: string;
+            hostedBy?: 'reddi';
+            operatorApprovalEvidenceRef?: string;
+            publicationGateEvidenceRef?: string;
+            publicationGateIssue: 395;
+        };
+    };
+    evidenceSummary: OffchainReputationPreview['evidenceSummary'] & {
+        previewId: string;
+        sourceProofRef?: string;
+        attestationProofRef?: string;
+        operatorApprovalEvidenceRef?: string;
+        publicationGateEvidenceRef?: string;
+    };
+    previewEvent?: OffchainReputationPreview['previewEvent'];
+    display: {
+        label: 'Hosted attestation ready' | 'Publication gate pending' | 'Insufficient evidence' | 'Blocked';
+        explanation: string;
+        buyerFacingClaimAllowed: false;
+    };
+    reasonCodes: HostedAttestationClaimReasonCode[];
+    guardrails: {
+        reputationMutated: false;
+        quasarInstructionBuilt: false;
+        walletSigning: false;
+        rpcCall: false;
+        hostedRegistryWrite: false;
+        marketplacePublished: false;
+        livePaymentExecuted: false;
+        providerCall: false;
+    };
+    createdAt: string;
+};
+export type HostedAttestationClaimInput = {
+    id: string;
+    binding: ReceiptEvidenceBinding;
+    preview: OffchainReputationPreview;
+    hostedAttestationProof?: HostedAttestationProofRef;
+    operatorApproval?: HostedAttestationOperatorApproval;
+    publicationGate?: HostedAttestationPublicationGate;
+    createdAt: string;
+};
+export type HostedAttestationClaimResult = {
+    ok: true;
+    claim: HostedAttestationClaim;
+} | {
+    ok: false;
+    claim: HostedAttestationClaim;
+};
+export declare function deriveHostedAttestationClaim(input: HostedAttestationClaimInput): HostedAttestationClaimResult;

--- a/packages/agent-protocol/dist/hosted-attestation-claim.js
+++ b/packages/agent-protocol/dist/hosted-attestation-claim.js
@@ -1,0 +1,258 @@
+import { OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION, } from './offchain-reputation-preview.js';
+import { RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION, } from './receipt-evidence-binding.js';
+export const HOSTED_ATTESTATION_CLAIM_SCHEMA_VERSION = 'reddi.hosted-attestation-claim.v1';
+const GUARDRAILS = {
+    reputationMutated: false,
+    quasarInstructionBuilt: false,
+    walletSigning: false,
+    rpcCall: false,
+    hostedRegistryWrite: false,
+    marketplacePublished: false,
+    livePaymentExecuted: false,
+    providerCall: false,
+};
+export function deriveHostedAttestationClaim(input) {
+    const reasonCodes = [];
+    const binding = input.binding;
+    const preview = input.preview;
+    if (!isNonEmptyString(input.id))
+        reasonCodes.push('missing_claim_id');
+    if (!isNonEmptyString(input.createdAt) || Number.isNaN(Date.parse(input.createdAt)))
+        reasonCodes.push('malformed_claim');
+    if (!binding || binding.schemaVersion !== RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION)
+        reasonCodes.push('malformed_binding');
+    if (!preview || preview.schemaVersion !== OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION)
+        reasonCodes.push('malformed_preview');
+    if (!bindingHasCoreShape(binding))
+        reasonCodes.push('malformed_binding');
+    if (!previewHasCoreShape(preview))
+        reasonCodes.push('malformed_preview');
+    if (!bindingGuardrailsAreSafe(binding) || !previewGuardrailsAreSafe(preview))
+        reasonCodes.push('unsafe_live_guardrail');
+    if (binding?.source?.kind !== 'hosted-rap-registry')
+        reasonCodes.push('source_not_hosted');
+    if (!binding?.attestation)
+        reasonCodes.push('missing_attestation');
+    if (binding?.attestation && (binding.attestation.verdict !== 'passed' || binding.receipt?.attestationStatus !== 'attested')) {
+        reasonCodes.push('attestation_not_passed');
+    }
+    if (binding?.attestation && !hostedAttestationBoundaryIsSupported(binding.attestation.trustBoundary)) {
+        reasonCodes.push('attestation_not_hosted_backed');
+    }
+    if (preview?.status !== 'preview_ready') {
+        reasonCodes.push(preview?.status === 'insufficient_evidence' ? 'insufficient_evidence' : 'preview_not_ready');
+    }
+    if (preview?.status === 'preview_ready' && !previewSourceAndSubjectMatchBinding(preview, binding)) {
+        reasonCodes.push('source_mismatch');
+    }
+    if (!previewEvidenceMatchesBinding(preview, binding))
+        reasonCodes.push('evidence_mismatch');
+    if (!isNonEmptyString(input.hostedAttestationProof?.sourceProofRef))
+        reasonCodes.push('missing_source_proof');
+    if (!hostedAttestationProofIsPresent(input.hostedAttestationProof)) {
+        reasonCodes.push('missing_hosted_attestation_proof');
+    }
+    if (!operatorApprovalIsPresent(input.operatorApproval))
+        reasonCodes.push('missing_operator_approval');
+    if (!input.publicationGate || input.publicationGate.issue !== 395 || !isNonEmptyString(input.publicationGate.evidenceRef)) {
+        reasonCodes.push('publication_gate_missing');
+    }
+    else if (input.publicationGate.state === 'blocked') {
+        reasonCodes.push('publication_gate_blocked');
+    }
+    else if (input.publicationGate.state !== 'claim_contract_ready') {
+        reasonCodes.push('publication_gate_missing');
+    }
+    const blockingReason = reasonCodes.find((code) => [
+        'missing_claim_id',
+        'malformed_claim',
+        'malformed_binding',
+        'malformed_preview',
+        'preview_not_ready',
+        'unsafe_live_guardrail',
+        'source_not_hosted',
+        'attestation_not_hosted_backed',
+        'attestation_not_passed',
+        'source_mismatch',
+        'evidence_mismatch',
+        'publication_gate_blocked',
+    ].includes(code));
+    const status = blockingReason
+        ? 'blocked'
+        : reasonCodes.includes('insufficient_evidence') || reasonCodes.includes('missing_attestation')
+            ? 'insufficient_evidence'
+            : reasonCodes.includes('missing_source_proof')
+                || reasonCodes.includes('missing_hosted_attestation_proof')
+                || reasonCodes.includes('missing_operator_approval')
+                || reasonCodes.includes('publication_gate_missing')
+                ? 'publication_gate_pending'
+                : 'hosted_attestation_ready';
+    const normalizedReasonCodes = unique([
+        ...(status === 'hosted_attestation_ready'
+            ? [
+                'binding_valid',
+                'preview_ready',
+                'hosted_attestation_evidence_present',
+                'operator_approval_present',
+                'publication_gate_present',
+            ]
+            : []),
+        ...reasonCodes,
+        'buyer_facing_claim_disabled',
+        'not_quasar_backed',
+    ]);
+    const claim = {
+        schemaVersion: HOSTED_ATTESTATION_CLAIM_SCHEMA_VERSION,
+        id: input.id,
+        status,
+        subject: preview?.subject ?? { id: 'unknown', type: 'listing' },
+        source: binding?.source ?? { kind: 'static-fixture', sourceId: 'unknown', fixtureRef: 'unknown' },
+        backing: {
+            claimKind: 'hosted_attestation_backed',
+            attestationKind: binding?.attestation?.trustBoundary ?? 'none',
+            reputationKind: 'offchain_preview',
+            quasarBacking: {
+                status: 'not_quasar_backed',
+                instructionFlow: 'not_built',
+                promotionChecklistIssue: 441,
+            },
+            hostedAttestationBacking: {
+                status: status === 'hosted_attestation_ready' ? 'ready' : status === 'blocked' ? 'blocked' : 'pending',
+                sourceProofRef: input.hostedAttestationProof?.sourceProofRef,
+                attestationProofRef: input.hostedAttestationProof?.attestationProofRef,
+                hostedBy: input.hostedAttestationProof?.hostedBy,
+                operatorApprovalEvidenceRef: input.operatorApproval?.evidenceRef,
+                publicationGateEvidenceRef: input.publicationGate?.evidenceRef,
+                publicationGateIssue: 395,
+            },
+        },
+        evidenceSummary: {
+            ...(preview?.evidenceSummary ?? {
+                bindingId: input.id,
+                receiptId: '',
+                evidenceId: '',
+                evidenceHash: '',
+                evidenceRef: '',
+                paymentProofRef: '',
+            }),
+            previewId: preview?.id ?? '',
+            sourceProofRef: input.hostedAttestationProof?.sourceProofRef,
+            attestationProofRef: input.hostedAttestationProof?.attestationProofRef,
+            operatorApprovalEvidenceRef: input.operatorApproval?.evidenceRef,
+            publicationGateEvidenceRef: input.publicationGate?.evidenceRef,
+        },
+        previewEvent: status === 'hosted_attestation_ready' ? preview.previewEvent : undefined,
+        display: {
+            label: displayLabel(status),
+            explanation: displayExplanation(status),
+            buyerFacingClaimAllowed: false,
+        },
+        reasonCodes: normalizedReasonCodes,
+        guardrails: GUARDRAILS,
+        createdAt: input.createdAt,
+    };
+    return status === 'hosted_attestation_ready' ? { ok: true, claim } : { ok: false, claim };
+}
+function bindingHasCoreShape(binding) {
+    return Boolean(binding?.receipt
+        && binding.evidence
+        && binding.payment
+        && binding.guardrails
+        && typeof binding.receipt === 'object'
+        && typeof binding.evidence === 'object'
+        && typeof binding.payment === 'object'
+        && typeof binding.guardrails === 'object');
+}
+function previewHasCoreShape(preview) {
+    return Boolean(preview?.evidenceSummary
+        && preview.display
+        && preview.guardrails
+        && preview.backing
+        && typeof preview.evidenceSummary === 'object'
+        && typeof preview.display === 'object'
+        && typeof preview.guardrails === 'object'
+        && typeof preview.backing === 'object');
+}
+function bindingGuardrailsAreSafe(binding) {
+    if (!binding?.guardrails)
+        return false;
+    return binding.guardrails.rawPromptStored === false
+        && binding.guardrails.rawOutputStored === false
+        && binding.guardrails.livePaymentExecuted === false
+        && binding.guardrails.walletSigning === false
+        && binding.guardrails.rpcCall === false
+        && binding.guardrails.hostedRegistryRequired === false
+        && binding.guardrails.reputationMutated === false;
+}
+function previewGuardrailsAreSafe(preview) {
+    if (!preview?.guardrails || preview.display?.buyerFacingClaimAllowed !== false)
+        return false;
+    return preview.guardrails.reputationMutated === false
+        && preview.guardrails.quasarInstructionBuilt === false
+        && preview.guardrails.walletSigning === false
+        && preview.guardrails.rpcCall === false
+        && preview.guardrails.hostedRegistryWrite === false
+        && preview.guardrails.marketplacePublished === false
+        && preview.guardrails.livePaymentExecuted === false;
+}
+function previewEvidenceMatchesBinding(preview, binding) {
+    if (!preview?.evidenceSummary || !bindingHasCoreShape(binding))
+        return false;
+    return preview.evidenceSummary.bindingId === binding?.id
+        && preview.evidenceSummary.receiptId === binding.receipt.id
+        && preview.evidenceSummary.evidenceId === binding.evidence.id
+        && preview.evidenceSummary.evidenceHash === binding.evidence.evidenceHash
+        && preview.evidenceSummary.evidenceRef === binding.receipt.evidenceRef
+        && preview.evidenceSummary.paymentProofRef === binding.receipt.paymentProofRef
+        && preview.evidenceSummary.attestationId === binding.attestation?.id
+        && preview.evidenceSummary.reputationEventDraftId === binding.reputationEventDraft?.id;
+}
+function previewSourceAndSubjectMatchBinding(preview, binding) {
+    if (!preview || !bindingHasCoreShape(binding))
+        return false;
+    if (JSON.stringify(preview.source) !== JSON.stringify(binding?.source))
+        return false;
+    if (binding?.source.kind === 'hosted-rap-registry') {
+        return preview.subject.id === binding.source.listingId
+            && preview.previewEvent?.subjectId === binding.source.listingId;
+    }
+    return false;
+}
+function operatorApprovalIsPresent(approval) {
+    return approval?.approved === true && isNonEmptyString(approval.evidenceRef);
+}
+function hostedAttestationBoundaryIsSupported(trustBoundary) {
+    return trustBoundary === 'reddi_attested' || trustBoundary === 'verified';
+}
+function hostedAttestationProofIsPresent(proof) {
+    return proof?.hostedBy === 'reddi'
+        && isNonEmptyString(proof.sourceProofRef)
+        && isNonEmptyString(proof.attestationProofRef);
+}
+function displayLabel(status) {
+    if (status === 'hosted_attestation_ready')
+        return 'Hosted attestation ready';
+    if (status === 'publication_gate_pending')
+        return 'Publication gate pending';
+    if (status === 'insufficient_evidence')
+        return 'Insufficient evidence';
+    return 'Blocked';
+}
+function displayExplanation(status) {
+    if (status === 'hosted_attestation_ready') {
+        return 'Hosted attestation evidence is ready for downstream publication gates, but buyer-facing claims remain disabled until #395 permits them.';
+    }
+    if (status === 'publication_gate_pending') {
+        return 'The preview has evidence, but hosted publication/operator gate metadata is not complete.';
+    }
+    if (status === 'insufficient_evidence') {
+        return 'The binding or preview is missing attestation or reputation evidence required for a hosted-backed claim.';
+    }
+    return 'The binding or preview failed a safety gate and cannot produce a hosted-backed claim.';
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function unique(items) {
+    return [...new Set(items)];
+}

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -13,3 +13,4 @@ export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';
 export * from './quasar-registry-compatibility.js';
+export * from './hosted-attestation-claim.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -13,3 +13,4 @@ export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';
 export * from './quasar-registry-compatibility.js';
+export * from './hosted-attestation-claim.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -70,6 +70,10 @@
       "types": "./dist/quasar-registry-compatibility.d.ts",
       "import": "./dist/quasar-registry-compatibility.js"
     },
+    "./hosted-attestation-claim": {
+      "types": "./dist/hosted-attestation-claim.d.ts",
+      "import": "./dist/hosted-attestation-claim.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/hosted-attestation-claim.ts
+++ b/packages/agent-protocol/src/hosted-attestation-claim.ts
@@ -1,0 +1,400 @@
+import {
+  OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION,
+  type OffchainReputationPreview,
+} from './offchain-reputation-preview.js';
+import {
+  RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION,
+  type ReceiptEvidenceBinding,
+} from './receipt-evidence-binding.js';
+
+export const HOSTED_ATTESTATION_CLAIM_SCHEMA_VERSION = 'reddi.hosted-attestation-claim.v1' as const;
+
+export type HostedAttestationClaimStatus =
+  | 'hosted_attestation_ready'
+  | 'publication_gate_pending'
+  | 'insufficient_evidence'
+  | 'blocked';
+
+export type HostedAttestationPublicationGate = {
+  issue: 395;
+  state: 'claim_contract_ready' | 'pending' | 'blocked';
+  evidenceRef?: string;
+  reviewedAt?: string;
+};
+
+export type HostedAttestationOperatorApproval = {
+  approved: boolean;
+  evidenceRef: string;
+  approvedAt?: string;
+};
+
+export type HostedAttestationProofRef = {
+  sourceProofRef: string;
+  attestationProofRef: string;
+  hostedBy: 'reddi';
+  reviewedAt?: string;
+};
+
+export type HostedAttestationClaimReasonCode =
+  | 'binding_valid'
+  | 'preview_ready'
+  | 'hosted_attestation_evidence_present'
+  | 'operator_approval_present'
+  | 'publication_gate_present'
+  | 'buyer_facing_claim_disabled'
+  | 'not_quasar_backed'
+  | 'missing_claim_id'
+  | 'malformed_claim'
+  | 'malformed_binding'
+  | 'malformed_preview'
+  | 'preview_not_ready'
+  | 'insufficient_evidence'
+  | 'unsafe_live_guardrail'
+  | 'source_not_hosted'
+  | 'attestation_not_hosted_backed'
+  | 'missing_source_proof'
+  | 'missing_hosted_attestation_proof'
+  | 'missing_attestation'
+  | 'attestation_not_passed'
+  | 'source_mismatch'
+  | 'evidence_mismatch'
+  | 'missing_operator_approval'
+  | 'publication_gate_missing'
+  | 'publication_gate_blocked';
+
+export type HostedAttestationClaim = {
+  schemaVersion: typeof HOSTED_ATTESTATION_CLAIM_SCHEMA_VERSION;
+  id: string;
+  status: HostedAttestationClaimStatus;
+  subject: OffchainReputationPreview['subject'];
+  source: ReceiptEvidenceBinding['source'];
+  backing: {
+    claimKind: 'hosted_attestation_backed';
+    attestationKind: NonNullable<ReceiptEvidenceBinding['attestation']>['trustBoundary'] | 'none';
+    reputationKind: 'offchain_preview';
+    quasarBacking: {
+      status: 'not_quasar_backed';
+      instructionFlow: 'not_built';
+      promotionChecklistIssue: 441;
+    };
+    hostedAttestationBacking: {
+      status: 'ready' | 'pending' | 'blocked';
+      sourceProofRef?: string;
+      attestationProofRef?: string;
+      hostedBy?: 'reddi';
+      operatorApprovalEvidenceRef?: string;
+      publicationGateEvidenceRef?: string;
+      publicationGateIssue: 395;
+    };
+  };
+  evidenceSummary: OffchainReputationPreview['evidenceSummary'] & {
+    previewId: string;
+    sourceProofRef?: string;
+    attestationProofRef?: string;
+    operatorApprovalEvidenceRef?: string;
+    publicationGateEvidenceRef?: string;
+  };
+  previewEvent?: OffchainReputationPreview['previewEvent'];
+  display: {
+    label:
+      | 'Hosted attestation ready'
+      | 'Publication gate pending'
+      | 'Insufficient evidence'
+      | 'Blocked';
+    explanation: string;
+    buyerFacingClaimAllowed: false;
+  };
+  reasonCodes: HostedAttestationClaimReasonCode[];
+  guardrails: {
+    reputationMutated: false;
+    quasarInstructionBuilt: false;
+    walletSigning: false;
+    rpcCall: false;
+    hostedRegistryWrite: false;
+    marketplacePublished: false;
+    livePaymentExecuted: false;
+    providerCall: false;
+  };
+  createdAt: string;
+};
+
+export type HostedAttestationClaimInput = {
+  id: string;
+  binding: ReceiptEvidenceBinding;
+  preview: OffchainReputationPreview;
+  hostedAttestationProof?: HostedAttestationProofRef;
+  operatorApproval?: HostedAttestationOperatorApproval;
+  publicationGate?: HostedAttestationPublicationGate;
+  createdAt: string;
+};
+
+export type HostedAttestationClaimResult =
+  | { ok: true; claim: HostedAttestationClaim }
+  | { ok: false; claim: HostedAttestationClaim };
+
+const GUARDRAILS: HostedAttestationClaim['guardrails'] = {
+  reputationMutated: false,
+  quasarInstructionBuilt: false,
+  walletSigning: false,
+  rpcCall: false,
+  hostedRegistryWrite: false,
+  marketplacePublished: false,
+  livePaymentExecuted: false,
+  providerCall: false,
+};
+
+export function deriveHostedAttestationClaim(input: HostedAttestationClaimInput): HostedAttestationClaimResult {
+  const reasonCodes: HostedAttestationClaimReasonCode[] = [];
+  const binding = input.binding;
+  const preview = input.preview;
+
+  if (!isNonEmptyString(input.id)) reasonCodes.push('missing_claim_id');
+  if (!isNonEmptyString(input.createdAt) || Number.isNaN(Date.parse(input.createdAt))) reasonCodes.push('malformed_claim');
+  if (!binding || binding.schemaVersion !== RECEIPT_EVIDENCE_BINDING_SCHEMA_VERSION) reasonCodes.push('malformed_binding');
+  if (!preview || preview.schemaVersion !== OFFCHAIN_REPUTATION_PREVIEW_SCHEMA_VERSION) reasonCodes.push('malformed_preview');
+  if (!bindingHasCoreShape(binding)) reasonCodes.push('malformed_binding');
+  if (!previewHasCoreShape(preview)) reasonCodes.push('malformed_preview');
+  if (!bindingGuardrailsAreSafe(binding) || !previewGuardrailsAreSafe(preview)) reasonCodes.push('unsafe_live_guardrail');
+  if (binding?.source?.kind !== 'hosted-rap-registry') reasonCodes.push('source_not_hosted');
+
+  if (!binding?.attestation) reasonCodes.push('missing_attestation');
+  if (binding?.attestation && (binding.attestation.verdict !== 'passed' || binding.receipt?.attestationStatus !== 'attested')) {
+    reasonCodes.push('attestation_not_passed');
+  }
+  if (binding?.attestation && !hostedAttestationBoundaryIsSupported(binding.attestation.trustBoundary)) {
+    reasonCodes.push('attestation_not_hosted_backed');
+  }
+
+  if (preview?.status !== 'preview_ready') {
+    reasonCodes.push(preview?.status === 'insufficient_evidence' ? 'insufficient_evidence' : 'preview_not_ready');
+  }
+
+  if (preview?.status === 'preview_ready' && !previewSourceAndSubjectMatchBinding(preview, binding)) {
+    reasonCodes.push('source_mismatch');
+  }
+  if (!previewEvidenceMatchesBinding(preview, binding)) reasonCodes.push('evidence_mismatch');
+  if (!isNonEmptyString(input.hostedAttestationProof?.sourceProofRef)) reasonCodes.push('missing_source_proof');
+  if (!hostedAttestationProofIsPresent(input.hostedAttestationProof)) {
+    reasonCodes.push('missing_hosted_attestation_proof');
+  }
+  if (!operatorApprovalIsPresent(input.operatorApproval)) reasonCodes.push('missing_operator_approval');
+
+  if (!input.publicationGate || input.publicationGate.issue !== 395 || !isNonEmptyString(input.publicationGate.evidenceRef)) {
+    reasonCodes.push('publication_gate_missing');
+  } else if (input.publicationGate.state === 'blocked') {
+    reasonCodes.push('publication_gate_blocked');
+  } else if (input.publicationGate.state !== 'claim_contract_ready') {
+    reasonCodes.push('publication_gate_missing');
+  }
+
+  const blockingReason = reasonCodes.find((code) => [
+    'missing_claim_id',
+    'malformed_claim',
+    'malformed_binding',
+    'malformed_preview',
+    'preview_not_ready',
+    'unsafe_live_guardrail',
+    'source_not_hosted',
+    'attestation_not_hosted_backed',
+    'attestation_not_passed',
+    'source_mismatch',
+    'evidence_mismatch',
+    'publication_gate_blocked',
+  ].includes(code));
+
+  const status: HostedAttestationClaimStatus = blockingReason
+    ? 'blocked'
+    : reasonCodes.includes('insufficient_evidence') || reasonCodes.includes('missing_attestation')
+      ? 'insufficient_evidence'
+      : reasonCodes.includes('missing_source_proof')
+        || reasonCodes.includes('missing_hosted_attestation_proof')
+        || reasonCodes.includes('missing_operator_approval')
+        || reasonCodes.includes('publication_gate_missing')
+        ? 'publication_gate_pending'
+        : 'hosted_attestation_ready';
+
+  const normalizedReasonCodes = unique([
+    ...(status === 'hosted_attestation_ready'
+      ? [
+          'binding_valid' as const,
+          'preview_ready' as const,
+          'hosted_attestation_evidence_present' as const,
+          'operator_approval_present' as const,
+          'publication_gate_present' as const,
+        ]
+      : []),
+    ...reasonCodes,
+    'buyer_facing_claim_disabled' as const,
+    'not_quasar_backed' as const,
+  ]);
+
+  const claim: HostedAttestationClaim = {
+    schemaVersion: HOSTED_ATTESTATION_CLAIM_SCHEMA_VERSION,
+    id: input.id,
+    status,
+    subject: preview?.subject ?? { id: 'unknown', type: 'listing' },
+    source: binding?.source ?? { kind: 'static-fixture', sourceId: 'unknown', fixtureRef: 'unknown' },
+    backing: {
+      claimKind: 'hosted_attestation_backed',
+      attestationKind: binding?.attestation?.trustBoundary ?? 'none',
+      reputationKind: 'offchain_preview',
+      quasarBacking: {
+        status: 'not_quasar_backed',
+        instructionFlow: 'not_built',
+        promotionChecklistIssue: 441,
+      },
+      hostedAttestationBacking: {
+        status: status === 'hosted_attestation_ready' ? 'ready' : status === 'blocked' ? 'blocked' : 'pending',
+        sourceProofRef: input.hostedAttestationProof?.sourceProofRef,
+        attestationProofRef: input.hostedAttestationProof?.attestationProofRef,
+        hostedBy: input.hostedAttestationProof?.hostedBy,
+        operatorApprovalEvidenceRef: input.operatorApproval?.evidenceRef,
+        publicationGateEvidenceRef: input.publicationGate?.evidenceRef,
+        publicationGateIssue: 395,
+      },
+    },
+    evidenceSummary: {
+      ...(preview?.evidenceSummary ?? {
+        bindingId: input.id,
+        receiptId: '',
+        evidenceId: '',
+        evidenceHash: '',
+        evidenceRef: '',
+        paymentProofRef: '',
+      }),
+      previewId: preview?.id ?? '',
+      sourceProofRef: input.hostedAttestationProof?.sourceProofRef,
+      attestationProofRef: input.hostedAttestationProof?.attestationProofRef,
+      operatorApprovalEvidenceRef: input.operatorApproval?.evidenceRef,
+      publicationGateEvidenceRef: input.publicationGate?.evidenceRef,
+    },
+    previewEvent: status === 'hosted_attestation_ready' ? preview.previewEvent : undefined,
+    display: {
+      label: displayLabel(status),
+      explanation: displayExplanation(status),
+      buyerFacingClaimAllowed: false,
+    },
+    reasonCodes: normalizedReasonCodes,
+    guardrails: GUARDRAILS,
+    createdAt: input.createdAt,
+  };
+
+  return status === 'hosted_attestation_ready' ? { ok: true, claim } : { ok: false, claim };
+}
+
+function bindingHasCoreShape(binding: ReceiptEvidenceBinding | undefined): boolean {
+  return Boolean(
+    binding?.receipt
+    && binding.evidence
+    && binding.payment
+    && binding.guardrails
+    && typeof binding.receipt === 'object'
+    && typeof binding.evidence === 'object'
+    && typeof binding.payment === 'object'
+    && typeof binding.guardrails === 'object',
+  );
+}
+
+function previewHasCoreShape(preview: OffchainReputationPreview | undefined): boolean {
+  return Boolean(
+    preview?.evidenceSummary
+    && preview.display
+    && preview.guardrails
+    && preview.backing
+    && typeof preview.evidenceSummary === 'object'
+    && typeof preview.display === 'object'
+    && typeof preview.guardrails === 'object'
+    && typeof preview.backing === 'object',
+  );
+}
+
+function bindingGuardrailsAreSafe(binding: ReceiptEvidenceBinding | undefined): boolean {
+  if (!binding?.guardrails) return false;
+  return binding.guardrails.rawPromptStored === false
+    && binding.guardrails.rawOutputStored === false
+    && binding.guardrails.livePaymentExecuted === false
+    && binding.guardrails.walletSigning === false
+    && binding.guardrails.rpcCall === false
+    && binding.guardrails.hostedRegistryRequired === false
+    && binding.guardrails.reputationMutated === false;
+}
+
+function previewGuardrailsAreSafe(preview: OffchainReputationPreview | undefined): boolean {
+  if (!preview?.guardrails || preview.display?.buyerFacingClaimAllowed !== false) return false;
+  return preview.guardrails.reputationMutated === false
+    && preview.guardrails.quasarInstructionBuilt === false
+    && preview.guardrails.walletSigning === false
+    && preview.guardrails.rpcCall === false
+    && preview.guardrails.hostedRegistryWrite === false
+    && preview.guardrails.marketplacePublished === false
+    && preview.guardrails.livePaymentExecuted === false;
+}
+
+function previewEvidenceMatchesBinding(preview: OffchainReputationPreview | undefined, binding: ReceiptEvidenceBinding | undefined): boolean {
+  if (!preview?.evidenceSummary || !bindingHasCoreShape(binding)) return false;
+  return preview.evidenceSummary.bindingId === binding?.id
+    && preview.evidenceSummary.receiptId === binding.receipt.id
+    && preview.evidenceSummary.evidenceId === binding.evidence.id
+    && preview.evidenceSummary.evidenceHash === binding.evidence.evidenceHash
+    && preview.evidenceSummary.evidenceRef === binding.receipt.evidenceRef
+    && preview.evidenceSummary.paymentProofRef === binding.receipt.paymentProofRef
+    && preview.evidenceSummary.attestationId === binding.attestation?.id
+    && preview.evidenceSummary.reputationEventDraftId === binding.reputationEventDraft?.id;
+}
+
+function previewSourceAndSubjectMatchBinding(
+  preview: OffchainReputationPreview | undefined,
+  binding: ReceiptEvidenceBinding | undefined,
+): boolean {
+  if (!preview || !bindingHasCoreShape(binding)) return false;
+  if (JSON.stringify(preview.source) !== JSON.stringify(binding?.source)) return false;
+  if (binding?.source.kind === 'hosted-rap-registry') {
+    return preview.subject.id === binding.source.listingId
+      && preview.previewEvent?.subjectId === binding.source.listingId;
+  }
+  return false;
+}
+
+function operatorApprovalIsPresent(approval: HostedAttestationOperatorApproval | undefined): boolean {
+  return approval?.approved === true && isNonEmptyString(approval.evidenceRef);
+}
+
+function hostedAttestationBoundaryIsSupported(
+  trustBoundary: NonNullable<ReceiptEvidenceBinding['attestation']>['trustBoundary'],
+): boolean {
+  return trustBoundary === 'reddi_attested' || trustBoundary === 'verified';
+}
+
+function hostedAttestationProofIsPresent(proof: HostedAttestationProofRef | undefined): boolean {
+  return proof?.hostedBy === 'reddi'
+    && isNonEmptyString(proof.sourceProofRef)
+    && isNonEmptyString(proof.attestationProofRef);
+}
+
+function displayLabel(status: HostedAttestationClaimStatus): HostedAttestationClaim['display']['label'] {
+  if (status === 'hosted_attestation_ready') return 'Hosted attestation ready';
+  if (status === 'publication_gate_pending') return 'Publication gate pending';
+  if (status === 'insufficient_evidence') return 'Insufficient evidence';
+  return 'Blocked';
+}
+
+function displayExplanation(status: HostedAttestationClaimStatus): string {
+  if (status === 'hosted_attestation_ready') {
+    return 'Hosted attestation evidence is ready for downstream publication gates, but buyer-facing claims remain disabled until #395 permits them.';
+  }
+  if (status === 'publication_gate_pending') {
+    return 'The preview has evidence, but hosted publication/operator gate metadata is not complete.';
+  }
+  if (status === 'insufficient_evidence') {
+    return 'The binding or preview is missing attestation or reputation evidence required for a hosted-backed claim.';
+  }
+  return 'The binding or preview failed a safety gate and cannot produce a hosted-backed claim.';
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function unique<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -13,3 +13,4 @@ export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';
 export * from './quasar-registry-compatibility.js';
+export * from './hosted-attestation-claim.js';

--- a/packages/agent-protocol/tests/hosted-attestation-claim.test.ts
+++ b/packages/agent-protocol/tests/hosted-attestation-claim.test.ts
@@ -1,0 +1,524 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  deriveHostedAttestationClaim,
+  type HostedAttestationClaimInput,
+  type OffchainReputationPreview,
+  type ReceiptEvidenceBinding,
+} from '../dist/index.js';
+
+const createdAt = '2026-06-20T03:40:00.000Z';
+
+function binding(overrides: Partial<ReceiptEvidenceBinding> = {}): ReceiptEvidenceBinding {
+  return {
+    schemaVersion: 'reddi.receipt-evidence-binding.v1',
+    id: 'binding:hosted-attestation:ready',
+    source: {
+      kind: 'hosted-rap-registry',
+      sourceId: 'source:hosted-attestation:ready',
+      catalogRef: '/.well-known/ai-catalog.json',
+      listingId: 'listing:hosted-attestation-ready',
+      rawSnapshotRef: 'sha256:hosted-attestation-source-snapshot',
+    },
+    receipt: {
+      id: 'job:hosted-attestation:ready',
+      sourceId: 'source:hosted-attestation:ready',
+      policyDecision: {
+        schemaVersion: 'reddi.policy-decision.v1',
+        allowed: true,
+        reasonCodes: ['allowed'],
+        quotedAmount: {
+          amount: '2500000',
+          asset: 'AUDD',
+          network: 'solana-devnet',
+          source: 'source:hosted-attestation:ready',
+          specialist: 'listing:hosted-attestation-ready',
+        },
+        approvalState: 'approved',
+        asset: 'AUDD',
+        network: 'solana-devnet',
+        auditNotes: ['Allowed by hosted attestation fixture.'],
+      },
+      paymentProofRef: 'dry-run:audd-proof:hosted-attestation-ready',
+      requestHash: 'sha256:request-hosted-attestation-ready',
+      responseHash: 'sha256:response-hosted-attestation-ready',
+      evidenceRef: 'file://fixtures/evidence/hosted-attestation-ready.json',
+      attestationStatus: 'attested',
+    },
+    evidence: {
+      id: 'evidence:hosted-attestation:ready',
+      receiptId: 'job:hosted-attestation:ready',
+      evidenceRef: 'file://fixtures/evidence/hosted-attestation-ready.json',
+      evidenceHash: 'sha256:evidence-hosted-attestation-ready',
+    },
+    payment: {
+      preflightAllowed: true,
+      reasonCodes: ['audd_payment_plan_allowed'],
+      paymentProofRef: 'dry-run:audd-proof:hosted-attestation-ready',
+      planRef: {
+        asset: 'AUDD',
+        network: 'solana-devnet',
+        amount: '2500000',
+        paymentMode: 'dry-run',
+        evidenceRequired: true,
+      },
+    },
+    attestation: {
+      id: 'attestation:hosted-attestation:ready',
+      status: 'attested',
+      verdict: 'passed',
+      trustBoundary: 'reddi_attested',
+    },
+    reputationEventDraft: {
+      schemaVersion: 'reddi.reputation-event.v1',
+      id: 'reputation:hosted-attestation:ready',
+      subjectId: 'listing:hosted-attestation-ready',
+      receiptId: 'job:hosted-attestation:ready',
+      evidenceId: 'evidence:hosted-attestation:ready',
+      attestationId: 'attestation:hosted-attestation:ready',
+      verdict: 'passed',
+      workStatus: 'completed',
+      trustBoundary: 'reddi_attested',
+      confidence: 92,
+      rubricScore: 92,
+      delta: 7,
+      previousScore: 50,
+      nextScore: 57,
+      routingImpact: 'eligible',
+      reasonCodes: ['attestation_passed'],
+      createdAt,
+    },
+    guardrails: {
+      rawPromptStored: false,
+      rawOutputStored: false,
+      livePaymentExecuted: false,
+      walletSigning: false,
+      rpcCall: false,
+      hostedRegistryRequired: false,
+      reputationMutated: false,
+    },
+    createdAt,
+    ...overrides,
+  };
+}
+
+function preview(bindingValue = binding(), overrides: Partial<OffchainReputationPreview> = {}): OffchainReputationPreview {
+  return {
+    schemaVersion: 'reddi.offchain-reputation-preview.v1',
+    id: 'preview:hosted-attestation:ready',
+    subject: { id: 'listing:hosted-attestation-ready', type: 'listing' },
+    source: bindingValue.source,
+    status: 'preview_ready',
+    backing: {
+      reputationKind: 'offchain_preview',
+      attestationKind: 'reddi_attested',
+      quasarBacking: {
+        status: 'compatibility_pending',
+        compatibilityIssue: 390,
+        instructionFlow: 'not_built',
+      },
+      hostedAttestationBacking: 'not_published',
+    },
+    evidenceSummary: {
+      bindingId: bindingValue.id,
+      receiptId: bindingValue.receipt.id,
+      evidenceId: bindingValue.evidence.id,
+      evidenceHash: bindingValue.evidence.evidenceHash,
+      evidenceRef: bindingValue.receipt.evidenceRef,
+      paymentProofRef: bindingValue.receipt.paymentProofRef,
+      attestationId: bindingValue.attestation?.id,
+      reputationEventDraftId: bindingValue.reputationEventDraft?.id,
+    },
+    previewEvent: bindingValue.reputationEventDraft,
+    display: {
+      label: 'Off-chain preview',
+      explanation: 'Preview only.',
+      buyerFacingClaimAllowed: false,
+    },
+    reasonCodes: [
+      'binding_valid',
+      'offchain_preview_only',
+      'quasar_compatibility_pending',
+      'buyer_facing_claim_disabled',
+    ],
+    guardrails: {
+      reputationMutated: false,
+      quasarInstructionBuilt: false,
+      walletSigning: false,
+      rpcCall: false,
+      hostedRegistryWrite: false,
+      marketplacePublished: false,
+      livePaymentExecuted: false,
+    },
+    createdAt,
+    ...overrides,
+  };
+}
+
+function validInput(overrides: Partial<HostedAttestationClaimInput> = {}): HostedAttestationClaimInput {
+  const bindingValue = binding();
+  return {
+    id: 'hosted-claim:hosted-attestation:ready',
+    binding: bindingValue,
+    preview: preview(bindingValue),
+    hostedAttestationProof: {
+      sourceProofRef: 'source-proof:hosted-attestation-ready',
+      attestationProofRef: 'hosted-attestation-proof:hosted-attestation-ready',
+      hostedBy: 'reddi',
+      reviewedAt: createdAt,
+    },
+    operatorApproval: {
+      approved: true,
+      evidenceRef: 'operator-approval:hosted-attestation-ready',
+      approvedAt: createdAt,
+    },
+    publicationGate: {
+      issue: 395,
+      state: 'claim_contract_ready',
+      evidenceRef: 'publication-gate:hosted-attestation-ready',
+      reviewedAt: createdAt,
+    },
+    createdAt,
+    ...overrides,
+  };
+}
+
+describe('hosted attestation-backed reputation claim', () => {
+  it('derives a hosted-backed claim from binding and preview without enabling buyer-facing claims', () => {
+    const result = deriveHostedAttestationClaim(validInput());
+
+    assert.equal(result.ok, true);
+    assert.equal(result.claim.schemaVersion, 'reddi.hosted-attestation-claim.v1');
+    assert.equal(result.claim.status, 'hosted_attestation_ready');
+    assert.equal(result.claim.backing.claimKind, 'hosted_attestation_backed');
+    assert.equal(result.claim.backing.attestationKind, 'reddi_attested');
+    assert.equal(result.claim.backing.hostedAttestationBacking.status, 'ready');
+    assert.equal(result.claim.backing.hostedAttestationBacking.sourceProofRef, 'source-proof:hosted-attestation-ready');
+    assert.equal(result.claim.backing.hostedAttestationBacking.attestationProofRef, 'hosted-attestation-proof:hosted-attestation-ready');
+    assert.equal(result.claim.backing.hostedAttestationBacking.hostedBy, 'reddi');
+    assert.equal(result.claim.backing.hostedAttestationBacking.publicationGateIssue, 395);
+    assert.equal(result.claim.evidenceSummary.sourceProofRef, 'source-proof:hosted-attestation-ready');
+    assert.equal(result.claim.evidenceSummary.attestationProofRef, 'hosted-attestation-proof:hosted-attestation-ready');
+    assert.equal(result.claim.backing.quasarBacking.status, 'not_quasar_backed');
+    assert.equal(result.claim.backing.quasarBacking.instructionFlow, 'not_built');
+    assert.equal(result.claim.backing.quasarBacking.promotionChecklistIssue, 441);
+    assert.equal(result.claim.display.buyerFacingClaimAllowed, false);
+    assert.equal(result.claim.previewEvent?.id, 'reputation:hosted-attestation:ready');
+    assert.ok(result.claim.reasonCodes.includes('operator_approval_present'));
+    assert.ok(result.claim.reasonCodes.includes('publication_gate_present'));
+    assert.deepEqual(result.claim.guardrails, {
+      reputationMutated: false,
+      quasarInstructionBuilt: false,
+      walletSigning: false,
+      rpcCall: false,
+      hostedRegistryWrite: false,
+      marketplacePublished: false,
+      livePaymentExecuted: false,
+      providerCall: false,
+    });
+  });
+
+  it('keeps otherwise valid evidence pending without operator approval or publication-gate metadata', () => {
+    const result = deriveHostedAttestationClaim(validInput({
+      operatorApproval: undefined,
+      publicationGate: undefined,
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'publication_gate_pending');
+    assert.ok(result.claim.reasonCodes.includes('missing_operator_approval'));
+    assert.ok(result.claim.reasonCodes.includes('publication_gate_missing'));
+    assert.equal(result.claim.display.buyerFacingClaimAllowed, false);
+    assert.equal(result.claim.previewEvent, undefined);
+  });
+
+  it('requires operator approval independently from publication metadata', () => {
+    const result = deriveHostedAttestationClaim(validInput({
+      operatorApproval: undefined,
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'publication_gate_pending');
+    assert.ok(result.claim.reasonCodes.includes('missing_operator_approval'));
+    assert.ok(!result.claim.reasonCodes.includes('publication_gate_missing'));
+    assert.equal(result.claim.display.buyerFacingClaimAllowed, false);
+  });
+
+  it('requires #395 publication metadata independently from operator approval', () => {
+    const result = deriveHostedAttestationClaim(validInput({
+      publicationGate: undefined,
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'publication_gate_pending');
+    assert.ok(result.claim.reasonCodes.includes('publication_gate_missing'));
+    assert.ok(!result.claim.reasonCodes.includes('missing_operator_approval'));
+    assert.equal(result.claim.display.buyerFacingClaimAllowed, false);
+  });
+
+  it('keeps malformed publication metadata pending or blocked', () => {
+    const wrongIssue = deriveHostedAttestationClaim(validInput({
+      publicationGate: {
+        issue: 394 as 395,
+        state: 'claim_contract_ready',
+        evidenceRef: 'publication-gate:wrong-issue',
+      },
+    }));
+    const missingEvidence = deriveHostedAttestationClaim(validInput({
+      publicationGate: {
+        issue: 395,
+        state: 'claim_contract_ready',
+        evidenceRef: ' ',
+      },
+    }));
+    const pendingGate = deriveHostedAttestationClaim(validInput({
+      publicationGate: {
+        issue: 395,
+        state: 'pending',
+        evidenceRef: 'publication-gate:pending',
+      },
+    }));
+    const blockedGate = deriveHostedAttestationClaim(validInput({
+      publicationGate: {
+        issue: 395,
+        state: 'blocked',
+        evidenceRef: 'publication-gate:blocked',
+      },
+    }));
+
+    assert.equal(wrongIssue.ok, false);
+    assert.equal(wrongIssue.claim.status, 'publication_gate_pending');
+    assert.ok(wrongIssue.claim.reasonCodes.includes('publication_gate_missing'));
+    assert.equal(missingEvidence.ok, false);
+    assert.equal(missingEvidence.claim.status, 'publication_gate_pending');
+    assert.ok(missingEvidence.claim.reasonCodes.includes('publication_gate_missing'));
+    assert.equal(pendingGate.ok, false);
+    assert.equal(pendingGate.claim.status, 'publication_gate_pending');
+    assert.ok(pendingGate.claim.reasonCodes.includes('publication_gate_missing'));
+    assert.equal(blockedGate.ok, false);
+    assert.equal(blockedGate.claim.status, 'blocked');
+    assert.ok(blockedGate.claim.reasonCodes.includes('publication_gate_blocked'));
+  });
+
+  it('keeps imported metadata pending when hosted source proof is missing', () => {
+    const result = deriveHostedAttestationClaim(validInput({
+      hostedAttestationProof: undefined,
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'publication_gate_pending');
+    assert.ok(result.claim.reasonCodes.includes('missing_source_proof'));
+    assert.ok(result.claim.reasonCodes.includes('missing_hosted_attestation_proof'));
+    assert.equal(result.claim.display.buyerFacingClaimAllowed, false);
+    assert.equal(result.claim.previewEvent, undefined);
+  });
+
+  it('keeps partial hosted proof metadata pending', () => {
+    const missingSource = deriveHostedAttestationClaim(validInput({
+      hostedAttestationProof: {
+        sourceProofRef: ' ',
+        attestationProofRef: 'hosted-attestation-proof:present',
+        hostedBy: 'reddi',
+      },
+    }));
+    const missingAttestationProof = deriveHostedAttestationClaim(validInput({
+      hostedAttestationProof: {
+        sourceProofRef: 'source-proof:present',
+        attestationProofRef: ' ',
+        hostedBy: 'reddi',
+      },
+    }));
+    const wrongHost = deriveHostedAttestationClaim(validInput({
+      hostedAttestationProof: {
+        sourceProofRef: 'source-proof:present',
+        attestationProofRef: 'hosted-attestation-proof:present',
+        hostedBy: 'external' as 'reddi',
+      },
+    }));
+
+    assert.equal(missingSource.ok, false);
+    assert.equal(missingSource.claim.status, 'publication_gate_pending');
+    assert.ok(missingSource.claim.reasonCodes.includes('missing_source_proof'));
+    assert.ok(missingSource.claim.reasonCodes.includes('missing_hosted_attestation_proof'));
+    assert.equal(missingAttestationProof.ok, false);
+    assert.equal(missingAttestationProof.claim.status, 'publication_gate_pending');
+    assert.ok(missingAttestationProof.claim.reasonCodes.includes('missing_hosted_attestation_proof'));
+    assert.equal(wrongHost.ok, false);
+    assert.equal(wrongHost.claim.status, 'publication_gate_pending');
+    assert.ok(wrongHost.claim.reasonCodes.includes('missing_hosted_attestation_proof'));
+  });
+
+  it('keeps insufficient preview evidence from becoming a hosted-backed claim', () => {
+    const bindingValue = binding({ attestation: undefined, reputationEventDraft: undefined });
+    const result = deriveHostedAttestationClaim(validInput({
+      binding: bindingValue,
+      preview: preview(bindingValue, {
+        status: 'insufficient_evidence',
+        evidenceSummary: {
+          ...preview(bindingValue).evidenceSummary,
+          attestationId: undefined,
+          reputationEventDraftId: undefined,
+        },
+        previewEvent: undefined,
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'insufficient_evidence');
+    assert.ok(result.claim.reasonCodes.includes('insufficient_evidence'));
+    assert.ok(result.claim.reasonCodes.includes('missing_attestation'));
+    assert.equal(result.claim.backing.hostedAttestationBacking.status, 'pending');
+    assert.equal(result.claim.backing.attestationKind, 'none');
+  });
+
+  it('blocks static or self-attested imported data from becoming hosted-ready', () => {
+    const importedBinding = binding({
+      source: {
+        kind: 'static-fixture',
+        sourceId: 'source:imported-static',
+        fixtureRef: 'fixtures/imported-static.json',
+      },
+      attestation: {
+        ...binding().attestation!,
+        trustBoundary: 'self_attested',
+      },
+      reputationEventDraft: {
+        ...binding().reputationEventDraft!,
+        trustBoundary: 'self_attested',
+      },
+    });
+    const result = deriveHostedAttestationClaim(validInput({
+      binding: importedBinding,
+      preview: preview(importedBinding, {
+        source: importedBinding.source,
+        previewEvent: importedBinding.reputationEventDraft,
+      }),
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'blocked');
+    assert.ok(result.claim.reasonCodes.includes('source_not_hosted'));
+    assert.ok(result.claim.reasonCodes.includes('attestation_not_hosted_backed'));
+    assert.equal(result.claim.display.buyerFacingClaimAllowed, false);
+    assert.equal(result.claim.previewEvent, undefined);
+  });
+
+  it('blocks preview source or subject mismatches from becoming hosted-ready', () => {
+    const bindingValue = binding();
+    const wrongSubject = deriveHostedAttestationClaim(validInput({
+      binding: bindingValue,
+      preview: preview(bindingValue, {
+        subject: { id: 'listing:other', type: 'listing' },
+      }),
+    }));
+    const wrongPreviewEventSubject = deriveHostedAttestationClaim(validInput({
+      binding: bindingValue,
+      preview: preview(bindingValue, {
+        previewEvent: {
+          ...bindingValue.reputationEventDraft!,
+          subjectId: 'listing:other',
+        },
+      }),
+    }));
+    const wrongSource = deriveHostedAttestationClaim(validInput({
+      binding: bindingValue,
+      preview: preview(bindingValue, {
+        source: {
+          ...bindingValue.source,
+          sourceId: 'source:other',
+        },
+      }),
+    }));
+
+    assert.equal(wrongSubject.ok, false);
+    assert.equal(wrongSubject.claim.status, 'blocked');
+    assert.ok(wrongSubject.claim.reasonCodes.includes('source_mismatch'));
+    assert.equal(wrongPreviewEventSubject.ok, false);
+    assert.equal(wrongPreviewEventSubject.claim.status, 'blocked');
+    assert.ok(wrongPreviewEventSubject.claim.reasonCodes.includes('source_mismatch'));
+    assert.equal(wrongSource.ok, false);
+    assert.equal(wrongSource.claim.status, 'blocked');
+    assert.ok(wrongSource.claim.reasonCodes.includes('source_mismatch'));
+  });
+
+  it('blocks failed attestations and blocked publication gates', () => {
+    const bindingValue = binding({
+      receipt: { ...binding().receipt, attestationStatus: 'failed' },
+      attestation: { ...binding().attestation!, verdict: 'failed', status: 'failed' },
+    });
+    const result = deriveHostedAttestationClaim(validInput({
+      binding: bindingValue,
+      preview: preview(bindingValue, { status: 'blocked' }),
+      publicationGate: {
+        issue: 395,
+        state: 'blocked',
+        evidenceRef: 'publication-gate:blocked',
+      },
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'blocked');
+    assert.ok(result.claim.reasonCodes.includes('attestation_not_passed'));
+    assert.ok(result.claim.reasonCodes.includes('preview_not_ready'));
+    assert.ok(result.claim.reasonCodes.includes('publication_gate_blocked'));
+  });
+
+  it('blocks mismatched evidence summaries and unsafe live guardrails', () => {
+    const result = deriveHostedAttestationClaim(validInput({
+      preview: preview(binding(), {
+        evidenceSummary: {
+          ...preview(binding()).evidenceSummary,
+          evidenceHash: 'sha256:tampered',
+        },
+      }),
+      binding: {
+        ...binding(),
+        guardrails: { ...binding().guardrails, rpcCall: true },
+      } as unknown as ReceiptEvidenceBinding,
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'blocked');
+    assert.ok(result.claim.reasonCodes.includes('evidence_mismatch'));
+    assert.ok(result.claim.reasonCodes.includes('unsafe_live_guardrail'));
+    assert.equal(result.claim.guardrails.rpcCall, false);
+  });
+
+  it('blocks buyer-facing or hosted-backed claims spoofed through imported preview metadata', () => {
+    const bindingValue = binding();
+    const result = deriveHostedAttestationClaim(validInput({
+      binding: bindingValue,
+      preview: {
+        ...preview(bindingValue),
+        backing: {
+          ...preview(bindingValue).backing,
+          hostedAttestationBacking: 'published' as 'not_published',
+        },
+        display: {
+          ...preview(bindingValue).display,
+          buyerFacingClaimAllowed: true as false,
+        },
+      },
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'blocked');
+    assert.ok(result.claim.reasonCodes.includes('unsafe_live_guardrail'));
+    assert.equal(result.claim.display.buyerFacingClaimAllowed, false);
+    assert.equal(result.claim.previewEvent, undefined);
+  });
+
+  it('fails closed for malformed schema-compatible input without throwing', () => {
+    const result = deriveHostedAttestationClaim(validInput({
+      binding: {
+        schemaVersion: 'reddi.receipt-evidence-binding.v1',
+        id: 'binding:malformed',
+        source: binding().source,
+      } as unknown as ReceiptEvidenceBinding,
+    }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.claim.status, 'blocked');
+    assert.ok(result.claim.reasonCodes.includes('malformed_binding'));
+  });
+});


### PR DESCRIPTION
Closes #442.

## Summary
- Add `reddi.hosted-attestation-claim.v1` package primitive.
- Derive hosted-attestation-backed claim readiness from #393 receipt/evidence bindings plus #394 off-chain reputation previews.
- Require explicit hosted source/attestation proof refs, operator approval evidence, and #395 publication-gate metadata before `hosted_attestation_ready`.
- Keep buyer-facing trust/reputation claims disabled; this is a read-model contract for downstream #395 publication gates, not publication itself.

## Guardrails
- No reputation mutation.
- No Quasar instruction building.
- No wallet signing, RPC, Surfpool/devnet, deploy, hosted registry write, marketplace publication, live payment, provider/MCP call, or fetch.
- Missing hosted proof/operator approval/#395 metadata remains `publication_gate_pending`.
- Malformed, failed, disputed/refunded, mismatched, unsafe, or blocked evidence fails closed.

## Validation
- `npm test` in `packages/agent-protocol`: 130/130 passed
- `npm run release:dry-run` in `packages/agent-protocol`: passed
- `git diff --check`: passed
- `npm run check:rap:naming`: passed
- Focused side-effect scan found no forbidden live imports/calls; only expected false guardrails and one negative test fixture with `rpcCall: true`.

## UI Evidence
Not applicable: package/read-model only, no UI files changed.

## Surfpool / Devnet
Not applicable under #441: no instruction builder, program, wallet/RPC, or deploy path changed.
