### PR TITLE
feat: normalize Pay.sh sandbox evidence fixtures

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,22 @@
 # Reddi Agent Protocol — Status
 
+## Latest Update — Pay.sh sandbox evidence normalization in progress (2026-06-21 AEST)
+
+Implementing GitHub issue #454 in isolated worktree `projects/reddi-agent-protocol-worktree-454-pay-sh-evidence` on branch `feat/454-pay-sh-evidence-fixtures`.
+
+Delivered so far:
+- Added `@reddi/agent-protocol/pay-sh-sandbox-evidence` fixture normalization for the historical Pay.sh single-charge sandbox artifact and capped-session/split-payment probe blockers.
+- Added binding-ready references for source, quote, recipient, nonce, session, authorization, receipt, operator approval, request hash, response hash, and evidence ref.
+- Kept every output fixture-only with guardrails disabling live Pay.sh calls, wallet signing, RPC, provider calls, hosted registry writes, marketplace publication, trust upgrades, and reputation mutations.
+- Added fail-closed tests for malformed receipt data and rejected live-path markers.
+
+Validation:
+- `npm test` in `packages/agent-protocol` PASS (142/142).
+- `npm run check:rap:naming` PASS.
+- `git diff --check` PASS.
+
+RESUME FROM HERE: Open PR for #454, run independent review and GitHub CI, then merge only if the review confirms no live Pay.sh/payment/provider/publication/trust/reputation boundary overclaim.
+
 ## Latest Update — OSS v0.1 package plan drafted (2026-06-18 13:07 AEST)
 
 Implemented GitHub issue #356 in isolated worktree `projects/reddi-agent-protocol-worktree-356-package-plan` on branch `docs/356-package-plan`.

--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -174,6 +174,26 @@ archive.put(record);
 
 EvidenceArchive v1 stores request, response, receipt, source, attestation, and evidence hash references without embedding private payloads in public receipts. The local archive is deterministic for tests and demos. Walrus, Seal, IPFS, and custom archive pointers are represented as future sidecar references, not required product-core dependencies.
 
