### PR TITLE
Harden Pay.sh catalog source metadata

### DIFF
--- a/lib/__tests__/source-adapter-pay-sh-profile.test.ts
+++ b/lib/__tests__/source-adapter-pay-sh-profile.test.ts
@@ -56,6 +56,12 @@ describe("source adapter pay-sh profile", () => {
 
     expect(candidate.candidateId).toBe("pay-sh:merit-systems:stablecrypto:market-data");
     expect(candidate.providerName).toBe("StableCrypto");
+    expect(candidate.serviceUrl).toBe("https://stablecrypto.dev/");
+    expect(candidate.sourceMetadata).toEqual({
+      sourceUrl: "https://pay.sh/api/catalog",
+      sourceHash: "2858c649a49c995a",
+      rawProviderFqn: "merit-systems/stablecrypto/market-data",
+    });
     expect(candidate.taskTypes).toEqual(["market-data", "financial-analysis"]);
     expect(candidate.pricing).toMatchObject({
       currency: "USDC",
@@ -80,6 +86,32 @@ describe("source adapter pay-sh profile", () => {
     expect(candidate.attestationState).toBe("externally_listed_unattested");
     expect(validateSourceAdapterManifest(candidate.sourceAdapter).ok).toBe(true);
     expect(candidate.trustNotes.join(" ")).toContain("Not RAP-attested");
+  });
+
+  it("fails closed for missing source hash, missing price, missing endpoint count, and non-HTTPS service URLs", () => {
+    const candidate = payShCatalogProviderToCandidate({
+      fqn: "unsafe/provider",
+      title: "Unsafe Provider",
+      category: "data",
+      service_url: "http://unsafe.example.com",
+    });
+
+    expect(candidate.serviceUrl).toBeUndefined();
+    expect(candidate.endpointCount).toBe(0);
+    expect(candidate.pricing).toMatchObject({
+      minUsd: 0,
+      maxUsd: 0,
+      hasFreeTier: true,
+      hasMetering: false,
+    });
+    expect(candidate.sourceMetadata).toEqual({
+      sourceUrl: "https://pay.sh/api/catalog",
+      sourceHash: undefined,
+      rawProviderFqn: "unsafe/provider",
+    });
+    expect(candidate.attestationState).toBe("externally_listed_unattested");
+    expect(candidate.trustNotes.join(" ")).toContain("non-HTTPS");
+    expect(candidate.trustNotes.join(" ")).toContain("source hash is missing");
   });
 
   it("preserves provider sandbox URLs for Pay.sh sandbox/localnet testing", () => {

--- a/lib/integrations/source-adapter/profiles/pay-sh.ts
+++ b/lib/integrations/source-adapter/profiles/pay-sh.ts
@@ -62,6 +62,11 @@ export type ReddiPayShCandidate = {
   providerFqn: string;
   providerName: string;
   serviceUrl?: string;
+  sourceMetadata: {
+    sourceUrl: "https://pay.sh/api/catalog";
+    sourceHash?: string;
+    rawProviderFqn: string;
+  };
   category: string;
   taskTypes: string[];
   endpointCount: number;
@@ -109,6 +114,16 @@ export function mapPayShCategoryToTaskTypes(category: PayShProviderCategory | un
 
 function stableCandidateId(fqn: string) {
   return `${PAY_SH_SOURCE_ID}:${fqn.replace(/\//g, ":").replace(/[^a-zA-Z0-9:-]+/g, "-").replace(/^[:\-]+|[:\-]+$/g, "").toLowerCase()}`;
+}
+
+function validHttpsUrl(value: string | undefined) {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function providerMentionsDevnet(provider: PayShCatalogProvider) {
@@ -197,13 +212,20 @@ export function payShCatalogProviderToCandidate(provider: PayShCatalogProvider):
   const taskTypes = mapPayShCategoryToTaskTypes(category);
   const minUsd = Math.max(0, provider.min_price_usd ?? 0);
   const maxUsd = Math.max(minUsd, provider.max_price_usd ?? minUsd);
+  const serviceUrl = validHttpsUrl(provider.service_url);
+  const sourceHash = provider.sha?.trim() || undefined;
 
   return {
     candidateId: stableCandidateId(provider.fqn),
     source: PAY_SH_SOURCE_ID,
     providerFqn: provider.fqn,
     providerName: provider.title,
-    serviceUrl: provider.service_url,
+    serviceUrl,
+    sourceMetadata: {
+      sourceUrl: "https://pay.sh/api/catalog",
+      sourceHash,
+      rawProviderFqn: provider.fqn,
+    },
     category,
     taskTypes,
     endpointCount: provider.endpoint_count ?? 0,
@@ -226,6 +248,8 @@ export function payShCatalogProviderToCandidate(provider: PayShCatalogProvider):
       "Imported from Pay.sh catalog as external Solana x402/MPP metadata.",
       "Not RAP-attested until a RAP attestor verifies output, receipt, and evidence.",
       "Preview only: RAP has not created a Pay.sh wallet, top-up, or paid API call for this candidate.",
+      ...(serviceUrl ? [] : ["Provider service URL is missing or non-HTTPS, so live probing stays disabled."]),
+      ...(sourceHash ? [] : ["Pay.sh catalog source hash is missing, so fixture provenance is incomplete."]),
     ],
   };
 }


### PR DESCRIPTION
Closes #472.\n\n## Summary\n- preserves Pay.sh catalog source metadata on RAP candidates, including source URL, raw provider FQN, and optional source hash\n- normalizes provider service URLs to HTTPS-only before they can appear on candidates\n- adds fail-closed trust notes for missing/non-HTTPS service URLs and missing source hashes\n- adds regression coverage for missing source hash, missing price, missing endpoint count, and non-HTTPS service URLs\n\n## Guardrails\n- no Pay.sh CLI install or setup\n- no wallet/top-up/RPC/Solana call\n- no provider call, live probe, paid request, or catalog submission\n- no hosted registry write, trust upgrade, reputation mutation, or marketplace publication\n- no UI changes; screenshot/video evidence not applicable\n\n## Validation\n- npx jest --runInBand lib/__tests__/source-adapter-pay-sh-profile.test.ts lib/__tests__/pay-sh-catalog-route.test.ts lib/__tests__/pay-sh-quote-preview-route.test.ts lib/__tests__/pay-sh-policy-plan.test.ts\n- git diff --check\n- npm run check:rap:naming\n- npm run build (passes with existing Turbopack/NFT and bigint/localStorage warnings)