### PR TITLE
Add marketplace publication eligibility matrix

### DIFF
--- a/lib/__tests__/manager-marketplace-public-export.test.ts
+++ b/lib/__tests__/manager-marketplace-public-export.test.ts
@@ -8,34 +8,12 @@ import {
   deriveMarketplacePublicExportItem,
   deriveMarketplacePublicExportSnapshot,
 } from "@/lib/manager/marketplace-public-export";
-import type { MarketplaceReadinessProofMetadata } from "@/lib/manager/marketplace-readiness-gate";
+import { fixturePublishReadyProof as publishReadyProof } from "@/lib/manager/marketplace-public-export-fixtures";
 import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
 import { validateAiCatalog } from "@reddi/agent-protocol/ai-catalog";
 
 const timestamp = "2026-06-20T00:00:00Z";
 const operatorId = "operator:test";
-
-const publishReadyProof: MarketplaceReadinessProofMetadata = {
-  endpointBindingRef: "endpoint-binding:anthropic-financial-services:dry-run",
-  paymentPlan: {
-    schemaVersion: "marketplace-payment-plan-proof:v1",
-    planId: "plan:anthropic-financial-services:dry-run",
-    currency: "USD",
-    amount: 0,
-    activation: "disabled",
-    settlement: "dry_run_only",
-    evidenceRef: "evidence:payment-plan:dry-run",
-  },
-  dryRunReceiptRefs: ["receipt:dry-run:approve-ready"],
-  evidenceRefs: ["evidence:static-review:approve-ready"],
-  attestationDraftRef: "attestation-draft:approve-ready",
-  operatorApproval: {
-    approved: true,
-    approvedBy: operatorId,
-    approvedAt: timestamp,
-    evidenceRef: "evidence:operator-approval:approve-ready",
-  },
-};
 
 describe("manager marketplace public export", () => {
   it("exports a published listing into hosted and ARD-compatible catalog snapshots", () => {

--- a/lib/__tests__/manager-marketplace-publication-eligibility.test.ts
+++ b/lib/__tests__/manager-marketplace-publication-eligibility.test.ts
@@ -1,0 +1,263 @@
+import {
+  applyMarketplaceApprovalAction,
+  type MarketplaceApprovalAction,
+  type MarketplaceApprovalRecord,
+  type MarketplaceApprovalRecordState,
+} from "@/lib/manager/marketplace-approval-actions";
+import {
+  deriveMarketplacePublicationEligibility,
+  type MarketplacePublicationEligibilityProof,
+} from "@/lib/manager/marketplace-publication-eligibility";
+import { fixturePublishReadyProof } from "@/lib/manager/marketplace-public-export-fixtures";
+import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
+
+const timestamp = "2026-06-20T00:00:00Z";
+const operatorId = "operator:test";
+
+describe("marketplace publication eligibility matrix", () => {
+  it("marks a reviewed published listing eligible without activating live publication", () => {
+    const record = publishedRecord();
+    const decision = deriveMarketplacePublicationEligibility(record, fixturePublishReadyProof);
+
+    expect(decision).toMatchObject({
+      schemaVersion: "reddi.marketplace-publication-eligibility.v1",
+      status: "eligible",
+      reasonCodes: ["eligible"],
+      claimSources: {
+        paymentProof: "readiness_proof",
+        receiptEvidence: "readiness_proof",
+        hostedAttestation: "hosted_attestation_claim",
+        quasarCompatibility: "metadata_only",
+        discoveryRelevance: "separate_from_trust",
+      },
+      boundaries: {
+        publicationAllowed: true,
+        hostedExportAllowed: true,
+        ardCatalogExportAllowed: true,
+        livePublicationActivated: false,
+        paymentActivationAllowed: false,
+        trustClaimAllowed: false,
+        reputationClaimAllowed: false,
+        discoveryRelevanceIsTrust: false,
+      },
+    });
+    expect(decision.evidenceRefs).toEqual(expect.arrayContaining([
+      "evidence:operator-action:publish",
+      "evidence:operator-approval:approve-ready",
+      "source-proof:approve-ready",
+      "hosted-attestation-proof:approve-ready",
+      "quasar-compatibility:metadata-only",
+    ]));
+  });
+
+  it.each([
+    ["approved but unpublished", recordFor("approved", "approveReadyDraft", false), fixturePublishReadyProof, "record_state_not_published"],
+    ["not public visible", { ...publishedRecord(), publicVisible: false }, fixturePublishReadyProof, "public_visibility_false"],
+    ["missing audit evidence", { ...publishedRecord(), auditHistory: [] }, fixturePublishReadyProof, "publish_audit_missing"],
+    ["blocked readiness", publishedRecord(), {}, "readiness_not_publish_ready"],
+    ["dry-run only readiness", publishedRecord(), { ...fixturePublishReadyProof, operatorApproval: undefined }, "readiness_not_publish_ready"],
+    ["missing endpoint binding", publishedRecord(), { ...fixturePublishReadyProof, endpointBindingRef: undefined }, "endpoint_binding_missing"],
+    ["missing payment proof", publishedRecord(), { ...fixturePublishReadyProof, paymentPlan: undefined }, "payment_proof_missing"],
+    ["missing receipt evidence", publishedRecord(), { ...fixturePublishReadyProof, dryRunReceiptRefs: [], evidenceRefs: [] }, "receipt_evidence_missing"],
+    ["missing hosted attestation", publishedRecord(), { ...fixturePublishReadyProof, hostedAttestationClaim: undefined }, "hosted_attestation_missing"],
+    [
+      "hosted attestation not ready",
+      publishedRecord(),
+      {
+        ...fixturePublishReadyProof,
+        hostedAttestationClaim: {
+          ...fixturePublishReadyProof.hostedAttestationClaim!,
+          status: "publication_gate_pending",
+        },
+      },
+      "hosted_attestation_not_ready",
+    ],
+    ["missing Quasar compatibility", publishedRecord(), { ...fixturePublishReadyProof, quasarCompatibility: undefined }, "missing_quasar_compatibility"],
+    [
+      "blocked Quasar compatibility",
+      publishedRecord(),
+      {
+        ...fixturePublishReadyProof,
+        quasarCompatibility: {
+          ...fixturePublishReadyProof.quasarCompatibility!,
+          status: "blocked",
+        },
+      },
+      "quasar_compatibility_blocked",
+    ],
+    [
+      "unsafe metadata",
+      publishedUnsafeRecord(),
+      fixturePublishReadyProof,
+      "unsafe_metadata",
+    ],
+    [
+      "suspended state",
+      recordFor("suspended", "approveReadyDraft", false),
+      fixturePublishReadyProof,
+      "suspended_or_unpublished_state",
+    ],
+  ] as Array<[string, MarketplaceApprovalRecord, MarketplacePublicationEligibilityProof, string]>)(
+    "blocks %s",
+    (_label, record, proof, reasonCode) => {
+      const decision = deriveMarketplacePublicationEligibility(record, proof);
+
+      expect(decision.status).toBe("blocked");
+      expect(decision.reasonCodes).toContain(reasonCode);
+      expect(decision.boundaries.hostedExportAllowed).toBe(false);
+      expect(decision.boundaries.ardCatalogExportAllowed).toBe(false);
+      expect(decision.boundaries.livePublicationActivated).toBe(false);
+      expect(decision.boundaries.trustClaimAllowed).toBe(false);
+      expect(decision.boundaries.reputationClaimAllowed).toBe(false);
+      expect(decision.claimSources.discoveryRelevance).toBe("separate_from_trust");
+    },
+  );
+
+  it.each([
+    [
+      "buyer-facing hosted claim",
+      {
+        ...fixturePublishReadyProof,
+        hostedAttestationClaim: {
+          ...fixturePublishReadyProof.hostedAttestationClaim!,
+          display: {
+            ...fixturePublishReadyProof.hostedAttestationClaim!.display,
+            buyerFacingClaimAllowed: true as false,
+          },
+        },
+      },
+      "hosted_claim_buyer_facing_enabled",
+    ],
+    [
+      "hosted claim guardrail escalation",
+      {
+        ...fixturePublishReadyProof,
+        hostedAttestationClaim: {
+          ...fixturePublishReadyProof.hostedAttestationClaim!,
+          guardrails: {
+            ...fixturePublishReadyProof.hostedAttestationClaim!.guardrails,
+            rpcCall: true as false,
+          },
+        },
+      },
+      "hosted_claim_guardrail_escalation",
+    ],
+    [
+      "hosted claim source proof mismatch",
+      {
+        ...fixturePublishReadyProof,
+        hostedAttestationClaim: {
+          ...fixturePublishReadyProof.hostedAttestationClaim!,
+          evidenceSummary: {
+            ...fixturePublishReadyProof.hostedAttestationClaim!.evidenceSummary,
+            sourceProofRef: "source-proof:other-listing",
+          },
+        },
+      },
+      "hosted_claim_evidence_mismatch",
+    ],
+    [
+      "hosted claim operator evidence mismatch",
+      {
+        ...fixturePublishReadyProof,
+        hostedAttestationClaim: {
+          ...fixturePublishReadyProof.hostedAttestationClaim!,
+          evidenceSummary: {
+            ...fixturePublishReadyProof.hostedAttestationClaim!.evidenceSummary,
+            operatorApprovalEvidenceRef: "evidence:operator-approval:other-listing",
+          },
+        },
+      },
+      "hosted_claim_operator_evidence_mismatch",
+    ],
+  ] as Array<[string, MarketplacePublicationEligibilityProof, string]>)(
+    "blocks %s",
+    (_label, proof, reasonCode) => {
+      const decision = deriveMarketplacePublicationEligibility(publishedRecord(), proof);
+
+      expect(decision.status).toBe("blocked");
+      expect(decision.reasonCodes).toContain(reasonCode);
+      expect(decision.boundaries.hostedExportAllowed).toBe(false);
+      expect(decision.boundaries.trustClaimAllowed).toBe(false);
+      expect(decision.boundaries.reputationClaimAllowed).toBe(false);
+    },
+  );
+
+  it("blocks live escalation or Quasar-backed claims", () => {
+    const decision = deriveMarketplacePublicationEligibility(publishedRecord(), {
+      ...fixturePublishReadyProof,
+      boundaryClaims: { walletSigningAllowed: true },
+      quasarCompatibility: {
+        ...fixturePublishReadyProof.quasarCompatibility!,
+        quasarBackedClaimAllowed: true as false,
+        instructionBuilt: true as false,
+      },
+    });
+
+    expect(decision.status).toBe("blocked");
+    expect(decision.reasonCodes).toEqual(expect.arrayContaining([
+      "live_escalation_not_allowed",
+      "quasar_backed_claim_not_allowed",
+      "quasar_instruction_built",
+    ]));
+    expect(decision.boundaries.walletSigningAllowed).toBe(false);
+    expect(decision.boundaries.reputationClaimAllowed).toBe(false);
+  });
+});
+
+function action(
+  type: MarketplaceApprovalAction["type"],
+  overrides: Partial<MarketplaceApprovalAction> = {},
+): MarketplaceApprovalAction {
+  return {
+    type,
+    operatorId,
+    timestamp,
+    ...overrides,
+  };
+}
+
+function publishedRecord() {
+  const approve = applyMarketplaceApprovalAction(recordFor("draft", "approveReadyDraft"), action("approve"));
+  if (!approve.ok) throw new Error(approve.reason);
+
+  const publish = applyMarketplaceApprovalAction(approve.record, action("publish", {
+    readinessProof: fixturePublishReadyProof,
+    evidenceRefs: ["evidence:operator-action:publish"],
+  }));
+  if (!publish.ok) throw new Error(publish.reason);
+
+  return publish.record;
+}
+
+function publishedUnsafeRecord() {
+  return {
+    ...recordFor("published", "rejectedMalformedConnector", true),
+    auditHistory: [{
+      operatorId,
+      action: "publish" as const,
+      reason: "Forged publish evidence.",
+      timestamp,
+      previousState: "approved" as const,
+      nextState: "published" as const,
+      evidenceRefs: ["evidence:forged:publish"],
+    }],
+  };
+}
+
+function recordFor(
+  state: MarketplaceApprovalRecordState,
+  fixtureKey: string,
+  publicVisible = false,
+): MarketplaceApprovalRecord {
+  const candidate = getStaticAgentStackReviewWorkspace().candidates.find((item) => item.fixtureKey === fixtureKey);
+  if (!candidate) throw new Error(`missing fixture candidate: ${fixtureKey}`);
+  return {
+    id: `${state}:${fixtureKey}`,
+    fixtureKey,
+    candidate,
+    state,
+    publicVisible,
+    auditHistory: [],
+  };
+}

--- a/lib/manager/marketplace-public-export-fixtures.ts
+++ b/lib/manager/marketplace-public-export-fixtures.ts
@@ -8,13 +8,13 @@ import {
   deriveMarketplacePublicExportSnapshot,
   type MarketplacePublicExportSnapshot,
 } from "@/lib/manager/marketplace-public-export";
-import type { MarketplaceReadinessProofMetadata } from "@/lib/manager/marketplace-readiness-gate";
+import type { MarketplacePublicationEligibilityProof } from "@/lib/manager/marketplace-publication-eligibility";
 import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
 
 const fixtureTimestamp = "2026-06-20T00:00:00Z";
 const fixtureOperatorId = "operator:fixture";
 
-export const fixturePublishReadyProof: MarketplaceReadinessProofMetadata = {
+export const fixturePublishReadyProof: MarketplacePublicationEligibilityProof = {
   endpointBindingRef: "endpoint-binding:anthropic-financial-services:dry-run",
   paymentPlan: {
     schemaVersion: "marketplace-payment-plan-proof:v1",
@@ -26,13 +26,101 @@ export const fixturePublishReadyProof: MarketplaceReadinessProofMetadata = {
     evidenceRef: "evidence:payment-plan:dry-run",
   },
   dryRunReceiptRefs: ["receipt:dry-run:approve-ready"],
-  evidenceRefs: ["evidence:static-review:approve-ready"],
+  evidenceRefs: [
+    "evidence:static-review:approve-ready",
+    "source-proof:approve-ready",
+    "hosted-attestation-proof:approve-ready",
+    "publication-gate:approve-ready",
+  ],
   attestationDraftRef: "attestation-draft:approve-ready",
   operatorApproval: {
     approved: true,
     approvedBy: fixtureOperatorId,
     approvedAt: fixtureTimestamp,
     evidenceRef: "evidence:operator-approval:approve-ready",
+  },
+  hostedAttestationClaim: {
+    schemaVersion: "reddi.hosted-attestation-claim.v1",
+    id: "hosted-claim:approve-ready",
+    status: "hosted_attestation_ready",
+    subject: { id: "listing:approve-ready", type: "listing" },
+    source: {
+      kind: "hosted-rap-registry",
+      sourceId: "source:approve-ready",
+      catalogRef: "/.well-known/ai-catalog.json",
+      listingId: "listing:approve-ready",
+      rawSnapshotRef: "snapshot:approve-ready",
+    },
+    backing: {
+      claimKind: "hosted_attestation_backed",
+      attestationKind: "reddi_attested",
+      reputationKind: "offchain_preview",
+      quasarBacking: {
+        status: "not_quasar_backed",
+        instructionFlow: "not_built",
+        promotionChecklistIssue: 441,
+      },
+      hostedAttestationBacking: {
+        status: "ready",
+        sourceProofRef: "source-proof:approve-ready",
+        attestationProofRef: "hosted-attestation-proof:approve-ready",
+        hostedBy: "reddi",
+        operatorApprovalEvidenceRef: "evidence:operator-approval:approve-ready",
+        publicationGateEvidenceRef: "publication-gate:approve-ready",
+        publicationGateIssue: 395,
+      },
+    },
+    evidenceSummary: {
+      bindingId: "binding:approve-ready",
+      receiptId: "receipt:dry-run:approve-ready",
+      evidenceId: "evidence:static-review:approve-ready",
+      evidenceHash: "sha256:approve-ready",
+      evidenceRef: "evidence:static-review:approve-ready",
+      paymentProofRef: "evidence:payment-plan:dry-run",
+      attestationId: "attestation:approve-ready",
+      reputationEventDraftId: "reputation:approve-ready",
+      previewId: "preview:approve-ready",
+      sourceProofRef: "source-proof:approve-ready",
+      attestationProofRef: "hosted-attestation-proof:approve-ready",
+      operatorApprovalEvidenceRef: "evidence:operator-approval:approve-ready",
+      publicationGateEvidenceRef: "publication-gate:approve-ready",
+    },
+    display: {
+      label: "Hosted attestation ready",
+      explanation: "Fixture hosted attestation claim.",
+      buyerFacingClaimAllowed: false,
+    },
+    reasonCodes: [
+      "binding_valid",
+      "preview_ready",
+      "hosted_attestation_evidence_present",
+      "operator_approval_present",
+      "publication_gate_present",
+      "buyer_facing_claim_disabled",
+      "not_quasar_backed",
+    ],
+    guardrails: {
+      reputationMutated: false,
+      quasarInstructionBuilt: false,
+      walletSigning: false,
+      rpcCall: false,
+      hostedRegistryWrite: false,
+      marketplacePublished: false,
+      livePaymentExecuted: false,
+      providerCall: false,
+    },
+    createdAt: fixtureTimestamp,
+  },
+  hostedSourceProofRef: "source-proof:approve-ready",
+  hostedAttestationProofRef: "hosted-attestation-proof:approve-ready",
+  publicationGateEvidenceRef: "publication-gate:approve-ready",
+  quasarCompatibility: {
+    schemaVersion: "reddi.publication-quasar-compatibility.v1",
+    issue: 390,
+    status: "metadata_only",
+    evidenceRef: "quasar-compatibility:metadata-only",
+    quasarBackedClaimAllowed: false,
+    instructionBuilt: false,
   },
 };
 

--- a/lib/manager/marketplace-public-export.ts
+++ b/lib/manager/marketplace-public-export.ts
@@ -3,11 +3,14 @@ import type {
   MarketplaceApprovalRecord,
 } from "@/lib/manager/marketplace-approval-actions";
 import {
-  evaluateMarketplaceReadiness,
   type MarketplaceReadinessBoundary,
-  type MarketplaceReadinessProofMetadata,
   type MarketplaceReadinessResult,
 } from "@/lib/manager/marketplace-readiness-gate";
+import {
+  deriveMarketplacePublicationEligibility,
+  type MarketplacePublicationEligibilityDecision,
+  type MarketplacePublicationEligibilityProof,
+} from "@/lib/manager/marketplace-publication-eligibility";
 
 export const MARKETPLACE_PUBLIC_EXPORT_SCHEMA_VERSION = "reddi.marketplace-public-export.v1" as const;
 
@@ -90,6 +93,7 @@ export type MarketplacePublicExportSuccess = {
   catalogResource: MarketplacePublicCatalogResource;
   readiness: MarketplaceReadinessResult;
   publishAudit: MarketplaceApprovalAuditEntry;
+  eligibility: MarketplacePublicationEligibilityDecision;
   boundaries: MarketplacePublicExportBoundary;
 };
 
@@ -139,20 +143,20 @@ const disclosureLabels = [
 
 export function deriveMarketplacePublicExportItem(
   record: MarketplaceApprovalRecord,
-  proof: MarketplaceReadinessProofMetadata = {},
+  proof: MarketplacePublicationEligibilityProof = {},
 ): MarketplacePublicExportItem {
-  const readiness = evaluateMarketplaceReadiness(record.id, record.fixtureKey, record.candidate, proof);
+  const eligibility = deriveMarketplacePublicationEligibility(record, proof);
+  const readiness = eligibility.readiness;
   const boundaries = publicExportBoundaries(readiness.boundaries, false);
-  const reasons = publicExportBlockReasons(record, proof, readiness);
-  if (reasons.length > 0) {
+  if (eligibility.status !== "eligible") {
     return {
       ok: false,
       listingId: record.id,
       fixtureKey: record.fixtureKey,
       recordState: record.state,
       readinessStatus: readiness.status,
-      reasons,
-      blockReasons: readiness.blockReasons,
+      reasons: publicExportReasonCodes(record, eligibility),
+      blockReasons: eligibility.blockedReasons,
       boundaries,
     };
   }
@@ -169,6 +173,7 @@ export function deriveMarketplacePublicExportItem(
     listing,
     catalogResource: buildCatalogResource(listing, allowedBoundaries),
     readiness,
+    eligibility,
     publishAudit,
     boundaries: allowedBoundaries,
   };
@@ -176,7 +181,7 @@ export function deriveMarketplacePublicExportItem(
 
 export function deriveMarketplacePublicExportSnapshot(
   records: MarketplaceApprovalRecord[],
-  proofByListingId: Record<string, MarketplaceReadinessProofMetadata> = {},
+  proofByListingId: Record<string, MarketplacePublicationEligibilityProof> = {},
   options: MarketplacePublicExportOptions = {},
 ): MarketplacePublicExportSnapshot {
   const items = records.map((record) => deriveMarketplacePublicExportItem(record, proofByListingId[record.id] ?? {}));
@@ -198,27 +203,24 @@ export function deriveMarketplacePublicExportSnapshot(
   };
 }
 
-function publicExportBlockReasons(
+function publicExportReasonCodes(
   record: MarketplaceApprovalRecord,
-  proof: MarketplaceReadinessProofMetadata,
-  readiness: MarketplaceReadinessResult,
+  eligibility: MarketplacePublicationEligibilityDecision,
 ) {
-  const reasons = [
-    record.state === "published" ? undefined : `record_state_not_published:${record.state}`,
-    record.publicVisible === true ? undefined : "public_visibility_false",
-    readiness.status === "publish_ready" ? undefined : `readiness_not_publish_ready:${readiness.status}`,
-    readiness.boundaries.publicationAllowed === true ? undefined : "publication_not_allowed",
-    proof.operatorApproval?.approved === true ? undefined : "operator_approval_missing",
-    isNonEmptyString(proof.operatorApproval?.evidenceRef) ? undefined : "operator_approval_evidence_missing",
-    latestPublishAudit(record) ? undefined : "publish_audit_missing",
-  ];
-
-  return reasons.filter(isNonEmptyString);
+  return eligibility.reasonCodes.map((code) => {
+    if (code === "record_state_not_published") {
+      return `record_state_not_published:${record.state}`;
+    }
+    if (code === "readiness_not_publish_ready") {
+      return `readiness_not_publish_ready:${eligibility.readiness.status}`;
+    }
+    return code;
+  });
 }
 
 function buildListing(
   record: MarketplaceApprovalRecord,
-  proof: MarketplaceReadinessProofMetadata,
+  proof: MarketplacePublicationEligibilityProof,
   readiness: MarketplaceReadinessResult,
   publishAudit: MarketplaceApprovalAuditEntry,
 ): MarketplacePublicListingSnapshot {

--- a/lib/manager/marketplace-publication-eligibility.ts
+++ b/lib/manager/marketplace-publication-eligibility.ts
@@ -1,0 +1,294 @@
+import type { MarketplaceApprovalRecord } from "@/lib/manager/marketplace-approval-actions";
+import type {
+  MarketplaceReadinessBoundary,
+  MarketplaceReadinessProofMetadata,
+  MarketplaceReadinessResult,
+} from "@/lib/manager/marketplace-readiness-gate";
+import { evaluateMarketplaceReadiness } from "@/lib/manager/marketplace-readiness-gate";
+import type { HostedAttestationClaim } from "@reddi/agent-protocol/hosted-attestation-claim";
+
+export const MARKETPLACE_PUBLICATION_ELIGIBILITY_SCHEMA_VERSION =
+  "reddi.marketplace-publication-eligibility.v1" as const;
+
+export type MarketplacePublicationEligibilityStatus = "eligible" | "blocked";
+
+export type MarketplacePublicationQuasarCompatibility = {
+  schemaVersion: "reddi.publication-quasar-compatibility.v1";
+  issue: 390;
+  status: "metadata_only" | "not_required" | "blocked";
+  evidenceRef: string;
+  quasarBackedClaimAllowed: boolean;
+  instructionBuilt: boolean;
+};
+
+export type MarketplacePublicationEligibilityProof = MarketplaceReadinessProofMetadata & {
+  hostedAttestationClaim?: HostedAttestationClaim;
+  hostedSourceProofRef?: string;
+  hostedAttestationProofRef?: string;
+  publicationGateEvidenceRef?: string;
+  quasarCompatibility?: MarketplacePublicationQuasarCompatibility;
+};
+
+export type MarketplacePublicationEligibilityReasonCode =
+  | "eligible"
+  | "record_state_not_published"
+  | "public_visibility_false"
+  | "readiness_not_publish_ready"
+  | "publication_not_allowed"
+  | "operator_approval_missing"
+  | "operator_approval_evidence_missing"
+  | "publish_audit_missing"
+  | "unsafe_metadata"
+  | "endpoint_binding_missing"
+  | "suspended_or_unpublished_state"
+  | "payment_proof_missing"
+  | "receipt_evidence_missing"
+  | "hosted_attestation_missing"
+  | "hosted_attestation_not_ready"
+  | "hosted_claim_guardrail_escalation"
+  | "hosted_claim_buyer_facing_enabled"
+  | "hosted_claim_evidence_mismatch"
+  | "hosted_claim_operator_evidence_mismatch"
+  | "missing_quasar_compatibility"
+  | "quasar_compatibility_blocked"
+  | "quasar_instruction_built"
+  | "quasar_backed_claim_not_allowed"
+  | "live_escalation_not_allowed";
+
+export type MarketplacePublicationEligibilityDecision = {
+  schemaVersion: typeof MARKETPLACE_PUBLICATION_ELIGIBILITY_SCHEMA_VERSION;
+  listingId: string;
+  fixtureKey: string;
+  status: MarketplacePublicationEligibilityStatus;
+  readiness: MarketplaceReadinessResult;
+  reasonCodes: MarketplacePublicationEligibilityReasonCode[];
+  blockedReasons: string[];
+  evidenceRefs: string[];
+  boundaries: MarketplaceReadinessBoundary & {
+    hostedExportAllowed: boolean;
+    ardCatalogExportAllowed: boolean;
+    livePublicationActivated: false;
+    paymentActivationAllowed: false;
+    trustClaimAllowed: false;
+    reputationClaimAllowed: false;
+    discoveryRelevanceIsTrust: false;
+  };
+  claimSources: {
+    paymentProof: "readiness_proof" | "missing";
+    receiptEvidence: "readiness_proof" | "missing";
+    hostedAttestation: "hosted_attestation_claim" | "missing" | "blocked";
+    quasarCompatibility: "metadata_only" | "not_required" | "missing" | "blocked";
+    discoveryRelevance: "separate_from_trust";
+  };
+};
+
+export function deriveMarketplacePublicationEligibility(
+  record: MarketplaceApprovalRecord,
+  proof: MarketplacePublicationEligibilityProof = {},
+): MarketplacePublicationEligibilityDecision {
+  const readiness = evaluateMarketplaceReadiness(record.id, record.fixtureKey, record.candidate, proof);
+  const reasonCodes = uniqueReasonCodes([
+    record.state === "published" ? undefined : "record_state_not_published",
+    record.publicVisible === true ? undefined : "public_visibility_false",
+    readiness.status === "publish_ready" ? undefined : "readiness_not_publish_ready",
+    readiness.boundaries.publicationAllowed === true ? undefined : "publication_not_allowed",
+    proof.operatorApproval?.approved === true ? undefined : "operator_approval_missing",
+    isNonEmptyString(proof.operatorApproval?.evidenceRef) ? undefined : "operator_approval_evidence_missing",
+    latestPublishAuditEvidenceRefs(record).length > 0 ? undefined : "publish_audit_missing",
+    readiness.gates.find((gate) => gate.id === "safe_metadata")?.passed === false ? "unsafe_metadata" : undefined,
+    isNonEmptyString(proof.endpointBindingRef) ? undefined : "endpoint_binding_missing",
+    ["suspended", "rejected", "needs_changes", "draft", "approved", "internal", "blocked"].includes(record.state)
+      ? "suspended_or_unpublished_state"
+      : undefined,
+    proof.paymentPlan?.evidenceRef ? undefined : "payment_proof_missing",
+    hasReceiptEvidence(proof) ? undefined : "receipt_evidence_missing",
+    proof.hostedAttestationClaim ? undefined : "hosted_attestation_missing",
+    proof.hostedAttestationClaim && proof.hostedAttestationClaim.status !== "hosted_attestation_ready"
+      ? "hosted_attestation_not_ready"
+      : undefined,
+    proof.hostedAttestationClaim && !hostedClaimGuardrailsAreSafe(proof.hostedAttestationClaim)
+      ? "hosted_claim_guardrail_escalation"
+      : undefined,
+    proof.hostedAttestationClaim && proof.hostedAttestationClaim.display.buyerFacingClaimAllowed !== false
+      ? "hosted_claim_buyer_facing_enabled"
+      : undefined,
+    proof.hostedAttestationClaim && !hostedClaimEvidenceMatchesProof(proof.hostedAttestationClaim, proof)
+      ? "hosted_claim_evidence_mismatch"
+      : undefined,
+    proof.hostedAttestationClaim && !hostedClaimOperatorEvidenceMatchesProof(proof.hostedAttestationClaim, proof)
+      ? "hosted_claim_operator_evidence_mismatch"
+      : undefined,
+    proof.quasarCompatibility ? undefined : "missing_quasar_compatibility",
+    proof.quasarCompatibility?.status === "blocked" ? "quasar_compatibility_blocked" : undefined,
+    proof.quasarCompatibility?.instructionBuilt === true ? "quasar_instruction_built" : undefined,
+    proof.quasarCompatibility?.quasarBackedClaimAllowed === true ? "quasar_backed_claim_not_allowed" : undefined,
+    proof.quasarCompatibility && !quasarCompatibilityIsSafe(proof.quasarCompatibility)
+      ? "live_escalation_not_allowed"
+      : undefined,
+    liveEscalationRequested(readiness.boundaries, proof.quasarCompatibility) ? "live_escalation_not_allowed" : undefined,
+  ]);
+  const status: MarketplacePublicationEligibilityStatus = reasonCodes.length === 0 ? "eligible" : "blocked";
+  const normalizedReasonCodes = status === "eligible" ? ["eligible" as const] : reasonCodes;
+
+  return {
+    schemaVersion: MARKETPLACE_PUBLICATION_ELIGIBILITY_SCHEMA_VERSION,
+    listingId: record.id,
+    fixtureKey: record.fixtureKey,
+    status,
+    readiness,
+    reasonCodes: normalizedReasonCodes,
+    blockedReasons: blockedReasonsFor(normalizedReasonCodes, readiness),
+    evidenceRefs: uniqueRefs([
+      ...latestPublishAuditEvidenceRefs(record),
+      ...readiness.gates.flatMap((gate) => gate.evidenceRefs),
+      proof.hostedSourceProofRef,
+      proof.hostedAttestationProofRef,
+      proof.publicationGateEvidenceRef,
+      proof.hostedAttestationClaim?.evidenceSummary.operatorApprovalEvidenceRef,
+      proof.quasarCompatibility?.evidenceRef,
+    ]),
+    boundaries: {
+      ...readiness.boundaries,
+      hostedExportAllowed: status === "eligible",
+      ardCatalogExportAllowed: status === "eligible",
+      livePublicationActivated: false,
+      paymentActivationAllowed: false,
+      trustClaimAllowed: false,
+      reputationClaimAllowed: false,
+      discoveryRelevanceIsTrust: false,
+    },
+    claimSources: {
+      paymentProof: proof.paymentPlan?.evidenceRef ? "readiness_proof" : "missing",
+      receiptEvidence: hasReceiptEvidence(proof) ? "readiness_proof" : "missing",
+      hostedAttestation: hostedAttestationClaimSource(proof.hostedAttestationClaim),
+      quasarCompatibility: quasarCompatibilityClaimSource(proof.quasarCompatibility),
+      discoveryRelevance: "separate_from_trust",
+    },
+  };
+}
+
+function latestPublishAuditEvidenceRefs(record: MarketplaceApprovalRecord) {
+  return [...record.auditHistory]
+    .reverse()
+    .find((entry) =>
+      entry.action === "publish"
+      && entry.nextState === "published"
+      && entry.evidenceRefs.some(isNonEmptyString)
+    )?.evidenceRefs ?? [];
+}
+
+function hasReceiptEvidence(proof: MarketplacePublicationEligibilityProof) {
+  return (proof.dryRunReceiptRefs ?? []).some(isNonEmptyString) && (proof.evidenceRefs ?? []).some(isNonEmptyString);
+}
+
+function quasarCompatibilityIsSafe(compatibility: MarketplacePublicationQuasarCompatibility) {
+  return compatibility.issue === 390
+    && isNonEmptyString(compatibility.evidenceRef)
+    && compatibility.quasarBackedClaimAllowed === false
+    && compatibility.instructionBuilt === false
+    && ["metadata_only", "not_required"].includes(compatibility.status);
+}
+
+function hostedClaimGuardrailsAreSafe(claim: HostedAttestationClaim) {
+  return claim.guardrails.reputationMutated === false
+    && claim.guardrails.quasarInstructionBuilt === false
+    && claim.guardrails.walletSigning === false
+    && claim.guardrails.rpcCall === false
+    && claim.guardrails.hostedRegistryWrite === false
+    && claim.guardrails.marketplacePublished === false
+    && claim.guardrails.livePaymentExecuted === false
+    && claim.guardrails.providerCall === false;
+}
+
+function hostedClaimEvidenceMatchesProof(
+  claim: HostedAttestationClaim,
+  proof: MarketplacePublicationEligibilityProof,
+) {
+  return claim.evidenceSummary.paymentProofRef === proof.paymentPlan?.evidenceRef
+    && (proof.dryRunReceiptRefs ?? []).includes(claim.evidenceSummary.receiptId)
+    && (proof.evidenceRefs ?? []).includes(claim.evidenceSummary.evidenceId)
+    && claim.evidenceSummary.sourceProofRef === proof.hostedSourceProofRef
+    && claim.evidenceSummary.attestationProofRef === proof.hostedAttestationProofRef
+    && claim.evidenceSummary.publicationGateEvidenceRef === proof.publicationGateEvidenceRef;
+}
+
+function hostedClaimOperatorEvidenceMatchesProof(
+  claim: HostedAttestationClaim,
+  proof: MarketplacePublicationEligibilityProof,
+) {
+  return claim.evidenceSummary.operatorApprovalEvidenceRef === proof.operatorApproval?.evidenceRef;
+}
+
+function liveEscalationRequested(
+  boundaries: MarketplaceReadinessBoundary,
+  compatibility?: MarketplacePublicationQuasarCompatibility,
+) {
+  return boundaries.livePaymentAllowed
+    || boundaries.walletSigningAllowed
+    || boundaries.rpcProbeAllowed
+    || boundaries.mcpCallAllowed
+    || boundaries.reputationAssignmentAllowed
+    || compatibility?.quasarBackedClaimAllowed !== false
+    || compatibility?.instructionBuilt !== false;
+}
+
+function hostedAttestationClaimSource(claim?: HostedAttestationClaim) {
+  if (!claim) return "missing";
+  return claim.status === "hosted_attestation_ready" ? "hosted_attestation_claim" : "blocked";
+}
+
+function quasarCompatibilityClaimSource(compatibility?: MarketplacePublicationQuasarCompatibility) {
+  if (!compatibility) return "missing";
+  return compatibility.status === "blocked" ? "blocked" : compatibility.status;
+}
+
+function blockedReasonsFor(
+  reasonCodes: MarketplacePublicationEligibilityReasonCode[],
+  readiness: MarketplaceReadinessResult,
+) {
+  if (reasonCodes.includes("eligible")) return [];
+  return uniqueRefs([
+    ...reasonCodes.map((code) => reasonText[code] ?? code),
+    ...readiness.blockReasons,
+  ]);
+}
+
+const reasonText: Partial<Record<MarketplacePublicationEligibilityReasonCode, string>> = {
+  record_state_not_published: "Listing record is not in published state.",
+  public_visibility_false: "Listing is not public visible.",
+  readiness_not_publish_ready: "Marketplace readiness is not publish_ready.",
+  publication_not_allowed: "Readiness boundary does not allow publication.",
+  operator_approval_missing: "Operator approval proof is missing.",
+  operator_approval_evidence_missing: "Operator approval evidence ref is missing.",
+  publish_audit_missing: "Publish audit evidence is missing.",
+  unsafe_metadata: "Imported metadata is unsafe or unresolved.",
+  endpoint_binding_missing: "Endpoint binding proof is missing.",
+  suspended_or_unpublished_state: "Listing is suspended, unpublished, or not in a publishable state.",
+  payment_proof_missing: "Payment proof metadata is missing.",
+  receipt_evidence_missing: "Receipt/evidence proof metadata is missing.",
+  hosted_attestation_missing: "Hosted attestation claim is missing.",
+  hosted_attestation_not_ready: "Hosted attestation claim is not ready.",
+  hosted_claim_guardrail_escalation: "Hosted attestation claim contains a live or mutation guardrail escalation.",
+  hosted_claim_buyer_facing_enabled: "Hosted attestation claim attempted to enable buyer-facing trust/reputation copy.",
+  hosted_claim_evidence_mismatch: "Hosted attestation claim evidence refs do not match local proof inputs.",
+  hosted_claim_operator_evidence_mismatch: "Hosted attestation claim operator approval evidence does not match local proof inputs.",
+  missing_quasar_compatibility: "Quasar compatibility metadata is missing.",
+  quasar_compatibility_blocked: "Quasar compatibility metadata is blocked.",
+  quasar_instruction_built: "Quasar instruction output is not allowed in this eligibility matrix.",
+  quasar_backed_claim_not_allowed: "Quasar-backed claim is not allowed in this eligibility matrix.",
+  live_escalation_not_allowed: "Live payment, wallet/RPC, MCP, reputation mutation, or Quasar instruction escalation is not allowed.",
+};
+
+function uniqueReasonCodes(
+  codes: Array<MarketplacePublicationEligibilityReasonCode | undefined>,
+): MarketplacePublicationEligibilityReasonCode[] {
+  return Array.from(new Set(codes.filter((code): code is MarketplacePublicationEligibilityReasonCode => Boolean(code))));
+}
+
+function uniqueRefs(refs: Array<string | undefined>) {
+  return Array.from(new Set(refs.filter(isNonEmptyString)));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}


### PR DESCRIPTION
Closes #444.

## Summary
- adds `reddi.marketplace-publication-eligibility.v1` as a pure manager read-model gate
- routes public marketplace export through the eligibility decision instead of local ad hoc block checks
- extends fixture proof with #442 hosted attestation claim refs and metadata-only #390 Quasar compatibility
- blocks missing/non-ready hosted claims, proof mismatches, buyer-facing claim escalation, Quasar instruction/backed claim escalation, unsafe metadata, missing audit/operator/evidence/payment proofs, and live-boundary escalation

## Boundary
- read-model/export eligibility only
- no route mutation, activation, publication write, hosted registry write, wallet/RPC, Surfpool/devnet, live payment, provider/MCP call, Quasar instruction, or reputation mutation
- no UI changes, so screenshots/video are not required

## Validation
- `npx jest --runInBand lib/__tests__/manager-marketplace-publication-eligibility.test.ts lib/__tests__/manager-marketplace-public-export.test.ts lib/__tests__/manager-marketplace-public-export-route.test.ts lib/__tests__/manager-marketplace-readiness-gate.test.ts lib/__tests__/manager-marketplace-approval-actions.test.ts` passed: 5 suites / 57 tests
- `git diff --check` passed
- `npm run check:rap:naming` passed
- scoped side-effect scan found only expected negative/false guardrail references