### PR TITLE
docs: add hosted marketplace runbook roadmap links

### DIFF
--- a/docs/HOSTED-MARKETPLACE-OPERATIONS-READINESS-RUNBOOK.md
+++ b/docs/HOSTED-MARKETPLACE-OPERATIONS-READINESS-RUNBOOK.md
@@ -16,6 +16,11 @@ This runbook applies after static ingestion and operator review have produced a 
 - Marketplace readiness, eligibility, public export, and dry-run activation helpers under `lib/manager/`
 - Pay.sh catalog/spec-preview helpers under `lib/integrations/source-adapter/`
 
+Related roadmap owners:
+
+- [#395](https://github.com/nissan/reddi-agent-protocol/issues/395) owns marketplace publication/export readiness.
+- [#417](https://github.com/nissan/reddi-agent-protocol/issues/417), [#349](https://github.com/nissan/reddi-agent-protocol/issues/349), and [#386](https://github.com/nissan/reddi-agent-protocol/issues/386) are UI/demo proof surfaces that can consume this runbook's states without bypassing approval gates.
+
 ## State Model
 
 Use these states in operator notes, issue comments, and support responses. Do not collapse them into a single "published" or "ready" label.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -1,6 +1,6 @@
 # BDD Feature Index
 
-_Last updated: 2026-05-13 AEST_
+_Last updated: 2026-06-21 AEST_
 
 Purpose: single lookup from BDD feature file -> bucket -> executable verification command(s).
 


### PR DESCRIPTION
Follow-up to #481 / #447.

## Summary
- Add the explicit #395 publication-owner link required by #447.
- Add #417/#349/#386 as UI/demo proof surfaces that can consume the runbook states without bypassing approval gates.
- Refresh the BDD feature index date after the docs update.

## Validation
- npm run check:rap:naming
- npm run test:bdd:index
- git diff --check
- rg -n "#395|#417|#349|#386|2026-06-21" docs/HOSTED-MARKETPLACE-OPERATIONS-READINESS-RUNBOOK.md docs/bdd/FEATURE-INDEX.md

## Guardrails
Docs-only. No Pay.sh CLI/setup, wallet/top-up, RPC/provider call, paid request, catalog submission, hosted registry write, trust/reputation mutation, live publication path, or UI change.