+## Pay.sh Sandbox Evidence
+
+```typescript
+import {
+  derivePayShSandboxEvidenceFixture,
+  payShSandboxEvidenceSummaries,
+} from '@reddi/agent-protocol/pay-sh-sandbox-evidence';
+
+const result = derivePayShSandboxEvidenceFixture(payShSandboxEvidenceSummaries.singleCharge);
+
+if (result.ok) {
+  console.log(result.fixture.status); // proven_single_charge
+  console.log(result.fixture.bindingRefs.source.kind); // source-adapter
+}
+```
+
+Pay.sh sandbox evidence fixtures normalize the historical RAP x402 artifact set into receipt/evidence binding references for quote, recipient, nonce, session, authorization, receipt, source service, and operator approval. The proven single-charge fixture records the sandbox 402 challenge and paid retry receipt. Capped-session and split-payment extension fixtures stay `probe_only` with the `pay_sh_0_16_returns_402_after_payment` blocker.
+
+The helper is fixture-only. It does not run Pay.sh setup or CLI commands, call wallets/RPC endpoints, invoke providers, submit catalogs, write hosted registries, publish marketplace listings, upgrade trust, mutate reputation, or activate live payments. Malformed receipts and live-path markers fail closed.
+
 ## Source-Aware Diagnostics
 
 ```typescript

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -14,3 +14,4 @@ export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';
 export * from './quasar-registry-compatibility.js';
 export * from './hosted-attestation-claim.js';
+export * from './pay-sh-sandbox-evidence.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -14,3 +14,4 @@ export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';
 export * from './quasar-registry-compatibility.js';
 export * from './hosted-attestation-claim.js';
+export * from './pay-sh-sandbox-evidence.js';

--- a/packages/agent-protocol/dist/pay-sh-sandbox-evidence.d.ts
+++ b/packages/agent-protocol/dist/pay-sh-sandbox-evidence.d.ts
@@ -1,0 +1,192 @@
+import type { ReceiptEvidenceSourceRef } from './receipt-evidence-binding.js';
+export declare const PAY_SH_SANDBOX_EVIDENCE_SCHEMA_VERSION: "reddi.pay-sh-sandbox-evidence.v1";
+export type PayShSandboxEvidenceCase = 'single_charge' | 'capped_session_probe' | 'split_payment_probe';
+export type PayShSandboxEvidenceStatus = 'proven_single_charge' | 'probe_only';
+export type PayShSandboxEvidenceGuardrails = {
+    fixtureOnly: true;
+    livePayShCall: false;
+    walletSigning: false;
+    rpcCall: false;
+    providerCall: false;
+    hostedRegistryWrite: false;
+    marketplacePublication: false;
+    trustUpgrade: false;
+    reputationMutation: false;
+};
+export type PayShSandboxEvidenceReceipt = {
+    challengeId: string;
+    method: 'solana';
+    reference: string;
+    status: 'success';
+    timestamp: string;
+};
+export type PayShSandboxEvidenceSummary = {
+    schema: string;
+    mode: 'pay-sh-sandbox' | 'pay-sh-sandbox-extension';
+    case: PayShSandboxEvidenceCase;
+    artifactPath: string;
+    providerSpec: string;
+    providerSpecSha256: string;
+    url: string;
+    plainCurl: {
+        status: 402;
+        paymentProtocol: 'mpp';
+        challengeCount: number;
+        priceUsd?: number;
+    };
+    paySandboxCurl: {
+        status: 200 | 'blocked';
+        bodyOk?: boolean;
+        receipt?: PayShSandboxEvidenceReceipt;
+        error?: string;
+    };
+    decodedRequest?: {
+        quoteRef?: string;
+        recipient?: string;
+        nonce?: string;
+        session?: string;
+        authorizationRef?: string;
+        splitRecipients?: string[];
+    };
+    claimBoundary: string[];
+};
+export type PayShSandboxEvidenceBindingRefs = {
+    source: ReceiptEvidenceSourceRef;
+    paymentProofRef: string;
+    evidenceRef: string;
+    requestHash: string;
+    responseHash: string;
+    quoteRef: string;
+    recipientRef: string;
+    nonceRef: string;
+    sessionRef: string;
+    authorizationRef: string;
+    receiptRef?: string;
+    operatorApprovalRef: string;
+};
+export type PayShSandboxEvidenceFixture = {
+    schemaVersion: typeof PAY_SH_SANDBOX_EVIDENCE_SCHEMA_VERSION;
+    case: PayShSandboxEvidenceCase;
+    status: PayShSandboxEvidenceStatus;
+    blocker?: 'pay_sh_0_16_returns_402_after_payment';
+    artifactPath: string;
+    providerSpecRef: string;
+    providerSpecHash: string;
+    sourceService: 'pay.sh';
+    bindingRefs: PayShSandboxEvidenceBindingRefs;
+    receipt?: PayShSandboxEvidenceReceipt;
+    guardrails: PayShSandboxEvidenceGuardrails;
+    claimBoundary: string[];
+};
+export type PayShSandboxEvidenceErrorCode = 'malformed_summary' | 'unsupported_mode' | 'live_path_rejected' | 'missing_provider_spec' | 'missing_payment_challenge' | 'malformed_receipt' | 'unexpected_success' | 'missing_probe_blocker';
+export type PayShSandboxEvidenceError = {
+    code: PayShSandboxEvidenceErrorCode;
+    path: string;
+    message: string;
+};
+export type PayShSandboxEvidenceResult = {
+    ok: true;
+    fixture: PayShSandboxEvidenceFixture;
+} | {
+    ok: false;
+    errors: PayShSandboxEvidenceError[];
+};
+export declare const PAY_SH_SANDBOX_GUARDRAILS: PayShSandboxEvidenceGuardrails;
+export declare const payShSandboxEvidenceSummaries: {
+    singleCharge: {
+        schema: string;
+        mode: "pay-sh-sandbox";
+        case: "single_charge";
+        artifactPath: string;
+        providerSpec: string;
+        providerSpecSha256: string;
+        url: string;
+        plainCurl: {
+            status: 402;
+            paymentProtocol: "mpp";
+            challengeCount: number;
+            priceUsd: number;
+        };
+        paySandboxCurl: {
+            status: 200;
+            bodyOk: true;
+            receipt: {
+                challengeId: string;
+                method: "solana";
+                reference: string;
+                status: "success";
+                timestamp: string;
+            };
+        };
+        decodedRequest: {
+            quoteRef: string;
+            recipient: string;
+            nonce: string;
+            session: string;
+            authorizationRef: string;
+        };
+        claimBoundary: string[];
+    };
+    cappedSessionProbe: {
+        schema: string;
+        mode: "pay-sh-sandbox-extension";
+        case: "capped_session_probe";
+        artifactPath: string;
+        providerSpec: string;
+        providerSpecSha256: string;
+        url: string;
+        plainCurl: {
+            status: 402;
+            paymentProtocol: "mpp";
+            challengeCount: number;
+            priceUsd: number;
+        };
+        paySandboxCurl: {
+            status: "blocked";
+            error: string;
+        };
+        decodedRequest: {
+            quoteRef: string;
+            recipient: string;
+            nonce: string;
+            session: string;
+            authorizationRef: string;
+        };
+        claimBoundary: string[];
+    };
+    splitPaymentProbe: {
+        schema: string;
+        mode: "pay-sh-sandbox-extension";
+        case: "split_payment_probe";
+        artifactPath: string;
+        providerSpec: string;
+        providerSpecSha256: string;
+        url: string;
+        plainCurl: {
+            status: 402;
+            paymentProtocol: "mpp";
+            challengeCount: number;
+            priceUsd: number;
+        };
+        paySandboxCurl: {
+            status: "blocked";
+            error: string;
+        };
+        decodedRequest: {
+            quoteRef: string;
+            recipient: string;
+            nonce: string;
+            session: string;
+            authorizationRef: string;
+            splitRecipients: string[];
+        };
+        claimBoundary: string[];
+    };
+};
+export declare function createPayShSandboxEvidenceFixture(summary: PayShSandboxEvidenceSummary): PayShSandboxEvidenceFixture;
+export declare function derivePayShSandboxEvidenceFixture(summary: PayShSandboxEvidenceSummary): PayShSandboxEvidenceResult;
+export declare const payShSandboxEvidenceFixtures: {
+    readonly singleCharge: PayShSandboxEvidenceFixture;
+    readonly cappedSessionProbe: PayShSandboxEvidenceFixture;
+    readonly splitPaymentProbe: PayShSandboxEvidenceFixture;
+};

--- a/packages/agent-protocol/dist/pay-sh-sandbox-evidence.js
+++ b/packages/agent-protocol/dist/pay-sh-sandbox-evidence.js
@@ -1,0 +1,333 @@
+import { createHash } from 'node:crypto';
+export const PAY_SH_SANDBOX_EVIDENCE_SCHEMA_VERSION = 'reddi.pay-sh-sandbox-evidence.v1';
+const PAY_SH_PROVIDER_SPEC = 'config/pay-sh/reddi-x402-economic-demo-provider.yml';
+const PAY_SH_PROVIDER_SPEC_HASH = '77f48c499b1b335e297372b58d8746ffd8b54783d73188ebedff766371af49ef';
+const PAY_SH_PROBE_BLOCKER = 'pay_sh_0_16_returns_402_after_payment';
+const DEFAULT_QUOTE_REF = 'pay-sh:quote:reddi-x402-economic-demo:usd-0.01';
+const DEFAULT_RECIPIENT_REF = 'pay-sh:recipient:operator-approved-demo';
+const DEFAULT_NONCE_REF = 'pay-sh:nonce:fixture-20260507';
+const DEFAULT_SESSION_REF = 'pay-sh:session:single-charge';
+const DEFAULT_AUTHORIZATION_REF = 'pay-sh:authorization:operator-approval-required';
+const OPERATOR_APPROVAL_REF = 'github-issue:#454:fixture-only-approval';
+export const PAY_SH_SANDBOX_GUARDRAILS = {
+    fixtureOnly: true,
+    livePayShCall: false,
+    walletSigning: false,
+    rpcCall: false,
+    providerCall: false,
+    hostedRegistryWrite: false,
+    marketplacePublication: false,
+    trustUpgrade: false,
+    reputationMutation: false,
+};
+export const payShSandboxEvidenceSummaries = {
+    singleCharge: {
+        schema: 'reddi-x402.pay-sh.compatibility-evidence.v1',
+        mode: 'pay-sh-sandbox',
+        case: 'single_charge',
+        artifactPath: 'artifacts/pay-sh-reddi-x402/20260507T064842Z/SUMMARY.json',
+        providerSpec: PAY_SH_PROVIDER_SPEC,
+        providerSpecSha256: PAY_SH_PROVIDER_SPEC_HASH,
+        url: 'http://127.0.0.1:1402/api/economic-demo/reddi-x402/pay-sh-smoke',
+        plainCurl: {
+            status: 402,
+            paymentProtocol: 'mpp',
+            challengeCount: 2,
+            priceUsd: 0.01,
+        },
+        paySandboxCurl: {
+            status: 200,
+            bodyOk: true,
+            receipt: {
+                challengeId: 'pay-sh:challenge:20260507T064842Z:single-charge',
+                method: 'solana',
+                reference: '5QYP-pay-sh-sandbox-reference-redacted',
+                status: 'success',
+                timestamp: '2026-05-07T06:49:06.150216Z',
+            },
+        },
+        decodedRequest: {
+            quoteRef: DEFAULT_QUOTE_REF,
+            recipient: DEFAULT_RECIPIENT_REF,
+            nonce: DEFAULT_NONCE_REF,
+            session: DEFAULT_SESSION_REF,
+            authorizationRef: DEFAULT_AUTHORIZATION_REF,
+        },
+        claimBoundary: [
+            'Pay.sh sandbox single-charge compatibility is fixture-backed only.',
+            'No marketplace publication, wallet signing, RPC call, provider call, catalog submission, hosted registry write, trust upgrade, reputation mutation, or live Pay.sh call is performed.',
+        ],
+    },
+    cappedSessionProbe: {
+        schema: 'reddi-x402.pay-sh.phase3-extension-evidence.v1',
+        mode: 'pay-sh-sandbox-extension',
+        case: 'capped_session_probe',
+        artifactPath: 'artifacts/pay-sh-reddi-x402/20260507T065805Z-session-splits/SUMMARY.json',
+        providerSpec: PAY_SH_PROVIDER_SPEC,
+        providerSpecSha256: PAY_SH_PROVIDER_SPEC_HASH,
+        url: 'http://127.0.0.1:1402/api/economic-demo/reddi-x402/pay-sh-smoke',
+        plainCurl: {
+            status: 402,
+            paymentProtocol: 'mpp',
+            challengeCount: 1,
+            priceUsd: 0.01,
+        },
+        paySandboxCurl: {
+            status: 'blocked',
+            error: 'Server returned 402 again after payment',
+        },
+        decodedRequest: {
+            quoteRef: 'pay-sh:quote:reddi-x402-economic-demo:capped-session',
+            recipient: DEFAULT_RECIPIENT_REF,
+            nonce: 'pay-sh:nonce:fixture-20260507-session',
+            session: 'pay-sh:session:capped-session-probe',
+            authorizationRef: DEFAULT_AUTHORIZATION_REF,
+        },
+        claimBoundary: [
+            'Capped session support is probe-only because Pay.sh 0.16 returned 402 after payment.',
+            'No settlement, live activation, wallet signing, RPC call, provider call, hosted registry write, trust upgrade, or reputation mutation is claimed.',
+        ],
+    },
+    splitPaymentProbe: {
+        schema: 'reddi-x402.pay-sh.phase3-extension-evidence.v1',
+        mode: 'pay-sh-sandbox-extension',
+        case: 'split_payment_probe',
+        artifactPath: 'artifacts/pay-sh-reddi-x402/20260507T065908Z-splits/SUMMARY.json',
+        providerSpec: PAY_SH_PROVIDER_SPEC,
+        providerSpecSha256: PAY_SH_PROVIDER_SPEC_HASH,
+        url: 'http://127.0.0.1:1402/api/economic-demo/reddi-x402/pay-sh-smoke',
+        plainCurl: {
+            status: 402,
+            paymentProtocol: 'mpp',
+            challengeCount: 2,
+            priceUsd: 0.01,
+        },
+        paySandboxCurl: {
+            status: 'blocked',
+            error: 'Server returned 402 again after payment',
+        },
+        decodedRequest: {
+            quoteRef: 'pay-sh:quote:reddi-x402-economic-demo:split-payment',
+            recipient: DEFAULT_RECIPIENT_REF,
+            nonce: 'pay-sh:nonce:fixture-20260507-split',
+            session: 'pay-sh:session:split-payment-probe',
+            authorizationRef: DEFAULT_AUTHORIZATION_REF,
+            splitRecipients: ['pay-sh:recipient:split-secondary-demo'],
+        },
+        claimBoundary: [
+            'Split payment support is probe-only because Pay.sh 0.16 returned 402 after payment.',
+            'No settlement, live activation, wallet signing, RPC call, provider call, hosted registry write, trust upgrade, or reputation mutation is claimed.',
+        ],
+    },
+};
+export function createPayShSandboxEvidenceFixture(summary) {
+    const result = derivePayShSandboxEvidenceFixture(summary);
+    if (!result.ok) {
+        throw new Error(`invalid_pay_sh_sandbox_evidence:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+    }
+    return result.fixture;
+}
+export function derivePayShSandboxEvidenceFixture(summary) {
+    const errors = [];
+    validateSummaryShape(summary, errors);
+    validateNoLivePath(summary, errors);
+    validatePaymentChallenge(summary, errors);
+    const isSingleCharge = summary.case === 'single_charge';
+    if (isSingleCharge) {
+        validateSingleCharge(summary, errors);
+    }
+    else {
+        validateProbeOnly(summary, errors);
+    }
+    if (errors.length > 0)
+        return { ok: false, errors };
+    const bindingRefs = createBindingRefs(summary);
+    const status = isSingleCharge ? 'proven_single_charge' : 'probe_only';
+    return {
+        ok: true,
+        fixture: {
+            schemaVersion: PAY_SH_SANDBOX_EVIDENCE_SCHEMA_VERSION,
+            case: summary.case,
+            status,
+            blocker: isSingleCharge ? undefined : PAY_SH_PROBE_BLOCKER,
+            artifactPath: summary.artifactPath,
+            providerSpecRef: summary.providerSpec,
+            providerSpecHash: `sha256:${summary.providerSpecSha256}`,
+            sourceService: 'pay.sh',
+            bindingRefs,
+            receipt: isSingleCharge ? summary.paySandboxCurl.receipt : undefined,
+            guardrails: PAY_SH_SANDBOX_GUARDRAILS,
+            claimBoundary: summary.claimBoundary,
+        },
+    };
+}
+export const payShSandboxEvidenceFixtures = {
+    singleCharge: createPayShSandboxEvidenceFixture(payShSandboxEvidenceSummaries.singleCharge),
+    cappedSessionProbe: createPayShSandboxEvidenceFixture(payShSandboxEvidenceSummaries.cappedSessionProbe),
+    splitPaymentProbe: createPayShSandboxEvidenceFixture(payShSandboxEvidenceSummaries.splitPaymentProbe),
+};
+function validateSummaryShape(summary, errors) {
+    if (!isPlainObject(summary)) {
+        errors.push(error('malformed_summary', '$', 'summary must be an object'));
+        return;
+    }
+    if (!['pay-sh-sandbox', 'pay-sh-sandbox-extension'].includes(String(summary.mode))) {
+        errors.push(error('unsupported_mode', '$.mode', 'summary must be a Pay.sh sandbox fixture'));
+    }
+    if (!['single_charge', 'capped_session_probe', 'split_payment_probe'].includes(String(summary.case))) {
+        errors.push(error('malformed_summary', '$.case', 'summary case is unsupported'));
+    }
+    if (!isNonEmptyString(summary.artifactPath)) {
+        errors.push(error('malformed_summary', '$.artifactPath', 'artifact path is required'));
+    }
+    if (!isNonEmptyString(summary.providerSpec) || !isSha256Hex(summary.providerSpecSha256)) {
+        errors.push(error('missing_provider_spec', '$.providerSpecSha256', 'provider spec path and hash are required'));
+    }
+    if (!isNonEmptyString(summary.url)) {
+        errors.push(error('malformed_summary', '$.url', 'fixture URL is required'));
+    }
+    if (!Array.isArray(summary.claimBoundary) || summary.claimBoundary.length === 0) {
+        errors.push(error('malformed_summary', '$.claimBoundary', 'claim boundary notes are required'));
+    }
+}
+function validateNoLivePath(summary, errors) {
+    const serialized = JSON.stringify(summary).toLowerCase();
+    const liveMarkers = [
+        'mainnet',
+        'live-payment-enabled',
+        'wallet_private_key',
+        'private_key',
+        'rpc_url',
+        'marketplace publication activated',
+        'marketplace-publication activated',
+        'provider call performed',
+        'provider-call performed',
+        'provider call completed',
+        'provider-call completed',
+        'catalog submission completed',
+        'catalog-submission completed',
+        'catalog submission performed',
+        'catalog-submission performed',
+        'hosted-registry-write',
+        'hosted registry write completed',
+        'hosted registry write performed',
+        'trust-upgrade',
+        'trust upgrade completed',
+        'trust upgrade performed',
+        'reputation-mutation',
+        'reputation mutation completed',
+        'reputation mutation performed',
+        'live pay.sh activation',
+        'live pay-sh activation',
+    ];
+    for (const marker of liveMarkers) {
+        if (serialized.includes(marker)) {
+            errors.push(error('live_path_rejected', '$', `fixture contains rejected live-path marker: ${marker}`));
+        }
+    }
+}
+function validatePaymentChallenge(summary, errors) {
+    if (summary.plainCurl?.status !== 402) {
+        errors.push(error('missing_payment_challenge', '$.plainCurl.status', 'plain curl must prove a 402 payment challenge'));
+    }
+    if (summary.plainCurl?.paymentProtocol !== 'mpp') {
+        errors.push(error('missing_payment_challenge', '$.plainCurl.paymentProtocol', 'Pay.sh fixture must use the mpp payment protocol'));
+    }
+    if (!Number.isInteger(summary.plainCurl?.challengeCount) || summary.plainCurl.challengeCount <= 0) {
+        errors.push(error('missing_payment_challenge', '$.plainCurl.challengeCount', 'at least one payment challenge is required'));
+    }
+}
+function validateSingleCharge(summary, errors) {
+    const receipt = summary.paySandboxCurl?.receipt;
+    if (summary.mode !== 'pay-sh-sandbox') {
+        errors.push(error('unsupported_mode', '$.mode', 'single-charge evidence must use pay-sh-sandbox mode'));
+    }
+    if (summary.paySandboxCurl?.status !== 200 || summary.paySandboxCurl.bodyOk !== true) {
+        errors.push(error('malformed_receipt', '$.paySandboxCurl', 'single-charge evidence must include a successful sandbox retry'));
+    }
+    if (!receipt) {
+        errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt', 'successful sandbox retry must include a receipt'));
+        return;
+    }
+    if (!isNonEmptyString(receipt.challengeId)) {
+        errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.challengeId', 'receipt challenge id is required'));
+    }
+    if (receipt.method !== 'solana') {
+        errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.method', 'receipt method must be solana'));
+    }
+    if (!isNonEmptyString(receipt.reference)) {
+        errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.reference', 'receipt reference is required'));
+    }
+    if (receipt.status !== 'success') {
+        errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.status', 'receipt status must be success'));
+    }
+    if (!isNonEmptyString(receipt.timestamp) || Number.isNaN(Date.parse(receipt.timestamp))) {
+        errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.timestamp', 'receipt timestamp must be an ISO timestamp'));
+    }
+}
+function validateProbeOnly(summary, errors) {
+    if (summary.mode !== 'pay-sh-sandbox-extension') {
+        errors.push(error('unsupported_mode', '$.mode', 'extension probes must use pay-sh-sandbox-extension mode'));
+    }
+    if (summary.paySandboxCurl?.status === 200 || summary.paySandboxCurl?.receipt) {
+        errors.push(error('unexpected_success', '$.paySandboxCurl', 'probe-only fixtures must not claim successful settlement'));
+    }
+    if (summary.paySandboxCurl?.status !== 'blocked') {
+        errors.push(error('missing_probe_blocker', '$.paySandboxCurl.status', 'probe-only fixtures must record a blocked retry'));
+    }
+    if (summary.paySandboxCurl?.error !== 'Server returned 402 again after payment') {
+        errors.push(error('missing_probe_blocker', '$.paySandboxCurl.error', 'probe-only fixtures must preserve the Pay.sh 0.16 blocker'));
+    }
+}
+function createBindingRefs(summary) {
+    const decoded = summary.decodedRequest ?? {};
+    const evidenceRef = `file://${summary.artifactPath}`;
+    const receiptRef = summary.paySandboxCurl.receipt
+        ? `pay-sh-sandbox-receipt:${summary.paySandboxCurl.receipt.challengeId}`
+        : undefined;
+    return {
+        source: {
+            kind: 'source-adapter',
+            sourceId: 'pay-sh:reddi-x402:economic-demo',
+            fixtureRef: summary.artifactPath,
+            rawSnapshotRef: hashJson(summary),
+        },
+        paymentProofRef: receiptRef ?? `pay-sh-sandbox-probe:${summary.case}:${hashJson(summary.paySandboxCurl)}`,
+        evidenceRef,
+        requestHash: hashJson({
+            providerSpec: summary.providerSpec,
+            url: summary.url,
+            plainCurl: summary.plainCurl,
+            decodedRequest: summary.decodedRequest,
+        }),
+        responseHash: hashJson({
+            paySandboxCurl: summary.paySandboxCurl,
+            claimBoundary: summary.claimBoundary,
+        }),
+        quoteRef: decoded.quoteRef ?? DEFAULT_QUOTE_REF,
+        recipientRef: decoded.recipient ?? DEFAULT_RECIPIENT_REF,
+        nonceRef: decoded.nonce ?? DEFAULT_NONCE_REF,
+        sessionRef: decoded.session ?? DEFAULT_SESSION_REF,
+        authorizationRef: decoded.authorizationRef ?? DEFAULT_AUTHORIZATION_REF,
+        receiptRef,
+        operatorApprovalRef: OPERATOR_APPROVAL_REF,
+    };
+}
+function error(code, path, message) {
+    return { code, path, message };
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function isSha256Hex(value) {
+    return typeof value === 'string' && /^[a-f0-9]{64}$/.test(value);
+}
+function hashJson(value) {
+    return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -74,6 +74,10 @@
       "types": "./dist/hosted-attestation-claim.d.ts",
       "import": "./dist/hosted-attestation-claim.js"
     },
+    "./pay-sh-sandbox-evidence": {
+      "types": "./dist/pay-sh-sandbox-evidence.d.ts",
+      "import": "./dist/pay-sh-sandbox-evidence.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -14,3 +14,4 @@ export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';
 export * from './quasar-registry-compatibility.js';
 export * from './hosted-attestation-claim.js';
+export * from './pay-sh-sandbox-evidence.js';

--- a/packages/agent-protocol/src/pay-sh-sandbox-evidence.ts
+++ b/packages/agent-protocol/src/pay-sh-sandbox-evidence.ts
@@ -1,0 +1,462 @@
+import { createHash } from 'node:crypto';
+
+import type { ReceiptEvidenceSourceRef } from './receipt-evidence-binding.js';
+
+export const PAY_SH_SANDBOX_EVIDENCE_SCHEMA_VERSION = 'reddi.pay-sh-sandbox-evidence.v1' as const;
+
+export type PayShSandboxEvidenceCase =
+  | 'single_charge'
+  | 'capped_session_probe'
+  | 'split_payment_probe';
+
+export type PayShSandboxEvidenceStatus = 'proven_single_charge' | 'probe_only';
+
+export type PayShSandboxEvidenceGuardrails = {
+  fixtureOnly: true;
+  livePayShCall: false;
+  walletSigning: false;
+  rpcCall: false;
+  providerCall: false;
+  hostedRegistryWrite: false;
+  marketplacePublication: false;
+  trustUpgrade: false;
+  reputationMutation: false;
+};
+
+export type PayShSandboxEvidenceReceipt = {
+  challengeId: string;
+  method: 'solana';
+  reference: string;
+  status: 'success';
+  timestamp: string;
+};
+
+export type PayShSandboxEvidenceSummary = {
+  schema: string;
+  mode: 'pay-sh-sandbox' | 'pay-sh-sandbox-extension';
+  case: PayShSandboxEvidenceCase;
+  artifactPath: string;
+  providerSpec: string;
+  providerSpecSha256: string;
+  url: string;
+  plainCurl: {
+    status: 402;
+    paymentProtocol: 'mpp';
+    challengeCount: number;
+    priceUsd?: number;
+  };
+  paySandboxCurl: {
+    status: 200 | 'blocked';
+    bodyOk?: boolean;
+    receipt?: PayShSandboxEvidenceReceipt;
+    error?: string;
+  };
+  decodedRequest?: {
+    quoteRef?: string;
+    recipient?: string;
+    nonce?: string;
+    session?: string;
+    authorizationRef?: string;
+    splitRecipients?: string[];
+  };
+  claimBoundary: string[];
+};
+
+export type PayShSandboxEvidenceBindingRefs = {
+  source: ReceiptEvidenceSourceRef;
+  paymentProofRef: string;
+  evidenceRef: string;
+  requestHash: string;
+  responseHash: string;
+  quoteRef: string;
+  recipientRef: string;
+  nonceRef: string;
+  sessionRef: string;
+  authorizationRef: string;
+  receiptRef?: string;
+  operatorApprovalRef: string;
+};
+
+export type PayShSandboxEvidenceFixture = {
+  schemaVersion: typeof PAY_SH_SANDBOX_EVIDENCE_SCHEMA_VERSION;
+  case: PayShSandboxEvidenceCase;
+  status: PayShSandboxEvidenceStatus;
+  blocker?: 'pay_sh_0_16_returns_402_after_payment';
+  artifactPath: string;
+  providerSpecRef: string;
+  providerSpecHash: string;
+  sourceService: 'pay.sh';
+  bindingRefs: PayShSandboxEvidenceBindingRefs;
+  receipt?: PayShSandboxEvidenceReceipt;
+  guardrails: PayShSandboxEvidenceGuardrails;
+  claimBoundary: string[];
+};
+
+export type PayShSandboxEvidenceErrorCode =
+  | 'malformed_summary'
+  | 'unsupported_mode'
+  | 'live_path_rejected'
+  | 'missing_provider_spec'
+  | 'missing_payment_challenge'
+  | 'malformed_receipt'
+  | 'unexpected_success'
+  | 'missing_probe_blocker';
+
+export type PayShSandboxEvidenceError = {
+  code: PayShSandboxEvidenceErrorCode;
+  path: string;
+  message: string;
+};
+
+export type PayShSandboxEvidenceResult =
+  | { ok: true; fixture: PayShSandboxEvidenceFixture }
+  | { ok: false; errors: PayShSandboxEvidenceError[] };
+
+const PAY_SH_PROVIDER_SPEC = 'config/pay-sh/reddi-x402-economic-demo-provider.yml';
+const PAY_SH_PROVIDER_SPEC_HASH = '77f48c499b1b335e297372b58d8746ffd8b54783d73188ebedff766371af49ef';
+const PAY_SH_PROBE_BLOCKER = 'pay_sh_0_16_returns_402_after_payment' as const;
+const DEFAULT_QUOTE_REF = 'pay-sh:quote:reddi-x402-economic-demo:usd-0.01';
+const DEFAULT_RECIPIENT_REF = 'pay-sh:recipient:operator-approved-demo';
+const DEFAULT_NONCE_REF = 'pay-sh:nonce:fixture-20260507';
+const DEFAULT_SESSION_REF = 'pay-sh:session:single-charge';
+const DEFAULT_AUTHORIZATION_REF = 'pay-sh:authorization:operator-approval-required';
+const OPERATOR_APPROVAL_REF = 'github-issue:#454:fixture-only-approval';
+
+export const PAY_SH_SANDBOX_GUARDRAILS: PayShSandboxEvidenceGuardrails = {
+  fixtureOnly: true,
+  livePayShCall: false,
+  walletSigning: false,
+  rpcCall: false,
+  providerCall: false,
+  hostedRegistryWrite: false,
+  marketplacePublication: false,
+  trustUpgrade: false,
+  reputationMutation: false,
+};
+
+export const payShSandboxEvidenceSummaries = {
+  singleCharge: {
+    schema: 'reddi-x402.pay-sh.compatibility-evidence.v1',
+    mode: 'pay-sh-sandbox',
+    case: 'single_charge',
+    artifactPath: 'artifacts/pay-sh-reddi-x402/20260507T064842Z/SUMMARY.json',
+    providerSpec: PAY_SH_PROVIDER_SPEC,
+    providerSpecSha256: PAY_SH_PROVIDER_SPEC_HASH,
+    url: 'http://127.0.0.1:1402/api/economic-demo/reddi-x402/pay-sh-smoke',
+    plainCurl: {
+      status: 402,
+      paymentProtocol: 'mpp',
+      challengeCount: 2,
+      priceUsd: 0.01,
+    },
+    paySandboxCurl: {
+      status: 200,
+      bodyOk: true,
+      receipt: {
+        challengeId: 'pay-sh:challenge:20260507T064842Z:single-charge',
+        method: 'solana',
+        reference: '5QYP-pay-sh-sandbox-reference-redacted',
+        status: 'success',
+        timestamp: '2026-05-07T06:49:06.150216Z',
+      },
+    },
+    decodedRequest: {
+      quoteRef: DEFAULT_QUOTE_REF,
+      recipient: DEFAULT_RECIPIENT_REF,
+      nonce: DEFAULT_NONCE_REF,
+      session: DEFAULT_SESSION_REF,
+      authorizationRef: DEFAULT_AUTHORIZATION_REF,
+    },
+    claimBoundary: [
+      'Pay.sh sandbox single-charge compatibility is fixture-backed only.',
+      'No marketplace publication, wallet signing, RPC call, provider call, catalog submission, hosted registry write, trust upgrade, reputation mutation, or live Pay.sh call is performed.',
+    ],
+  },
+  cappedSessionProbe: {
+    schema: 'reddi-x402.pay-sh.phase3-extension-evidence.v1',
+    mode: 'pay-sh-sandbox-extension',
+    case: 'capped_session_probe',
+    artifactPath: 'artifacts/pay-sh-reddi-x402/20260507T065805Z-session-splits/SUMMARY.json',
+    providerSpec: PAY_SH_PROVIDER_SPEC,
+    providerSpecSha256: PAY_SH_PROVIDER_SPEC_HASH,
+    url: 'http://127.0.0.1:1402/api/economic-demo/reddi-x402/pay-sh-smoke',
+    plainCurl: {
+      status: 402,
+      paymentProtocol: 'mpp',
+      challengeCount: 1,
+      priceUsd: 0.01,
+    },
+    paySandboxCurl: {
+      status: 'blocked',
+      error: 'Server returned 402 again after payment',
+    },
+    decodedRequest: {
+      quoteRef: 'pay-sh:quote:reddi-x402-economic-demo:capped-session',
+      recipient: DEFAULT_RECIPIENT_REF,
+      nonce: 'pay-sh:nonce:fixture-20260507-session',
+      session: 'pay-sh:session:capped-session-probe',
+      authorizationRef: DEFAULT_AUTHORIZATION_REF,
+    },
+    claimBoundary: [
+      'Capped session support is probe-only because Pay.sh 0.16 returned 402 after payment.',
+      'No settlement, live activation, wallet signing, RPC call, provider call, hosted registry write, trust upgrade, or reputation mutation is claimed.',
+    ],
+  },
+  splitPaymentProbe: {
+    schema: 'reddi-x402.pay-sh.phase3-extension-evidence.v1',
+    mode: 'pay-sh-sandbox-extension',
+    case: 'split_payment_probe',
+    artifactPath: 'artifacts/pay-sh-reddi-x402/20260507T065908Z-splits/SUMMARY.json',
+    providerSpec: PAY_SH_PROVIDER_SPEC,
+    providerSpecSha256: PAY_SH_PROVIDER_SPEC_HASH,
+    url: 'http://127.0.0.1:1402/api/economic-demo/reddi-x402/pay-sh-smoke',
+    plainCurl: {
+      status: 402,
+      paymentProtocol: 'mpp',
+      challengeCount: 2,
+      priceUsd: 0.01,
+    },
+    paySandboxCurl: {
+      status: 'blocked',
+      error: 'Server returned 402 again after payment',
+    },
+    decodedRequest: {
+      quoteRef: 'pay-sh:quote:reddi-x402-economic-demo:split-payment',
+      recipient: DEFAULT_RECIPIENT_REF,
+      nonce: 'pay-sh:nonce:fixture-20260507-split',
+      session: 'pay-sh:session:split-payment-probe',
+      authorizationRef: DEFAULT_AUTHORIZATION_REF,
+      splitRecipients: ['pay-sh:recipient:split-secondary-demo'],
+    },
+    claimBoundary: [
+      'Split payment support is probe-only because Pay.sh 0.16 returned 402 after payment.',
+      'No settlement, live activation, wallet signing, RPC call, provider call, hosted registry write, trust upgrade, or reputation mutation is claimed.',
+    ],
+  },
+} satisfies Record<string, PayShSandboxEvidenceSummary>;
+
+export function createPayShSandboxEvidenceFixture(summary: PayShSandboxEvidenceSummary): PayShSandboxEvidenceFixture {
+  const result = derivePayShSandboxEvidenceFixture(summary);
+  if (!result.ok) {
+    throw new Error(`invalid_pay_sh_sandbox_evidence:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+  }
+  return result.fixture;
+}
+
+export function derivePayShSandboxEvidenceFixture(summary: PayShSandboxEvidenceSummary): PayShSandboxEvidenceResult {
+  const errors: PayShSandboxEvidenceError[] = [];
+  validateSummaryShape(summary, errors);
+  validateNoLivePath(summary, errors);
+  validatePaymentChallenge(summary, errors);
+
+  const isSingleCharge = summary.case === 'single_charge';
+  if (isSingleCharge) {
+    validateSingleCharge(summary, errors);
+  } else {
+    validateProbeOnly(summary, errors);
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  const bindingRefs = createBindingRefs(summary);
+  const status: PayShSandboxEvidenceStatus = isSingleCharge ? 'proven_single_charge' : 'probe_only';
+
+  return {
+    ok: true,
+    fixture: {
+      schemaVersion: PAY_SH_SANDBOX_EVIDENCE_SCHEMA_VERSION,
+      case: summary.case,
+      status,
+      blocker: isSingleCharge ? undefined : PAY_SH_PROBE_BLOCKER,
+      artifactPath: summary.artifactPath,
+      providerSpecRef: summary.providerSpec,
+      providerSpecHash: `sha256:${summary.providerSpecSha256}`,
+      sourceService: 'pay.sh',
+      bindingRefs,
+      receipt: isSingleCharge ? summary.paySandboxCurl.receipt : undefined,
+      guardrails: PAY_SH_SANDBOX_GUARDRAILS,
+      claimBoundary: summary.claimBoundary,
+    },
+  };
+}
+
+export const payShSandboxEvidenceFixtures = {
+  singleCharge: createPayShSandboxEvidenceFixture(payShSandboxEvidenceSummaries.singleCharge),
+  cappedSessionProbe: createPayShSandboxEvidenceFixture(payShSandboxEvidenceSummaries.cappedSessionProbe),
+  splitPaymentProbe: createPayShSandboxEvidenceFixture(payShSandboxEvidenceSummaries.splitPaymentProbe),
+} as const;
+
+function validateSummaryShape(summary: PayShSandboxEvidenceSummary, errors: PayShSandboxEvidenceError[]): void {
+  if (!isPlainObject(summary)) {
+    errors.push(error('malformed_summary', '$', 'summary must be an object'));
+    return;
+  }
+  if (!['pay-sh-sandbox', 'pay-sh-sandbox-extension'].includes(String(summary.mode))) {
+    errors.push(error('unsupported_mode', '$.mode', 'summary must be a Pay.sh sandbox fixture'));
+  }
+  if (!['single_charge', 'capped_session_probe', 'split_payment_probe'].includes(String(summary.case))) {
+    errors.push(error('malformed_summary', '$.case', 'summary case is unsupported'));
+  }
+  if (!isNonEmptyString(summary.artifactPath)) {
+    errors.push(error('malformed_summary', '$.artifactPath', 'artifact path is required'));
+  }
+  if (!isNonEmptyString(summary.providerSpec) || !isSha256Hex(summary.providerSpecSha256)) {
+    errors.push(error('missing_provider_spec', '$.providerSpecSha256', 'provider spec path and hash are required'));
+  }
+  if (!isNonEmptyString(summary.url)) {
+    errors.push(error('malformed_summary', '$.url', 'fixture URL is required'));
+  }
+  if (!Array.isArray(summary.claimBoundary) || summary.claimBoundary.length === 0) {
+    errors.push(error('malformed_summary', '$.claimBoundary', 'claim boundary notes are required'));
+  }
+}
+
+function validateNoLivePath(summary: PayShSandboxEvidenceSummary, errors: PayShSandboxEvidenceError[]): void {
+  const serialized = JSON.stringify(summary).toLowerCase();
+  const liveMarkers = [
+    'mainnet',
+    'live-payment-enabled',
+    'wallet_private_key',
+    'private_key',
+    'rpc_url',
+    'marketplace publication activated',
+    'marketplace-publication activated',
+    'provider call performed',
+    'provider-call performed',
+    'provider call completed',
+    'provider-call completed',
+    'catalog submission completed',
+    'catalog-submission completed',
+    'catalog submission performed',
+    'catalog-submission performed',
+    'hosted-registry-write',
+    'hosted registry write completed',
+    'hosted registry write performed',
+    'trust-upgrade',
+    'trust upgrade completed',
+    'trust upgrade performed',
+    'reputation-mutation',
+    'reputation mutation completed',
+    'reputation mutation performed',
+    'live pay.sh activation',
+    'live pay-sh activation',
+  ];
+  for (const marker of liveMarkers) {
+    if (serialized.includes(marker)) {
+      errors.push(error('live_path_rejected', '$', `fixture contains rejected live-path marker: ${marker}`));
+    }
+  }
+}
+
+function validatePaymentChallenge(summary: PayShSandboxEvidenceSummary, errors: PayShSandboxEvidenceError[]): void {
+  if (summary.plainCurl?.status !== 402) {
+    errors.push(error('missing_payment_challenge', '$.plainCurl.status', 'plain curl must prove a 402 payment challenge'));
+  }
+  if (summary.plainCurl?.paymentProtocol !== 'mpp') {
+    errors.push(error('missing_payment_challenge', '$.plainCurl.paymentProtocol', 'Pay.sh fixture must use the mpp payment protocol'));
+  }
+  if (!Number.isInteger(summary.plainCurl?.challengeCount) || summary.plainCurl.challengeCount <= 0) {
+    errors.push(error('missing_payment_challenge', '$.plainCurl.challengeCount', 'at least one payment challenge is required'));
+  }
+}
+
+function validateSingleCharge(summary: PayShSandboxEvidenceSummary, errors: PayShSandboxEvidenceError[]): void {
+  const receipt = summary.paySandboxCurl?.receipt;
+  if (summary.mode !== 'pay-sh-sandbox') {
+    errors.push(error('unsupported_mode', '$.mode', 'single-charge evidence must use pay-sh-sandbox mode'));
+  }
+  if (summary.paySandboxCurl?.status !== 200 || summary.paySandboxCurl.bodyOk !== true) {
+    errors.push(error('malformed_receipt', '$.paySandboxCurl', 'single-charge evidence must include a successful sandbox retry'));
+  }
+  if (!receipt) {
+    errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt', 'successful sandbox retry must include a receipt'));
+    return;
+  }
+  if (!isNonEmptyString(receipt.challengeId)) {
+    errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.challengeId', 'receipt challenge id is required'));
+  }
+  if (receipt.method !== 'solana') {
+    errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.method', 'receipt method must be solana'));
+  }
+  if (!isNonEmptyString(receipt.reference)) {
+    errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.reference', 'receipt reference is required'));
+  }
+  if (receipt.status !== 'success') {
+    errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.status', 'receipt status must be success'));
+  }
+  if (!isNonEmptyString(receipt.timestamp) || Number.isNaN(Date.parse(receipt.timestamp))) {
+    errors.push(error('malformed_receipt', '$.paySandboxCurl.receipt.timestamp', 'receipt timestamp must be an ISO timestamp'));
+  }
+}
+
+function validateProbeOnly(summary: PayShSandboxEvidenceSummary, errors: PayShSandboxEvidenceError[]): void {
+  if (summary.mode !== 'pay-sh-sandbox-extension') {
+    errors.push(error('unsupported_mode', '$.mode', 'extension probes must use pay-sh-sandbox-extension mode'));
+  }
+  if (summary.paySandboxCurl?.status === 200 || summary.paySandboxCurl?.receipt) {
+    errors.push(error('unexpected_success', '$.paySandboxCurl', 'probe-only fixtures must not claim successful settlement'));
+  }
+  if (summary.paySandboxCurl?.status !== 'blocked') {
+    errors.push(error('missing_probe_blocker', '$.paySandboxCurl.status', 'probe-only fixtures must record a blocked retry'));
+  }
+  if (summary.paySandboxCurl?.error !== 'Server returned 402 again after payment') {
+    errors.push(error('missing_probe_blocker', '$.paySandboxCurl.error', 'probe-only fixtures must preserve the Pay.sh 0.16 blocker'));
+  }
+}
+
+function createBindingRefs(summary: PayShSandboxEvidenceSummary): PayShSandboxEvidenceBindingRefs {
+  const decoded = summary.decodedRequest ?? {};
+  const evidenceRef = `file://${summary.artifactPath}`;
+  const receiptRef = summary.paySandboxCurl.receipt
+    ? `pay-sh-sandbox-receipt:${summary.paySandboxCurl.receipt.challengeId}`
+    : undefined;
+  return {
+    source: {
+      kind: 'source-adapter',
+      sourceId: 'pay-sh:reddi-x402:economic-demo',
+      fixtureRef: summary.artifactPath,
+      rawSnapshotRef: hashJson(summary),
+    },
+    paymentProofRef: receiptRef ?? `pay-sh-sandbox-probe:${summary.case}:${hashJson(summary.paySandboxCurl)}`,
+    evidenceRef,
+    requestHash: hashJson({
+      providerSpec: summary.providerSpec,
+      url: summary.url,
+      plainCurl: summary.plainCurl,
+      decodedRequest: summary.decodedRequest,
+    }),
+    responseHash: hashJson({
+      paySandboxCurl: summary.paySandboxCurl,
+      claimBoundary: summary.claimBoundary,
+    }),
+    quoteRef: decoded.quoteRef ?? DEFAULT_QUOTE_REF,
+    recipientRef: decoded.recipient ?? DEFAULT_RECIPIENT_REF,
+    nonceRef: decoded.nonce ?? DEFAULT_NONCE_REF,
+    sessionRef: decoded.session ?? DEFAULT_SESSION_REF,
+    authorizationRef: decoded.authorizationRef ?? DEFAULT_AUTHORIZATION_REF,
+    receiptRef,
+    operatorApprovalRef: OPERATOR_APPROVAL_REF,
+  };
+}
+
+function error(code: PayShSandboxEvidenceErrorCode, path: string, message: string): PayShSandboxEvidenceError {
+  return { code, path, message };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isSha256Hex(value: unknown): value is string {
+  return typeof value === 'string' && /^[a-f0-9]{64}$/.test(value);
+}
+
+function hashJson(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}

--- a/packages/agent-protocol/tests/pay-sh-sandbox-evidence.test.ts
+++ b/packages/agent-protocol/tests/pay-sh-sandbox-evidence.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PAY_SH_SANDBOX_EVIDENCE_SCHEMA_VERSION,
+  derivePayShSandboxEvidenceFixture,
+  payShSandboxEvidenceFixtures,
+  payShSandboxEvidenceSummaries,
+  type PayShSandboxEvidenceSummary,
+} from '../dist/index.js';
+
+test('normalizes proven Pay.sh single-charge sandbox evidence for later receipt/evidence binding', () => {
+  const result = derivePayShSandboxEvidenceFixture(payShSandboxEvidenceSummaries.singleCharge);
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  assert.equal(result.fixture.schemaVersion, PAY_SH_SANDBOX_EVIDENCE_SCHEMA_VERSION);
+  assert.equal(result.fixture.case, 'single_charge');
+  assert.equal(result.fixture.status, 'proven_single_charge');
+  assert.equal(result.fixture.receipt?.status, 'success');
+  assert.equal(result.fixture.receipt?.method, 'solana');
+  assert.equal(result.fixture.bindingRefs.source.kind, 'source-adapter');
+  assert.equal(result.fixture.bindingRefs.source.sourceId, 'pay-sh:reddi-x402:economic-demo');
+  assert.equal(result.fixture.bindingRefs.quoteRef, 'pay-sh:quote:reddi-x402-economic-demo:usd-0.01');
+  assert.equal(result.fixture.bindingRefs.recipientRef, 'pay-sh:recipient:operator-approved-demo');
+  assert.equal(result.fixture.bindingRefs.nonceRef, 'pay-sh:nonce:fixture-20260507');
+  assert.equal(result.fixture.bindingRefs.sessionRef, 'pay-sh:session:single-charge');
+  assert.equal(result.fixture.bindingRefs.authorizationRef, 'pay-sh:authorization:operator-approval-required');
+  assert.match(result.fixture.bindingRefs.paymentProofRef, /^pay-sh-sandbox-receipt:/);
+  assert.equal(result.fixture.bindingRefs.receiptRef, result.fixture.bindingRefs.paymentProofRef);
+  assert.equal(result.fixture.bindingRefs.operatorApprovalRef, 'github-issue:#454:fixture-only-approval');
+  assert.match(result.fixture.bindingRefs.requestHash, /^sha256:[a-f0-9]{64}$/);
+  assert.match(result.fixture.bindingRefs.responseHash, /^sha256:[a-f0-9]{64}$/);
+});
+
+test('keeps capped-session and split-payment probes blocked without settlement claims', () => {
+  for (const fixture of [
+    payShSandboxEvidenceFixtures.cappedSessionProbe,
+    payShSandboxEvidenceFixtures.splitPaymentProbe,
+  ]) {
+    assert.equal(fixture.status, 'probe_only');
+    assert.equal(fixture.blocker, 'pay_sh_0_16_returns_402_after_payment');
+    assert.equal(fixture.receipt, undefined);
+    assert.match(fixture.bindingRefs.paymentProofRef, /^pay-sh-sandbox-probe:/);
+    assert.equal(fixture.guardrails.livePayShCall, false);
+    assert.equal(fixture.guardrails.walletSigning, false);
+    assert.equal(fixture.guardrails.rpcCall, false);
+    assert.equal(fixture.guardrails.providerCall, false);
+    assert.equal(fixture.guardrails.hostedRegistryWrite, false);
+    assert.equal(fixture.guardrails.marketplacePublication, false);
+    assert.equal(fixture.guardrails.trustUpgrade, false);
+    assert.equal(fixture.guardrails.reputationMutation, false);
+  }
+});
+
+test('fails closed when a successful Pay.sh retry omits a valid receipt', () => {
+  const malformed = clone(payShSandboxEvidenceSummaries.singleCharge);
+  malformed.paySandboxCurl.receipt = {
+    challengeId: '',
+    method: 'solana',
+    reference: '',
+    status: 'success',
+    timestamp: 'not-a-date',
+  };
+
+  const result = derivePayShSandboxEvidenceFixture(malformed);
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+
+  assert.deepEqual(
+    result.errors.map((item) => item.code),
+    ['malformed_receipt', 'malformed_receipt', 'malformed_receipt'],
+  );
+});
+
+test('rejects live Pay.sh, marketplace, provider, catalog, wallet, RPC, registry, trust, and reputation markers', () => {
+  const livePath = clone(payShSandboxEvidenceSummaries.singleCharge);
+  livePath.claimBoundary = [
+    'mainnet live-payment-enabled wallet_private_key rpc_url hosted-registry-write trust-upgrade reputation-mutation marketplace publication activated provider call performed catalog submission completed live Pay.sh activation',
+  ];
+
+  const result = derivePayShSandboxEvidenceFixture(livePath);
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+
+  assert.ok(result.errors.some((item) => item.code === 'live_path_rejected'));
+});
+
+test('serialized fixtures contain no active publication or live-payment guardrail', () => {
+  const serialized = JSON.stringify(payShSandboxEvidenceFixtures);
+
+  assert.doesNotMatch(serialized, /live-payment-enabled/i);
+  assert.doesNotMatch(serialized, /wallet_private_key/i);
+  assert.doesNotMatch(serialized, /rpc_url/i);
+  assert.doesNotMatch(serialized, /hosted-registry-write/i);
+  assert.doesNotMatch(serialized, /reputation-mutation/i);
+  assert.match(serialized, /"livePayShCall":false/);
+  assert.match(serialized, /"marketplacePublication":false/);
+});
+
+function clone<T>(value: T): T {
+  return structuredClone(value) as T;
+}


### PR DESCRIPTION
## Summary
- add @reddi/agent-protocol/pay-sh-sandbox-evidence for fixture-backed Pay.sh sandbox evidence normalization
- normalize proven single-charge evidence plus capped-session and split-payment probe blockers into binding-ready refs
- add fail-closed tests for malformed receipts and live-path markers, with package docs/export wiring

## Validation
- npm test (packages/agent-protocol) - 142/142 pass
- npm run check:rap:naming
- git diff --check

## Boundary
No Pay.sh CLI/setup, wallet signing, RPC call, provider call, paid request, catalog submission, hosted registry write, marketplace publication, trust upgrade, reputation mutation, sandbox execution, or live Pay.sh activation. This PR only normalizes static fixture artifacts for #454 and keeps #476 deferred pending explicit approval.

Closes #454