### PR TITLE
Harden Circle x402 support states

### DIFF
--- a/docs/CIRCLE-X402-SOURCE-ADAPTER-SPEC-2026-05-13.md
+++ b/docs/CIRCLE-X402-SOURCE-ADAPTER-SPEC-2026-05-13.md
@@ -119,6 +119,9 @@ The preview returns:
 - source-aware route policy with `preferredSource: circle-x402`, `strictSourceMatch: true`
 - `livePaymentAllowed: false`
 - rail/network/estimated USDC amount from Circle Discovery metadata
+- explicit support states: `discovery_visible`, `externally_listed_unattested`, `x402_required`, `dry_run_quote_preview`, `live_payment_disabled`
+- diagnostics for missing payment requirements, missing numeric price, missing payee, unsupported network, and malformed resource URL
 - required gates before paid invocation: explicit user approval, tiny spend cap, runtime-only Circle credentials, receipt capture, and RAP attestor verification
 
 This is still not a payment or invocation path. It creates no x402 payment headers and makes no external service request.
+Diagnostics do not upgrade trust, settlement, reputation, publication readiness, or custody claims.

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -81,6 +81,7 @@ Feature: Bucket S Source Adapter Onboarding
     Then the candidate includes a valid source-adapter specialist manifest
     And the candidate is marked externally listed and not RAP-attested
     And payment options preserve rail network amount and payee fields
+    And support states and diagnostics do not upgrade trust, publication, or reputation readiness
 
   @S5.6 @conformance @circle-x402 @settlement-safety
   Scenario: Circle x402 quote preview remains dry-run until explicit approval

--- a/lib/__tests__/circle-x402-quote-preview-route.test.ts
+++ b/lib/__tests__/circle-x402-quote-preview-route.test.ts
@@ -49,6 +49,14 @@ describe("Circle x402 quote preview route", () => {
         rail: "circle_gateway",
         estimatedUsd: 0.005,
       },
+      paymentSupport: {
+        supportStates: ["discovery_visible", "externally_listed_unattested", "x402_required", "dry_run_quote_preview", "live_payment_disabled"],
+        diagnostics: [],
+        livePaymentAllowed: false,
+        trustUpgradeAllowed: false,
+        reputationMutationAllowed: false,
+        publicationReady: false,
+      },
       requiredGates: ["User explicitly approves live x402 payment experiment."],
       trustNotes: ["Preview only: no x402 payment header is created and no external endpoint is invoked."],
     });
@@ -70,6 +78,11 @@ describe("Circle x402 quote preview route", () => {
     });
     expect(data.mode).toBe("dry-run-quote-preview");
     expect(data.routePreview.plannerPolicy.livePaymentAllowed).toBe(false);
+    expect(data.paymentSupport.livePaymentAllowed).toBe(false);
+    expect(data.paymentSupport.trustUpgradeAllowed).toBe(false);
+    expect(data.paymentSupport.reputationMutationAllowed).toBe(false);
+    expect(data.paymentSupport.publicationReady).toBe(false);
+    expect(data.paymentSupport.supportStates).toContain("live_payment_disabled");
     expect(data.requiredGates[0]).toContain("approves");
   });
 
