### PR TITLE
Add MPP Tempo receipt shape fixtures

### DIFF
--- a/docs/MPP-TEMPO-RECEIPT-SHAPE-CONTRACT.md
+++ b/docs/MPP-TEMPO-RECEIPT-SHAPE-CONTRACT.md
@@ -1,0 +1,64 @@
+# MPP / Tempo Receipt Shape Contract
+
+_Issue:_ #455  
+_Package export:_ `@reddi/agent-protocol/mpp-tempo-receipt-shapes`
+
+## Purpose
+
+This contract captures fixture-backed MPP / Tempo challenge and receipt shapes before RAP implements a rail-neutral receipt normalizer. It is a source-shape and evidence-binding contract only.
+
+## Source Notes
+
+- Stripe MPP docs describe MPP as an HTTP 402 payment flow where a client authorizes payment, retries the request, and receives access plus a receipt.
+- Tempo docs describe Tempo as a payments-oriented chain with wallet, payment, and agentic-payment docs.
+- Parallel's MPP integration docs describe Tempo stablecoin payment options for MPP with pathUSD / USDC.
+- Existing RAP Pay.sh evidence shows MPP 402 challenges for single-charge, session-cap, and split-payment shapes, with only simple sandbox charge currently proven through the Pay.sh sandbox path.
+
+## Support States
+
+`binding_candidate`
+
+- A fixture has a coherent MPP challenge and receipt shape.
+- The receipt binds protocol, method, network, asset, amount, and nonce back to the challenge.
+- RAP may map this into a future rail-neutral receipt binding candidate.
+- This is not settlement verification.
+
+`probe_only`
+
+- A fixture has useful MPP challenge metadata, such as session cap or split recipients.
+- It does not include a receipt success claim.
+- RAP may use it for compatibility planning and parser tests only.
+
+`unsupported_live_rail`
+
+- Live Tempo receipts are rejected in this fixture corpus.
+- A future live lane must define wallet custody, spend limits, verifier behavior, operator approval, replay handling, evidence retention, and rollback expectations before accepting live settlement claims.
+
+## Guardrails
+
+The fixture contract is fail-closed:
+
+- no wallet signing
+- no RPC call
+- no provider call
+- no live payment
+- no Pay.sh setup or activation
+- no hosted registry write
+- no trust upgrade
+- no reputation mutation
+
+Fixtures reject imported claim text that contains secret markers or live-path markers such as private keys, RPC URLs, completed provider calls, hosted registry writes, trust upgrades, or reputation mutations.
+
+## Validation
+
+Run:
+
+```sh
+cd packages/agent-protocol && npm test -- --test-name-pattern mpp
+```
+
+For full package confidence:
+
+```sh
+cd packages/agent-protocol && npm test
+```

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -33,6 +33,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Verify:
   - `npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts --runInBand`
   - `cd packages/x402-solana && npm test -- --runInBand tests/payment.test.ts`
+  - `cd packages/agent-protocol && npm test -- --test-name-pattern mpp`
 
 ### Bucket G — Torque Retention
 - Feature: `docs/bdd/features/bucket-g-torque-retention.feature`

--- a/docs/bdd/features/bucket-f-jupiter-settlement.feature
+++ b/docs/bdd/features/bucket-f-jupiter-settlement.feature
@@ -26,3 +26,11 @@ Feature: Bucket F Cross-Token Settlement (Jupiter)
     When planner invoke route executes settlement path
     Then swap client wiring remains connected for cross-token calls
     And the behavior is covered by "lib/__tests__/planner-invoke-route.test.ts"
+
+  @F2.1 @package-contract
+  Scenario: MPP Tempo receipt shapes remain fixture-only until a live verifier is approved
+    When MPP Tempo challenge and receipt fixtures are normalized
+    Then single-charge receipt shapes can become binding candidates
+    And session and split shapes remain probe-only without settlement claims
+    And live Tempo receipts are rejected until a separate verifier lane is approved
+    And the behavior is covered by "packages/agent-protocol/tests/mpp-tempo-receipt-shapes.test.ts"

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -15,3 +15,4 @@ export * from './offchain-reputation-preview.js';
 export * from './quasar-registry-compatibility.js';
 export * from './hosted-attestation-claim.js';
 export * from './pay-sh-sandbox-evidence.js';
+export * from './mpp-tempo-receipt-shapes.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -15,3 +15,4 @@ export * from './offchain-reputation-preview.js';
 export * from './quasar-registry-compatibility.js';
 export * from './hosted-attestation-claim.js';
 export * from './pay-sh-sandbox-evidence.js';
+export * from './mpp-tempo-receipt-shapes.js';

