### PR TITLE
Add Pay.sh preview state to manager listings

### DIFF
--- a/components/manager/listings/MarketplaceApprovalQueue.tsx
+++ b/components/manager/listings/MarketplaceApprovalQueue.tsx
@@ -13,6 +13,7 @@ import {
   Rocket,
   Send,
   ShieldAlert,
+  WalletCards,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -20,6 +21,8 @@ import type {
   MarketplaceApprovalQueueItem,
   MarketplaceApprovalQueueState,
   MarketplaceApprovalQueueView,
+  PayShPreviewScenarioState,
+  PayShPreviewScenarioView,
 } from "@/lib/manager/marketplace-listings";
 import { cn } from "@/lib/utils";
 
@@ -34,11 +37,24 @@ const stateOrder: MarketplaceApprovalQueueState[] = [
   "suspended",
 ];
 
+const payShScenarioOrder: PayShPreviewScenarioState[] = [
+  "preview_ready",
+  "missing_pricing",
+  "invalid_endpoint",
+  "live_disabled",
+  "unsafe_metadata",
+];
+
 export function MarketplaceApprovalQueue({ queue }: { queue: MarketplaceApprovalQueueView }) {
   const [selectedState, setSelectedState] = useState<MarketplaceApprovalQueueState>("draft");
+  const [selectedPayShState, setSelectedPayShState] = useState<PayShPreviewScenarioState>("preview_ready");
   const selected = useMemo(
     () => queue.items.find((item) => item.state === selectedState) ?? queue.items[0] ?? null,
     [queue.items, selectedState],
+  );
+  const selectedPayShScenario = useMemo(
+    () => queue.payShPreviewScenarios.find((item) => item.id === selectedPayShState) ?? queue.payShPreviewScenarios[0] ?? null,
+    [queue.payShPreviewScenarios, selectedPayShState],
   );
 
   if (!selected) {
@@ -107,7 +123,13 @@ export function MarketplaceApprovalQueue({ queue }: { queue: MarketplaceApproval
           })}
         </section>
 
-        <ListingPreview item={selected} boundaryLabels={queue.boundaryLabels} />
+        <ListingPreview
+          item={selected}
+          boundaryLabels={queue.boundaryLabels}
+          payShScenarios={queue.payShPreviewScenarios}
+          selectedPayShScenario={selectedPayShScenario}
+          onSelectPayShScenario={setSelectedPayShState}
+        />
       </div>
     </div>
   );
@@ -116,9 +138,15 @@ export function MarketplaceApprovalQueue({ queue }: { queue: MarketplaceApproval
 function ListingPreview({
   item,
   boundaryLabels,
+  payShScenarios,
+  selectedPayShScenario,
+  onSelectPayShScenario,
 }: {
   item: MarketplaceApprovalQueueItem;
   boundaryLabels: string[];
+  payShScenarios: PayShPreviewScenarioView[];
+  selectedPayShScenario: PayShPreviewScenarioView | null;
+  onSelectPayShScenario: (state: PayShPreviewScenarioState) => void;
 }) {
   return (
     <article className="space-y-5" data-testid="marketplace-listing-preview">
@@ -188,6 +216,14 @@ function ListingPreview({
             </section>
 
             <PublicationEvidencePanel item={item} />
+
+            {selectedPayShScenario ? (
+              <PayShPreviewPanel
+                scenarios={payShScenarios}
+                selected={selectedPayShScenario}
+                onSelect={onSelectPayShScenario}
+              />
+            ) : null}
           </div>
 
           <aside className="space-y-4">
@@ -235,6 +271,138 @@ function ListingPreview({
         </p>
       </section>
     </article>
+  );
+}
+
+function PayShPreviewPanel({
+  scenarios,
+  selected,
+  onSelect,
+}: {
+  scenarios: PayShPreviewScenarioView[];
+  selected: PayShPreviewScenarioView;
+  onSelect: (state: PayShPreviewScenarioState) => void;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-page/50 p-4" data-testid="pay-sh-preview-evidence">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase text-muted-foreground">Pay.sh provider preview</p>
+          <h3 className="mt-1 font-display text-lg font-semibold text-white">{selected.label}</h3>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">{selected.summary}</p>
+        </div>
+        <Badge variant="outline" className={cn("w-fit", payShPreviewStatusClass(selected.status))}>
+          {selected.status.replaceAll("_", " ")}
+        </Badge>
+      </div>
+
+      <div className="mt-4 grid gap-2" aria-label="Pay.sh preview state selector">
+        {payShScenarioOrder.map((state) => {
+          const scenario = scenarios.find((item) => item.id === state);
+          if (!scenario) return null;
+
+          return (
+            <button
+              key={scenario.id}
+              type="button"
+              data-testid={`pay-sh-preview-state-${scenario.id}`}
+              onClick={() => onSelect(scenario.id)}
+              className={cn(
+                "min-h-10 rounded-lg border px-3 py-2 text-left text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                selected.id === scenario.id
+                  ? "border-accent-green bg-accent-green/10 text-white"
+                  : "border-border bg-surface/60 text-muted-foreground hover:border-muted-foreground/50 hover:text-white",
+              )}
+              aria-pressed={selected.id === scenario.id}
+            >
+              {scenario.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-4 grid gap-3">
+        <ClaimMetric label="Catalog visible" value={selected.supportStates.catalogVisible} />
+        <ClaimMetric label="Provider spec preview" value={selected.supportStates.providerSpecPreview} />
+        <ClaimMetric label="Sandbox tested" value={selected.supportStates.sandboxTested} />
+        <ClaimMetric label="Dry-run ready" value={selected.supportStates.dryRunReady} />
+        <ClaimMetric label="Live payment" value={selected.supportStates.livePayment} />
+      </div>
+
+      <div className="mt-4 grid gap-3">
+        <div className="rounded-lg border border-border bg-surface/60 p-3">
+          <p className="text-xs font-semibold uppercase text-muted-foreground">Disabled Pay.sh controls</p>
+          <div className="mt-3 grid gap-2" data-testid="pay-sh-disabled-controls">
+            {selected.disabledControls.map((control) => (
+              <Button
+                key={control.label}
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled
+                title={control.reason}
+                className="min-h-10 justify-start"
+              >
+                <WalletCards className="size-3.5" aria-hidden="true" />
+                {control.label}
+              </Button>
+            ))}
+          </div>
+          <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+            {selected.disabledControls.map((control) => (
+              <li key={control.reason}>
+                <span className="font-medium text-gray-200">{control.label}:</span> {control.reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="rounded-lg border border-border bg-surface/60 p-3">
+          <p className="text-xs font-semibold uppercase text-muted-foreground">Preview boundary</p>
+          <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+            <li>Submitted to Pay.sh: {selected.previewBoundary.submittedToPaySh ? "yes" : "no"}</li>
+            <li>Listed on Pay.sh: {selected.previewBoundary.listedOnPaySh ? "yes" : "no"}</li>
+            <li>Sandbox tested: {selected.previewBoundary.sandboxTested ? "yes" : "no"}</li>
+            <li>Live payment enabled: {selected.previewBoundary.livePaymentEnabled ? "yes" : "no"}</li>
+          </ul>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3">
+        <div className="rounded-lg border border-border bg-surface/60 p-3">
+          <p className="text-xs font-semibold uppercase text-muted-foreground">Generated preview artifacts</p>
+          <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+            <li>PAY.md preview: {selected.payMdAvailable ? "available" : "blocked"}</li>
+            <li>Provider YAML preview: {selected.providerYamlAvailable ? "available" : "blocked"}</li>
+            <li className="break-all">Provider FQN: {selected.providerFqn}</li>
+          </ul>
+        </div>
+
+        <div className="rounded-lg border border-border bg-surface/60 p-3">
+          <p className="text-xs font-semibold uppercase text-muted-foreground">Pay.sh blockers and evidence</p>
+          {selected.blockers.length ? (
+            <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+              {selected.blockers.map((blocker) => (
+                <li key={`${blocker.code}:${blocker.detail}`}>
+                  <span className="font-mono text-xs text-red-200">{blocker.code}</span>: {blocker.detail}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-2 text-sm text-muted-foreground">
+              No blocker diagnostics. Preview remains no-spend and live-payment-disabled.
+            </p>
+          )}
+          <div className="mt-3 flex flex-wrap gap-2">
+            {selected.evidenceRefs.map((ref) => (
+              <code key={ref} className="rounded-md border border-white/10 bg-black/20 px-2 py-1 text-xs text-gray-200">
+                {ref}
+              </code>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -309,6 +477,13 @@ function publicationStatusClass(status: MarketplaceApprovalQueueItem["publicatio
     return "border-red-500/30 bg-red-500/10 text-red-200";
   }
   return "border-white/10 bg-white/5 text-gray-300";
+}
+
+function payShPreviewStatusClass(status: PayShPreviewScenarioView["status"]) {
+  if (status === "preview_ready") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-200";
+  }
+  return "border-red-500/30 bg-red-500/10 text-red-200";
 }
 
 function StateBadge({ state }: { state: MarketplaceApprovalQueueState }) {

--- a/e2e/manager-listings.spec.ts
+++ b/e2e/manager-listings.spec.ts
@@ -22,6 +22,21 @@ const actionLabels = [
   'Publication readiness',
 ]
 
+const payShPreviewStates = [
+  'preview_ready',
+  'missing_pricing',
+  'invalid_endpoint',
+  'live_disabled',
+  'unsafe_metadata',
+]
+
+const payShControlLabels = [
+  'Submit to Pay.sh',
+  'Paid call',
+  'Wallet/RPC',
+  'Live activation',
+]
+
 async function gotoListings(page: Page) {
   await page.goto('/manager/listings', { waitUntil: 'domcontentloaded' })
 }
@@ -56,6 +71,7 @@ test.describe('/manager/listings', () => {
     }
     await expect(preview.getByText(/Placeholder only/i)).toBeVisible()
     await expect(page.getByTestId('marketplace-publication-evidence')).toBeVisible()
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toBeVisible()
     await expect(page.getByTestId('marketplace-static-boundary-note')).toContainText(/not a generic agent builder/i)
   })
 
@@ -68,6 +84,44 @@ test.describe('/manager/listings', () => {
     }
 
     await expect(page.getByText(/no API mutation, live marketplace publication, payment activation, wallet signing, RPC probe, MCP call, repo fetch/i)).toBeVisible()
+
+    const payShActions = page.getByTestId('pay-sh-disabled-controls')
+    for (const label of payShControlLabels) {
+      await expect(payShActions.getByRole('button', { name: new RegExp(`^${label}$`, 'i') })).toBeDisabled()
+    }
+
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Provider preview is review-only/i)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Wallet signing, top-up, and Solana RPC probes are out of scope/i)
+  })
+
+  test('distinguishes Pay.sh preview-ready, blocker, and live-disabled states', async ({ page }) => {
+    await gotoListings(page)
+
+    await page.getByTestId('pay-sh-preview-state-preview_ready').click()
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Pay.sh-compatible preview/i)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Provider spec preview/)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/ready/)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Live payment/)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/disabled/)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Submitted to Pay.sh: no/)
+
+    await page.getByTestId('pay-sh-preview-state-missing_pricing').click()
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Missing pricing/i)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/missing_price/)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/PAY.md preview: blocked/i)
+
+    await page.getByTestId('pay-sh-preview-state-invalid_endpoint').click()
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Invalid endpoint/i)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/zero_endpoints/)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/unstable_provider_url/)
+
+    await page.getByTestId('pay-sh-preview-state-live_disabled').click()
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Live payment disabled/i)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Live payment enabled: no/)
+
+    await page.getByTestId('pay-sh-preview-state-unsafe_metadata').click()
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Blocked unsafe metadata/i)
+    await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/unsafe_category_use_case/)
   })
 
   test('records preview to approval placeholder to request changes to publish and suspend placeholder path', async ({ page }) => {
@@ -124,20 +178,20 @@ test.describe('/manager/listings', () => {
     { name: 'tablet', width: 834, height: 1112 },
     { name: 'desktop', width: 1440, height: 900 },
   ]) {
-    for (const state of queueStates) {
-      test(`captures ${state} at ${viewport.name} ${viewport.width}x${viewport.height}`, async ({ page }) => {
+    for (const state of payShPreviewStates) {
+      test(`captures Pay.sh ${state} at ${viewport.name} ${viewport.width}x${viewport.height}`, async ({ page }) => {
         await page.setViewportSize({ width: viewport.width, height: viewport.height })
         await gotoListings(page)
         await stabilizeEvidenceScreenshot(page)
-        await page.getByTestId(`marketplace-queue-state-${state}`).click()
+        await page.getByTestId('marketplace-queue-state-published_placeholder').click()
+        await page.getByTestId(`pay-sh-preview-state-${state}`).click()
 
         await expect(page.getByTestId('marketplace-listing-preview')).toBeVisible()
-        await expect(page.getByTestId('marketplace-publication-evidence')).toBeVisible()
-        await expect(page.getByText(/not RAP-attested/i).first()).toBeVisible()
-        await expect(page.getByText(/not published/i).first()).toBeVisible()
-        await page.screenshot({
-          path: `artifacts/manager-listings/${viewport.name}-${state}-${viewport.width}x${viewport.height}.png`,
-          fullPage: true,
+        await expect(page.getByTestId('pay-sh-preview-evidence')).toBeVisible()
+        await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Submitted to Pay.sh: no/)
+        await expect(page.getByTestId('pay-sh-preview-evidence')).toContainText(/Live payment enabled: no/)
+        await page.getByTestId('pay-sh-preview-evidence').screenshot({
+          path: `artifacts/manager-listings/${viewport.name}-pay-sh-${state}-${viewport.width}x${viewport.height}.png`,
         })
       })
     }

--- a/lib/manager/marketplace-listings.ts
+++ b/lib/manager/marketplace-listings.ts
@@ -1,3 +1,5 @@
+import { buildPayShProviderSpecPreview, type PayShProviderSpecPreview } from "@/lib/integrations/source-adapter/pay-sh-provider-spec-preview";
+import { payShCatalogProviderToCandidate, type PayShCatalogProvider } from "@/lib/integrations/source-adapter/profiles/pay-sh";
 import type { OperatorDiscoveryCandidateView } from "@/lib/manager/static-agent-stack-review";
 import { getStaticAgentStackReviewWorkspace } from "@/lib/manager/static-agent-stack-review";
 
@@ -58,8 +60,48 @@ export type MarketplaceApprovalQueueItem = {
   publicationEvidence: MarketplacePublicationEvidenceView;
 };
 
+export type PayShPreviewScenarioState =
+  | "preview_ready"
+  | "missing_pricing"
+  | "invalid_endpoint"
+  | "live_disabled"
+  | "unsafe_metadata";
+
+export type PayShPreviewScenarioView = {
+  id: PayShPreviewScenarioState;
+  label: string;
+  providerFqn: string;
+  status: PayShProviderSpecPreview["status"];
+  summary: string;
+  supportStates: {
+    catalogVisible: "catalog_visible";
+    providerSpecPreview: "ready" | "blocked";
+    sandboxTested: "not_tested";
+    dryRunReady: "ready" | "blocked";
+    livePayment: "disabled";
+  };
+  previewBoundary: {
+    submittedToPaySh: false;
+    listedOnPaySh: false;
+    sandboxTested: false;
+    livePaymentEnabled: false;
+  };
+  disabledControls: {
+    label: string;
+    reason: string;
+  }[];
+  blockers: {
+    code: string;
+    detail: string;
+  }[];
+  evidenceRefs: string[];
+  payMdAvailable: boolean;
+  providerYamlAvailable: boolean;
+};
+
 export type MarketplaceApprovalQueueView = {
   items: MarketplaceApprovalQueueItem[];
+  payShPreviewScenarios: PayShPreviewScenarioView[];
   boundaryLabels: string[];
   emptyState: {
     title: string;
@@ -87,6 +129,7 @@ export function getMarketplaceApprovalQueue(): MarketplaceApprovalQueueView {
 
   return {
     boundaryLabels,
+    payShPreviewScenarios: getPayShPreviewScenarios(),
     items: [
       buildQueueItem("draft", "Draft", approveReady, {
         statusCopy: "Draft listing generated from static fixture metadata.",
@@ -251,6 +294,135 @@ export function getMarketplaceApprovalQueue(): MarketplaceApprovalQueueView {
       message:
         "The approval queue is built from package-owned static fixture states and never fetches repositories, contacts MCP servers, activates payments, or publishes listings.",
     },
+  };
+}
+
+function getPayShPreviewScenarios(): PayShPreviewScenarioView[] {
+  const baseProvider: PayShCatalogProvider = {
+    fqn: "reddi/market-intel/stablecoin-feed",
+    title: "Stablecoin Feed",
+    description: "Reviewed market data feed for Pay.sh provider preview.",
+    category: "finance",
+    service_url: "https://stablecoin-feed.example.com",
+    docs_url: "https://stablecoin-feed.example.com/docs",
+    endpoint_count: 3,
+    has_metering: true,
+    has_free_tier: false,
+    min_price_usd: 0.01,
+    max_price_usd: 0.05,
+    payment_rails: ["x402"],
+    networks: ["solana"],
+    sha: "pay-sh-source-hash-stablecoin-feed",
+  };
+
+  return [
+    payShScenario("preview_ready", "Pay.sh-compatible preview", baseProvider, {
+      summary: "PAY.md and provider YAML preview are available, but nothing has been submitted or paid.",
+    }),
+    payShScenario("missing_pricing", "Missing pricing", {
+      ...baseProvider,
+      fqn: "reddi/market-intel/missing-pricing",
+      title: "Missing Pricing Feed",
+      min_price_usd: undefined,
+      max_price_usd: undefined,
+      has_free_tier: undefined,
+    }, {
+      summary: "Pricing metadata is absent, so the provider spec preview is blocked.",
+    }),
+    payShScenario("invalid_endpoint", "Invalid endpoint", {
+      ...baseProvider,
+      fqn: "reddi/market-intel/invalid-endpoint",
+      title: "Invalid Endpoint Feed",
+      service_url: "http://stablecoin-feed.example.com",
+      endpoint_count: 0,
+    }, {
+      summary: "The provider URL or endpoint count is invalid, so Pay.sh submission and paid calls remain disabled.",
+    }),
+    payShScenario("live_disabled", "Live payment disabled", baseProvider, {
+      summary: "Preview is ready for review, but live Pay.sh payment stays disabled until a later approval/spend-policy issue.",
+    }),
+    payShScenario("unsafe_metadata", "Blocked unsafe metadata", {
+      ...baseProvider,
+      fqn: "reddi/market-intel/credential-tools",
+      title: "Credential Tools Feed",
+      category: "credential_tools",
+    }, {
+      summary: "Unsafe category metadata blocks preview use for marketplace submission.",
+    }),
+  ];
+}
+
+function payShScenario(
+  id: PayShPreviewScenarioState,
+  label: string,
+  provider: PayShCatalogProvider,
+  copy: { summary: string },
+): PayShPreviewScenarioView {
+  const candidate = payShCatalogProviderToCandidate(provider);
+  const preview = buildPayShProviderSpecPreview({
+    candidate,
+    listing: {
+      name: "stablecoin-feed",
+      subdomain: "stablecoin-feed",
+      title: provider.title,
+      description: provider.description,
+      version: "1.0.0",
+      operatorNotes: ["Operator reviewed Pay.sh provider metadata."],
+    },
+    operatorApproval: {
+      approved: true,
+      evidenceRef: "evidence:operator-approval:pay-sh-preview",
+    },
+    publication: {
+      status: "eligible",
+      evidenceRef: "evidence:publication:eligible",
+    },
+  });
+  const ready = preview.status === "preview_ready";
+
+  return {
+    id,
+    label,
+    providerFqn: candidate.providerFqn,
+    status: preview.status,
+    summary: copy.summary,
+    supportStates: {
+      catalogVisible: "catalog_visible",
+      providerSpecPreview: ready ? "ready" : "blocked",
+      sandboxTested: "not_tested",
+      dryRunReady: ready ? "ready" : "blocked",
+      livePayment: "disabled",
+    },
+    previewBoundary: preview.boundaries,
+    disabledControls: [
+      {
+        label: "Submit to Pay.sh",
+        reason: ready ? "Provider preview is review-only and has not been submitted to Pay.sh." : "Provider preview blockers must clear first.",
+      },
+      {
+        label: "Paid call",
+        reason: "Paid calls are unavailable; this UI never invokes Pay.sh providers.",
+      },
+      {
+        label: "Wallet/RPC",
+        reason: "Wallet signing, top-up, and Solana RPC probes are out of scope for this read-only UI.",
+      },
+      {
+        label: "Live activation",
+        reason: "Live Pay.sh activation is disabled until a later spend-policy and operator-approval issue.",
+      },
+    ],
+    blockers: preview.blockers.map((blocker) => ({
+      code: blocker.diagnosticCode ?? blocker.code,
+      detail: blocker.detail,
+    })),
+    evidenceRefs: [
+      candidate.sourceMetadata.sourceHash ? `source:${candidate.sourceMetadata.sourceHash}` : "source:hash-missing",
+      "evidence:operator-approval:pay-sh-preview",
+      "evidence:publication:eligible",
+    ],
+    payMdAvailable: Boolean(preview.payMd),
+    providerYamlAvailable: Boolean(preview.providerYaml),
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds a Pay.sh provider preview evidence panel to `/manager/listings`.
- Surfaces fixture-backed Pay.sh states: preview-ready, missing pricing, invalid endpoint, live-payment-disabled, and unsafe metadata.
- Shows catalog-visible, provider-spec-preview, sandbox-tested, dry-run-ready, and live-payment-disabled support states.
- Adds disabled Pay.sh controls for submission, paid call, wallet/RPC, and live activation with inline reasons.
- Preserves the existing publication/evidence state panel and read-only marketplace boundary.

## UI evidence
Generated locally under `artifacts/manager-listings/`:
- 15 Pay.sh panel screenshots across mobile/tablet/desktop:
  - `mobile-pay-sh-{preview_ready,missing_pricing,invalid_endpoint,live_disabled,unsafe_metadata}-390x844.png`
  - `tablet-pay-sh-{preview_ready,missing_pricing,invalid_endpoint,live_disabled,unsafe_metadata}-834x1112.png`
  - `desktop-pay-sh-{preview_ready,missing_pricing,invalid_endpoint,live_disabled,unsafe_metadata}-1440x900.png`
- Operator review trace:
  - `pay-sh-operator-review-trace.zip`

I inspected the mobile preview-ready and desktop unsafe-metadata screenshots after the layout fix; the Pay.sh controls, support states, boundaries, and blockers are readable with no overlap.

## Validation
- `npx eslint components/manager/listings/MarketplaceApprovalQueue.tsx lib/manager/marketplace-listings.ts e2e/manager-listings.spec.ts` passed.
- `PLAYWRIGHT_BROWSER_CHANNEL=chrome PLAYWRIGHT_VIDEO=off PLAYWRIGHT_SCREENSHOT=off npx playwright test e2e/manager-listings.spec.ts --timeout 120000 --trace off --reporter=line` passed: 20/20.
- `npm run build` passed with existing Next/Turbopack/NFT/localStorage/bigint warnings.
- `git diff --check` passed.
- `npm run check:rap:naming` passed.

Notes:
- Playwright's bundled headless shell was missing locally after dependency install. I installed/used local Chrome via `PLAYWRIGHT_BROWSER_CHANNEL=chrome` for evidence capture.
- Playwright test-runner trace/video capture stalled locally, so I produced a manual Playwright trace for the operator path at `artifacts/manager-listings/pay-sh-operator-review-trace.zip`.

Guardrail: no Pay.sh CLI/setup, wallet/top-up, RPC/provider call, paid request, catalog submission, hosted registry write, trust/reputation mutation, or live publication path.

Closes #475.
