### PR TITLE
Add publication UI evidence states

### DIFF
--- a/components/manager/listings/MarketplaceApprovalQueue.tsx
+++ b/components/manager/listings/MarketplaceApprovalQueue.tsx
@@ -28,6 +28,7 @@ const stateOrder: MarketplaceApprovalQueueState[] = [
   "needs_changes",
   "approve_ready",
   "published_placeholder",
+  "unpublished",
   "rejected",
   "blocked",
   "suspended",
@@ -185,6 +186,8 @@ function ListingPreview({
                 ))}
               </ul>
             </section>
+
+            <PublicationEvidencePanel item={item} />
           </div>
 
           <aside className="space-y-4">
@@ -235,6 +238,79 @@ function ListingPreview({
   );
 }
 
+function PublicationEvidencePanel({ item }: { item: MarketplaceApprovalQueueItem }) {
+  const evidence = item.publicationEvidence;
+
+  return (
+    <section className="rounded-lg border border-border bg-page/50 p-4" data-testid="marketplace-publication-evidence">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase text-muted-foreground">Publication claim evidence</p>
+          <h3 className="mt-1 font-display text-lg font-semibold text-white">{evidence.label}</h3>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">{evidence.description}</p>
+        </div>
+        <Badge variant="outline" className={cn("w-fit", publicationStatusClass(evidence.status))}>
+          {evidence.status.replaceAll("_", " ")}
+        </Badge>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <ClaimMetric label="Off-chain preview" value={evidence.offchainPreview} />
+        <ClaimMetric label="Hosted attestation" value={evidence.hostedAttestation} />
+        <ClaimMetric label="Quasar" value={evidence.quasar} />
+        <ClaimMetric label="Activation" value={evidence.activationMode} />
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <div className="rounded-lg border border-border bg-surface/60 p-3">
+          <p className="text-xs font-semibold uppercase text-muted-foreground">Evidence refs</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {evidence.evidenceRefs.map((ref) => (
+              <code key={ref} className="rounded-md border border-white/10 bg-black/20 px-2 py-1 text-xs text-gray-200">
+                {ref}
+              </code>
+            ))}
+          </div>
+        </div>
+        <div className="rounded-lg border border-border bg-surface/60 p-3">
+          <p className="text-xs font-semibold uppercase text-muted-foreground">Claim boundary</p>
+          <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+            <li>Buyer-facing trust/reputation claims: {evidence.buyerFacingClaimsAllowed ? "enabled" : "disabled"}</li>
+            <li>Live publication: {evidence.livePublication}</li>
+            {evidence.blockedReasons.length ? (
+              evidence.blockedReasons.slice(0, 3).map((reason) => <li key={reason}>{reason}</li>)
+            ) : (
+              <li>Dry-run activation only; no hosted registry write.</li>
+            )}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ClaimMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-surface/60 p-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 break-words text-sm font-medium text-white">{value.replaceAll("_", " ")}</p>
+    </div>
+  );
+}
+
+function publicationStatusClass(status: MarketplaceApprovalQueueItem["publicationEvidence"]["status"]) {
+  if (status === "published_dry_run" || status === "dry_run_activation_ready" || status === "hosted_attestation_ready") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-200";
+  }
+  if (status === "hosted_attestation_pending" || status === "quasar_pending" || status === "live_unavailable") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-200";
+  }
+  if (status === "blocked_evidence" || status === "suspended") {
+    return "border-red-500/30 bg-red-500/10 text-red-200";
+  }
+  return "border-white/10 bg-white/5 text-gray-300";
+}
+
 function StateBadge({ state }: { state: MarketplaceApprovalQueueState }) {
   const label = state.replaceAll("_", " ");
   const className =
@@ -242,6 +318,8 @@ function StateBadge({ state }: { state: MarketplaceApprovalQueueState }) {
       ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
       : state === "published_placeholder"
         ? "border-sky-500/30 bg-sky-500/10 text-sky-200"
+        : state === "unpublished"
+          ? "border-slate-400/30 bg-slate-400/10 text-slate-200"
         : state === "needs_changes"
           ? "border-amber-500/30 bg-amber-500/10 text-amber-200"
           : state === "rejected" || state === "blocked" || state === "suspended"

--- a/e2e/manager-listings.spec.ts
+++ b/e2e/manager-listings.spec.ts
@@ -1,10 +1,11 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 
 const queueStates = [
   'draft',
   'needs_changes',
   'approve_ready',
   'published_placeholder',
+  'unpublished',
   'rejected',
   'blocked',
   'suspended',
@@ -21,9 +22,26 @@ const actionLabels = [
   'Publication readiness',
 ]
 
+async function gotoListings(page: Page) {
+  await page.goto('/manager/listings', { waitUntil: 'domcontentloaded' })
+}
+
+async function stabilizeEvidenceScreenshot(page: Page) {
+  await page.addStyleTag({
+    content: `
+      nav.sticky {
+        position: static !important;
+        top: auto !important;
+      }
+    `,
+  })
+}
+
 test.describe('/manager/listings', () => {
+  test.describe.configure({ timeout: 90_000 })
+
   test('renders every static approval queue state with visible marketplace boundaries', async ({ page }) => {
-    await page.goto('/manager/listings')
+    await gotoListings(page)
 
     await expect(page.getByRole('heading', { name: /imported listing preview queue/i })).toBeVisible()
     await expect(page.getByText(/Imported agent stacks remain untrusted static metadata/i)).toBeVisible()
@@ -37,11 +55,12 @@ test.describe('/manager/listings', () => {
       await expect(preview.getByText(label).first()).toBeVisible()
     }
     await expect(preview.getByText(/Placeholder only/i)).toBeVisible()
+    await expect(page.getByTestId('marketplace-publication-evidence')).toBeVisible()
     await expect(page.getByTestId('marketplace-static-boundary-note')).toContainText(/not a generic agent builder/i)
   })
 
   test('keeps approve, reject, publish, payment, and readiness actions disabled', async ({ page }) => {
-    await page.goto('/manager/listings')
+    await gotoListings(page)
 
     const actions = page.getByTestId('marketplace-placeholder-actions')
     for (const label of actionLabels) {
@@ -52,7 +71,7 @@ test.describe('/manager/listings', () => {
   })
 
   test('records preview to approval placeholder to request changes to publish and suspend placeholder path', async ({ page }) => {
-    await page.goto('/manager/listings')
+    await gotoListings(page)
 
     await page.getByTestId('marketplace-queue-state-draft').click()
     await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Draft listing generated/i)
@@ -66,12 +85,38 @@ test.describe('/manager/listings', () => {
     await expect(page.getByRole('button', { name: /^Request changes$/i })).toBeDisabled()
 
     await page.getByTestId('marketplace-queue-state-published_placeholder').click()
-    await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Published state is represented only as a UI placeholder/i)
+    await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Published state is represented as dry-run activation evidence/i)
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Published \/ dry-run activation/i)
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Dry-run activation only/i)
     await expect(page.getByRole('button', { name: /^Publish$/i })).toBeDisabled()
+
+    await page.getByTestId('marketplace-queue-state-unpublished').click()
+    await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Unpublished lifecycle state/i)
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Latest lifecycle audit is unpublish/i)
 
     await page.getByTestId('marketplace-queue-state-suspended').click()
     await expect(page.getByTestId('marketplace-listing-preview')).toContainText(/Suspended imported listing fixture/i)
     await expect(page.getByRole('button', { name: /^Suspend$/i })).toBeDisabled()
+  })
+
+  test('distinguishes hosted attestation, Quasar, blocked, unpublished, and live-unavailable claim states', async ({ page }) => {
+    await gotoListings(page)
+
+    await page.getByTestId('marketplace-queue-state-approve_ready').click()
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Hosted attestation pending/i)
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Quasar/)
+
+    await page.getByTestId('marketplace-queue-state-blocked').click()
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Quasar compatibility pending/i)
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Quasar-backed claim unavailable/i)
+
+    await page.getByTestId('marketplace-queue-state-needs_changes').click()
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Blocked evidence/i)
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Payment proof missing/i)
+
+    await page.getByTestId('marketplace-queue-state-published_placeholder').click()
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Live publication: unavailable/i)
+    await expect(page.getByTestId('marketplace-publication-evidence')).toContainText(/Buyer-facing trust\/reputation claims: disabled/i)
   })
 
   for (const viewport of [
@@ -82,10 +127,12 @@ test.describe('/manager/listings', () => {
     for (const state of queueStates) {
       test(`captures ${state} at ${viewport.name} ${viewport.width}x${viewport.height}`, async ({ page }) => {
         await page.setViewportSize({ width: viewport.width, height: viewport.height })
-        await page.goto('/manager/listings')
+        await gotoListings(page)
+        await stabilizeEvidenceScreenshot(page)
         await page.getByTestId(`marketplace-queue-state-${state}`).click()
 
         await expect(page.getByTestId('marketplace-listing-preview')).toBeVisible()
+        await expect(page.getByTestId('marketplace-publication-evidence')).toBeVisible()
         await expect(page.getByText(/not RAP-attested/i).first()).toBeVisible()
         await expect(page.getByText(/not published/i).first()).toBeVisible()
         await page.screenshot({

--- a/lib/__tests__/manager-marketplace-readiness-gate.test.ts
+++ b/lib/__tests__/manager-marketplace-readiness-gate.test.ts
@@ -31,7 +31,8 @@ describe("manager marketplace readiness gate", () => {
   it("fails closed for imported listing fixtures without local proof metadata", () => {
     const results = getMarketplaceReadinessResults();
 
-    expect(results).toHaveLength(7);
+    expect(results).toHaveLength(8);
+    expect(results.map((result) => result.listingId)).toContain("unpublished:approveReadyDraft");
     expect(results.every((result) => result.status === "blocked")).toBe(true);
     expect(results.every((result) => result.boundaries.livePaymentAllowed === false)).toBe(true);
     expect(results.every((result) => result.boundaries.walletSigningAllowed === false)).toBe(true);

--- a/lib/manager/marketplace-listings.ts
+++ b/lib/manager/marketplace-listings.ts
@@ -6,9 +6,36 @@ export type MarketplaceApprovalQueueState =
   | "needs_changes"
   | "approve_ready"
   | "published_placeholder"
+  | "unpublished"
   | "rejected"
   | "blocked"
   | "suspended";
+
+export type MarketplacePublicationClaimState =
+  | "unverified_external_metadata"
+  | "blocked_evidence"
+  | "hosted_attestation_pending"
+  | "hosted_attestation_ready"
+  | "quasar_pending"
+  | "dry_run_activation_ready"
+  | "published_dry_run"
+  | "unpublished"
+  | "suspended"
+  | "live_unavailable";
+
+export type MarketplacePublicationEvidenceView = {
+  status: MarketplacePublicationClaimState;
+  label: string;
+  description: string;
+  activationMode: "not_available" | "dry_run" | "blocked";
+  offchainPreview: "available" | "pending" | "blocked" | "not_available";
+  hostedAttestation: "ready" | "pending" | "blocked" | "not_available";
+  quasar: "metadata_only" | "pending" | "not_backed" | "blocked";
+  livePublication: "unavailable";
+  buyerFacingClaimsAllowed: false;
+  evidenceRefs: string[];
+  blockedReasons: string[];
+};
 
 export type MarketplaceApprovalQueueItem = {
   id: string;
@@ -28,6 +55,7 @@ export type MarketplaceApprovalQueueItem = {
     paymentCopy: string;
     readinessCopy: string;
   };
+  publicationEvidence: MarketplacePublicationEvidenceView;
 };
 
 export type MarketplaceApprovalQueueView = {
@@ -65,42 +93,157 @@ export function getMarketplaceApprovalQueue(): MarketplaceApprovalQueueView {
         publicationCopy: "Not published. Operator approval, readiness, and attestation gates are deferred.",
         paymentCopy: "Payment readiness is missing and cannot be activated here.",
         readinessCopy: "Publication readiness check is a disabled placeholder.",
+        publicationEvidence: {
+          status: "unverified_external_metadata",
+          label: "Unverified external metadata",
+          description: "Imported source metadata is visible for review but cannot claim trust, payment readiness, reputation, or publication.",
+          activationMode: "not_available",
+          offchainPreview: "not_available",
+          hostedAttestation: "not_available",
+          quasar: "pending",
+          livePublication: "unavailable",
+          buyerFacingClaimsAllowed: false,
+          evidenceRefs: ["source:snapshot:approve-ready"],
+          blockedReasons: ["Operator approval, receipt evidence, hosted attestation, and activation gates are not complete."],
+        },
       }),
       buildQueueItem("needs_changes", "Needs changes", requestChanges, {
         statusCopy: "Needs changes before approval because payment and endpoint setup are incomplete.",
         publicationCopy: "Not published. Request-changes action is display-only.",
         paymentCopy: "Missing payment setup; activation remains disabled.",
         readinessCopy: "Readiness is blocked by fixture review items.",
+        publicationEvidence: {
+          status: "blocked_evidence",
+          label: "Blocked evidence",
+          description: "Payment setup and endpoint binding evidence are incomplete, so publication remains blocked.",
+          activationMode: "blocked",
+          offchainPreview: "blocked",
+          hostedAttestation: "pending",
+          quasar: "pending",
+          livePublication: "unavailable",
+          buyerFacingClaimsAllowed: false,
+          evidenceRefs: ["review:missing-payment", "review:missing-endpoint"],
+          blockedReasons: ["Payment proof missing.", "Endpoint binding missing.", "Hosted attestation not ready."],
+        },
       }),
       buildQueueItem("approve_ready", "Approved / approve-ready placeholder", approveReady, {
         statusCopy: "Approve-ready fixture state only. Approval is not written anywhere.",
         publicationCopy: "Not published. Approve and publish are disabled placeholders.",
         paymentCopy: "Payment readiness remains separate from this static preview.",
         readinessCopy: "Publication readiness will be evaluated by a later gate.",
+        publicationEvidence: {
+          status: "hosted_attestation_pending",
+          label: "Hosted attestation pending",
+          description: "The listing has safe review evidence, but hosted-attestation and activation evidence must still be attached before publication can be represented.",
+          activationMode: "blocked",
+          offchainPreview: "pending",
+          hostedAttestation: "pending",
+          quasar: "metadata_only",
+          livePublication: "unavailable",
+          buyerFacingClaimsAllowed: false,
+          evidenceRefs: ["readiness-proof:approve-ready"],
+          blockedReasons: ["Hosted attestation claim missing.", "Activation approval missing."],
+        },
       }),
       buildQueueItem("published_placeholder", "Published placeholder", approveReady, {
-        statusCopy: "Published state is represented only as a UI placeholder for operator review.",
-        publicationCopy: "No live marketplace publication exists from this page.",
+        statusCopy: "Published state is represented as dry-run activation evidence for operator review.",
+        publicationCopy: "Dry-run publication activation is ready; live publication remains unavailable.",
         paymentCopy: "No live payment activation, wallet signing, or settlement setup occurs.",
-        readinessCopy: "Readiness is illustrative until the deferred publication workflow ships.",
+        readinessCopy: "Publication eligibility, lifecycle audit, and activation evidence are fixture-backed.",
+        publicationEvidence: {
+          status: "published_dry_run",
+          label: "Published / dry-run activation",
+          description: "This state consumes the public export item and dry-run activation decision. It does not publish to a hosted registry.",
+          activationMode: "dry_run",
+          offchainPreview: "available",
+          hostedAttestation: "ready",
+          quasar: "metadata_only",
+          livePublication: "unavailable",
+          buyerFacingClaimsAllowed: false,
+          evidenceRefs: [
+            "evidence:operator-action:publish",
+            "evidence:activation:approve-ready",
+            "publication-gate:approve-ready",
+            "quasar-compatibility:metadata-only",
+          ],
+          blockedReasons: [],
+        },
+      }),
+      buildQueueItem("unpublished", "Unpublished", approveReady, {
+        statusCopy: "Unpublished lifecycle state after public visibility was forced off.",
+        publicationCopy: "Not public. Older publish evidence is ignored after unpublish.",
+        paymentCopy: "Payment activation remains disabled.",
+        readinessCopy: "Current lifecycle audit blocks public export and activation.",
+        publicationEvidence: {
+          status: "unpublished",
+          label: "Unpublished",
+          description: "The latest lifecycle audit removes public visibility, so activation and export are blocked even if older publish evidence exists.",
+          activationMode: "blocked",
+          offchainPreview: "available",
+          hostedAttestation: "ready",
+          quasar: "metadata_only",
+          livePublication: "unavailable",
+          buyerFacingClaimsAllowed: false,
+          evidenceRefs: ["evidence:operator-action:unpublish"],
+          blockedReasons: ["Latest lifecycle audit is unpublish.", "Public visibility is false."],
+        },
       }),
       buildQueueItem("rejected", "Rejected", rejected, {
         statusCopy: "Rejected fixture state with malformed connector evidence.",
         publicationCopy: "Not published. Rejection is already fixture metadata, not a live mutation.",
         paymentCopy: "Payment remains inactive for rejected imported metadata.",
         readinessCopy: "Publication readiness remains unavailable.",
+        publicationEvidence: {
+          status: "blocked_evidence",
+          label: "Blocked evidence",
+          description: "Malformed connector evidence prevents publication claims.",
+          activationMode: "blocked",
+          offchainPreview: "blocked",
+          hostedAttestation: "blocked",
+          quasar: "blocked",
+          livePublication: "unavailable",
+          buyerFacingClaimsAllowed: false,
+          evidenceRefs: ["review:malformed-connector"],
+          blockedReasons: ["Malformed connector metadata.", "Operator rejected this import."],
+        },
       }),
       buildQueueItem("blocked", "Blocked", blocked, {
         statusCopy: "Blocked by static risk diagnostics and operator guardrails.",
         publicationCopy: "Not published. Blockers must be cleared outside this read-only UI.",
         paymentCopy: "Payment activation is disabled while blockers remain.",
         readinessCopy: "Readiness cannot pass while static risk blockers are present.",
+        publicationEvidence: {
+          status: "quasar_pending",
+          label: "Quasar compatibility pending",
+          description: "Quasar-backed claims are not enabled from static metadata; #443 must provide fixture-only intent before UI can show backed state.",
+          activationMode: "blocked",
+          offchainPreview: "blocked",
+          hostedAttestation: "blocked",
+          quasar: "pending",
+          livePublication: "unavailable",
+          buyerFacingClaimsAllowed: false,
+          evidenceRefs: ["quasar-compatibility:pending", "review:static-risk-blocker"],
+          blockedReasons: ["Quasar-backed claim unavailable.", "Static risk blockers remain."],
+        },
       }),
       buildQueueItem("suspended", "Suspended", suspended, {
         statusCopy: "Suspended imported listing fixture with unsafe metadata warnings.",
         publicationCopy: "Not published. Suspend/unpublish controls are non-live placeholders.",
         paymentCopy: "Payment readiness is disabled for suspended metadata.",
         readinessCopy: "Publication readiness is unavailable for suspended metadata.",
+        publicationEvidence: {
+          status: "suspended",
+          label: "Suspended",
+          description: "Suspension forces public visibility off and blocks activation until current readiness evidence restores publication.",
+          activationMode: "blocked",
+          offchainPreview: "blocked",
+          hostedAttestation: "blocked",
+          quasar: "pending",
+          livePublication: "unavailable",
+          buyerFacingClaimsAllowed: false,
+          evidenceRefs: ["evidence:operator-action:suspend"],
+          blockedReasons: ["Latest lifecycle audit is suspend.", "Public visibility is false."],
+        },
       }),
     ],
     emptyState: {
@@ -124,9 +267,12 @@ function buildQueueItem(
   state: MarketplaceApprovalQueueState,
   label: string,
   candidate: OperatorDiscoveryCandidateView,
-  copy: Pick<MarketplaceApprovalQueueItem["listingPreview"], "statusCopy" | "publicationCopy" | "paymentCopy" | "readinessCopy">,
+  copy: Pick<MarketplaceApprovalQueueItem["listingPreview"], "statusCopy" | "publicationCopy" | "paymentCopy" | "readinessCopy"> & {
+    publicationEvidence: MarketplacePublicationEvidenceView;
+  },
 ): MarketplaceApprovalQueueItem {
   const buyerPreview = candidate.draftPreview.buyerPreview;
+  const { publicationEvidence, ...listingCopy } = copy;
   const capabilityValues = Object.values(buyerPreview)
     .flatMap((value) => value.split(/[,;]/))
     .map((value) => value.trim())
@@ -145,7 +291,8 @@ function buildQueueItem(
       capabilities: capabilityValues.slice(0, 5),
       tools: candidate.groups.flatMap((group) => group.capabilityRefs).slice(0, 4),
       skills: candidate.requiredGroupKinds.slice(0, 4),
-      ...copy,
+      ...listingCopy,
     },
+    publicationEvidence,
   };
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,8 @@ import { defineConfig, devices } from "@playwright/test";
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3010";
 const useExternalBaseURL = Boolean(process.env.PLAYWRIGHT_BASE_URL);
 const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL;
+const screenshotMode = process.env.PLAYWRIGHT_SCREENSHOT === "off" ? "off" : "on";
+const videoMode = process.env.PLAYWRIGHT_VIDEO === "off" ? "off" : "on";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -13,8 +15,8 @@ export default defineConfig({
   use: {
     baseURL,
     trace: "on-first-retry",
-    screenshot: "on",
-    video: "on",
+    screenshot: screenshotMode,
+    video: videoMode,
   },
   projects: [
     {


### PR DESCRIPTION
## Summary
- extends `/manager/listings` with publication claim evidence states for #444 eligibility, #445 dry-run activation, and #446 lifecycle audit evidence
- adds an unpublished lifecycle state and labels blocked evidence, hosted-attestation pending, Quasar pending, published/dry-run activation, suspended, and unverified external metadata
- keeps all controls non-live and explicitly labels buyer-facing trust/reputation claims, live publication, hosted registry writes, payment activation, wallet/RPC, provider/MCP calls, and reputation mutation as unavailable/disabled

## UI evidence
Screenshots generated by `e2e/manager-listings.spec.ts`:
- `artifacts/manager-listings/mobile-*.png` (8 states at 390x844)
- `artifacts/manager-listings/tablet-*.png` (8 states at 834x1112)
- `artifacts/manager-listings/desktop-*.png` (8 states at 1440x900)

Walkthrough video generated locally:
- `artifacts/manager-listings/videos/manager-listings-publication-evidence-walkthrough.webm`
- covers approve-ready hosted-attestation pending, blocked Quasar pending, published/dry-run activation, and unpublished lifecycle evidence

## Validation
- `npx jest --runInBand lib/__tests__/manager-marketplace-publication-eligibility.test.ts lib/__tests__/manager-marketplace-public-export.test.ts lib/__tests__/manager-marketplace-public-export-route.test.ts lib/__tests__/manager-marketplace-publication-activation.test.ts lib/__tests__/manager-marketplace-publication-activation-route.test.ts lib/__tests__/manager-marketplace-readiness-gate.test.ts` → 6 suites / 68 tests passed
- `npx eslint app/manager/listings/page.tsx components/manager/listings/MarketplaceApprovalQueue.tsx lib/manager/marketplace-listings.ts e2e/manager-listings.spec.ts playwright.config.ts lib/__tests__/manager-marketplace-readiness-gate.test.ts` → passed
- `PLAYWRIGHT_BROWSER_CHANNEL=chrome PLAYWRIGHT_VIDEO=off PLAYWRIGHT_SCREENSHOT=off npx playwright test e2e/manager-listings.spec.ts --project=chromium` → 28/28 passed, generated 24 screenshots
- `npm run build` → passed with existing Turbopack/NFT and bigint/localStorage warnings
- `git diff --check` → passed
- `npm run check:rap:naming` → passed
- scoped side-effect scan over touched UI/view-model/test files → no wallet/RPC/provider/MCP/live mutation path found

Closes #460.
