### PR TITLE
Add hosted publication activation gate

### DIFF
--- a/app/api/manager/marketplace-publication-activation/route.ts
+++ b/app/api/manager/marketplace-publication-activation/route.ts
@@ -1,0 +1,59 @@
+import { deriveMarketplacePublicationActivationGate } from "@/lib/manager/marketplace-publication-activation";
+import { getFixtureBackedMarketplacePublicExportSnapshot } from "@/lib/manager/marketplace-public-export-fixtures";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const fixtureTimestamp = "2026-06-20T00:00:00Z";
+
+export async function GET() {
+  try {
+    const exportSnapshot = getFixtureBackedMarketplacePublicExportSnapshot();
+    const exportItem = exportSnapshot.exported[0];
+    if (!exportItem) {
+      return Response.json(
+        { ok: false, error: "No eligible fixture export is available for dry-run activation" },
+        { status: 409 },
+      );
+    }
+
+    const result = deriveMarketplacePublicationActivationGate({
+      id: "activation:approve-ready:dry-run",
+      exportItem,
+      activationApproval: {
+        approved: true,
+        approvedBy: "operator:fixture",
+        approvedAt: fixtureTimestamp,
+        evidenceRef: "evidence:activation:approve-ready",
+        activationIntentRef: "evidence:activation-intent:approve-ready",
+        operatorApprovalRef: "evidence:operator-approval:approve-ready",
+        publicationAuditEvidenceRef: "evidence:operator-action:publish",
+      },
+      requestedAt: fixtureTimestamp,
+    });
+
+    return Response.json({
+      ok: result.status === "dry_run_ready",
+      result,
+      guardrails: {
+        readOnly: true,
+        fixtureBacked: true,
+        dryRunOnly: true,
+        livePublication: false,
+        livePayment: false,
+        hostedRegistryWrite: false,
+        walletSigning: false,
+        rpcProbe: false,
+        mcpCall: false,
+        providerCall: false,
+        reputationAssignment: false,
+      },
+    }, { status: result.status === "dry_run_ready" ? 200 : 409 });
+  } catch (error) {
+    return Response.json(
+      { ok: false, error: error instanceof Error ? error.message : "Marketplace publication activation failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/__tests__/manager-marketplace-publication-activation-route.test.ts
+++ b/lib/__tests__/manager-marketplace-publication-activation-route.test.ts
@@ -1,0 +1,69 @@
+jest.mock("@/lib/registry/bridge", () => {
+  throw new Error("live registry bridge must not be imported by marketplace publication activation route");
+});
+
+jest.mock("@solana/web3.js", () => {
+  throw new Error("Solana RPC helpers must not be imported by marketplace publication activation route");
+});
+
+jest.mock("@/lib/onboarding/x402-settlement", () => {
+  throw new Error("live payment settlement must not be imported by marketplace publication activation route");
+}, { virtual: true });
+
+describe("manager marketplace publication activation route", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("returns a read-only fixture-backed dry-run activation decision", async () => {
+    const { GET } = await import("@/app/api/manager/marketplace-publication-activation/route");
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      guardrails: {
+        readOnly: true,
+        fixtureBacked: true,
+        dryRunOnly: true,
+        livePublication: false,
+        livePayment: false,
+        hostedRegistryWrite: false,
+        walletSigning: false,
+        rpcProbe: false,
+        mcpCall: false,
+        providerCall: false,
+        reputationAssignment: false,
+      },
+      result: {
+        schemaVersion: "reddi.marketplace-publication-activation.v1",
+        status: "dry_run_ready",
+        mode: "dry_run",
+        source: "public_export_item",
+        reasonCodes: ["dry_run_activation_ready"],
+        outputs: {
+          hostedRap: "dry_run_only",
+          ardCatalog: "dry_run_only",
+          publicExportSnapshot: "dry_run_only",
+        },
+        activationPlan: {
+          hostedRegistryWrite: false,
+          ardCatalogWrite: false,
+          livePublication: false,
+          walletSigning: false,
+          rpcProbe: false,
+          livePayment: false,
+          providerCall: false,
+          mcpCall: false,
+        },
+      },
+    });
+    expect(body.result.evidenceRefs).toEqual(expect.arrayContaining([
+      "evidence:activation:approve-ready",
+      "evidence:activation-intent:approve-ready",
+      "evidence:operator-action:publish",
+    ]));
+  });
+});

--- a/lib/__tests__/manager-marketplace-publication-activation.test.ts
+++ b/lib/__tests__/manager-marketplace-publication-activation.test.ts
@@ -1,0 +1,316 @@
+import {
+  applyMarketplaceApprovalAction,
+  type MarketplaceApprovalAction,
+  type MarketplaceApprovalRecord,
+  type MarketplaceApprovalRecordState,
+} from "@/lib/manager/marketplace-approval-actions";
+import {
+  deriveMarketplacePublicationActivationGate,
+  type MarketplacePublicationActivationApproval,
+} from "@/lib/manager/marketplace-publication-activation";
+import { deriveMarketplacePublicExportItem } from "@/lib/manager/marketplace-public-export";
+import { fixturePublishReadyProof } from "@/lib/manager/marketplace-public-export-fixtures";
+import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
+
+const timestamp = "2026-06-20T00:00:00Z";
+const operatorId = "operator:test";
+
+describe("marketplace publication activation gate", () => {
+  it("returns a dry-run activation decision for an eligible public export item", () => {
+    const exportItem = exportedItem();
+    const decision = deriveMarketplacePublicationActivationGate({
+      id: "activation:approve-ready:dry-run",
+      exportItem,
+      activationApproval: activationApproval(),
+      requestedAt: timestamp,
+    });
+
+    expect(decision).toMatchObject({
+      schemaVersion: "reddi.marketplace-publication-activation.v1",
+      status: "dry_run_ready",
+      mode: "dry_run",
+      source: "public_export_item",
+      reasonCodes: ["dry_run_activation_ready"],
+      outputs: {
+        hostedRap: "dry_run_only",
+        ardCatalog: "dry_run_only",
+        publicExportSnapshot: "dry_run_only",
+      },
+      activationPlan: {
+        hostedRegistryWrite: false,
+        ardCatalogWrite: false,
+        livePublication: false,
+        walletSigning: false,
+        rpcProbe: false,
+        livePayment: false,
+        providerCall: false,
+        mcpCall: false,
+      },
+      guardrails: {
+        dryRunOnly: true,
+        livePublicationActivated: false,
+        hostedRegistryWrite: false,
+        marketplacePublished: false,
+        paymentActivationAllowed: false,
+        walletSigning: false,
+        rpcCall: false,
+        providerCall: false,
+        reputationMutated: false,
+        quasarInstructionBuilt: false,
+      },
+    });
+    expect(decision.evidenceRefs).toEqual(expect.arrayContaining([
+      "evidence:operator-action:publish",
+      "evidence:activation:approve-ready",
+      "evidence:activation-intent:approve-ready",
+      "evidence:operator-approval:approve-ready",
+    ]));
+  });
+
+  it("is idempotent for repeated dry-run activation checks", () => {
+    const input = {
+      id: "activation:approve-ready:dry-run",
+      exportItem: exportedItem(),
+      activationApproval: activationApproval(),
+      requestedAt: timestamp,
+    };
+
+    expect(deriveMarketplacePublicationActivationGate(input)).toEqual(deriveMarketplacePublicationActivationGate(input));
+  });
+
+  it.each([
+    ["missing activation approval", undefined, "explicit_operator_gate_missing"],
+    [
+      "activation approval missing evidence",
+      activationApproval({ evidenceRef: "" }),
+      "explicit_operator_gate_evidence_missing",
+    ],
+    [
+      "activation approval missing actor",
+      activationApproval({ approvedBy: "" }),
+      "explicit_operator_gate_actor_missing",
+    ],
+    [
+      "activation intent missing",
+      activationApproval({ activationIntentRef: "" }),
+      "activation_gate_intent_missing",
+    ],
+    [
+      "activation approval not approved",
+      activationApproval({ approved: false }),
+      "explicit_operator_gate_not_approved",
+    ],
+    [
+      "activation approval operator mismatch",
+      activationApproval({ operatorApprovalRef: "evidence:operator-approval:stale" }),
+      "activation_gate_operator_mismatch",
+    ],
+    [
+      "activation approval audit mismatch",
+      activationApproval({ publicationAuditEvidenceRef: "evidence:operator-action:stale" }),
+      "activation_gate_audit_mismatch",
+    ],
+    ["activation approval timestamp invalid", activationApproval({ approvedAt: "not-a-date" }), "activation_gate_timestamp_invalid"],
+    ["activation approval timestamp too loose", activationApproval({ approvedAt: "June 20, 2026" }), "activation_gate_timestamp_invalid"],
+    ["activation approval timestamp normalized invalid", activationApproval({ approvedAt: "2026-02-30T00:00:00Z" }), "activation_gate_timestamp_invalid"],
+    [
+      "live activation request",
+      activationApproval({ mode: "live" }),
+      "live_mode_unavailable",
+    ],
+  ] as Array<[string, MarketplacePublicationActivationApproval | undefined, string]>)(
+    "blocks %s",
+    (_label, approval, reasonCode) => {
+      const decision = deriveMarketplacePublicationActivationGate({
+        id: "activation:approve-ready:dry-run",
+        exportItem: exportedItem(),
+        activationApproval: approval,
+        requestedAt: timestamp,
+      });
+
+      expect(decision.status).toBe("blocked");
+      expect(decision.reasonCodes).toContain(reasonCode);
+      expect(decision.outputs.hostedRap).toBe("blocked");
+      expect(decision.outputs.ardCatalog).toBe("blocked");
+      expect(decision.activationPlan.hostedRegistryWrite).toBe(false);
+      expect(decision.activationPlan.livePublication).toBe(false);
+      expect(decision.guardrails.hostedRegistryWrite).toBe(false);
+      expect(decision.guardrails.marketplacePublished).toBe(false);
+      expect(decision.guardrails.paymentActivationAllowed).toBe(false);
+    },
+  );
+
+  it("blocks when public export is not eligible", () => {
+    const exportItem = deriveMarketplacePublicExportItem(recordFor("approved", "approveReadyDraft"), fixturePublishReadyProof);
+
+    const decision = deriveMarketplacePublicationActivationGate({
+      id: "activation:blocked",
+      exportItem,
+      activationApproval: activationApproval(),
+      requestedAt: timestamp,
+    });
+
+    expect(exportItem.ok).toBe(false);
+    expect(decision.status).toBe("blocked");
+    expect(decision.reasonCodes).toContain("export_not_eligible");
+    expect(decision.blockedReasons).toEqual(expect.arrayContaining(exportItem.ok ? [] : exportItem.blockReasons));
+    expect(decision.outputs.publicExportSnapshot).toBe("blocked");
+  });
+
+  it.each([
+    [
+      "latest lifecycle unpublishes",
+      {
+        action: "unpublish" as const,
+        previousState: "published" as const,
+        nextState: "approved" as const,
+        evidenceRefs: ["evidence:operator-action:unpublish"],
+      },
+    ],
+    [
+      "latest lifecycle suspends with malformed evidence",
+      {
+        action: "suspend" as const,
+        previousState: "published" as const,
+        nextState: "suspended" as const,
+        evidenceRefs: [],
+      },
+    ],
+  ])("blocks when public export blocks because %s", (_label, latestAudit) => {
+    const record: MarketplaceApprovalRecord = {
+      ...publishedRecord(),
+      auditHistory: [
+        ...publishedRecord().auditHistory,
+        {
+          operatorId,
+          reason: "Operator lifecycle action.",
+          timestamp,
+          sourceListingRef: "draft-listing:agent-stack-fixture:anthropic-financial-services:2026-06-18",
+          readinessProofRef: null,
+          operatorApprovalRef: null,
+          ...latestAudit,
+        },
+      ],
+    };
+    const exportItem = deriveMarketplacePublicExportItem(record, fixturePublishReadyProof);
+
+    const decision = deriveMarketplacePublicationActivationGate({
+      id: "activation:blocked-lifecycle",
+      exportItem,
+      activationApproval: activationApproval(),
+      requestedAt: timestamp,
+    });
+
+    expect(exportItem.ok).toBe(false);
+    expect(decision.status).toBe("blocked");
+    expect(decision.reasonCodes).toContain("export_not_eligible");
+    expect(decision.blockedReasons.join(" ")).toContain("Publish audit evidence");
+  });
+
+  it("blocks forged live flags on a public export success", () => {
+    const exportItem = exportedItem();
+    const forgedLiveExport = {
+      ...exportItem,
+      listing: {
+        ...exportItem.listing,
+        payment: {
+          ...exportItem.listing.payment,
+          activation: "enabled" as "disabled",
+        },
+      },
+    };
+
+    const decision = deriveMarketplacePublicationActivationGate({
+      id: "activation:forged-live",
+      exportItem: forgedLiveExport,
+      activationApproval: activationApproval(),
+      requestedAt: timestamp,
+    });
+
+    expect(decision.status).toBe("blocked");
+    expect(decision.reasonCodes).toContain("export_live_boundary_escalation");
+    expect(decision.guardrails.livePublicationActivated).toBe(false);
+    expect(decision.guardrails.paymentActivationAllowed).toBe(false);
+  });
+
+  it("blocks malformed request ids and timestamps without throwing", () => {
+    for (const requestedAt of ["bad-date", "2026", "2026-02-30T00:00:00Z"]) {
+      const decision = deriveMarketplacePublicationActivationGate({
+        id: "",
+        exportItem: exportedItem(),
+        activationApproval: activationApproval(),
+        requestedAt,
+      });
+
+      expect(decision.status).toBe("blocked");
+      expect(decision.reasonCodes).toEqual(expect.arrayContaining([
+        "missing_activation_id",
+        "invalid_request_timestamp",
+      ]));
+    }
+  });
+});
+
+function activationApproval(
+  overrides: Partial<MarketplacePublicationActivationApproval> = {},
+): MarketplacePublicationActivationApproval {
+  return {
+    approved: true,
+    approvedBy: "operator:fixture",
+    approvedAt: timestamp,
+    evidenceRef: "evidence:activation:approve-ready",
+    activationIntentRef: "evidence:activation-intent:approve-ready",
+    operatorApprovalRef: "evidence:operator-approval:approve-ready",
+    publicationAuditEvidenceRef: "evidence:operator-action:publish",
+    ...overrides,
+  };
+}
+
+function action(
+  type: MarketplaceApprovalAction["type"],
+  overrides: Partial<MarketplaceApprovalAction> = {},
+): MarketplaceApprovalAction {
+  return {
+    type,
+    operatorId,
+    timestamp,
+    ...(type === "publish" || type === "restore" ? { readinessProofRef: "readiness-proof:approve-ready" } : {}),
+    ...overrides,
+  };
+}
+
+function exportedItem() {
+  const item = deriveMarketplacePublicExportItem(publishedRecord(), fixturePublishReadyProof);
+  if (!item.ok) throw new Error(item.reasons.join(", "));
+  return item;
+}
+
+function publishedRecord() {
+  const approve = applyMarketplaceApprovalAction(recordFor("draft", "approveReadyDraft"), action("approve"));
+  if (!approve.ok) throw new Error(approve.reason);
+
+  const publish = applyMarketplaceApprovalAction(approve.record, action("publish", {
+    readinessProof: fixturePublishReadyProof,
+    evidenceRefs: ["evidence:operator-action:publish"],
+  }));
+  if (!publish.ok) throw new Error(publish.reason);
+
+  return publish.record;
+}
+
+function recordFor(
+  state: MarketplaceApprovalRecordState,
+  fixtureKey: string,
+  publicVisible = false,
+): MarketplaceApprovalRecord {
+  const candidate = getStaticAgentStackReviewWorkspace().candidates.find((item) => item.fixtureKey === fixtureKey);
+  if (!candidate) throw new Error(`missing fixture candidate: ${fixtureKey}`);
+  return {
+    id: `${state}:${fixtureKey}`,
+    fixtureKey,
+    candidate,
+    state,
+    publicVisible,
+    auditHistory: [],
+  };
+}

--- a/lib/manager/marketplace-publication-activation.ts
+++ b/lib/manager/marketplace-publication-activation.ts
@@ -1,0 +1,267 @@
+import type {
+  MarketplacePublicExportItem,
+  MarketplacePublicExportSuccess,
+} from "@/lib/manager/marketplace-public-export";
+
+export const MARKETPLACE_PUBLICATION_ACTIVATION_SCHEMA_VERSION =
+  "reddi.marketplace-publication-activation.v1" as const;
+
+export type MarketplacePublicationActivationMode = "dry_run" | "live";
+
+export type MarketplacePublicationActivationStatus = "dry_run_ready" | "blocked";
+
+export type MarketplacePublicationActivationApproval = {
+  approved: boolean;
+  approvedBy: string;
+  approvedAt: string;
+  evidenceRef: string;
+  activationIntentRef: string;
+  mode?: MarketplacePublicationActivationMode;
+  operatorApprovalRef: string;
+  publicationAuditEvidenceRef: string;
+};
+
+export type MarketplacePublicationActivationInput = {
+  id: string;
+  exportItem: MarketplacePublicExportItem;
+  activationApproval?: MarketplacePublicationActivationApproval;
+  requestedAt: string;
+};
+
+export type MarketplacePublicationActivationReasonCode =
+  | "dry_run_activation_ready"
+  | "missing_activation_id"
+  | "invalid_request_timestamp"
+  | "export_not_eligible"
+  | "export_live_boundary_escalation"
+  | "publish_audit_not_current"
+  | "explicit_operator_gate_missing"
+  | "explicit_operator_gate_evidence_missing"
+  | "explicit_operator_gate_actor_missing"
+  | "explicit_operator_gate_not_approved"
+  | "activation_gate_operator_mismatch"
+  | "activation_gate_audit_mismatch"
+  | "activation_gate_intent_missing"
+  | "activation_gate_timestamp_invalid"
+  | "live_mode_unavailable"
+  | "live_escalation_not_allowed";
+
+export type MarketplacePublicationActivationDecision = {
+  schemaVersion: typeof MARKETPLACE_PUBLICATION_ACTIVATION_SCHEMA_VERSION;
+  id: string;
+  listingId: string;
+  fixtureKey: string;
+  status: MarketplacePublicationActivationStatus;
+  mode: MarketplacePublicationActivationMode;
+  source: "public_export_item";
+  reasonCodes: MarketplacePublicationActivationReasonCode[];
+  blockedReasons: string[];
+  evidenceRefs: string[];
+  outputs: {
+    hostedRap: "dry_run_only" | "blocked";
+    ardCatalog: "dry_run_only" | "blocked";
+    publicExportSnapshot: "dry_run_only" | "blocked";
+  };
+  activationPlan: {
+    hostedRegistryWrite: false;
+    ardCatalogWrite: false;
+    livePublication: false;
+    walletSigning: false;
+    rpcProbe: false;
+    livePayment: false;
+    providerCall: false;
+    mcpCall: false;
+  };
+  guardrails: {
+    dryRunOnly: true;
+    livePublicationActivated: false;
+    hostedRegistryWrite: false;
+    marketplacePublished: false;
+    paymentActivationAllowed: false;
+    walletSigning: false;
+    rpcCall: false;
+    providerCall: false;
+    reputationMutated: false;
+    quasarInstructionBuilt: false;
+  };
+  createdAt: string;
+};
+
+export function deriveMarketplacePublicationActivationGate(
+  input: MarketplacePublicationActivationInput,
+): MarketplacePublicationActivationDecision {
+  const mode = input.activationApproval?.mode ?? "dry_run";
+  const exportSuccess = input.exportItem.ok ? input.exportItem : undefined;
+  const reasonCodes = uniqueReasonCodes([
+    isNonEmptyString(input.id) ? undefined : "missing_activation_id",
+    isoTimestampIsValid(input.requestedAt) ? undefined : "invalid_request_timestamp",
+    exportSuccess ? undefined : "export_not_eligible",
+    exportSuccess && !exportBoundariesAreNonLive(exportSuccess) ? "export_live_boundary_escalation" : undefined,
+    exportSuccess && !publishAuditIsCurrent(exportSuccess) ? "publish_audit_not_current" : undefined,
+    input.activationApproval ? undefined : "explicit_operator_gate_missing",
+    input.activationApproval && !isNonEmptyString(input.activationApproval.evidenceRef)
+      ? "explicit_operator_gate_evidence_missing"
+      : undefined,
+    input.activationApproval && !isNonEmptyString(input.activationApproval.approvedBy)
+      ? "explicit_operator_gate_actor_missing"
+      : undefined,
+    input.activationApproval && !isNonEmptyString(input.activationApproval.activationIntentRef)
+      ? "activation_gate_intent_missing"
+      : undefined,
+    input.activationApproval && input.activationApproval.approved !== true ? "explicit_operator_gate_not_approved" : undefined,
+    input.activationApproval && exportSuccess && !activationGateOperatorMatches(input.activationApproval, exportSuccess)
+      ? "activation_gate_operator_mismatch"
+      : undefined,
+    input.activationApproval && exportSuccess && !activationGateAuditMatches(input.activationApproval, exportSuccess)
+      ? "activation_gate_audit_mismatch"
+      : undefined,
+    input.activationApproval && !isoTimestampIsValid(input.activationApproval.approvedAt)
+      ? "activation_gate_timestamp_invalid"
+      : undefined,
+    mode === "live" ? "live_mode_unavailable" : undefined,
+    mode === "live" ? "live_escalation_not_allowed" : undefined,
+  ]);
+  const status: MarketplacePublicationActivationStatus = reasonCodes.length === 0 ? "dry_run_ready" : "blocked";
+  const normalizedReasonCodes = status === "dry_run_ready"
+    ? ["dry_run_activation_ready" as const]
+    : reasonCodes;
+
+  return {
+    schemaVersion: MARKETPLACE_PUBLICATION_ACTIVATION_SCHEMA_VERSION,
+    id: input.id,
+    listingId: listingIdFor(input.exportItem),
+    fixtureKey: fixtureKeyFor(input.exportItem),
+    status,
+    mode,
+    source: "public_export_item",
+    reasonCodes: normalizedReasonCodes,
+    blockedReasons: blockedReasonsFor(normalizedReasonCodes, input.exportItem),
+    evidenceRefs: uniqueRefs([
+      ...(exportSuccess?.listing.evidenceRefs ?? []),
+      ...(exportSuccess?.eligibility.evidenceRefs ?? []),
+      ...(exportSuccess?.publishAudit.evidenceRefs ?? []),
+      input.activationApproval?.evidenceRef,
+      input.activationApproval?.activationIntentRef,
+      input.activationApproval?.operatorApprovalRef,
+      input.activationApproval?.publicationAuditEvidenceRef,
+    ]),
+    outputs: {
+      hostedRap: status === "dry_run_ready" ? "dry_run_only" : "blocked",
+      ardCatalog: status === "dry_run_ready" ? "dry_run_only" : "blocked",
+      publicExportSnapshot: status === "dry_run_ready" ? "dry_run_only" : "blocked",
+    },
+    activationPlan: {
+      hostedRegistryWrite: false,
+      ardCatalogWrite: false,
+      livePublication: false,
+      walletSigning: false,
+      rpcProbe: false,
+      livePayment: false,
+      providerCall: false,
+      mcpCall: false,
+    },
+    guardrails: {
+      dryRunOnly: true,
+      livePublicationActivated: false,
+      hostedRegistryWrite: false,
+      marketplacePublished: false,
+      paymentActivationAllowed: false,
+      walletSigning: false,
+      rpcCall: false,
+      providerCall: false,
+      reputationMutated: false,
+      quasarInstructionBuilt: false,
+    },
+    createdAt: input.requestedAt,
+  };
+}
+
+function exportBoundariesAreNonLive(exportItem: MarketplacePublicExportSuccess) {
+  return exportItem.listing.endpoint.liveUrl === null
+    && exportItem.listing.endpoint.healthStatus === "not_probed"
+    && exportItem.listing.payment.activation === "disabled"
+    && exportItem.listing.payment.settlement === "dry_run_only"
+    && exportItem.listing.trust.rapAttested === false
+    && exportItem.listing.trust.reputationAssigned === false
+    && exportItem.eligibility.boundaries.livePublicationActivated === false
+    && exportItem.eligibility.boundaries.paymentActivationAllowed === false
+    && exportItem.eligibility.boundaries.trustClaimAllowed === false
+    && exportItem.eligibility.boundaries.reputationClaimAllowed === false;
+}
+
+function listingIdFor(exportItem: MarketplacePublicExportItem) {
+  return exportItem.ok ? exportItem.listing.listingId : exportItem.listingId;
+}
+
+function fixtureKeyFor(exportItem: MarketplacePublicExportItem) {
+  return exportItem.ok ? exportItem.listing.fixtureKey : exportItem.fixtureKey;
+}
+
+function publishAuditIsCurrent(exportItem: MarketplacePublicExportSuccess) {
+  return (exportItem.publishAudit.action === "publish" || exportItem.publishAudit.action === "restore")
+    && exportItem.publishAudit.nextState === "published"
+    && exportItem.publishAudit.evidenceRefs.some(isNonEmptyString);
+}
+
+function activationGateOperatorMatches(
+  approval: MarketplacePublicationActivationApproval,
+  exportItem: MarketplacePublicExportSuccess,
+) {
+  return approval.operatorApprovalRef === exportItem.listing.trust.operatorApprovalEvidenceRef;
+}
+
+function activationGateAuditMatches(
+  approval: MarketplacePublicationActivationApproval,
+  exportItem: MarketplacePublicExportSuccess,
+) {
+  return exportItem.publishAudit.evidenceRefs.includes(approval.publicationAuditEvidenceRef);
+}
+
+function isoTimestampIsValid(value: unknown) {
+  if (!isNonEmptyString(value)) return false;
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value)) return false;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return false;
+  const normalized = value.includes(".") ? parsed.toISOString() : parsed.toISOString().replace(".000Z", "Z");
+  return normalized === value;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function uniqueRefs(refs: Array<string | undefined | null>) {
+  return Array.from(new Set(refs.filter(isNonEmptyString)));
+}
+
+function uniqueReasonCodes(codes: Array<MarketplacePublicationActivationReasonCode | undefined>) {
+  return Array.from(new Set(codes.filter((code): code is MarketplacePublicationActivationReasonCode => Boolean(code))));
+}
+
+function blockedReasonsFor(codes: MarketplacePublicationActivationReasonCode[], exportItem: MarketplacePublicExportItem) {
+  return [
+    ...codes
+      .filter((code) => code !== "dry_run_activation_ready")
+      .map((code) => activationReasonDescriptions[code]),
+    ...(!exportItem.ok ? exportItem.blockReasons : []),
+  ];
+}
+
+const activationReasonDescriptions: Record<MarketplacePublicationActivationReasonCode, string> = {
+  dry_run_activation_ready: "Dry-run activation is ready; no live publication side effect is executed.",
+  missing_activation_id: "Activation decision id is missing.",
+  invalid_request_timestamp: "Activation request timestamp is missing or invalid.",
+  export_not_eligible: "Public export item is blocked or not eligible.",
+  export_live_boundary_escalation: "Public export item contains live or trust boundary escalation.",
+  publish_audit_not_current: "Current public export audit is missing or not a publish/restore audit.",
+  explicit_operator_gate_missing: "Explicit activation operator gate is missing.",
+  explicit_operator_gate_evidence_missing: "Explicit activation operator gate evidence is missing.",
+  explicit_operator_gate_actor_missing: "Explicit activation operator identity is missing.",
+  explicit_operator_gate_not_approved: "Explicit activation operator gate is not approved.",
+  activation_gate_operator_mismatch: "Activation gate operator approval does not match the public export evidence.",
+  activation_gate_audit_mismatch: "Activation gate audit evidence does not match the public export audit.",
+  activation_gate_intent_missing: "Activation intent evidence is missing.",
+  activation_gate_timestamp_invalid: "Activation gate approval timestamp is missing or invalid.",
+  live_mode_unavailable: "Live hosted publication activation is unavailable in this issue.",
+  live_escalation_not_allowed: "Live publication escalation is not allowed by this dry-run gate.",
+};


