### PR TITLE
Add Pay.sh provider spec preview

### DIFF
--- a/lib/__tests__/pay-sh-provider-spec-preview.test.ts
+++ b/lib/__tests__/pay-sh-provider-spec-preview.test.ts
@@ -1,0 +1,181 @@
+import { buildPayShProviderSpecPreview } from "@/lib/integrations/source-adapter/pay-sh-provider-spec-preview";
+import { payShCatalogProviderToCandidate, type PayShCatalogProvider } from "@/lib/integrations/source-adapter/profiles/pay-sh";
+
+const validProvider: PayShCatalogProvider = {
+  fqn: "reddi/market-intel/stablecoin-feed",
+  title: "Stablecoin Feed",
+  description: "Reviewed market data feed.",
+  category: "finance",
+  service_url: "https://stablecoin-feed.example.com",
+  docs_url: "https://stablecoin-feed.example.com/docs",
+  endpoint_count: 3,
+  has_metering: true,
+  has_free_tier: false,
+  min_price_usd: 0.01,
+  max_price_usd: 0.05,
+  payment_rails: ["x402"],
+  networks: ["solana"],
+  sha: "source-hash-123",
+};
+
+function previewInput(provider: PayShCatalogProvider = validProvider) {
+  return {
+    candidate: payShCatalogProviderToCandidate(provider),
+    listing: {
+      name: "stablecoin-feed",
+      subdomain: "stablecoin-feed",
+      title: "Stablecoin Feed",
+      description: "Reviewed RAP listing preview for a Pay.sh-compatible market data provider.",
+      version: "1.0.0",
+      operatorNotes: ["Operator reviewed Pay.sh provider metadata."],
+    },
+    operatorApproval: {
+      approved: true,
+      evidenceRef: "evidence:operator-approval:pay-sh-preview",
+    },
+    publication: {
+      status: "eligible" as const,
+      evidenceRef: "evidence:publication:eligible",
+    },
+  };
+}
+
+describe("Pay.sh provider spec preview", () => {
+  it("generates a no-spend provider spec preview for an eligible reviewed listing", () => {
+    const preview = buildPayShProviderSpecPreview(previewInput());
+
+    expect(preview.status).toBe("preview_ready");
+    expect(preview.boundaries).toEqual({
+      submittedToPaySh: false,
+      listedOnPaySh: false,
+      sandboxTested: false,
+      livePaymentEnabled: false,
+    });
+    expect(preview.spec).toMatchObject({
+      name: "stablecoin-feed",
+      subdomain: "stablecoin-feed",
+      fqn: "reddi/market-intel/stablecoin-feed",
+      title: "Stablecoin Feed",
+      category: "finance",
+      version: "1.0.0",
+      routing: {
+        serviceUrl: "https://stablecoin-feed.example.com/",
+      },
+      endpoints: {
+        count: 3,
+        source: "pay-sh-catalog-preview",
+      },
+      pricing: {
+        currency: "USDC",
+        network: "solana",
+        minUsd: 0.01,
+        maxUsd: 0.05,
+        hasMetering: true,
+      },
+      evidence: {
+        operatorApprovalRef: "evidence:operator-approval:pay-sh-preview",
+        publicationEvidenceRef: "evidence:publication:eligible",
+        sourceHash: "source-hash-123",
+      },
+    });
+    expect(preview.payMd).toContain("Not submitted to Pay.sh.");
+    expect(preview.payMd).toContain("Live payment is disabled.");
+    expect(preview.providerYaml).toContain('listed_on_pay_sh: false');
+    expect(preview.providerYaml).toContain('live_payment_enabled: false');
+  });
+
+  it("blocks previews when pricing metadata is missing", () => {
+    const provider: PayShCatalogProvider = {
+      ...validProvider,
+      min_price_usd: undefined,
+      max_price_usd: undefined,
+      has_free_tier: undefined,
+    };
+    const preview = buildPayShProviderSpecPreview(previewInput(provider));
+
+    expect(preview.status).toBe("blocked");
+    expect(preview.blockers.map((item) => item.code)).toContain("catalog_diagnostic_blocker");
+    expect(preview.blockers.map((item) => item.diagnosticCode)).toContain("missing_price");
+    expect(preview.payMd).toBeUndefined();
+    expect(preview.providerYaml).toBeUndefined();
+  });
+
+  it("blocks previews when the endpoint boundary is invalid", () => {
+    const preview = buildPayShProviderSpecPreview(
+      previewInput({
+        ...validProvider,
+        service_url: "http://stablecoin-feed.example.com",
+        endpoint_count: 0,
+      })
+    );
+
+    expect(preview.status).toBe("blocked");
+    expect(preview.blockers.map((item) => item.code)).toContain("invalid_endpoint");
+    expect(preview.blockers.map((item) => item.diagnosticCode)).toEqual(expect.arrayContaining(["zero_endpoints", "unstable_provider_url"]));
+  });
+
+  it("blocks previews for unsupported Pay.sh categories", () => {
+    const preview = buildPayShProviderSpecPreview(
+      previewInput({
+        ...validProvider,
+        category: "unknown_vendor_category",
+      })
+    );
+
+    expect(preview.status).toBe("blocked");
+    expect(preview.blockers).toContainEqual({
+      code: "unsupported_category",
+      detail: "Pay.sh preview category 'unknown_vendor_category' is not in RAP's supported provider spec export set.",
+    });
+  });
+
+  it("blocks previews for unsafe metadata", () => {
+    const preview = buildPayShProviderSpecPreview(
+      previewInput({
+        ...validProvider,
+        category: "credential_tools",
+      })
+    );
+
+    expect(preview.status).toBe("blocked");
+    expect(preview.blockers).toContainEqual({
+      code: "unsafe_metadata",
+      diagnosticCode: "unsafe_category_use_case",
+      detail: "Pay.sh catalog provider category or use case is unsafe for marketplace publication without separate review.",
+    });
+  });
+
+  it("blocks previews without operator approval evidence", () => {
+    const input = previewInput();
+    const preview = buildPayShProviderSpecPreview({
+      ...input,
+      operatorApproval: {
+        approved: false,
+        evidenceRef: "",
+      },
+    });
+
+    expect(preview.status).toBe("blocked");
+    expect(preview.blockers).toContainEqual({
+      code: "operator_approval_missing",
+      detail: "Pay.sh provider spec preview requires explicit operator approval evidence.",
+    });
+  });
+
+  it("blocks previews when the RAP listing is not publication eligible", () => {
+    const input = previewInput();
+    const preview = buildPayShProviderSpecPreview({
+      ...input,
+      publication: {
+        status: "blocked",
+        evidenceRef: "evidence:publication:blocked",
+      },
+    });
+
+    expect(preview.status).toBe("blocked");
+    expect(preview.blockers).toContainEqual({
+      code: "publication_ineligible",
+      detail: "Pay.sh provider spec preview requires a publication-eligible RAP listing.",
+    });
+  });
+});