--- a/packages/agent-protocol/dist/mpp-tempo-receipt-shapes.d.ts
+++ b/packages/agent-protocol/dist/mpp-tempo-receipt-shapes.d.ts
@@ -1,0 +1,201 @@
+export declare const MPP_TEMPO_RECEIPT_SHAPE_SCHEMA_VERSION: "reddi.mpp-tempo-receipt-shape.v1";
+export type MppTempoReceiptFixtureCase = 'mpp_single_charge_tempo_candidate' | 'mpp_session_probe' | 'mpp_split_probe' | 'tempo_live_receipt_unsupported';
+export type MppTempoReceiptSupportState = 'binding_candidate' | 'probe_only' | 'unsupported_live_rail';
+export type MppTempoPaymentMethod = 'tempo-stablecoin';
+export type MppTempoChallengeShape = {
+    protocol: 'mpp';
+    status: 402;
+    intent: 'charge' | 'session';
+    paymentMethod: MppTempoPaymentMethod;
+    network: 'tempo';
+    asset: 'USDC' | 'pathUSD';
+    amount: string;
+    unit: 'microusd' | 'base-units';
+    endpoint: string;
+    nonce: string;
+    recipientRef: string;
+    sessionCap?: string;
+    splitRecipients?: string[];
+};
+export type MppTempoReceiptShape = {
+    protocol: 'mpp';
+    paymentMethod: MppTempoPaymentMethod;
+    network: 'tempo';
+    asset: 'USDC' | 'pathUSD';
+    amount: string;
+    status: 'success';
+    nonce: string;
+    receiptRef: string;
+    settledAt: string;
+};
+export type MppTempoFixtureSummary = {
+    schema: string;
+    case: MppTempoReceiptFixtureCase;
+    sourceRefs: string[];
+    artifactPath: string;
+    challenge: MppTempoChallengeShape;
+    receipt?: MppTempoReceiptShape;
+    liveReceipt?: unknown;
+    claimBoundary: string[];
+};
+export type MppTempoBindingRefs = {
+    sourceId: 'mpp-tempo:fixture-corpus';
+    challengeRef: string;
+    paymentProofRef: string;
+    evidenceRef: string;
+    requestHash: string;
+    responseHash: string;
+    recipientRef: string;
+    nonceRef: string;
+    operatorApprovalRef: string;
+};
+export type MppTempoReceiptShapeFixture = {
+    schemaVersion: typeof MPP_TEMPO_RECEIPT_SHAPE_SCHEMA_VERSION;
+    case: MppTempoReceiptFixtureCase;
+    supportState: MppTempoReceiptSupportState;
+    artifactPath: string;
+    challenge: MppTempoChallengeShape;
+    receipt?: MppTempoReceiptShape;
+    bindingRefs: MppTempoBindingRefs;
+    guardrails: {
+        fixtureOnly: true;
+        walletSigning: false;
+        rpcCall: false;
+        providerCall: false;
+        livePayment: false;
+        hostedRegistryWrite: false;
+        trustUpgrade: false;
+        reputationMutation: false;
+    };
+    claimBoundary: string[];
+};
+export type MppTempoReceiptShapeErrorCode = 'malformed_fixture' | 'unsupported_protocol' | 'unsupported_payment_method' | 'malformed_challenge' | 'malformed_receipt' | 'receipt_challenge_mismatch' | 'live_path_rejected' | 'unsupported_live_rail';
+export type MppTempoReceiptShapeError = {
+    code: MppTempoReceiptShapeErrorCode;
+    path: string;
+    message: string;
+};
+export type MppTempoReceiptShapeResult = {
+    ok: true;
+    fixture: MppTempoReceiptShapeFixture;
+} | {
+    ok: false;
+    errors: MppTempoReceiptShapeError[];
+};
+export declare const MPP_TEMPO_RECEIPT_SHAPE_GUARDRAILS: {
+    readonly fixtureOnly: true;
+    readonly walletSigning: false;
+    readonly rpcCall: false;
+    readonly providerCall: false;
+    readonly livePayment: false;
+    readonly hostedRegistryWrite: false;
+    readonly trustUpgrade: false;
+    readonly reputationMutation: false;
+};
+export declare const mppTempoReceiptShapeSummaries: {
+    tempoSingleChargeCandidate: {
+        schema: string;
+        case: "mpp_single_charge_tempo_candidate";
+        sourceRefs: string[];
+        artifactPath: string;
+        challenge: {
+            protocol: "mpp";
+            status: 402;
+            intent: "charge";
+            paymentMethod: "tempo-stablecoin";
+            network: "tempo";
+            asset: "USDC";
+            amount: string;
+            unit: "microusd";
+            endpoint: string;
+            nonce: string;
+            recipientRef: string;
+        };
+        receipt: {
+            protocol: "mpp";
+            paymentMethod: "tempo-stablecoin";
+            network: "tempo";
+            asset: "USDC";
+            amount: string;
+            status: "success";
+            nonce: string;
+            receiptRef: string;
+            settledAt: string;
+        };
+        claimBoundary: string[];
+    };
+    tempoSessionProbe: {
+        schema: string;
+        case: "mpp_session_probe";
+        sourceRefs: string[];
+        artifactPath: string;
+        challenge: {
+            protocol: "mpp";
+            status: 402;
+            intent: "session";
+            paymentMethod: "tempo-stablecoin";
+            network: "tempo";
+            asset: "pathUSD";
+            amount: string;
+            unit: "base-units";
+            endpoint: string;
+            nonce: string;
+            recipientRef: string;
+            sessionCap: string;
+        };
+        claimBoundary: string[];
+    };
+    tempoSplitProbe: {
+        schema: string;
+        case: "mpp_split_probe";
+        sourceRefs: string[];
+        artifactPath: string;
+        challenge: {
+            protocol: "mpp";
+            status: 402;
+            intent: "charge";
+            paymentMethod: "tempo-stablecoin";
+            network: "tempo";
+            asset: "USDC";
+            amount: string;
+            unit: "microusd";
+            endpoint: string;
+            nonce: string;
+            recipientRef: string;
+            splitRecipients: string[];
+        };
+        claimBoundary: string[];
+    };
+    tempoLiveReceiptUnsupported: {
+        schema: string;
+        case: "tempo_live_receipt_unsupported";
+        sourceRefs: string[];
+        artifactPath: string;
+        challenge: {
+            protocol: "mpp";
+            status: 402;
+            intent: "charge";
+            paymentMethod: "tempo-stablecoin";
+            network: "tempo";
+            asset: "USDC";
+            amount: string;
+            unit: "microusd";
+            endpoint: string;
+            nonce: string;
+            recipientRef: string;
+        };
+        liveReceipt: {
+            status: string;
+            network: string;
+            txHash: string;
+        };
+        claimBoundary: string[];
+    };
+};
+export declare function createMppTempoReceiptShapeFixture(summary: MppTempoFixtureSummary): MppTempoReceiptShapeFixture;
+export declare function deriveMppTempoReceiptShapeFixture(summary: MppTempoFixtureSummary): MppTempoReceiptShapeResult;
+export declare const mppTempoReceiptShapeFixtures: {
+    readonly tempoSingleChargeCandidate: MppTempoReceiptShapeFixture;
+    readonly tempoSessionProbe: MppTempoReceiptShapeFixture;
+    readonly tempoSplitProbe: MppTempoReceiptShapeFixture;
+};