### PR DESCRIPTION
Closes #445.

## Summary
- add `reddi.marketplace-publication-activation.v1` dry-run activation decision layer
- consume the already-derived public export item as the activation boundary so #444 eligibility and #446 lifecycle audit validation stay authoritative
- add GET-only fixture-backed `/api/manager/marketplace-publication-activation` route for dry-run activation evidence
- block missing/non-approved activation approval, stale operator/audit refs, live mode, blocked export items, and forged live boundary escalation

## Guardrails
- dry-run/non-live only
- no hosted registry write, marketplace publication side effect, wallet/RPC, live payment, provider/MCP call, Surfpool/devnet, Quasar instruction, or reputation mutation
- no UI changes, so no screenshots/video required

## Validation
- `npx jest --runInBand lib/__tests__/manager-marketplace-publication-activation.test.ts lib/__tests__/manager-marketplace-publication-activation-route.test.ts lib/__tests__/manager-marketplace-publication-eligibility.test.ts lib/__tests__/manager-marketplace-public-export.test.ts lib/__tests__/manager-marketplace-public-export-route.test.ts lib/__tests__/manager-marketplace-approval-actions.test.ts lib/__tests__/manager-marketplace-readiness-gate.test.ts` — 82/82 passed
- `npm run build` passed
- `npx eslint lib/manager/marketplace-publication-activation.ts lib/__tests__/manager-marketplace-publication-activation.test.ts lib/__tests__/manager-marketplace-publication-activation-route.test.ts app/api/manager/marketplace-publication-activation/route.ts` passed
- `git diff --check` passed
- `npm run check:rap:naming` passed
- scoped side-effect scan found only false guardrail fields/test sentinels