@@ -82,6 +95,7 @@ describe("Circle x402 quote preview route", () => {
       task: "Preview",
       routePreview: null,
       quotePreview: null,
+      paymentSupport: null,
       requiredGates: [],
       trustNotes: [],
       error: "Circle x402 candidate not found: missing",

--- a/lib/__tests__/source-adapter-circle-x402-profile.test.ts
+++ b/lib/__tests__/source-adapter-circle-x402-profile.test.ts
@@ -2,6 +2,8 @@ import {
   buildCircleX402SourceManifest,
   circleX402DiscoveryResourceToCandidate,
   CIRCLE_X402_SOURCE_PROFILE,
+  getCircleX402Diagnostics,
+  getCircleX402SupportStates,
   mapCircleX402CategoryToTaskTypes,
   type CircleX402DiscoveryResource,
 } from "@/lib/integrations/source-adapter/profiles/circle-x402";
@@ -68,6 +70,14 @@ describe("source adapter circle-x402 profile", () => {
     expect(candidate.providerName).toBe("Example Research API");
     expect(candidate.taskTypes).toEqual(["research", "web-search"]);
     expect(candidate.attestationState).toBe("externally_listed_unattested");
+    expect(candidate.supportStates).toEqual([
+      "discovery_visible",
+      "externally_listed_unattested",
+      "x402_required",
+      "dry_run_quote_preview",
+      "live_payment_disabled",
+    ]);
+    expect(candidate.diagnostics).toEqual([]);
     expect(candidate.payment[0]).toMatchObject({
       rail: "circle_gateway",
       network: "eip155:8453",
@@ -75,5 +85,119 @@ describe("source adapter circle-x402 profile", () => {
     });
     expect(validateSourceAdapterManifest(candidate.sourceAdapter).ok).toBe(true);
     expect(candidate.trustNotes.join(" ")).toContain("Not RAP-attested");
+    expect(candidate.trustNotes.join(" ")).toContain("live-payment-disabled");
+  });
+
+  it("exports explicit Circle x402 support states without implying live payment", () => {
+    expect(getCircleX402SupportStates()).toEqual([
+      "discovery_visible",
+      "externally_listed_unattested",
+      "x402_required",
+      "dry_run_quote_preview",
+      "live_payment_disabled",
+    ]);
+  });
+
+  it("flags missing price and payee as blockers without upgrading trust", () => {
+    const resource: CircleX402DiscoveryResource = {
+      resource: "https://api.example.com/v1/report",
+      accepts: [
+        {
+          scheme: "exact",
+          network: "eip155:8453",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        },
+      ],
+      metadata: {
+        provider: {
+          name: "Missing Price API",
+          category: "FINANCIAL_ANALYSIS",
+        },
+        supportsCircleGateway: true,
+      },
+    };
+
+    const candidate = circleX402DiscoveryResourceToCandidate(resource);
+
+    expect(candidate.payment[0].priceUsdc).toBeUndefined();
+    expect(candidate.diagnostics.map((item) => item.code)).toEqual(["missing_price", "missing_payee"]);
+    expect(candidate.diagnostics.every((item) => item.severity === "blocker")).toBe(true);
+    expect(candidate.attestationState).toBe("externally_listed_unattested");
+    expect(candidate.trustNotes.join(" ")).toContain("diagnostics do not upgrade trust");
+  });
+
+  it("flags unsupported networks while preserving original Circle payment metadata", () => {
+    const resource: CircleX402DiscoveryResource = {
+      resource: "https://api.example.com/v1/legacy",
+      accepts: [
+        {
+          scheme: "exact",
+          network: "eip155:1",
+          asset: "USDC",
+          maxAmountRequired: "1000",
+          payTo: "0x1234567890123456789012345678901234567890",
+        },
+      ],
+      metadata: {
+        provider: {
+          name: "Legacy Mainnet API",
+          category: "UNKNOWN_VENDOR_CATEGORY",
+        },
+      },
+    };
+
+    const candidate = circleX402DiscoveryResourceToCandidate(resource);
+
+    expect(candidate.payment[0]).toMatchObject({
+      network: "eip155:1",
+      maxAmountRequired: "1000",
+      payTo: "0x1234567890123456789012345678901234567890",
+    });
+    expect(candidate.diagnostics).toEqual([
+      {
+        code: "unsupported_network",
+        severity: "blocker",
+        detail: "Circle x402 payment network is unsupported or missing: eip155:1.",
+      },
+    ]);
+  });
+
+  it("flags resources without payment requirements", () => {
+    const diagnostics = getCircleX402Diagnostics({
+      resource: "https://api.example.com/v1/free-looking",
+      accepts: [],
+    });
+
+    expect(diagnostics).toEqual([
+      {
+        code: "no_payment_requirements",
+        severity: "blocker",
+        detail: "Circle x402 resource does not declare any payment requirements.",
+      },
+    ]);
+  });
+
+  it("keeps malformed resources as blocked candidates instead of throwing", () => {
+    const candidate = circleX402DiscoveryResourceToCandidate({
+      resource: "not a url",
+      accepts: [
+        {
+          scheme: "exact",
+          network: "eip155:8453",
+          asset: "USDC",
+          maxAmountRequired: "1000",
+          payTo: "0x1234567890123456789012345678901234567890",
+        },
+      ],
+    });
+
+    expect(candidate.candidateId).toBe("circle-x402:malformed:not-a-url");
+    expect(candidate.diagnostics).toEqual([
+      {
+        code: "malformed_resource",
+        severity: "blocker",
+        detail: "Circle x402 resource URL is malformed.",
+      },
+    ]);
   });
 });

--- a/lib/integrations/source-adapter/circle-x402-quote-preview.ts
+++ b/lib/integrations/source-adapter/circle-x402-quote-preview.ts
@@ -29,6 +29,14 @@ export type CircleX402QuotePreview = {
     estimatedUsd?: number;
     payTo?: string;
   } | null;
+  paymentSupport: {
+    supportStates: ReddiCircleX402Candidate["supportStates"];
+    diagnostics: ReddiCircleX402Candidate["diagnostics"];
+    livePaymentAllowed: false;
+    trustUpgradeAllowed: false;
+    reputationMutationAllowed: false;
+    publicationReady: false;
+  } | null;
   requiredGates: string[];
   trustNotes: string[];
   error?: string;
@@ -56,6 +64,7 @@ export function buildCircleX402QuotePreview(input: {
       task,
       routePreview: null,
       quotePreview: null,
+      paymentSupport: null,
       requiredGates: [],
       trustNotes: [],
       error: candidateResult.error ?? `Circle x402 candidate not found: ${input.candidateId}`,
@@ -92,6 +101,14 @@ export function buildCircleX402QuotePreview(input: {
           payTo: payment.payTo,
         }
       : null,
+    paymentSupport: {
+      supportStates: candidate.supportStates,
+      diagnostics: candidate.diagnostics,
+      livePaymentAllowed: false,
+      trustUpgradeAllowed: false,
+      reputationMutationAllowed: false,
+      publicationReady: false,
+    },
     requiredGates: [
       "User explicitly approves live x402 payment experiment.",
       "Tiny spend cap is configured before payment.",

--- a/lib/integrations/source-adapter/profiles/circle-x402.ts
+++ b/lib/integrations/source-adapter/profiles/circle-x402.ts
@@ -19,6 +19,26 @@ export type CircleX402PaymentRequirement = {
   payTo?: string;
 };
 
+export type CircleX402SupportState =
+  | "discovery_visible"
+  | "externally_listed_unattested"
+  | "x402_required"
+  | "dry_run_quote_preview"
+  | "live_payment_disabled";
+
+export type CircleX402DiagnosticCode =
+  | "no_payment_requirements"
+  | "missing_price"
+  | "missing_payee"
+  | "unsupported_network"
+  | "malformed_resource";
+
+export type CircleX402Diagnostic = {
+  code: CircleX402DiagnosticCode;
+  severity: "warning" | "blocker";
+  detail: string;
+};
+
 export type CircleX402DiscoveryResource = {
   resource: string;
   type?: "http" | "mcp" | string;
@@ -57,6 +77,8 @@ export type ReddiCircleX402Candidate = {
     maxAmountRequired?: string;
     priceUsdc?: number;
   }>;
+  supportStates: CircleX402SupportState[];
+  diagnostics: CircleX402Diagnostic[];
   attestationState: "externally_listed_unattested";
   trustNotes: string[];
 };
@@ -82,6 +104,13 @@ const CATEGORY_TASK_TYPES: Record<string, string[]> = {
   INFRASTRUCTURE: ["infrastructure", "developer-tooling"],
 };
 
+const SUPPORTED_CIRCLE_X402_NETWORKS = new Set([
+  "eip155:8453",
+  "eip155:84532",
+  "base",
+  "base-sepolia",
+]);
+
 export function mapCircleX402CategoryToTaskTypes(category: CircleX402Category | undefined) {
   if (!category) return ["external-api"];
   return CATEGORY_TASK_TYPES[category] ?? ["external-api"];
@@ -92,13 +121,25 @@ function parseUsdcSubunits(value: string | undefined) {
   return Number(value) / 1_000_000;
 }
 
+function hasNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 function stableCandidateId(resource: string) {
-  const url = new URL(resource);
-  const pathSlug = url.pathname
-    .replace(/[^a-zA-Z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .toLowerCase();
-  return `${CIRCLE_X402_SOURCE_ID}:${url.hostname}:${pathSlug || "root"}`;
+  try {
+    const url = new URL(resource);
+    const pathSlug = url.pathname
+      .replace(/[^a-zA-Z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .toLowerCase();
+    return `${CIRCLE_X402_SOURCE_ID}:${url.hostname}:${pathSlug || "root"}`;
+  } catch {
+    const fallback = resource
+      .replace(/[^a-zA-Z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .toLowerCase();
+    return `${CIRCLE_X402_SOURCE_ID}:malformed:${fallback || "resource"}`;
+  }
 }
 
 export function buildCircleX402SourceManifest(input: {
@@ -126,10 +167,82 @@ export function buildCircleX402SourceManifest(input: {
   };
 }
 
+export function getCircleX402SupportStates(): CircleX402SupportState[] {
+  return [
+    "discovery_visible",
+    "externally_listed_unattested",
+    "x402_required",
+    "dry_run_quote_preview",
+    "live_payment_disabled",
+  ];
+}
+
+export function getCircleX402Diagnostics(resource: CircleX402DiscoveryResource): CircleX402Diagnostic[] {
+  const diagnostics: CircleX402Diagnostic[] = [];
+  const accepts = resource.accepts ?? [];
+
+  try {
+    const url = new URL(resource.resource);
+    if (url.protocol !== "https:") {
+      diagnostics.push({
+        code: "malformed_resource",
+        severity: "blocker",
+        detail: "Circle x402 resource must be an HTTPS URL before route preview or invocation.",
+      });
+    }
+  } catch {
+    diagnostics.push({
+      code: "malformed_resource",
+      severity: "blocker",
+      detail: "Circle x402 resource URL is malformed.",
+    });
+  }
+
+  if (accepts.length === 0) {
+    diagnostics.push({
+      code: "no_payment_requirements",
+      severity: "blocker",
+      detail: "Circle x402 resource does not declare any payment requirements.",
+    });
+    return diagnostics;
+  }
+
+  if (accepts.some((accept) => parseUsdcSubunits(accept.maxAmountRequired) === undefined)) {
+    diagnostics.push({
+      code: "missing_price",
+      severity: "blocker",
+      detail: "Circle x402 payment requirement is missing a numeric maxAmountRequired value.",
+    });
+  }
+
+  if (accepts.some((accept) => !hasNonEmptyString(accept.payTo))) {
+    diagnostics.push({
+      code: "missing_payee",
+      severity: "blocker",
+      detail: "Circle x402 payment requirement is missing a payTo address.",
+    });
+  }
+
+  const unsupportedNetworks = accepts
+    .map((accept) => accept.network?.trim())
+    .filter((network): network is string => Boolean(network))
+    .filter((network) => !SUPPORTED_CIRCLE_X402_NETWORKS.has(network.toLowerCase()));
+  if (unsupportedNetworks.length > 0 || accepts.some((accept) => !hasNonEmptyString(accept.network))) {
+    diagnostics.push({
+      code: "unsupported_network",
+      severity: "blocker",
+      detail: `Circle x402 payment network is unsupported or missing: ${unsupportedNetworks.join(", ") || "missing"}.`,
+    });
+  }
+
+  return diagnostics;
+}
+
 export function circleX402DiscoveryResourceToCandidate(resource: CircleX402DiscoveryResource): ReddiCircleX402Candidate {
   const category = resource.metadata?.provider?.category ?? "UNKNOWN";
   const taskTypes = mapCircleX402CategoryToTaskTypes(category);
   const supportsCircleGateway = resource.metadata?.supportsCircleGateway === true;
+  const diagnostics = getCircleX402Diagnostics(resource);
 
   return {
     candidateId: stableCandidateId(resource.resource),
@@ -152,10 +265,14 @@ export function circleX402DiscoveryResourceToCandidate(resource: CircleX402Disco
       maxAmountRequired: accept.maxAmountRequired,
       priceUsdc: parseUsdcSubunits(accept.maxAmountRequired),
     })),
+    supportStates: getCircleX402SupportStates(),
+    diagnostics,
     attestationState: CIRCLE_X402_SOURCE_PROFILE.defaultAttestationState,
     trustNotes: [
       "Imported from Circle x402 Discovery as external catalog metadata.",
       "Not RAP-attested until a RAP attestor verifies output, receipt, and evidence.",
+      "Circle x402 support state remains discovery-visible/dry-run-quote-preview/live-payment-disabled until RAP evidence gates approve a narrower claim.",
+      ...(diagnostics.length ? ["Circle x402 diagnostics do not upgrade trust, settlement, reputation, or publication readiness."] : []),
     ],
   };
 }


### PR DESCRIPTION
## Summary
- add explicit Circle x402 support states and diagnostics for discovery resources
- expose quote-preview paymentSupport with live payment, trust upgrade, reputation mutation, and publication readiness all fail-closed
- keep malformed, missing-price/payee, no-requirement, and unsupported-network resources as blocked candidates instead of throwing or implying readiness
- update Circle x402 docs and Bucket S BDD coverage

## Validation
- npx jest lib/__tests__/source-adapter-circle-x402-profile.test.ts lib/__tests__/circle-x402-quote-preview-route.test.ts --runInBand
- npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts lib/__tests__/source-adapter-circle-x402-profile.test.ts lib/__tests__/circle-x402-catalog-route.test.ts lib/__tests__/circle-x402-quote-preview-route.test.ts lib/__tests__/source-adapter-pay-sh-profile.test.ts lib/__tests__/pay-sh-catalog-route.test.ts lib/__tests__/pay-sh-quote-preview-route.test.ts lib/__tests__/pay-sh-mcp-inspection.test.ts lib/__tests__/pay-sh-policy-plan.test.ts lib/__tests__/pay-sh-policy-plan-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand
- npm run test:bdd:index
- npm run check:rap:naming
- git diff --check
- ./scripts/run-source-conformance.sh --source circle-x402 --mode smoke

## Boundary
Fixture/static contract only. No Circle call, wallet/RPC, provider call, paid request, hosted registry write, trust/reputation mutation, marketplace publication, or live payment.

Closes #453