--- a/packages/agent-protocol/dist/mpp-tempo-receipt-shapes.js
+++ b/packages/agent-protocol/dist/mpp-tempo-receipt-shapes.js
@@ -1,0 +1,330 @@
+import { createHash } from 'node:crypto';
+export const MPP_TEMPO_RECEIPT_SHAPE_SCHEMA_VERSION = 'reddi.mpp-tempo-receipt-shape.v1';
+export const MPP_TEMPO_RECEIPT_SHAPE_GUARDRAILS = {
+    fixtureOnly: true,
+    walletSigning: false,
+    rpcCall: false,
+    providerCall: false,
+    livePayment: false,
+    hostedRegistryWrite: false,
+    trustUpgrade: false,
+    reputationMutation: false,
+};
+const OPERATOR_APPROVAL_REF = 'github-issue:#455:fixture-only-approval';
+const MPP_DOC_REF = 'https://docs.stripe.com/payments/machine/mpp';
+const TEMPO_DOC_REF = 'https://docs.tempo.xyz/';
+const PARALLEL_MPP_REF = 'https://docs.parallel.ai/integrations/agentic-payments';
+export const mppTempoReceiptShapeSummaries = {
+    tempoSingleChargeCandidate: {
+        schema: 'reddi.mpp-tempo.fixture-summary.v1',
+        case: 'mpp_single_charge_tempo_candidate',
+        sourceRefs: [MPP_DOC_REF, TEMPO_DOC_REF, PARALLEL_MPP_REF],
+        artifactPath: 'fixtures/payment/mpp-tempo/single-charge-candidate.json',
+        challenge: {
+            protocol: 'mpp',
+            status: 402,
+            intent: 'charge',
+            paymentMethod: 'tempo-stablecoin',
+            network: 'tempo',
+            asset: 'USDC',
+            amount: '1000',
+            unit: 'microusd',
+            endpoint: 'https://example.invalid/paid/search',
+            nonce: 'mpp-tempo-nonce-single-charge',
+            recipientRef: 'tempo:recipient:operator-approved-fixture',
+        },
+        receipt: {
+            protocol: 'mpp',
+            paymentMethod: 'tempo-stablecoin',
+            network: 'tempo',
+            asset: 'USDC',
+            amount: '1000',
+            status: 'success',
+            nonce: 'mpp-tempo-nonce-single-charge',
+            receiptRef: 'mpp-tempo-receipt:single-charge-fixture',
+            settledAt: '2026-06-22T00:00:00.000Z',
+        },
+        claimBoundary: [
+            'MPP Tempo single-charge fixture is a receipt-shape binding candidate only.',
+            'No Tempo wallet, RPC, provider call, live payment, hosted registry write, trust upgrade, or reputation mutation is performed.',
+        ],
+    },
+    tempoSessionProbe: {
+        schema: 'reddi.mpp-tempo.fixture-summary.v1',
+        case: 'mpp_session_probe',
+        sourceRefs: [MPP_DOC_REF, TEMPO_DOC_REF],
+        artifactPath: 'fixtures/payment/mpp-tempo/session-probe.json',
+        challenge: {
+            protocol: 'mpp',
+            status: 402,
+            intent: 'session',
+            paymentMethod: 'tempo-stablecoin',
+            network: 'tempo',
+            asset: 'pathUSD',
+            amount: '1000000',
+            unit: 'base-units',
+            endpoint: 'https://example.invalid/paid/session',
+            nonce: 'mpp-tempo-nonce-session',
+            recipientRef: 'tempo:recipient:operator-approved-fixture',
+            sessionCap: '1000000',
+        },
+        claimBoundary: [
+            'MPP Tempo session fixture records challenge shape only.',
+            'RAP does not claim settlement, repeated-call authorization, wallet signing, provider execution, or live activation from this fixture.',
+        ],
+    },
+    tempoSplitProbe: {
+        schema: 'reddi.mpp-tempo.fixture-summary.v1',
+        case: 'mpp_split_probe',
+        sourceRefs: [MPP_DOC_REF, TEMPO_DOC_REF],
+        artifactPath: 'fixtures/payment/mpp-tempo/split-probe.json',
+        challenge: {
+            protocol: 'mpp',
+            status: 402,
+            intent: 'charge',
+            paymentMethod: 'tempo-stablecoin',
+            network: 'tempo',
+            asset: 'USDC',
+            amount: '2000',
+            unit: 'microusd',
+            endpoint: 'https://example.invalid/paid/split',
+            nonce: 'mpp-tempo-nonce-split',
+            recipientRef: 'tempo:recipient:operator-approved-fixture',
+            splitRecipients: ['tempo:recipient:downstream-specialist-fixture'],
+        },
+        claimBoundary: [
+            'MPP Tempo split fixture records challenge metadata only.',
+            'RAP does not claim split settlement, provider payment, trust upgrade, reputation mutation, or live activation from this fixture.',
+        ],
+    },
+    tempoLiveReceiptUnsupported: {
+        schema: 'reddi.mpp-tempo.fixture-summary.v1',
+        case: 'tempo_live_receipt_unsupported',
+        sourceRefs: [TEMPO_DOC_REF],
+        artifactPath: 'fixtures/payment/mpp-tempo/live-receipt-unsupported.json',
+        challenge: {
+            protocol: 'mpp',
+            status: 402,
+            intent: 'charge',
+            paymentMethod: 'tempo-stablecoin',
+            network: 'tempo',
+            asset: 'USDC',
+            amount: '1000',
+            unit: 'microusd',
+            endpoint: 'https://example.invalid/live/paid/search',
+            nonce: 'mpp-tempo-nonce-live-unsupported',
+            recipientRef: 'tempo:recipient:operator-approved-fixture',
+        },
+        liveReceipt: {
+            status: 'success',
+            network: 'tempo',
+            txHash: '0xlive-path-not-accepted-in-fixtures',
+        },
+        claimBoundary: [
+            'Live Tempo receipts are unsupported in this fixture corpus.',
+            'A future live lane needs explicit wallet, spend, verifier, and operator approval gates before RAP can accept live settlement claims.',
+        ],
+    },
+};
+export function createMppTempoReceiptShapeFixture(summary) {
+    const result = deriveMppTempoReceiptShapeFixture(summary);
+    if (!result.ok) {
+        throw new Error(`invalid_mpp_tempo_receipt_shape:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+    }
+    return result.fixture;
+}
+export function deriveMppTempoReceiptShapeFixture(summary) {
+    const errors = [];
+    validateFixture(summary, errors);
+    validateChallenge(summary.challenge, errors);
+    validateNoLivePath(summary, errors);
+    if (summary.case === 'tempo_live_receipt_unsupported') {
+        errors.push(error('unsupported_live_rail', '$.liveReceipt', 'live Tempo receipts require a separate approved live verifier lane'));
+    }
+    else if (summary.case === 'mpp_single_charge_tempo_candidate') {
+        validateReceipt(summary, errors);
+    }
+    else if (summary.receipt) {
+        errors.push(error('malformed_receipt', '$.receipt', 'probe-only fixtures must not include receipt success claims'));
+    }
+    if (errors.length > 0)
+        return { ok: false, errors };
+    return {
+        ok: true,
+        fixture: {
+            schemaVersion: MPP_TEMPO_RECEIPT_SHAPE_SCHEMA_VERSION,
+            case: summary.case,
+            supportState: summary.case === 'mpp_single_charge_tempo_candidate' ? 'binding_candidate' : 'probe_only',
+            artifactPath: summary.artifactPath,
+            challenge: summary.challenge,
+            receipt: summary.receipt,
+            bindingRefs: createBindingRefs(summary),
+            guardrails: MPP_TEMPO_RECEIPT_SHAPE_GUARDRAILS,
+            claimBoundary: summary.claimBoundary,
+        },
+    };
+}
+export const mppTempoReceiptShapeFixtures = {
+    tempoSingleChargeCandidate: createMppTempoReceiptShapeFixture(mppTempoReceiptShapeSummaries.tempoSingleChargeCandidate),
+    tempoSessionProbe: createMppTempoReceiptShapeFixture(mppTempoReceiptShapeSummaries.tempoSessionProbe),
+    tempoSplitProbe: createMppTempoReceiptShapeFixture(mppTempoReceiptShapeSummaries.tempoSplitProbe),
+};
+function validateFixture(summary, errors) {
+    if (!isPlainObject(summary)) {
+        errors.push(error('malformed_fixture', '$', 'fixture summary must be an object'));
+        return;
+    }
+    if (!isNonEmptyString(summary.schema)) {
+        errors.push(error('malformed_fixture', '$.schema', 'schema is required'));
+    }
+    if (!['mpp_single_charge_tempo_candidate', 'mpp_session_probe', 'mpp_split_probe', 'tempo_live_receipt_unsupported'].includes(String(summary.case))) {
+        errors.push(error('malformed_fixture', '$.case', 'unsupported fixture case'));
+    }
+    if (!Array.isArray(summary.sourceRefs) || summary.sourceRefs.length === 0 || !summary.sourceRefs.every(isNonEmptyString)) {
+        errors.push(error('malformed_fixture', '$.sourceRefs', 'docs-backed source refs are required'));
+    }
+    if (!isNonEmptyString(summary.artifactPath)) {
+        errors.push(error('malformed_fixture', '$.artifactPath', 'artifact path is required'));
+    }
+    if (!Array.isArray(summary.claimBoundary) || summary.claimBoundary.length === 0) {
+        errors.push(error('malformed_fixture', '$.claimBoundary', 'claim boundary notes are required'));
+    }
+}
+function validateChallenge(challenge, errors) {
+    if (!isPlainObject(challenge)) {
+        errors.push(error('malformed_challenge', '$.challenge', 'challenge must be an object'));
+        return;
+    }
+    if (challenge.protocol !== 'mpp') {
+        errors.push(error('unsupported_protocol', '$.challenge.protocol', 'challenge protocol must be mpp'));
+    }
+    if (challenge.status !== 402) {
+        errors.push(error('malformed_challenge', '$.challenge.status', 'challenge status must be 402'));
+    }
+    if (!['charge', 'session'].includes(String(challenge.intent))) {
+        errors.push(error('malformed_challenge', '$.challenge.intent', 'challenge intent must be charge or session'));
+    }
+    if (challenge.paymentMethod !== 'tempo-stablecoin') {
+        errors.push(error('unsupported_payment_method', '$.challenge.paymentMethod', 'only Tempo stablecoin MPP fixtures are accepted'));
+    }
+    if (challenge.network !== 'tempo') {
+        errors.push(error('unsupported_payment_method', '$.challenge.network', 'network must be tempo'));
+    }
+    if (!['USDC', 'pathUSD'].includes(String(challenge.asset))) {
+        errors.push(error('unsupported_payment_method', '$.challenge.asset', 'asset must be USDC or pathUSD'));
+    }
+    if (!positiveAmount(challenge.amount)) {
+        errors.push(error('malformed_challenge', '$.challenge.amount', 'amount must be a positive integer string'));
+    }
+    if (!['microusd', 'base-units'].includes(String(challenge.unit))) {
+        errors.push(error('malformed_challenge', '$.challenge.unit', 'unit is unsupported'));
+    }
+    if (!isHttpsUrl(challenge.endpoint)) {
+        errors.push(error('malformed_challenge', '$.challenge.endpoint', 'endpoint must be an HTTPS URL'));
+    }
+    if (!isNonEmptyString(challenge.nonce)) {
+        errors.push(error('malformed_challenge', '$.challenge.nonce', 'nonce is required'));
+    }
+    if (!isNonEmptyString(challenge.recipientRef)) {
+        errors.push(error('malformed_challenge', '$.challenge.recipientRef', 'recipient ref is required'));
+    }
+    if (challenge.intent === 'session' && !positiveAmount(challenge.sessionCap)) {
+        errors.push(error('malformed_challenge', '$.challenge.sessionCap', 'session fixtures require a positive cap'));
+    }
+    if (challenge.splitRecipients && (!Array.isArray(challenge.splitRecipients) || challenge.splitRecipients.length === 0 || !challenge.splitRecipients.every(isNonEmptyString))) {
+        errors.push(error('malformed_challenge', '$.challenge.splitRecipients', 'split recipients must be non-empty string refs'));
+    }
+}
+function validateReceipt(summary, errors) {
+    const { receipt, challenge } = summary;
+    if (!isPlainObject(receipt)) {
+        errors.push(error('malformed_receipt', '$.receipt', 'single-charge candidates require a receipt shape'));
+        return;
+    }
+    if (receipt.protocol !== 'mpp') {
+        errors.push(error('unsupported_protocol', '$.receipt.protocol', 'receipt protocol must be mpp'));
+    }
+    if (receipt.paymentMethod !== challenge.paymentMethod || receipt.network !== challenge.network || receipt.asset !== challenge.asset || receipt.amount !== challenge.amount || receipt.nonce !== challenge.nonce) {
+        errors.push(error('receipt_challenge_mismatch', '$.receipt', 'receipt must bind method, network, asset, amount, and nonce to the challenge'));
+    }
+    if (receipt.status !== 'success') {
+        errors.push(error('malformed_receipt', '$.receipt.status', 'receipt status must be success'));
+    }
+    if (!isNonEmptyString(receipt.receiptRef)) {
+        errors.push(error('malformed_receipt', '$.receipt.receiptRef', 'receipt ref is required'));
+    }
+    if (!isNonEmptyString(receipt.settledAt) || Number.isNaN(Date.parse(receipt.settledAt))) {
+        errors.push(error('malformed_receipt', '$.receipt.settledAt', 'settledAt must be an ISO timestamp'));
+    }
+}
+function validateNoLivePath(summary, errors) {
+    const serialized = JSON.stringify(summary).toLowerCase();
+    const rejectedMarkers = [
+        'wallet_private_key',
+        'private_key',
+        'rpc_url',
+        'provider call completed',
+        'provider call performed',
+        'hosted-registry-write',
+        'hosted registry write completed',
+        'hosted registry write performed',
+        'trust-upgrade',
+        'trust upgrade completed',
+        'trust upgrade performed',
+        'reputation-mutation',
+        'reputation mutation completed',
+        'reputation mutation performed',
+        'live payment completed',
+        'live tempo payment accepted',
+    ];
+    for (const marker of rejectedMarkers) {
+        if (serialized.includes(marker)) {
+            errors.push(error('live_path_rejected', '$', `fixture contains rejected live-path marker: ${marker}`));
+        }
+    }
+}
+function createBindingRefs(summary) {
+    return {
+        sourceId: 'mpp-tempo:fixture-corpus',
+        challengeRef: `mpp-tempo-challenge:${summary.challenge.nonce}`,
+        paymentProofRef: summary.receipt?.receiptRef ?? `mpp-tempo-probe:${summary.case}:${hashJson(summary.challenge)}`,
+        evidenceRef: `file://${summary.artifactPath}`,
+        requestHash: hashJson(summary.challenge),
+        responseHash: hashJson({
+            receipt: summary.receipt ?? null,
+            supportState: summary.case === 'mpp_single_charge_tempo_candidate' ? 'binding_candidate' : 'probe_only',
+            claimBoundary: summary.claimBoundary,
+        }),
+        recipientRef: summary.challenge.recipientRef,
+        nonceRef: `mpp-tempo-nonce:${summary.challenge.nonce}`,
+        operatorApprovalRef: OPERATOR_APPROVAL_REF,
+    };
+}
+function error(code, path, message) {
+    return { code, path, message };
+}
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function positiveAmount(value) {
+    return typeof value === 'string' && /^[1-9]\d*$/.test(value);
+}
+function isHttpsUrl(value) {
+    if (!isNonEmptyString(value))
+        return false;
+    try {
+        return new URL(value).protocol === 'https:';
+    }
+    catch {
+        return false;
+    }
+}
+function hashJson(value) {
+    return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -78,6 +78,10 @@
       "types": "./dist/pay-sh-sandbox-evidence.d.ts",
       "import": "./dist/pay-sh-sandbox-evidence.js"
     },
+    "./mpp-tempo-receipt-shapes": {
+      "types": "./dist/mpp-tempo-receipt-shapes.d.ts",
+      "import": "./dist/mpp-tempo-receipt-shapes.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -15,3 +15,4 @@ export * from './offchain-reputation-preview.js';
 export * from './quasar-registry-compatibility.js';
 export * from './hosted-attestation-claim.js';
 export * from './pay-sh-sandbox-evidence.js';
+export * from './mpp-tempo-receipt-shapes.js';

--- a/packages/agent-protocol/src/mpp-tempo-receipt-shapes.ts
+++ b/packages/agent-protocol/src/mpp-tempo-receipt-shapes.ts
@@ -1,0 +1,450 @@
+import { createHash } from 'node:crypto';
+
+export const MPP_TEMPO_RECEIPT_SHAPE_SCHEMA_VERSION = 'reddi.mpp-tempo-receipt-shape.v1' as const;
+
+export type MppTempoReceiptFixtureCase =
+  | 'mpp_single_charge_tempo_candidate'
+  | 'mpp_session_probe'
+  | 'mpp_split_probe'
+  | 'tempo_live_receipt_unsupported';
+
+export type MppTempoReceiptSupportState =
+  | 'binding_candidate'
+  | 'probe_only'
+  | 'unsupported_live_rail';
+
+export type MppTempoPaymentMethod = 'tempo-stablecoin';
+
+export type MppTempoChallengeShape = {
+  protocol: 'mpp';
+  status: 402;
+  intent: 'charge' | 'session';
+  paymentMethod: MppTempoPaymentMethod;
+  network: 'tempo';
+  asset: 'USDC' | 'pathUSD';
+  amount: string;
+  unit: 'microusd' | 'base-units';
+  endpoint: string;
+  nonce: string;
+  recipientRef: string;
+  sessionCap?: string;
+  splitRecipients?: string[];
+};
+
+export type MppTempoReceiptShape = {
+  protocol: 'mpp';
+  paymentMethod: MppTempoPaymentMethod;
+  network: 'tempo';
+  asset: 'USDC' | 'pathUSD';
+  amount: string;
+  status: 'success';
+  nonce: string;
+  receiptRef: string;
+  settledAt: string;
+};
+
+export type MppTempoFixtureSummary = {
+  schema: string;
+  case: MppTempoReceiptFixtureCase;
+  sourceRefs: string[];
+  artifactPath: string;
+  challenge: MppTempoChallengeShape;
+  receipt?: MppTempoReceiptShape;
+  liveReceipt?: unknown;
+  claimBoundary: string[];
+};
+
+export type MppTempoBindingRefs = {
+  sourceId: 'mpp-tempo:fixture-corpus';
+  challengeRef: string;
+  paymentProofRef: string;
+  evidenceRef: string;
+  requestHash: string;
+  responseHash: string;
+  recipientRef: string;
+  nonceRef: string;
+  operatorApprovalRef: string;
+};
+
+export type MppTempoReceiptShapeFixture = {
+  schemaVersion: typeof MPP_TEMPO_RECEIPT_SHAPE_SCHEMA_VERSION;
+  case: MppTempoReceiptFixtureCase;
+  supportState: MppTempoReceiptSupportState;
+  artifactPath: string;
+  challenge: MppTempoChallengeShape;
+  receipt?: MppTempoReceiptShape;
+  bindingRefs: MppTempoBindingRefs;
+  guardrails: {
+    fixtureOnly: true;
+    walletSigning: false;
+    rpcCall: false;
+    providerCall: false;
+    livePayment: false;
+    hostedRegistryWrite: false;
+    trustUpgrade: false;
+    reputationMutation: false;
+  };
+  claimBoundary: string[];
+};
+
+export type MppTempoReceiptShapeErrorCode =
+  | 'malformed_fixture'
+  | 'unsupported_protocol'
+  | 'unsupported_payment_method'
+  | 'malformed_challenge'
+  | 'malformed_receipt'
+  | 'receipt_challenge_mismatch'
+  | 'live_path_rejected'
+  | 'unsupported_live_rail';
+
+export type MppTempoReceiptShapeError = {
+  code: MppTempoReceiptShapeErrorCode;
+  path: string;
+  message: string;
+};
+
+export type MppTempoReceiptShapeResult =
+  | { ok: true; fixture: MppTempoReceiptShapeFixture }
+  | { ok: false; errors: MppTempoReceiptShapeError[] };
+
+export const MPP_TEMPO_RECEIPT_SHAPE_GUARDRAILS = {
+  fixtureOnly: true,
+  walletSigning: false,
+  rpcCall: false,
+  providerCall: false,
+  livePayment: false,
+  hostedRegistryWrite: false,
+  trustUpgrade: false,
+  reputationMutation: false,
+} as const;
+
+const OPERATOR_APPROVAL_REF = 'github-issue:#455:fixture-only-approval';
+const MPP_DOC_REF = 'https://docs.stripe.com/payments/machine/mpp';
+const TEMPO_DOC_REF = 'https://docs.tempo.xyz/';
+const PARALLEL_MPP_REF = 'https://docs.parallel.ai/integrations/agentic-payments';
+
+export const mppTempoReceiptShapeSummaries = {
+  tempoSingleChargeCandidate: {
+    schema: 'reddi.mpp-tempo.fixture-summary.v1',
+    case: 'mpp_single_charge_tempo_candidate',
+    sourceRefs: [MPP_DOC_REF, TEMPO_DOC_REF, PARALLEL_MPP_REF],
+    artifactPath: 'fixtures/payment/mpp-tempo/single-charge-candidate.json',
+    challenge: {
+      protocol: 'mpp',
+      status: 402,
+      intent: 'charge',
+      paymentMethod: 'tempo-stablecoin',
+      network: 'tempo',
+      asset: 'USDC',
+      amount: '1000',
+      unit: 'microusd',
+      endpoint: 'https://example.invalid/paid/search',
+      nonce: 'mpp-tempo-nonce-single-charge',
+      recipientRef: 'tempo:recipient:operator-approved-fixture',
+    },
+    receipt: {
+      protocol: 'mpp',
+      paymentMethod: 'tempo-stablecoin',
+      network: 'tempo',
+      asset: 'USDC',
+      amount: '1000',
+      status: 'success',
+      nonce: 'mpp-tempo-nonce-single-charge',
+      receiptRef: 'mpp-tempo-receipt:single-charge-fixture',
+      settledAt: '2026-06-22T00:00:00.000Z',
+    },
+    claimBoundary: [
+      'MPP Tempo single-charge fixture is a receipt-shape binding candidate only.',
+      'No Tempo wallet, RPC, provider call, live payment, hosted registry write, trust upgrade, or reputation mutation is performed.',
+    ],
+  },
+  tempoSessionProbe: {
+    schema: 'reddi.mpp-tempo.fixture-summary.v1',
+    case: 'mpp_session_probe',
+    sourceRefs: [MPP_DOC_REF, TEMPO_DOC_REF],
+    artifactPath: 'fixtures/payment/mpp-tempo/session-probe.json',
+    challenge: {
+      protocol: 'mpp',
+      status: 402,
+      intent: 'session',
+      paymentMethod: 'tempo-stablecoin',
+      network: 'tempo',
+      asset: 'pathUSD',
+      amount: '1000000',
+      unit: 'base-units',
+      endpoint: 'https://example.invalid/paid/session',
+      nonce: 'mpp-tempo-nonce-session',
+      recipientRef: 'tempo:recipient:operator-approved-fixture',
+      sessionCap: '1000000',
+    },
+    claimBoundary: [
+      'MPP Tempo session fixture records challenge shape only.',
+      'RAP does not claim settlement, repeated-call authorization, wallet signing, provider execution, or live activation from this fixture.',
+    ],
+  },
+  tempoSplitProbe: {
+    schema: 'reddi.mpp-tempo.fixture-summary.v1',
+    case: 'mpp_split_probe',
+    sourceRefs: [MPP_DOC_REF, TEMPO_DOC_REF],
+    artifactPath: 'fixtures/payment/mpp-tempo/split-probe.json',
+    challenge: {
+      protocol: 'mpp',
+      status: 402,
+      intent: 'charge',
+      paymentMethod: 'tempo-stablecoin',
+      network: 'tempo',
+      asset: 'USDC',
+      amount: '2000',
+      unit: 'microusd',
+      endpoint: 'https://example.invalid/paid/split',
+      nonce: 'mpp-tempo-nonce-split',
+      recipientRef: 'tempo:recipient:operator-approved-fixture',
+      splitRecipients: ['tempo:recipient:downstream-specialist-fixture'],
+    },
+    claimBoundary: [
+      'MPP Tempo split fixture records challenge metadata only.',
+      'RAP does not claim split settlement, provider payment, trust upgrade, reputation mutation, or live activation from this fixture.',
+    ],
+  },
+  tempoLiveReceiptUnsupported: {
+    schema: 'reddi.mpp-tempo.fixture-summary.v1',
+    case: 'tempo_live_receipt_unsupported',
+    sourceRefs: [TEMPO_DOC_REF],
+    artifactPath: 'fixtures/payment/mpp-tempo/live-receipt-unsupported.json',
+    challenge: {
+      protocol: 'mpp',
+      status: 402,
+      intent: 'charge',
+      paymentMethod: 'tempo-stablecoin',
+      network: 'tempo',
+      asset: 'USDC',
+      amount: '1000',
+      unit: 'microusd',
+      endpoint: 'https://example.invalid/live/paid/search',
+      nonce: 'mpp-tempo-nonce-live-unsupported',
+      recipientRef: 'tempo:recipient:operator-approved-fixture',
+    },
+    liveReceipt: {
+      status: 'success',
+      network: 'tempo',
+      txHash: '0xlive-path-not-accepted-in-fixtures',
+    },
+    claimBoundary: [
+      'Live Tempo receipts are unsupported in this fixture corpus.',
+      'A future live lane needs explicit wallet, spend, verifier, and operator approval gates before RAP can accept live settlement claims.',
+    ],
+  },
+} satisfies Record<string, MppTempoFixtureSummary>;
+
+export function createMppTempoReceiptShapeFixture(summary: MppTempoFixtureSummary): MppTempoReceiptShapeFixture {
+  const result = deriveMppTempoReceiptShapeFixture(summary);
+  if (!result.ok) {
+    throw new Error(`invalid_mpp_tempo_receipt_shape:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+  }
+  return result.fixture;
+}
+
+export function deriveMppTempoReceiptShapeFixture(summary: MppTempoFixtureSummary): MppTempoReceiptShapeResult {
+  const errors: MppTempoReceiptShapeError[] = [];
+  validateFixture(summary, errors);
+  validateChallenge(summary.challenge, errors);
+  validateNoLivePath(summary, errors);
+
+  if (summary.case === 'tempo_live_receipt_unsupported') {
+    errors.push(error('unsupported_live_rail', '$.liveReceipt', 'live Tempo receipts require a separate approved live verifier lane'));
+  } else if (summary.case === 'mpp_single_charge_tempo_candidate') {
+    validateReceipt(summary, errors);
+  } else if (summary.receipt) {
+    errors.push(error('malformed_receipt', '$.receipt', 'probe-only fixtures must not include receipt success claims'));
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    fixture: {
+      schemaVersion: MPP_TEMPO_RECEIPT_SHAPE_SCHEMA_VERSION,
+      case: summary.case,
+      supportState: summary.case === 'mpp_single_charge_tempo_candidate' ? 'binding_candidate' : 'probe_only',
+      artifactPath: summary.artifactPath,
+      challenge: summary.challenge,
+      receipt: summary.receipt,
+      bindingRefs: createBindingRefs(summary),
+      guardrails: MPP_TEMPO_RECEIPT_SHAPE_GUARDRAILS,
+      claimBoundary: summary.claimBoundary,
+    },
+  };
+}
+
+export const mppTempoReceiptShapeFixtures = {
+  tempoSingleChargeCandidate: createMppTempoReceiptShapeFixture(mppTempoReceiptShapeSummaries.tempoSingleChargeCandidate),
+  tempoSessionProbe: createMppTempoReceiptShapeFixture(mppTempoReceiptShapeSummaries.tempoSessionProbe),
+  tempoSplitProbe: createMppTempoReceiptShapeFixture(mppTempoReceiptShapeSummaries.tempoSplitProbe),
+} as const;
+
+function validateFixture(summary: MppTempoFixtureSummary, errors: MppTempoReceiptShapeError[]): void {
+  if (!isPlainObject(summary)) {
+    errors.push(error('malformed_fixture', '$', 'fixture summary must be an object'));
+    return;
+  }
+  if (!isNonEmptyString(summary.schema)) {
+    errors.push(error('malformed_fixture', '$.schema', 'schema is required'));
+  }
+  if (!['mpp_single_charge_tempo_candidate', 'mpp_session_probe', 'mpp_split_probe', 'tempo_live_receipt_unsupported'].includes(String(summary.case))) {
+    errors.push(error('malformed_fixture', '$.case', 'unsupported fixture case'));
+  }
+  if (!Array.isArray(summary.sourceRefs) || summary.sourceRefs.length === 0 || !summary.sourceRefs.every(isNonEmptyString)) {
+    errors.push(error('malformed_fixture', '$.sourceRefs', 'docs-backed source refs are required'));
+  }
+  if (!isNonEmptyString(summary.artifactPath)) {
+    errors.push(error('malformed_fixture', '$.artifactPath', 'artifact path is required'));
+  }
+  if (!Array.isArray(summary.claimBoundary) || summary.claimBoundary.length === 0) {
+    errors.push(error('malformed_fixture', '$.claimBoundary', 'claim boundary notes are required'));
+  }
+}
+
+function validateChallenge(challenge: MppTempoChallengeShape, errors: MppTempoReceiptShapeError[]): void {
+  if (!isPlainObject(challenge)) {
+    errors.push(error('malformed_challenge', '$.challenge', 'challenge must be an object'));
+    return;
+  }
+  if (challenge.protocol !== 'mpp') {
+    errors.push(error('unsupported_protocol', '$.challenge.protocol', 'challenge protocol must be mpp'));
+  }
+  if (challenge.status !== 402) {
+    errors.push(error('malformed_challenge', '$.challenge.status', 'challenge status must be 402'));
+  }
+  if (!['charge', 'session'].includes(String(challenge.intent))) {
+    errors.push(error('malformed_challenge', '$.challenge.intent', 'challenge intent must be charge or session'));
+  }
+  if (challenge.paymentMethod !== 'tempo-stablecoin') {
+    errors.push(error('unsupported_payment_method', '$.challenge.paymentMethod', 'only Tempo stablecoin MPP fixtures are accepted'));
+  }
+  if (challenge.network !== 'tempo') {
+    errors.push(error('unsupported_payment_method', '$.challenge.network', 'network must be tempo'));
+  }
+  if (!['USDC', 'pathUSD'].includes(String(challenge.asset))) {
+    errors.push(error('unsupported_payment_method', '$.challenge.asset', 'asset must be USDC or pathUSD'));
+  }
+  if (!positiveAmount(challenge.amount)) {
+    errors.push(error('malformed_challenge', '$.challenge.amount', 'amount must be a positive integer string'));
+  }
+  if (!['microusd', 'base-units'].includes(String(challenge.unit))) {
+    errors.push(error('malformed_challenge', '$.challenge.unit', 'unit is unsupported'));
+  }
+  if (!isHttpsUrl(challenge.endpoint)) {
+    errors.push(error('malformed_challenge', '$.challenge.endpoint', 'endpoint must be an HTTPS URL'));
+  }
+  if (!isNonEmptyString(challenge.nonce)) {
+    errors.push(error('malformed_challenge', '$.challenge.nonce', 'nonce is required'));
+  }
+  if (!isNonEmptyString(challenge.recipientRef)) {
+    errors.push(error('malformed_challenge', '$.challenge.recipientRef', 'recipient ref is required'));
+  }
+  if (challenge.intent === 'session' && !positiveAmount(challenge.sessionCap)) {
+    errors.push(error('malformed_challenge', '$.challenge.sessionCap', 'session fixtures require a positive cap'));
+  }
+  if (challenge.splitRecipients && (!Array.isArray(challenge.splitRecipients) || challenge.splitRecipients.length === 0 || !challenge.splitRecipients.every(isNonEmptyString))) {
+    errors.push(error('malformed_challenge', '$.challenge.splitRecipients', 'split recipients must be non-empty string refs'));
+  }
+}
+
+function validateReceipt(summary: MppTempoFixtureSummary, errors: MppTempoReceiptShapeError[]): void {
+  const { receipt, challenge } = summary;
+  if (!isPlainObject(receipt)) {
+    errors.push(error('malformed_receipt', '$.receipt', 'single-charge candidates require a receipt shape'));
+    return;
+  }
+  if (receipt.protocol !== 'mpp') {
+    errors.push(error('unsupported_protocol', '$.receipt.protocol', 'receipt protocol must be mpp'));
+  }
+  if (receipt.paymentMethod !== challenge.paymentMethod || receipt.network !== challenge.network || receipt.asset !== challenge.asset || receipt.amount !== challenge.amount || receipt.nonce !== challenge.nonce) {
+    errors.push(error('receipt_challenge_mismatch', '$.receipt', 'receipt must bind method, network, asset, amount, and nonce to the challenge'));
+  }
+  if (receipt.status !== 'success') {
+    errors.push(error('malformed_receipt', '$.receipt.status', 'receipt status must be success'));
+  }
+  if (!isNonEmptyString(receipt.receiptRef)) {
+    errors.push(error('malformed_receipt', '$.receipt.receiptRef', 'receipt ref is required'));
+  }
+  if (!isNonEmptyString(receipt.settledAt) || Number.isNaN(Date.parse(receipt.settledAt))) {
+    errors.push(error('malformed_receipt', '$.receipt.settledAt', 'settledAt must be an ISO timestamp'));
+  }
+}
+
+function validateNoLivePath(summary: MppTempoFixtureSummary, errors: MppTempoReceiptShapeError[]): void {
+  const serialized = JSON.stringify(summary).toLowerCase();
+  const rejectedMarkers = [
+    'wallet_private_key',
+    'private_key',
+    'rpc_url',
+    'provider call completed',
+    'provider call performed',
+    'hosted-registry-write',
+    'hosted registry write completed',
+    'hosted registry write performed',
+    'trust-upgrade',
+    'trust upgrade completed',
+    'trust upgrade performed',
+    'reputation-mutation',
+    'reputation mutation completed',
+    'reputation mutation performed',
+    'live payment completed',
+    'live tempo payment accepted',
+  ];
+  for (const marker of rejectedMarkers) {
+    if (serialized.includes(marker)) {
+      errors.push(error('live_path_rejected', '$', `fixture contains rejected live-path marker: ${marker}`));
+    }
+  }
+}
+
+function createBindingRefs(summary: MppTempoFixtureSummary): MppTempoBindingRefs {
+  return {
+    sourceId: 'mpp-tempo:fixture-corpus',
+    challengeRef: `mpp-tempo-challenge:${summary.challenge.nonce}`,
+    paymentProofRef: summary.receipt?.receiptRef ?? `mpp-tempo-probe:${summary.case}:${hashJson(summary.challenge)}`,
+    evidenceRef: `file://${summary.artifactPath}`,
+    requestHash: hashJson(summary.challenge),
+    responseHash: hashJson({
+      receipt: summary.receipt ?? null,
+      supportState: summary.case === 'mpp_single_charge_tempo_candidate' ? 'binding_candidate' : 'probe_only',
+      claimBoundary: summary.claimBoundary,
+    }),
+    recipientRef: summary.challenge.recipientRef,
+    nonceRef: `mpp-tempo-nonce:${summary.challenge.nonce}`,
+    operatorApprovalRef: OPERATOR_APPROVAL_REF,
+  };
+}
+
+function error(code: MppTempoReceiptShapeErrorCode, path: string, message: string): MppTempoReceiptShapeError {
+  return { code, path, message };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function positiveAmount(value: unknown): value is string {
+  return typeof value === 'string' && /^[1-9]\d*$/.test(value);
+}
+
+function isHttpsUrl(value: unknown): value is string {
+  if (!isNonEmptyString(value)) return false;
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function hashJson(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}

--- a/packages/agent-protocol/tests/mpp-tempo-receipt-shapes.test.ts
+++ b/packages/agent-protocol/tests/mpp-tempo-receipt-shapes.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  MPP_TEMPO_RECEIPT_SHAPE_SCHEMA_VERSION,
+  deriveMppTempoReceiptShapeFixture,
+  mppTempoReceiptShapeFixtures,
+  mppTempoReceiptShapeSummaries,
+} from '../dist/index.js';
+
+test('normalizes a docs-backed MPP Tempo single-charge receipt shape as a binding candidate', () => {
+  const result = deriveMppTempoReceiptShapeFixture(mppTempoReceiptShapeSummaries.tempoSingleChargeCandidate);
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  assert.equal(result.fixture.schemaVersion, MPP_TEMPO_RECEIPT_SHAPE_SCHEMA_VERSION);
+  assert.equal(result.fixture.case, 'mpp_single_charge_tempo_candidate');
+  assert.equal(result.fixture.supportState, 'binding_candidate');
+  assert.equal(result.fixture.challenge.protocol, 'mpp');
+  assert.equal(result.fixture.challenge.status, 402);
+  assert.equal(result.fixture.challenge.paymentMethod, 'tempo-stablecoin');
+  assert.equal(result.fixture.challenge.network, 'tempo');
+  assert.equal(result.fixture.receipt?.status, 'success');
+  assert.equal(result.fixture.receipt?.nonce, result.fixture.challenge.nonce);
+  assert.equal(result.fixture.bindingRefs.paymentProofRef, 'mpp-tempo-receipt:single-charge-fixture');
+  assert.match(result.fixture.bindingRefs.requestHash, /^sha256:[a-f0-9]{64}$/);
+  assert.match(result.fixture.bindingRefs.responseHash, /^sha256:[a-f0-9]{64}$/);
+  assert.equal(result.fixture.guardrails.fixtureOnly, true);
+  assert.equal(result.fixture.guardrails.livePayment, false);
+});
+
+test('keeps MPP Tempo session and split shapes probe-only without receipt success claims', () => {
+  for (const fixture of [
+    mppTempoReceiptShapeFixtures.tempoSessionProbe,
+    mppTempoReceiptShapeFixtures.tempoSplitProbe,
+  ]) {
+    assert.equal(fixture.supportState, 'probe_only');
+    assert.equal(fixture.receipt, undefined);
+    assert.match(fixture.bindingRefs.paymentProofRef, /^mpp-tempo-probe:/);
+    assert.equal(fixture.guardrails.walletSigning, false);
+    assert.equal(fixture.guardrails.rpcCall, false);
+    assert.equal(fixture.guardrails.providerCall, false);
+    assert.equal(fixture.guardrails.hostedRegistryWrite, false);
+    assert.equal(fixture.guardrails.trustUpgrade, false);
+    assert.equal(fixture.guardrails.reputationMutation, false);
+  }
+});
+
+test('fails closed when a receipt does not bind to its MPP Tempo challenge', () => {
+  const malformed = clone(mppTempoReceiptShapeSummaries.tempoSingleChargeCandidate);
+  if (!malformed.receipt) throw new Error('fixture setup failed');
+  malformed.receipt.amount = '9999';
+
+  const result = deriveMppTempoReceiptShapeFixture(malformed);
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+
+  assert.ok(result.errors.some((item) => item.code === 'receipt_challenge_mismatch'));
+});
+
+test('rejects malformed and unsupported MPP Tempo challenge shapes', () => {
+  const malformed = clone(mppTempoReceiptShapeSummaries.tempoSingleChargeCandidate);
+  malformed.challenge.status = 200 as 402;
+  malformed.challenge.protocol = 'x402' as 'mpp';
+  malformed.challenge.endpoint = 'http://example.invalid/paid/search';
+
+  const result = deriveMppTempoReceiptShapeFixture(malformed);
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+
+  assert.deepEqual(
+    result.errors.map((item) => item.code),
+    ['unsupported_protocol', 'malformed_challenge', 'malformed_challenge'],
+  );
+});
+
+test('rejects live Tempo receipt imports until a separate live verifier lane exists', () => {
+  const result = deriveMppTempoReceiptShapeFixture(mppTempoReceiptShapeSummaries.tempoLiveReceiptUnsupported);
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+
+  assert.ok(result.errors.some((item) => item.code === 'unsupported_live_rail'));
+});
+
+test('rejects live-path and secret markers in imported claim text', () => {
+  const livePath = clone(mppTempoReceiptShapeSummaries.tempoSingleChargeCandidate);
+  livePath.claimBoundary = [
+    'provider call completed with wallet_private_key and hosted registry write plus reputation mutation completed',
+  ];
+
+  const result = deriveMppTempoReceiptShapeFixture(livePath);
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+
+  assert.ok(result.errors.some((item) => item.code === 'live_path_rejected'));
+});
+
+test('serialized fixtures contain no active live-payment or mutation guardrail', () => {
+  const serialized = JSON.stringify(mppTempoReceiptShapeFixtures);
+
+  assert.doesNotMatch(serialized, /wallet_private_key/i);
+  assert.doesNotMatch(serialized, /rpc_url/i);
+  assert.doesNotMatch(serialized, /hosted-registry-write/i);
+  assert.doesNotMatch(serialized, /reputation-mutation/i);
+  assert.match(serialized, /"fixtureOnly":true/);
+  assert.match(serialized, /"livePayment":false/);
+});
+
+function clone<T>(value: T): T {
+  return structuredClone(value) as T;
+}


### PR DESCRIPTION
## Summary\n- add @reddi/agent-protocol MPP/Tempo receipt-shape fixture export\n- normalize single-charge Tempo MPP receipt shapes as binding candidates while keeping session/split shapes probe-only\n- reject live Tempo receipt imports and live-path/secret markers until a separate verifier lane is approved\n- document support states and wire Bucket F BDD index coverage\n\n## Validation\n- cd packages/agent-protocol && npm test -- --test-name-pattern mpp\n- cd packages/agent-protocol && npm test\n- npm run test:bdd:index\n- npm run check:rap:naming\n- git diff --check\n\n## Boundaries\nNo Pay.sh CLI/setup, Tempo wallet/key use, wallet signing, RPC call, provider call, paid request, sandbox execution, hosted registry write, trust upgrade, reputation mutation, marketplace publication, or live payment path.