### PR TITLE
Add Pay.sh catalog diagnostics and support states

### DIFF
--- a/lib/__tests__/source-adapter-pay-sh-profile.test.ts
+++ b/lib/__tests__/source-adapter-pay-sh-profile.test.ts
@@ -1,6 +1,8 @@
 import {
   buildPayShEnvironmentCapabilities,
   buildPayShSourceManifest,
+  getPayShCatalogDiagnostics,
+  getPayShCatalogSupportStates,
   mapPayShCategoryToTaskTypes,
   payShCatalogProviderToCandidate,
   PAY_SH_SOURCE_PROFILE,
@@ -62,6 +64,20 @@ describe("source adapter pay-sh profile", () => {
       sourceHash: "2858c649a49c995a",
       rawProviderFqn: "merit-systems/stablecrypto/market-data",
     });
+    expect(candidate.supportStates).toEqual([
+      "catalog_visible",
+      "pay_sh_compatible_unknown",
+      "sandbox_untested",
+      "dry_run_only",
+      "live_disabled",
+    ]);
+    expect(candidate.diagnostics).toEqual([
+      {
+        code: "missing_openapi_detail",
+        severity: "warning",
+        detail: "Pay.sh catalog provider does not expose OpenAPI, detail, or docs metadata in the fixture.",
+      },
+    ]);
     expect(candidate.taskTypes).toEqual(["market-data", "financial-analysis"]);
     expect(candidate.pricing).toMatchObject({
       currency: "USDC",
@@ -109,9 +125,98 @@ describe("source adapter pay-sh profile", () => {
       sourceHash: undefined,
       rawProviderFqn: "unsafe/provider",
     });
+    expect(candidate.diagnostics.map((item) => item.code)).toEqual([
+      "missing_price",
+      "zero_endpoints",
+      "missing_openapi_detail",
+      "unstable_provider_url",
+    ]);
     expect(candidate.attestationState).toBe("externally_listed_unattested");
+    expect(candidate.supportStates).toContain("live_disabled");
     expect(candidate.trustNotes.join(" ")).toContain("non-HTTPS");
     expect(candidate.trustNotes.join(" ")).toContain("source hash is missing");
+    expect(candidate.trustNotes.join(" ")).toContain("do not upgrade trust");
+  });
+
+  it("emits explicit support states without implying live payment or trust readiness", () => {
+    expect(getPayShCatalogSupportStates()).toEqual([
+      "catalog_visible",
+      "pay_sh_compatible_unknown",
+      "sandbox_untested",
+      "dry_run_only",
+      "live_disabled",
+    ]);
+  });
+
+  it("flags unsupported rails and networks before marketplace publication use", () => {
+    const diagnostics = getPayShCatalogDiagnostics({
+      fqn: "unsupported/provider",
+      title: "Unsupported Provider",
+      category: "data",
+      service_url: "https://unsupported.example.com",
+      endpoint_count: 1,
+      min_price_usd: 0.01,
+      openapi_url: "https://unsupported.example.com/openapi.json",
+      payment_rails: ["stripe"],
+      networks: ["ethereum"],
+    });
+
+    expect(diagnostics).toContainEqual({
+      code: "unsupported_rail_network",
+      severity: "blocker",
+      detail: "Pay.sh catalog provider declares payment rail or network metadata outside RAP's Pay.sh x402/MPP Solana boundary.",
+    });
+  });
+
+  it("flags mixed supported and unsupported rail or network metadata", () => {
+    const diagnostics = getPayShCatalogDiagnostics({
+      fqn: "mixed/provider",
+      title: "Mixed Provider",
+      category: "data",
+      service_url: "https://mixed.example.com",
+      endpoint_count: 1,
+      min_price_usd: 0.01,
+      openapi_url: "https://mixed.example.com/openapi.json",
+      payment_rails: ["x402", "stripe"],
+      networks: ["solana", "ethereum"],
+    });
+
+    expect(diagnostics.map((item) => item.code)).toContain("unsupported_rail_network");
+  });
+
+  it("flags unsafe categories and malformed provider identity as blockers", () => {
+    const diagnostics = getPayShCatalogDiagnostics({
+      fqn: "",
+      title: "",
+      category: "credential_tools",
+      use_case: "Automation",
+      service_url: "https://unsafe.example.com",
+      endpoint_count: 1,
+      min_price_usd: 0.01,
+      docs_url: "https://unsafe.example.com/docs",
+    });
+
+    expect(diagnostics.map((item) => item.code)).toEqual([
+      "malformed_provider_identity",
+      "unsafe_category_use_case",
+    ]);
+  });
+
+  it("flags underscore-delimited unsafe categories", () => {
+    for (const category of ["credential_tools", "adult_content", "gambling_services"]) {
+      const diagnostics = getPayShCatalogDiagnostics({
+        fqn: `unsafe/${category}`,
+        title: "Unsafe Provider",
+        category,
+        use_case: "Automation",
+        service_url: "https://unsafe.example.com",
+        endpoint_count: 1,
+        min_price_usd: 0.01,
+        docs_url: "https://unsafe.example.com/docs",
+      });
+
+      expect(diagnostics.map((item) => item.code)).toContain("unsafe_category_use_case");
+    }
   });
 
   it("preserves provider sandbox URLs for Pay.sh sandbox/localnet testing", () => {

--- a/lib/integrations/source-adapter/profiles/pay-sh.ts
+++ b/lib/integrations/source-adapter/profiles/pay-sh.ts
@@ -21,6 +21,11 @@ export type PayShCatalogProvider = {
   category?: PayShProviderCategory;
   service_url?: string;
   sandbox_service_url?: string;
+  detail_url?: string;
+  docs_url?: string;
+  openapi_url?: string;
+  payment_rails?: string[];
+  networks?: string[];
   endpoint_count?: number;
   has_metering?: boolean;
   has_free_tier?: boolean;
@@ -30,6 +35,26 @@ export type PayShCatalogProvider = {
 };
 
 export type PayShDevnetSupportState = "provider_declared" | "challenge_detected" | "unknown";
+export type PayShCatalogSupportState =
+  | "catalog_visible"
+  | "pay_sh_compatible_unknown"
+  | "sandbox_untested"
+  | "dry_run_only"
+  | "live_disabled";
+export type PayShCatalogDiagnosticCode =
+  | "missing_price"
+  | "zero_endpoints"
+  | "missing_openapi_detail"
+  | "unsupported_rail_network"
+  | "unstable_provider_url"
+  | "unsafe_category_use_case"
+  | "malformed_provider_identity";
+
+export type PayShCatalogDiagnostic = {
+  code: PayShCatalogDiagnosticCode;
+  severity: "warning" | "blocker";
+  detail: string;
+};
 
 export type PayShEnvironmentCapabilities = {
   sandbox: {
@@ -79,6 +104,8 @@ export type ReddiPayShCandidate = {
     hasMetering: boolean;
   };
   environmentCapabilities: PayShEnvironmentCapabilities;
+  supportStates: PayShCatalogSupportState[];
+  diagnostics: PayShCatalogDiagnostic[];
   sourceAdapter: SourceAdapterManifest;
   attestationState: "externally_listed_unattested";
   trustNotes: string[];
@@ -126,10 +153,103 @@ function validHttpsUrl(value: string | undefined) {
   }
 }
 
+function hasNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 function providerMentionsDevnet(provider: PayShCatalogProvider) {
   return [provider.fqn, provider.title, provider.description, provider.use_case, provider.category, provider.service_url]
     .filter(Boolean)
     .some((value) => String(value).toLowerCase().includes("devnet"));
+}
+
+function declaresUnsupportedRailOrNetwork(provider: PayShCatalogProvider) {
+  const rails = provider.payment_rails?.map((item) => item.toLowerCase().trim()).filter(Boolean) ?? [];
+  const networks = provider.networks?.map((item) => item.toLowerCase().trim()).filter(Boolean) ?? [];
+  const unsupportedRails = rails.some((rail) => rail !== "x402" && rail !== "mpp");
+  const unsupportedNetworks =
+    networks.length > 0 && networks.some((network) => network !== "solana" && network !== "localnet" && network !== "devnet" && network !== "mainnet");
+  return unsupportedRails || unsupportedNetworks;
+}
+
+function hasUnsafePayShCategoryOrUseCase(provider: PayShCatalogProvider) {
+  const haystack = [provider.category, provider.use_case, provider.description, provider.title]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return /(^|[^a-z0-9])(adult|gambling|credential|credentials|surveillance|weapon|exploit|malware|phishing)([^a-z0-9]|$)/.test(
+    haystack
+  );
+}
+
+export function getPayShCatalogDiagnostics(provider: PayShCatalogProvider): PayShCatalogDiagnostic[] {
+  const diagnostics: PayShCatalogDiagnostic[] = [];
+  const hasPrice =
+    provider.has_free_tier === true ||
+    Number.isFinite(provider.min_price_usd) ||
+    Number.isFinite(provider.max_price_usd);
+
+  if (!hasNonEmptyString(provider.fqn) || !hasNonEmptyString(provider.title)) {
+    diagnostics.push({
+      code: "malformed_provider_identity",
+      severity: "blocker",
+      detail: "Pay.sh catalog provider requires non-empty fqn and title before RAP can use it as a source candidate.",
+    });
+  }
+
+  if (!hasPrice) {
+    diagnostics.push({
+      code: "missing_price",
+      severity: "blocker",
+      detail: "Pay.sh catalog provider does not declare price or free-tier metadata.",
+    });
+  }
+
+  if (!Number.isFinite(provider.endpoint_count) || (provider.endpoint_count ?? 0) <= 0) {
+    diagnostics.push({
+      code: "zero_endpoints",
+      severity: "blocker",
+      detail: "Pay.sh catalog provider does not declare at least one callable endpoint.",
+    });
+  }
+
+  if (!hasNonEmptyString(provider.openapi_url) && !hasNonEmptyString(provider.detail_url) && !hasNonEmptyString(provider.docs_url)) {
+    diagnostics.push({
+      code: "missing_openapi_detail",
+      severity: "warning",
+      detail: "Pay.sh catalog provider does not expose OpenAPI, detail, or docs metadata in the fixture.",
+    });
+  }
+
+  if (declaresUnsupportedRailOrNetwork(provider)) {
+    diagnostics.push({
+      code: "unsupported_rail_network",
+      severity: "blocker",
+      detail: "Pay.sh catalog provider declares payment rail or network metadata outside RAP's Pay.sh x402/MPP Solana boundary.",
+    });
+  }
+
+  if (!validHttpsUrl(provider.service_url)) {
+    diagnostics.push({
+      code: "unstable_provider_url",
+      severity: "blocker",
+      detail: "Pay.sh catalog provider service URL is missing, malformed, or non-HTTPS.",
+    });
+  }
+
+  if (hasUnsafePayShCategoryOrUseCase(provider)) {
+    diagnostics.push({
+      code: "unsafe_category_use_case",
+      severity: "blocker",
+      detail: "Pay.sh catalog provider category or use case is unsafe for marketplace publication without separate review.",
+    });
+  }
+
+  return diagnostics;
+}
+
+export function getPayShCatalogSupportStates(): PayShCatalogSupportState[] {
+  return ["catalog_visible", "pay_sh_compatible_unknown", "sandbox_untested", "dry_run_only", "live_disabled"];
 }
 
 export function buildPayShEnvironmentCapabilities(provider: PayShCatalogProvider): PayShEnvironmentCapabilities {
@@ -214,6 +334,7 @@ export function payShCatalogProviderToCandidate(provider: PayShCatalogProvider):
   const maxUsd = Math.max(minUsd, provider.max_price_usd ?? minUsd);
   const serviceUrl = validHttpsUrl(provider.service_url);
   const sourceHash = provider.sha?.trim() || undefined;
+  const diagnostics = getPayShCatalogDiagnostics(provider);
 
   return {
     candidateId: stableCandidateId(provider.fqn),
@@ -238,6 +359,8 @@ export function payShCatalogProviderToCandidate(provider: PayShCatalogProvider):
       hasMetering: provider.has_metering === true,
     },
     environmentCapabilities: buildPayShEnvironmentCapabilities(provider),
+    supportStates: getPayShCatalogSupportStates(),
+    diagnostics,
     sourceAdapter: buildPayShSourceManifest({
       role: "specialist",
       runtime: "http",
@@ -248,6 +371,8 @@ export function payShCatalogProviderToCandidate(provider: PayShCatalogProvider):
       "Imported from Pay.sh catalog as external Solana x402/MPP metadata.",
       "Not RAP-attested until a RAP attestor verifies output, receipt, and evidence.",
       "Preview only: RAP has not created a Pay.sh wallet, top-up, or paid API call for this candidate.",
+      "Pay.sh support state is catalog-visible/dry-run-only/live-disabled until RAP evidence gates approve a narrower claim.",
+      ...(diagnostics.length ? ["Pay.sh catalog diagnostics do not upgrade trust, settlement, reputation, or publication readiness."] : []),
       ...(serviceUrl ? [] : ["Provider service URL is missing or non-HTTPS, so live probing stays disabled."]),
       ...(sourceHash ? [] : ["Pay.sh catalog source hash is missing, so fixture provenance is incomplete."]),
     ],


### PR DESCRIPTION
Closes #473.\n\n## Summary\n- adds Pay.sh catalog diagnostic codes for missing price, zero endpoints, missing OpenAPI/detail/docs metadata, unsupported rail/network, unstable provider URL, unsafe category/use case, and malformed provider identity\n- adds explicit support states: catalog-visible, compatibility unknown, sandbox untested, dry-run only, and live disabled\n- attaches diagnostics and support states to Pay.sh candidates while keeping them externally listed and unattested\n- adds regression coverage proving diagnostics do not upgrade trust, reputation, settlement, or publication readiness\n\n## Guardrails\n- no Pay.sh CLI install or setup\n- no wallet/top-up/RPC/Solana call\n- no provider call, live probe, paid request, or catalog submission\n- no hosted registry write, trust upgrade, reputation mutation, marketplace publication, or UI change\n- no UI changes; screenshot/video evidence not applicable\n\n## Validation\n- npx jest --runInBand lib/__tests__/source-adapter-pay-sh-profile.test.ts lib/__tests__/pay-sh-catalog-route.test.ts lib/__tests__/pay-sh-quote-preview-route.test.ts lib/__tests__/pay-sh-policy-plan.test.ts\n- git diff --check\n- npm run check:rap:naming\n- npm run build (passes with existing Turbopack/NFT and bigint/localStorage warnings)