### PR TITLE
Bind hosted attestation claims to publication records

### DIFF
--- a/lib/__tests__/manager-marketplace-publication-eligibility.test.ts
+++ b/lib/__tests__/manager-marketplace-publication-eligibility.test.ts
@@ -170,6 +170,22 @@ describe("marketplace publication eligibility matrix", () => {
       },
       "hosted_claim_operator_evidence_mismatch",
     ],
+    [
+      "hosted claim listing mismatch",
+      {
+        ...fixturePublishReadyProof,
+        hostedAttestationClaim: {
+          ...fixturePublishReadyProof.hostedAttestationClaim!,
+          subject: { id: "draft-listing:other-listing", type: "listing" },
+          source: {
+            ...fixturePublishReadyProof.hostedAttestationClaim!.source,
+            listingId: "draft-listing:other-listing",
+            sourceId: "source:other-listing",
+          },
+        },
+      },
+      "hosted_claim_listing_mismatch",
+    ],
   ] as Array<[string, MarketplacePublicationEligibilityProof, string]>)(
     "blocks %s",
     (_label, proof, reasonCode) => {

--- a/lib/manager/marketplace-public-export-fixtures.ts
+++ b/lib/manager/marketplace-public-export-fixtures.ts
@@ -43,12 +43,12 @@ export const fixturePublishReadyProof: MarketplacePublicationEligibilityProof = 
     schemaVersion: "reddi.hosted-attestation-claim.v1",
     id: "hosted-claim:approve-ready",
     status: "hosted_attestation_ready",
-    subject: { id: "listing:approve-ready", type: "listing" },
+    subject: { id: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18", type: "listing" },
     source: {
       kind: "hosted-rap-registry",
-      sourceId: "source:approve-ready",
+      sourceId: "source:agent-stack-fixture:anthropic-financial-services:2026-06-18",
       catalogRef: "/.well-known/ai-catalog.json",
-      listingId: "listing:approve-ready",
+      listingId: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
       rawSnapshotRef: "snapshot:approve-ready",
     },
     backing: {

--- a/lib/manager/marketplace-publication-eligibility.ts
+++ b/lib/manager/marketplace-publication-eligibility.ts
@@ -49,6 +49,7 @@ export type MarketplacePublicationEligibilityReasonCode =
   | "hosted_claim_buyer_facing_enabled"
   | "hosted_claim_evidence_mismatch"
   | "hosted_claim_operator_evidence_mismatch"
+  | "hosted_claim_listing_mismatch"
   | "missing_quasar_compatibility"
   | "quasar_compatibility_blocked"
   | "quasar_instruction_built"
@@ -117,6 +118,9 @@ export function deriveMarketplacePublicationEligibility(
       : undefined,
     proof.hostedAttestationClaim && !hostedClaimOperatorEvidenceMatchesProof(proof.hostedAttestationClaim, proof)
       ? "hosted_claim_operator_evidence_mismatch"
+      : undefined,
+    proof.hostedAttestationClaim && !hostedClaimMatchesRecord(proof.hostedAttestationClaim, record)
+      ? "hosted_claim_listing_mismatch"
       : undefined,
     proof.quasarCompatibility ? undefined : "missing_quasar_compatibility",
     proof.quasarCompatibility?.status === "blocked" ? "quasar_compatibility_blocked" : undefined,
@@ -219,6 +223,38 @@ function hostedClaimOperatorEvidenceMatchesProof(
   return claim.evidenceSummary.operatorApprovalEvidenceRef === proof.operatorApproval?.evidenceRef;
 }
 
+function hostedClaimMatchesRecord(
+  claim: HostedAttestationClaim,
+  record: MarketplaceApprovalRecord,
+) {
+  const expectedListingId = expectedHostedListingId(record);
+  const expectedSourceId = expectedHostedSourceId(record);
+  return isNonEmptyString(expectedListingId)
+    && isNonEmptyString(expectedSourceId)
+    && claim.subject.type === "listing"
+    && claim.subject.id === expectedListingId
+    && claim.source.listingId === expectedListingId
+    && claim.source.sourceId === expectedSourceId
+    && isNonEmptyString(claim.source.catalogRef);
+}
+
+function expectedHostedListingId(record: MarketplaceApprovalRecord) {
+  const corpusId = candidateCorpusId(record);
+  return corpusId ? `draft-listing:${corpusId}` : undefined;
+}
+
+function expectedHostedSourceId(record: MarketplaceApprovalRecord) {
+  const corpusId = candidateCorpusId(record);
+  return corpusId ? `source:${corpusId}` : undefined;
+}
+
+function candidateCorpusId(record: MarketplaceApprovalRecord) {
+  const prefix = "operator-review:";
+  const suffix = `:${record.fixtureKey}`;
+  if (!record.candidate.id.startsWith(prefix) || !record.candidate.id.endsWith(suffix)) return undefined;
+  return record.candidate.id.slice(prefix.length, -suffix.length);
+}
+
 function liveEscalationRequested(
   boundaries: MarketplaceReadinessBoundary,
   compatibility?: MarketplacePublicationQuasarCompatibility,
@@ -272,6 +308,7 @@ const reasonText: Partial<Record<MarketplacePublicationEligibilityReasonCode, st
   hosted_claim_buyer_facing_enabled: "Hosted attestation claim attempted to enable buyer-facing trust/reputation copy.",
   hosted_claim_evidence_mismatch: "Hosted attestation claim evidence refs do not match local proof inputs.",
   hosted_claim_operator_evidence_mismatch: "Hosted attestation claim operator approval evidence does not match local proof inputs.",
+  hosted_claim_listing_mismatch: "Hosted attestation claim subject/source does not match the exported listing.",
   missing_quasar_compatibility: "Quasar compatibility metadata is missing.",
   quasar_compatibility_blocked: "Quasar compatibility metadata is blocked.",
   quasar_instruction_built: "Quasar instruction output is not allowed in this eligibility matrix.",


### PR DESCRIPTION
Follow-up to #464 / #444.

## Summary
- binds `hosted_attestation_ready` claims back to the exported approval record identity
- derives the expected draft listing/source ids from the local operator-review candidate id
- blocks cross-listing hosted claims with `hosted_claim_listing_mismatch`
- updates the fixture hosted claim identity to the real draft listing/source id

## Boundary
- read-model eligibility fix only
- no route mutation, publication activation, hosted registry write, wallet/RPC, Surfpool/devnet, live payment, provider/MCP call, Quasar instruction, or reputation mutation
- no UI changes

## Validation
- `npx jest --runInBand lib/__tests__/manager-marketplace-publication-eligibility.test.ts lib/__tests__/manager-marketplace-public-export.test.ts lib/__tests__/manager-marketplace-public-export-route.test.ts lib/__tests__/manager-marketplace-readiness-gate.test.ts lib/__tests__/manager-marketplace-approval-actions.test.ts` passed: 5 suites / 58 tests
- `npm run build` passed
- `git diff --check` passed
- `npm run check:rap:naming` passed
- scoped side-effect scan found only expected negative/false guardrail references