--- a/lib/integrations/source-adapter/pay-sh-provider-spec-preview.ts
+++ b/lib/integrations/source-adapter/pay-sh-provider-spec-preview.ts
@@ -1,0 +1,280 @@
+import { type PayShCatalogDiagnostic, type ReddiPayShCandidate } from "@/lib/integrations/source-adapter/profiles/pay-sh";
+
+export type PayShProviderSpecPreviewBlockerCode =
+  | "catalog_diagnostic_blocker"
+  | "missing_pricing"
+  | "invalid_endpoint"
+  | "unsupported_category"
+  | "unsafe_metadata"
+  | "operator_approval_missing"
+  | "publication_ineligible";
+
+export type PayShProviderSpecPreviewBlocker = {
+  code: PayShProviderSpecPreviewBlockerCode;
+  detail: string;
+  diagnosticCode?: PayShCatalogDiagnostic["code"];
+};
+
+export type PayShProviderSpecPreviewInput = {
+  candidate: ReddiPayShCandidate;
+  listing: {
+    name: string;
+    subdomain: string;
+    version: string;
+    title?: string;
+    description?: string;
+    operatorNotes?: string[];
+  };
+  operatorApproval?: {
+    approved: boolean;
+    evidenceRef: string;
+  };
+  publication: {
+    status: "eligible" | "blocked";
+    evidenceRef?: string;
+  };
+};
+
+export type PayShProviderSpecPreview = {
+  status: "preview_ready" | "blocked";
+  providerFqn: string;
+  boundaries: {
+    submittedToPaySh: false;
+    listedOnPaySh: false;
+    sandboxTested: false;
+    livePaymentEnabled: false;
+  };
+  blockers: PayShProviderSpecPreviewBlocker[];
+  payMd?: string;
+  providerYaml?: string;
+  spec?: {
+    name: string;
+    subdomain: string;
+    fqn: string;
+    title: string;
+    description: string;
+    category: string;
+    version: string;
+    routing: {
+      serviceUrl: string;
+    };
+    endpoints: {
+      count: number;
+      source: "pay-sh-catalog-preview";
+    };
+    pricing: {
+      currency: "USDC";
+      network: "solana";
+      minUsd: number;
+      maxUsd: number;
+      hasFreeTier: boolean;
+      hasMetering: boolean;
+    };
+    operatorNotes: string[];
+    evidence: {
+      operatorApprovalRef: string;
+      publicationEvidenceRef?: string;
+      sourceHash?: string;
+    };
+    previewState: {
+      submittedToPaySh: false;
+      listedOnPaySh: false;
+      sandboxTested: false;
+      livePaymentEnabled: false;
+    };
+  };
+};
+
+const SUPPORTED_PAY_SH_PREVIEW_CATEGORIES = new Set([
+  "ai_ml",
+  "compute",
+  "data",
+  "finance",
+  "messaging",
+  "media",
+  "shopping",
+  "solana_infrastructure",
+]);
+
+const PREVIEW_BOUNDARIES = {
+  submittedToPaySh: false,
+  listedOnPaySh: false,
+  sandboxTested: false,
+  livePaymentEnabled: false,
+} as const;
+
+function yamlString(value: string) {
+  return JSON.stringify(value);
+}
+
+function yamlList(items: string[], indent: string) {
+  if (items.length === 0) return `${indent}[]`;
+  return items.map((item) => `${indent}- ${yamlString(item)}`).join("\n");
+}
+
+function buildProviderYaml(spec: NonNullable<PayShProviderSpecPreview["spec"]>) {
+  return [
+    `name: ${yamlString(spec.name)}`,
+    `subdomain: ${yamlString(spec.subdomain)}`,
+    `fqn: ${yamlString(spec.fqn)}`,
+    `title: ${yamlString(spec.title)}`,
+    `description: ${yamlString(spec.description)}`,
+    `category: ${yamlString(spec.category)}`,
+    `version: ${yamlString(spec.version)}`,
+    "routing:",
+    `  service_url: ${yamlString(spec.routing.serviceUrl)}`,
+    "endpoints:",
+    `  count: ${spec.endpoints.count}`,
+    `  source: ${yamlString(spec.endpoints.source)}`,
+    "pricing:",
+    `  currency: ${yamlString(spec.pricing.currency)}`,
+    `  network: ${yamlString(spec.pricing.network)}`,
+    `  min_usd: ${spec.pricing.minUsd}`,
+    `  max_usd: ${spec.pricing.maxUsd}`,
+    `  has_free_tier: ${spec.pricing.hasFreeTier}`,
+    `  has_metering: ${spec.pricing.hasMetering}`,
+    "operator_notes:",
+    yamlList(spec.operatorNotes, "  "),
+    "evidence:",
+    `  operator_approval_ref: ${yamlString(spec.evidence.operatorApprovalRef)}`,
+    spec.evidence.publicationEvidenceRef ? `  publication_evidence_ref: ${yamlString(spec.evidence.publicationEvidenceRef)}` : undefined,
+    spec.evidence.sourceHash ? `  source_hash: ${yamlString(spec.evidence.sourceHash)}` : undefined,
+    "preview_state:",
+    "  submitted_to_pay_sh: false",
+    "  listed_on_pay_sh: false",
+    "  sandbox_tested: false",
+    "  live_payment_enabled: false",
+  ]
+    .filter((line): line is string => typeof line === "string")
+    .join("\n");
+}
+
+function buildPayMd(spec: NonNullable<PayShProviderSpecPreview["spec"]>) {
+  return [
+    `# ${spec.title}`,
+    "",
+    spec.description,
+    "",
+    "## Pay.sh Preview Boundary",
+    "",
+    "- Not submitted to Pay.sh.",
+    "- Not listed on Pay.sh.",
+    "- Not sandbox-tested by RAP.",
+    "- Live payment is disabled.",
+    "",
+    "## Provider",
+    "",
+    `- FQN: ${spec.fqn}`,
+    `- Category: ${spec.category}`,
+    `- Version: ${spec.version}`,
+    `- Service URL: ${spec.routing.serviceUrl}`,
+    `- Endpoints: ${spec.endpoints.count}`,
+    `- Pricing: ${spec.pricing.currency} ${spec.pricing.minUsd}-${spec.pricing.maxUsd} on ${spec.pricing.network}`,
+  ].join("\n");
+}
+
+function collectBlockers(input: PayShProviderSpecPreviewInput): PayShProviderSpecPreviewBlocker[] {
+  const { candidate } = input;
+  const blockers: PayShProviderSpecPreviewBlocker[] = [];
+
+  for (const diagnostic of candidate.diagnostics) {
+    if (diagnostic.severity !== "blocker") continue;
+    blockers.push({
+      code: diagnostic.code === "unsafe_category_use_case" ? "unsafe_metadata" : "catalog_diagnostic_blocker",
+      diagnosticCode: diagnostic.code,
+      detail: diagnostic.detail,
+    });
+  }
+
+  if (!SUPPORTED_PAY_SH_PREVIEW_CATEGORIES.has(candidate.category)) {
+    blockers.push({
+      code: "unsupported_category",
+      detail: `Pay.sh preview category '${candidate.category}' is not in RAP's supported provider spec export set.`,
+    });
+  }
+
+  if (!candidate.serviceUrl || candidate.endpointCount <= 0) {
+    blockers.push({
+      code: "invalid_endpoint",
+      detail: "Pay.sh provider spec preview requires a normalized HTTPS service URL and at least one endpoint.",
+    });
+  }
+
+  if (!candidate.pricing.hasFreeTier && candidate.pricing.minUsd <= 0 && candidate.pricing.maxUsd <= 0) {
+    blockers.push({
+      code: "missing_pricing",
+      detail: "Pay.sh provider spec preview requires explicit pricing metadata or a declared free tier.",
+    });
+  }
+
+  if (input.operatorApproval?.approved !== true || input.operatorApproval.evidenceRef.trim().length === 0) {
+    blockers.push({
+      code: "operator_approval_missing",
+      detail: "Pay.sh provider spec preview requires explicit operator approval evidence.",
+    });
+  }
+
+  if (input.publication.status !== "eligible") {
+    blockers.push({
+      code: "publication_ineligible",
+      detail: "Pay.sh provider spec preview requires a publication-eligible RAP listing.",
+    });
+  }
+
+  return blockers;
+}
+
+export function buildPayShProviderSpecPreview(input: PayShProviderSpecPreviewInput): PayShProviderSpecPreview {
+  const blockers = collectBlockers(input);
+
+  if (blockers.length > 0) {
+    return {
+      status: "blocked",
+      providerFqn: input.candidate.providerFqn,
+      boundaries: PREVIEW_BOUNDARIES,
+      blockers,
+    };
+  }
+
+  const operatorApprovalRef = input.operatorApproval?.evidenceRef ?? "";
+  const serviceUrl = input.candidate.serviceUrl ?? "";
+
+  const spec: NonNullable<PayShProviderSpecPreview["spec"]> = {
+    name: input.listing.name,
+    subdomain: input.listing.subdomain,
+    fqn: input.candidate.providerFqn,
+    title: input.listing.title ?? input.candidate.providerName,
+    description: input.listing.description ?? `${input.candidate.providerName} Pay.sh-compatible provider preview.`,
+    category: input.candidate.category,
+    version: input.listing.version,
+    routing: {
+      serviceUrl,
+    },
+    endpoints: {
+      count: input.candidate.endpointCount,
+      source: "pay-sh-catalog-preview",
+    },
+    pricing: input.candidate.pricing,
+    operatorNotes: [
+      ...(input.listing.operatorNotes ?? []),
+      "Preview only: RAP has not submitted this provider to Pay.sh.",
+      "Preview only: RAP has not run Pay.sh sandbox testing or enabled live payment.",
+    ],
+    evidence: {
+      operatorApprovalRef,
+      publicationEvidenceRef: input.publication.evidenceRef,
+      sourceHash: input.candidate.sourceMetadata.sourceHash,
+    },
+    previewState: PREVIEW_BOUNDARIES,
+  };
+
+  return {
+    status: "preview_ready",
+    providerFqn: input.candidate.providerFqn,
+    boundaries: PREVIEW_BOUNDARIES,
+    blockers: [],
+    spec,
+    payMd: buildPayMd(spec),
+    providerYaml: buildProviderYaml(spec),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a no-spend Pay.sh provider spec preview builder for reviewed RAP listings.
- Emits PAY.md and provider YAML preview text only after Pay.sh catalog diagnostics, endpoint, pricing, category, operator approval, and publication eligibility gates pass.
- Keeps explicit preview boundaries: not submitted to Pay.sh, not listed on Pay.sh, not sandbox-tested, and live payment disabled.

## Acceptance coverage
- Maps name, subdomain, FQN, title, description, category, version, routing, endpoint count, pricing/metering, operator notes, and evidence refs.
- Blocks missing pricing, invalid endpoint, unsupported category, unsafe metadata, missing operator approval, and publication-ineligible state.
- Does not add Pay.sh catalog PR/submission, live validation probe, CLI setup, wallet/RPC, provider call, paid call, hosted registry write, trust mutation, reputation mutation, UI change, or live publication path.

## Validation
- `npx jest --runInBand lib/__tests__/pay-sh-provider-spec-preview.test.ts lib/__tests__/source-adapter-pay-sh-profile.test.ts` passed: 2 suites, 19 tests.
- `git diff --check` passed.
- `npm run check:rap:naming` passed.
- `npx eslint lib/integrations/source-adapter/pay-sh-provider-spec-preview.ts lib/__tests__/pay-sh-provider-spec-preview.test.ts` passed.
- `npm run build` passed with existing Next/Turbopack/NFT/localStorage/bigint warnings.
- `npm run lint` remains blocked by existing unrelated full-repo lint debt in app/tour, jest config/tests, packages, generated dist, and scripts; no new Pay.sh preview file findings after scoped lint.

Closes #474.
