### PR TITLE
Add publication lifecycle audit evidence

### DIFF
--- a/lib/__tests__/manager-marketplace-approval-actions.test.ts
+++ b/lib/__tests__/manager-marketplace-approval-actions.test.ts
@@ -64,6 +64,9 @@ describe("manager marketplace approval actions", () => {
         action: "publish",
         previousState: "approved",
         nextState: "published",
+        sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+        readinessProofRef: "readiness-proof:approve-ready",
+        operatorApprovalRef: "evidence:operator-approval:approve-ready",
         evidenceRefs: expect.arrayContaining([
           "evidence:operator-action:publish",
           "evidence:operator-approval:approve-ready",
@@ -183,9 +186,54 @@ describe("manager marketplace approval actions", () => {
     expect(fromPublished.ok).toBe(true);
     expect(fromPublished.record.state).toBe("approved");
     expect(fromPublished.record.publicVisible).toBe(false);
+    expect(fromPublished.record.auditHistory[0]).toMatchObject({
+      action: "unpublish",
+      sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+      readinessProofRef: null,
+      operatorApprovalRef: null,
+    });
     expect(fromApproved.ok).toBe(true);
     expect(fromApproved.record.state).toBe("approved");
     expect(fromApproved.record.publicVisible).toBe(false);
+  });
+
+  it("restores suspended listings only with current publish-ready evidence", () => {
+    const result = applyMarketplaceApprovalAction(recordFor("suspended", "approveReadyDraft", false), action("restore", {
+      readinessProof: publishReadyProof,
+      evidenceRefs: ["evidence:operator-action:restore"],
+    }));
+
+    expect(result.ok).toBe(true);
+    expect(result.record.state).toBe("published");
+    expect(result.record.publicVisible).toBe(true);
+    expect(result.record.auditHistory[0]).toMatchObject({
+      action: "restore",
+      previousState: "suspended",
+      nextState: "published",
+      sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+      readinessProofRef: "readiness-proof:approve-ready",
+      operatorApprovalRef: "evidence:operator-approval:approve-ready",
+      evidenceRefs: expect.arrayContaining([
+        "evidence:operator-action:restore",
+        "evidence:operator-approval:approve-ready",
+        "receipt:dry-run:approve-ready",
+      ]),
+    });
+  });
+
+  it("blocks restore when current readiness is stale or incomplete", () => {
+    const { operatorApproval, ...staleProof } = publishReadyProof;
+    expect(operatorApproval).toBeDefined();
+
+    const result = applyMarketplaceApprovalAction(recordFor("suspended", "approveReadyDraft", false), action("restore", {
+      readinessProof: staleProof,
+    }));
+
+    expect(result.ok).toBe(false);
+    expect(result.readiness?.status).toBe("dry_run_ready");
+    expect(result.record.state).toBe("suspended");
+    expect(result.record.publicVisible).toBe(false);
+    expect(result.record.auditHistory).toEqual([]);
   });
 
   it.each([
@@ -247,6 +295,7 @@ function action(
     type,
     operatorId,
     timestamp,
+    ...(type === "publish" || type === "restore" ? { readinessProofRef: "readiness-proof:approve-ready" } : {}),
     ...overrides,
   };
 }

--- a/lib/__tests__/manager-marketplace-public-export.test.ts
+++ b/lib/__tests__/manager-marketplace-public-export.test.ts
@@ -161,7 +161,7 @@ describe("manager marketplace public export", () => {
     ]));
   });
 
-  it("blocks export when publish audit evidence is missing", () => {
+  it("blocks export when publish audit evidence is malformed", () => {
     const publishedWithoutAuditEvidence: MarketplaceApprovalRecord = {
       ...publishedRecord(),
       auditHistory: [
@@ -172,6 +172,9 @@ describe("manager marketplace public export", () => {
           timestamp,
           previousState: "approved",
           nextState: "published",
+          sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+          readinessProofRef: "readiness-proof:approve-ready",
+          operatorApprovalRef: "evidence:operator-approval:approve-ready",
           evidenceRefs: [],
         },
       ],
@@ -181,7 +184,33 @@ describe("manager marketplace public export", () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected blocked export");
-    expect(result.reasons).toContain("publish_audit_missing");
+    expect(result.reasons).toContain("publish_audit_malformed");
+  });
+
+  it("blocks export when publish audit evidence mismatches the listing", () => {
+    const publishedWithMalformedAudit: MarketplaceApprovalRecord = {
+      ...publishedRecord(),
+      auditHistory: [
+        {
+          operatorId,
+          action: "publish",
+          reason: "Manual fixture with mismatched source listing evidence.",
+          timestamp,
+          previousState: "approved",
+          nextState: "published",
+          sourceListingRef: "draft-listing:other-listing",
+          readinessProofRef: "readiness-proof:approve-ready",
+          operatorApprovalRef: "evidence:operator-approval:approve-ready",
+          evidenceRefs: ["evidence:operator-action:publish"],
+        },
+      ],
+    };
+
+    const result = deriveMarketplacePublicExportItem(publishedWithMalformedAudit, publishReadyProof);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked export");
+    expect(result.reasons).toContain("publish_audit_malformed");
   });
 
   it("does not export unsafe imported metadata even with forged published state and proof", () => {
@@ -194,6 +223,9 @@ describe("manager marketplace public export", () => {
         timestamp,
         previousState: "approved",
         nextState: "published",
+        sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+        readinessProofRef: "readiness-proof:forged",
+        operatorApprovalRef: "evidence:operator-approval:approve-ready",
         evidenceRefs: ["evidence:forged:publish"],
       }],
     };
@@ -215,6 +247,7 @@ function action(
     type,
     operatorId,
     timestamp,
+    ...(type === "publish" || type === "restore" ? { readinessProofRef: "readiness-proof:approve-ready" } : {}),
     ...overrides,
   };
 }

--- a/lib/__tests__/manager-marketplace-publication-eligibility.test.ts
+++ b/lib/__tests__/manager-marketplace-publication-eligibility.test.ts
@@ -199,6 +199,95 @@ describe("marketplace publication eligibility matrix", () => {
     },
   );
 
+  it("accepts a restore audit only when current proof still matches", () => {
+    const restore = applyMarketplaceApprovalAction(recordFor("suspended", "approveReadyDraft"), action("restore", {
+      readinessProof: fixturePublishReadyProof,
+      evidenceRefs: ["evidence:operator-action:restore"],
+    }));
+    if (!restore.ok) throw new Error(restore.reason);
+
+    const decision = deriveMarketplacePublicationEligibility(restore.record, fixturePublishReadyProof);
+
+    expect(decision.status).toBe("eligible");
+    expect(decision.reasonCodes).toEqual(["eligible"]);
+    expect(decision.evidenceRefs).toEqual(expect.arrayContaining([
+      "evidence:operator-action:restore",
+      "evidence:operator-approval:approve-ready",
+    ]));
+  });
+
+  it.each([
+    [
+      "latest lifecycle audit unpublishes",
+      {
+        ...publishedRecord(),
+        auditHistory: [
+          ...publishedRecord().auditHistory,
+          {
+            operatorId,
+            action: "unpublish" as const,
+            reason: "Operator removed public visibility.",
+            timestamp,
+            previousState: "published" as const,
+            nextState: "approved" as const,
+            sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+            readinessProofRef: null,
+            operatorApprovalRef: null,
+            evidenceRefs: ["evidence:operator-action:unpublish"],
+          },
+        ],
+      },
+    ],
+    [
+      "latest lifecycle audit unpublishes without evidence",
+      {
+        ...publishedRecord(),
+        auditHistory: [
+          ...publishedRecord().auditHistory,
+          {
+            operatorId,
+            action: "unpublish" as const,
+            reason: "Malformed operator unpublish evidence.",
+            timestamp,
+            previousState: "published" as const,
+            nextState: "approved" as const,
+            sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+            readinessProofRef: null,
+            operatorApprovalRef: null,
+            evidenceRefs: [],
+          },
+        ],
+      },
+    ],
+    [
+      "readiness proof ref is stale",
+      {
+        ...publishedRecord(),
+        auditHistory: publishedRecord().auditHistory.map((entry) => entry.action === "publish"
+          ? { ...entry, readinessProofRef: "readiness-proof:stale" }
+          : entry),
+      },
+    ],
+    [
+      "operator approval ref is stale",
+      {
+        ...publishedRecord(),
+        auditHistory: publishedRecord().auditHistory.map((entry) => entry.action === "publish"
+          ? { ...entry, operatorApprovalRef: "evidence:operator-approval:stale" }
+          : entry),
+      },
+    ],
+  ] as Array<[string, MarketplaceApprovalRecord]>)(
+    "blocks when %s",
+    (_label, record) => {
+      const decision = deriveMarketplacePublicationEligibility(record, fixturePublishReadyProof);
+
+      expect(decision.status).toBe("blocked");
+      expect(decision.reasonCodes).toContain("publish_audit_malformed");
+      expect(decision.boundaries.hostedExportAllowed).toBe(false);
+    },
+  );
+
   it("blocks live escalation or Quasar-backed claims", () => {
     const decision = deriveMarketplacePublicationEligibility(publishedRecord(), {
       ...fixturePublishReadyProof,
@@ -229,6 +318,7 @@ function action(
     type,
     operatorId,
     timestamp,
+    ...(type === "publish" || type === "restore" ? { readinessProofRef: "readiness-proof:approve-ready" } : {}),
     ...overrides,
   };
 }
@@ -256,6 +346,9 @@ function publishedUnsafeRecord() {
       timestamp,
       previousState: "approved" as const,
       nextState: "published" as const,
+      sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+      readinessProofRef: "readiness-proof:forged",
+      operatorApprovalRef: "evidence:operator-approval:approve-ready",
       evidenceRefs: ["evidence:forged:publish"],
     }],
   };

--- a/lib/manager/marketplace-approval-actions.ts
+++ b/lib/manager/marketplace-approval-actions.ts
@@ -22,7 +22,8 @@ export type MarketplaceApprovalActionType =
   | "reject"
   | "suspend"
   | "publish"
-  | "unpublish";
+  | "unpublish"
+  | "restore";
 
 export type MarketplaceApprovalAuditEntry = {
   operatorId: string;
@@ -31,6 +32,9 @@ export type MarketplaceApprovalAuditEntry = {
   timestamp: string;
   previousState: MarketplaceApprovalRecordState;
   nextState: MarketplaceApprovalRecordState;
+  sourceListingRef: string;
+  readinessProofRef: string | null;
+  operatorApprovalRef: string | null;
   evidenceRefs: string[];
 };
 
@@ -50,6 +54,9 @@ export type MarketplaceApprovalAction = {
   reason?: string;
   evidenceRefs?: string[];
   readinessProof?: MarketplaceReadinessProofMetadata;
+  readinessProofRef?: string;
+  operatorApprovalRef?: string;
+  sourceListingRef?: string;
 };
 
 export type MarketplaceApprovalActionResult =
@@ -98,6 +105,8 @@ export function applyMarketplaceApprovalAction(
       return publish(record, action);
     case "unpublish":
       return unpublish(record, action);
+    case "restore":
+      return restore(record, action);
   }
 }
 
@@ -149,6 +158,21 @@ function publish(record: MarketplaceApprovalRecord, action: MarketplaceApprovalA
   if (record.state !== "approved") {
     return fail(record, `Publish requires approved state; got ${record.state}.`);
   }
+  return publishWithProof(record, action, "published");
+}
+
+function restore(record: MarketplaceApprovalRecord, action: MarketplaceApprovalAction): MarketplaceApprovalActionResult {
+  if (record.state !== "suspended") {
+    return fail(record, `Restore requires suspended state; got ${record.state}.`);
+  }
+  return publishWithProof(record, action, "published");
+}
+
+function publishWithProof(
+  record: MarketplaceApprovalRecord,
+  action: MarketplaceApprovalAction,
+  nextState: MarketplaceApprovalRecordState,
+): MarketplaceApprovalActionResult {
   const readiness = evaluateMarketplaceReadiness(
     record.id,
     record.fixtureKey,
@@ -165,12 +189,25 @@ function publish(record: MarketplaceApprovalRecord, action: MarketplaceApprovalA
   if (!action.readinessProof?.operatorApproval?.approved || !isNonEmptyString(action.readinessProof.operatorApproval.evidenceRef)) {
     return fail(record, "Publish requires explicit operator approval evidence.", readiness);
   }
+  if (!isNonEmptyString(action.readinessProofRef)) {
+    return fail(record, "Publish requires explicit readiness proof evidence.", readiness);
+  }
 
   const evidenceRefs = uniqueRefs([
     ...(action.evidenceRefs ?? []),
     ...readiness.gates.flatMap((gate) => gate.evidenceRefs),
   ]);
-  return transition(record, { ...action, evidenceRefs }, "published", true, readiness);
+  return transition(
+    record,
+    {
+      ...action,
+      evidenceRefs,
+      operatorApprovalRef: action.readinessProof.operatorApproval.evidenceRef,
+    },
+    nextState,
+    true,
+    readiness,
+  );
 }
 
 function unpublish(record: MarketplaceApprovalRecord, action: MarketplaceApprovalAction): MarketplaceApprovalActionResult {
@@ -192,6 +229,9 @@ function transition(
     timestamp: action.timestamp,
     previousState: record.state,
     nextState,
+    sourceListingRef: action.sourceListingRef?.trim() || sourceListingRefFor(record),
+    readinessProofRef: action.readinessProofRef?.trim() || null,
+    operatorApprovalRef: action.operatorApprovalRef?.trim() || null,
     evidenceRefs: uniqueRefs(action.evidenceRefs ?? []),
   };
 
@@ -236,7 +276,19 @@ function defaultReasonFor(action: MarketplaceApprovalActionType) {
       return "Operator published after local readiness evidence passed.";
     case "unpublish":
       return "Operator forced public visibility off.";
+    case "restore":
+      return "Operator restored publication after current readiness evidence passed.";
   }
+}
+
+function sourceListingRefFor(record: MarketplaceApprovalRecord) {
+  const prefix = "operator-review:";
+  const suffix = `:${record.fixtureKey}`;
+  if (!record.candidate.id.startsWith(prefix) || !record.candidate.id.endsWith(suffix)) {
+    return record.candidate.id;
+  }
+  const corpusId = record.candidate.id.slice(prefix.length, -suffix.length);
+  return `draft-listing:${corpusId}`;
 }
 
 function uniqueRefs(refs: string[]) {

--- a/lib/manager/marketplace-public-export-fixtures.ts
+++ b/lib/manager/marketplace-public-export-fixtures.ts
@@ -15,6 +15,7 @@ const fixtureTimestamp = "2026-06-20T00:00:00Z";
 const fixtureOperatorId = "operator:fixture";
 
 export const fixturePublishReadyProof: MarketplacePublicationEligibilityProof = {
+  readinessProofRef: "readiness-proof:approve-ready",
   endpointBindingRef: "endpoint-binding:anthropic-financial-services:dry-run",
   paymentPlan: {
     schemaVersion: "marketplace-payment-plan-proof:v1",
@@ -136,6 +137,9 @@ export function getFixtureBackedMarketplacePublicExportSnapshot(): MarketplacePu
       timestamp: fixtureTimestamp,
       previousState: "approved" as const,
       nextState: "published" as const,
+      sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+      readinessProofRef: "readiness-proof:forged",
+      operatorApprovalRef: "evidence:operator-approval:approve-ready",
       evidenceRefs: ["evidence:forged:publish"],
     }],
   };
@@ -159,6 +163,7 @@ function action(
     type,
     operatorId: fixtureOperatorId,
     timestamp: fixtureTimestamp,
+    ...(type === "publish" || type === "restore" ? { readinessProofRef: "readiness-proof:approve-ready" } : {}),
     ...overrides,
   };
 }

--- a/lib/manager/marketplace-public-export.ts
+++ b/lib/manager/marketplace-public-export.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/manager/marketplace-readiness-gate";
 import {
   deriveMarketplacePublicationEligibility,
+  selectCurrentPublicationAudit,
   type MarketplacePublicationEligibilityDecision,
   type MarketplacePublicationEligibilityProof,
 } from "@/lib/manager/marketplace-publication-eligibility";
@@ -161,7 +162,7 @@ export function deriveMarketplacePublicExportItem(
     };
   }
 
-  const publishAudit = latestPublishAudit(record);
+  const publishAudit = selectCurrentPublicationAudit(record, proof);
   if (!publishAudit) {
     throw new Error("invariant: public export requires publish audit evidence");
   }
@@ -296,16 +297,6 @@ function buildCatalogResource(
       capabilities: listing.capabilities.tags,
     },
   };
-}
-
-function latestPublishAudit(record: MarketplaceApprovalRecord) {
-  return [...record.auditHistory]
-    .reverse()
-    .find((entry) =>
-      entry.action === "publish"
-      && entry.nextState === "published"
-      && entry.evidenceRefs.some(isNonEmptyString)
-    );
 }
 
 function publicExportBoundaries(

--- a/lib/manager/marketplace-publication-eligibility.ts
+++ b/lib/manager/marketplace-publication-eligibility.ts
@@ -22,6 +22,7 @@ export type MarketplacePublicationQuasarCompatibility = {
 };
 
 export type MarketplacePublicationEligibilityProof = MarketplaceReadinessProofMetadata & {
+  readinessProofRef?: string;
   hostedAttestationClaim?: HostedAttestationClaim;
   hostedSourceProofRef?: string;
   hostedAttestationProofRef?: string;
@@ -38,6 +39,7 @@ export type MarketplacePublicationEligibilityReasonCode =
   | "operator_approval_missing"
   | "operator_approval_evidence_missing"
   | "publish_audit_missing"
+  | "publish_audit_malformed"
   | "unsafe_metadata"
   | "endpoint_binding_missing"
   | "suspended_or_unpublished_state"
@@ -88,6 +90,8 @@ export function deriveMarketplacePublicationEligibility(
   proof: MarketplacePublicationEligibilityProof = {},
 ): MarketplacePublicationEligibilityDecision {
   const readiness = evaluateMarketplaceReadiness(record.id, record.fixtureKey, record.candidate, proof);
+  const latestLifecycleAudit = latestPublicationLifecycleAudit(record);
+  const currentPublicationAudit = selectCurrentPublicationAudit(record, proof);
   const reasonCodes = uniqueReasonCodes([
     record.state === "published" ? undefined : "record_state_not_published",
     record.publicVisible === true ? undefined : "public_visibility_false",
@@ -95,7 +99,8 @@ export function deriveMarketplacePublicationEligibility(
     readiness.boundaries.publicationAllowed === true ? undefined : "publication_not_allowed",
     proof.operatorApproval?.approved === true ? undefined : "operator_approval_missing",
     isNonEmptyString(proof.operatorApproval?.evidenceRef) ? undefined : "operator_approval_evidence_missing",
-    latestPublishAuditEvidenceRefs(record).length > 0 ? undefined : "publish_audit_missing",
+    latestLifecycleAudit ? undefined : "publish_audit_missing",
+    latestLifecycleAudit && !currentPublicationAudit ? "publish_audit_malformed" : undefined,
     readiness.gates.find((gate) => gate.id === "safe_metadata")?.passed === false ? "unsafe_metadata" : undefined,
     isNonEmptyString(proof.endpointBindingRef) ? undefined : "endpoint_binding_missing",
     ["suspended", "rejected", "needs_changes", "draft", "approved", "internal", "blocked"].includes(record.state)
@@ -143,7 +148,7 @@ export function deriveMarketplacePublicationEligibility(
     reasonCodes: normalizedReasonCodes,
     blockedReasons: blockedReasonsFor(normalizedReasonCodes, readiness),
     evidenceRefs: uniqueRefs([
-      ...latestPublishAuditEvidenceRefs(record),
+      ...(currentPublicationAudit?.evidenceRefs ?? []),
       ...readiness.gates.flatMap((gate) => gate.evidenceRefs),
       proof.hostedSourceProofRef,
       proof.hostedAttestationProofRef,
@@ -171,14 +176,34 @@ export function deriveMarketplacePublicationEligibility(
   };
 }
 
-function latestPublishAuditEvidenceRefs(record: MarketplaceApprovalRecord) {
+export function selectCurrentPublicationAudit(
+  record: MarketplaceApprovalRecord,
+  proof: MarketplacePublicationEligibilityProof = {},
+) {
+  const audit = latestPublicationLifecycleAudit(record);
+  if (!audit || (audit.action !== "publish" && audit.action !== "restore")) return undefined;
+  return publishAuditMatchesProof(audit, record, proof) ? audit : undefined;
+}
+
+function latestPublicationLifecycleAudit(record: MarketplaceApprovalRecord) {
   return [...record.auditHistory]
     .reverse()
-    .find((entry) =>
-      entry.action === "publish"
-      && entry.nextState === "published"
-      && entry.evidenceRefs.some(isNonEmptyString)
-    )?.evidenceRefs ?? [];
+    .find((entry) => ["publish", "restore", "unpublish", "suspend"].includes(entry.action));
+}
+
+function publishAuditMatchesProof(
+  audit: NonNullable<ReturnType<typeof latestPublicationLifecycleAudit>>,
+  record: MarketplaceApprovalRecord,
+  proof: MarketplacePublicationEligibilityProof,
+) {
+  return audit.nextState === "published"
+    && audit.sourceListingRef === expectedHostedListingId(record)
+    && audit.readinessProofRef === proof.readinessProofRef
+    && audit.operatorApprovalRef === proof.operatorApproval?.evidenceRef
+    && Array.isArray(audit.evidenceRefs)
+    && audit.evidenceRefs.some(isNonEmptyString)
+    && isNonEmptyString(audit.timestamp)
+    && !Number.isNaN(Date.parse(audit.timestamp));
 }
 
 function hasReceiptEvidence(proof: MarketplacePublicationEligibilityProof) {
@@ -297,6 +322,7 @@ const reasonText: Partial<Record<MarketplacePublicationEligibilityReasonCode, st
   operator_approval_missing: "Operator approval proof is missing.",
   operator_approval_evidence_missing: "Operator approval evidence ref is missing.",
   publish_audit_missing: "Publish audit evidence is missing.",
+  publish_audit_malformed: "Publish audit evidence is malformed or does not match current proof inputs.",
   unsafe_metadata: "Imported metadata is unsafe or unresolved.",
   endpoint_binding_missing: "Endpoint binding proof is missing.",
   suspended_or_unpublished_state: "Listing is suspended, unpublished, or not in a publishable state.",


### PR DESCRIPTION
Closes #446.

## Summary
- enriches marketplace approval audit entries with source listing, readiness proof, and operator approval refs
- adds restore as a current-readiness-gated publication lifecycle action from suspended state
- shares validated publication audit selection between eligibility and export
- blocks stale/malformed lifecycle audit evidence, including latest unpublish/suspend, stale readiness proof refs, stale operator approval refs, and missing evidence

## Boundary
- read-model/state-transition evidence only
- no activation route, hosted registry write, wallet/RPC, Surfpool/devnet, live payment, provider/MCP call, Quasar instruction, UI, or reputation mutation

## Validation
- `npx jest --runInBand lib/__tests__/manager-marketplace-approval-actions.test.ts lib/__tests__/manager-marketplace-publication-eligibility.test.ts lib/__tests__/manager-marketplace-public-export.test.ts lib/__tests__/manager-marketplace-public-export-route.test.ts lib/__tests__/manager-marketplace-readiness-gate.test.ts` passed: 5 suites / 65 tests
- `npm run build` passed
- `git diff --check` passed
- `npm run check:rap:naming` passed
- `npx eslint` on touched files passed
- scoped side-effect scan found only helper/false/negative guardrail references