### PR TITLE
Add rail-neutral payment receipt normalizer

### DIFF
--- a/docs/bdd/features/bucket-f-jupiter-settlement.feature
+++ b/docs/bdd/features/bucket-f-jupiter-settlement.feature
@@ -34,3 +34,11 @@ Feature: Bucket F Cross-Token Settlement (Jupiter)
     And session and split shapes remain probe-only without settlement claims
     And live Tempo receipts are rejected until a separate verifier lane is approved
     And the behavior is covered by "packages/agent-protocol/tests/mpp-tempo-receipt-shapes.test.ts"
+
+  @F2.2 @package-contract
+  Scenario: Rail-neutral payment receipts bind only supported fixture evidence
+    When Pay.sh sandbox and MPP Tempo receipt metadata are normalized into rail-neutral payment receipts
+    Then proven Pay.sh single-charge evidence can feed receipt/evidence binding
+    And probe-only malformed denied-policy and unsupported network receipts fail closed
+    And rail metadata does not imply trust reputation publication custody settlement proof or live payment
+    And the behavior is covered by "packages/agent-protocol/tests/rail-neutral-payment-receipts.test.ts"

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -16,3 +16,4 @@ export * from './quasar-registry-compatibility.js';
 export * from './hosted-attestation-claim.js';
 export * from './pay-sh-sandbox-evidence.js';
 export * from './mpp-tempo-receipt-shapes.js';
+export * from './rail-neutral-payment-receipts.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -16,3 +16,4 @@ export * from './quasar-registry-compatibility.js';
 export * from './hosted-attestation-claim.js';
 export * from './pay-sh-sandbox-evidence.js';
 export * from './mpp-tempo-receipt-shapes.js';
+export * from './rail-neutral-payment-receipts.js';

--- a/packages/agent-protocol/dist/rail-neutral-payment-receipts.d.ts
+++ b/packages/agent-protocol/dist/rail-neutral-payment-receipts.d.ts
@@ -1,0 +1,87 @@
+import type { PayShSandboxEvidenceFixture } from './pay-sh-sandbox-evidence.js';
+import type { MppTempoReceiptShapeFixture } from './mpp-tempo-receipt-shapes.js';
+import type { ReceiptEvidenceSourceRef } from './receipt-evidence-binding.js';
+export declare const RAIL_NEUTRAL_PAYMENT_RECEIPT_SCHEMA_VERSION: "reddi.rail-neutral-payment-receipt.v1";
+export type RailNeutralPaymentReceiptRail = 'pay-sh-sandbox' | 'mpp-tempo';
+export type RailNeutralPaymentReceiptSupportState = 'receipt_binding_candidate' | 'probe_only' | 'unsupported_receipt_v1_network';
+export type RailNeutralPaymentReceiptGuardrails = {
+    fixtureOnly: true;
+    livePaymentExecuted: false;
+    walletSigning: false;
+    rpcCall: false;
+    providerCall: false;
+    hostedRegistryWrite: false;
+    marketplacePublication: false;
+    trustUpgrade: false;
+    reputationMutation: false;
+    settlementProof: false;
+    custodyClaim: false;
+};
+export type RailNeutralPaymentReceiptPolicyInput = {
+    allowed: boolean;
+    reasonCodes: string[];
+    auditNotes?: string[];
+};
+export type RailNeutralPaymentReceiptOptions = {
+    policy?: RailNeutralPaymentReceiptPolicyInput;
+    networkOverride?: string;
+    assetOverride?: string;
+};
+export type RailNeutralPaymentReceipt = {
+    schemaVersion: typeof RAIL_NEUTRAL_PAYMENT_RECEIPT_SCHEMA_VERSION;
+    rail: RailNeutralPaymentReceiptRail;
+    case: string;
+    supportState: RailNeutralPaymentReceiptSupportState;
+    source: ReceiptEvidenceSourceRef;
+    payment: {
+        network: string;
+        asset: string;
+        amount: string;
+        unit: 'microusd' | 'base-units';
+        paymentProofRef: string;
+        receiptRef?: string;
+    };
+    bindingRefs: {
+        evidenceRef: string;
+        requestHash: string;
+        responseHash: string;
+        recipientRef: string;
+        nonceRef: string;
+        operatorApprovalRef: string;
+    };
+    policy: {
+        allowed: true;
+        reasonCodes: string[];
+        auditNotes: string[];
+    };
+    bindingIntegration: {
+        schemaVersion: 'reddi.receipt-evidence-binding.v1';
+        compatible: true;
+        requiredReceiptSchemaVersion: 'reddi.receipt.v1';
+    };
+    claimBoundary: string[];
+    guardrails: RailNeutralPaymentReceiptGuardrails;
+};
+export type RailNeutralPaymentReceiptInput = {
+    rail: 'pay-sh-sandbox';
+    fixture: PayShSandboxEvidenceFixture;
+} | {
+    rail: 'mpp-tempo';
+    fixture: MppTempoReceiptShapeFixture;
+};
+export type RailNeutralPaymentReceiptErrorCode = 'malformed_receipt' | 'unsupported_asset_network' | 'policy_denied' | 'unsupported_fixture_state' | 'live_path_rejected';
+export type RailNeutralPaymentReceiptError = {
+    code: RailNeutralPaymentReceiptErrorCode;
+    path: string;
+    message: string;
+};
+export type RailNeutralPaymentReceiptResult = {
+    ok: true;
+    receipt: RailNeutralPaymentReceipt;
+} | {
+    ok: false;
+    errors: RailNeutralPaymentReceiptError[];
+};
+export declare const RAIL_NEUTRAL_PAYMENT_RECEIPT_GUARDRAILS: RailNeutralPaymentReceiptGuardrails;
+export declare function createRailNeutralPaymentReceipt(input: RailNeutralPaymentReceiptInput, options?: RailNeutralPaymentReceiptOptions): RailNeutralPaymentReceipt;
+export declare function deriveRailNeutralPaymentReceipt(input: RailNeutralPaymentReceiptInput, options?: RailNeutralPaymentReceiptOptions): RailNeutralPaymentReceiptResult;

--- a/packages/agent-protocol/dist/rail-neutral-payment-receipts.js
+++ b/packages/agent-protocol/dist/rail-neutral-payment-receipts.js
@@ -1,0 +1,187 @@
+export const RAIL_NEUTRAL_PAYMENT_RECEIPT_SCHEMA_VERSION = 'reddi.rail-neutral-payment-receipt.v1';
+export const RAIL_NEUTRAL_PAYMENT_RECEIPT_GUARDRAILS = {
+    fixtureOnly: true,
+    livePaymentExecuted: false,
+    walletSigning: false,
+    rpcCall: false,
+    providerCall: false,
+    hostedRegistryWrite: false,
+    marketplacePublication: false,
+    trustUpgrade: false,
+    reputationMutation: false,
+    settlementProof: false,
+    custodyClaim: false,
+};
+const RECEIPT_V1_SUPPORTED_NETWORK_ASSETS = new Set([
+    'solana-devnet:USDC',
+    'solana-testnet:USDC',
+    'solana-mainnet-beta:USDC',
+]);
+const PAY_SH_SINGLE_CHARGE_MICRO_USD = '10000';
+export function createRailNeutralPaymentReceipt(input, options = {}) {
+    const result = deriveRailNeutralPaymentReceipt(input, options);
+    if (!result.ok) {
+        throw new Error(`invalid_rail_neutral_payment_receipt:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+    }
+    return result.receipt;
+}
+export function deriveRailNeutralPaymentReceipt(input, options = {}) {
+    const errors = [];
+    const policy = options.policy ?? {
+        allowed: true,
+        reasonCodes: ['allowed'],
+        auditNotes: ['Rail-neutral receipt normalization is fixture-only.'],
+    };
+    if (!policy.allowed) {
+        errors.push(error('policy_denied', '$.policy.allowed', 'policy denial blocks receipt/evidence binding normalization'));
+    }
+    if (!Array.isArray(policy.reasonCodes) || policy.reasonCodes.length === 0 || !policy.reasonCodes.every(isNonEmptyString)) {
+        errors.push(error('policy_denied', '$.policy.reasonCodes', 'policy reason codes are required'));
+    }
+    validateNoLivePath(input, errors);
+    const candidate = input.rail === 'pay-sh-sandbox'
+        ? fromPayShSandbox(input.fixture, options, errors)
+        : fromMppTempo(input.fixture, options, errors);
+    if (!candidate)
+        return { ok: false, errors };
+    const networkAsset = `${candidate.payment.network}:${candidate.payment.asset}`;
+    if (!RECEIPT_V1_SUPPORTED_NETWORK_ASSETS.has(networkAsset)) {
+        errors.push(error('unsupported_asset_network', '$.payment', `${networkAsset} is not supported by Reddi receipt v1 binding`));
+    }
+    if (errors.length > 0)
+        return { ok: false, errors };
+    return {
+        ok: true,
+        receipt: {
+            schemaVersion: RAIL_NEUTRAL_PAYMENT_RECEIPT_SCHEMA_VERSION,
+            rail: candidate.rail,
+            case: candidate.case,
+            supportState: 'receipt_binding_candidate',
+            source: candidate.source,
+            payment: candidate.payment,
+            bindingRefs: candidate.bindingRefs,
+            policy: {
+                allowed: true,
+                reasonCodes: policy.reasonCodes,
+                auditNotes: policy.auditNotes ?? [],
+            },
+            bindingIntegration: {
+                schemaVersion: 'reddi.receipt-evidence-binding.v1',
+                compatible: true,
+                requiredReceiptSchemaVersion: 'reddi.receipt.v1',
+            },
+            claimBoundary: candidate.claimBoundary,
+            guardrails: RAIL_NEUTRAL_PAYMENT_RECEIPT_GUARDRAILS,
+        },
+    };
+}
+function fromPayShSandbox(fixture, options, errors) {
+    if (fixture.status !== 'proven_single_charge' || fixture.case !== 'single_charge') {
+        errors.push(error('unsupported_fixture_state', '$.fixture.status', 'only proven Pay.sh sandbox single-charge evidence can become a binding candidate'));
+        return undefined;
+    }
+    if (!fixture.receipt || fixture.receipt.status !== 'success' || fixture.receipt.method !== 'solana' || !isNonEmptyString(fixture.bindingRefs.receiptRef)) {
+        errors.push(error('malformed_receipt', '$.fixture.receipt', 'Pay.sh sandbox single-charge evidence requires a successful Solana receipt ref'));
+        return undefined;
+    }
+    return {
+        rail: 'pay-sh-sandbox',
+        case: fixture.case,
+        source: fixture.bindingRefs.source,
+        payment: {
+            network: options.networkOverride ?? 'solana-devnet',
+            asset: options.assetOverride ?? 'USDC',
+            amount: PAY_SH_SINGLE_CHARGE_MICRO_USD,
+            unit: 'microusd',
+            paymentProofRef: fixture.bindingRefs.paymentProofRef,
+            receiptRef: fixture.bindingRefs.receiptRef,
+        },
+        bindingRefs: {
+            evidenceRef: fixture.bindingRefs.evidenceRef,
+            requestHash: fixture.bindingRefs.requestHash,
+            responseHash: fixture.bindingRefs.responseHash,
+            recipientRef: fixture.bindingRefs.recipientRef,
+            nonceRef: fixture.bindingRefs.nonceRef,
+            operatorApprovalRef: fixture.bindingRefs.operatorApprovalRef,
+        },
+        claimBoundary: [
+            ...fixture.claimBoundary,
+            'Rail-neutral normalization does not prove settlement finality, custody, trust, reputation, publication, provider execution, wallet signing, or RPC activity.',
+        ],
+    };
+}
+function fromMppTempo(fixture, options, errors) {
+    if (fixture.supportState !== 'binding_candidate' || fixture.case !== 'mpp_single_charge_tempo_candidate') {
+        errors.push(error('unsupported_fixture_state', '$.fixture.supportState', 'only MPP Tempo single-charge binding candidates can be normalized'));
+        return undefined;
+    }
+    if (!fixture.receipt || fixture.receipt.status !== 'success' || fixture.receipt.nonce !== fixture.challenge.nonce) {
+        errors.push(error('malformed_receipt', '$.fixture.receipt', 'MPP Tempo candidate requires a successful receipt bound to the challenge nonce'));
+        return undefined;
+    }
+    return {
+        rail: 'mpp-tempo',
+        case: fixture.case,
+        source: {
+            kind: 'static-fixture',
+            sourceId: fixture.bindingRefs.sourceId,
+            fixtureRef: fixture.artifactPath,
+            rawSnapshotRef: fixture.bindingRefs.challengeRef,
+        },
+        payment: {
+            network: options.networkOverride ?? fixture.challenge.network,
+            asset: options.assetOverride ?? fixture.challenge.asset,
+            amount: fixture.challenge.amount,
+            unit: fixture.challenge.unit,
+            paymentProofRef: fixture.bindingRefs.paymentProofRef,
+            receiptRef: fixture.receipt.receiptRef,
+        },
+        bindingRefs: {
+            evidenceRef: fixture.bindingRefs.evidenceRef,
+            requestHash: fixture.bindingRefs.requestHash,
+            responseHash: fixture.bindingRefs.responseHash,
+            recipientRef: fixture.bindingRefs.recipientRef,
+            nonceRef: fixture.bindingRefs.nonceRef,
+            operatorApprovalRef: fixture.bindingRefs.operatorApprovalRef,
+        },
+        claimBoundary: [
+            ...fixture.claimBoundary,
+            'Rail-neutral normalization does not accept Tempo as Reddi receipt v1 settlement proof until a separate verifier and network allowlist lane is approved.',
+        ],
+    };
+}
+function validateNoLivePath(input, errors) {
+    const serialized = JSON.stringify(input).toLowerCase();
+    const rejectedMarkers = [
+        'wallet_private_key',
+        'private_key',
+        'rpc_url',
+        'provider call completed',
+        'provider call performed',
+        'hosted-registry-write',
+        'hosted registry write completed',
+        'hosted registry write performed',
+        'marketplace publication completed',
+        'marketplace publication performed',
+        'trust upgrade completed',
+        'trust upgrade performed',
+        'reputation mutation completed',
+        'reputation mutation performed',
+        'custody accepted',
+        'settlement finality proven',
+        'live payment completed',
+        'live pay.sh activation',
+        'live tempo payment accepted',
+    ];
+    for (const marker of rejectedMarkers) {
+        if (serialized.includes(marker)) {
+            errors.push(error('live_path_rejected', '$', `rail-neutral receipt input contains rejected live-path marker: ${marker}`));
+        }
+    }
+}
+function error(code, path, message) {
+    return { code, path, message };
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -82,6 +82,10 @@
       "types": "./dist/mpp-tempo-receipt-shapes.d.ts",
       "import": "./dist/mpp-tempo-receipt-shapes.js"
     },
+    "./rail-neutral-payment-receipts": {
+      "types": "./dist/rail-neutral-payment-receipts.d.ts",
+      "import": "./dist/rail-neutral-payment-receipts.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -16,3 +16,4 @@ export * from './quasar-registry-compatibility.js';
 export * from './hosted-attestation-claim.js';
 export * from './pay-sh-sandbox-evidence.js';
 export * from './mpp-tempo-receipt-shapes.js';
+export * from './rail-neutral-payment-receipts.js';

--- a/packages/agent-protocol/src/rail-neutral-payment-receipts.ts
+++ b/packages/agent-protocol/src/rail-neutral-payment-receipts.ts
@@ -1,0 +1,313 @@
+import type {
+  PayShSandboxEvidenceFixture,
+} from './pay-sh-sandbox-evidence.js';
+import type {
+  MppTempoReceiptShapeFixture,
+} from './mpp-tempo-receipt-shapes.js';
+import type { ReceiptEvidenceSourceRef } from './receipt-evidence-binding.js';
+
+export const RAIL_NEUTRAL_PAYMENT_RECEIPT_SCHEMA_VERSION = 'reddi.rail-neutral-payment-receipt.v1' as const;
+
+export type RailNeutralPaymentReceiptRail = 'pay-sh-sandbox' | 'mpp-tempo';
+
+export type RailNeutralPaymentReceiptSupportState =
+  | 'receipt_binding_candidate'
+  | 'probe_only'
+  | 'unsupported_receipt_v1_network';
+
+export type RailNeutralPaymentReceiptGuardrails = {
+  fixtureOnly: true;
+  livePaymentExecuted: false;
+  walletSigning: false;
+  rpcCall: false;
+  providerCall: false;
+  hostedRegistryWrite: false;
+  marketplacePublication: false;
+  trustUpgrade: false;
+  reputationMutation: false;
+  settlementProof: false;
+  custodyClaim: false;
+};
+
+export type RailNeutralPaymentReceiptPolicyInput = {
+  allowed: boolean;
+  reasonCodes: string[];
+  auditNotes?: string[];
+};
+
+export type RailNeutralPaymentReceiptOptions = {
+  policy?: RailNeutralPaymentReceiptPolicyInput;
+  networkOverride?: string;
+  assetOverride?: string;
+};
+
+export type RailNeutralPaymentReceipt = {
+  schemaVersion: typeof RAIL_NEUTRAL_PAYMENT_RECEIPT_SCHEMA_VERSION;
+  rail: RailNeutralPaymentReceiptRail;
+  case: string;
+  supportState: RailNeutralPaymentReceiptSupportState;
+  source: ReceiptEvidenceSourceRef;
+  payment: {
+    network: string;
+    asset: string;
+    amount: string;
+    unit: 'microusd' | 'base-units';
+    paymentProofRef: string;
+    receiptRef?: string;
+  };
+  bindingRefs: {
+    evidenceRef: string;
+    requestHash: string;
+    responseHash: string;
+    recipientRef: string;
+    nonceRef: string;
+    operatorApprovalRef: string;
+  };
+  policy: {
+    allowed: true;
+    reasonCodes: string[];
+    auditNotes: string[];
+  };
+  bindingIntegration: {
+    schemaVersion: 'reddi.receipt-evidence-binding.v1';
+    compatible: true;
+    requiredReceiptSchemaVersion: 'reddi.receipt.v1';
+  };
+  claimBoundary: string[];
+  guardrails: RailNeutralPaymentReceiptGuardrails;
+};
+
+export type RailNeutralPaymentReceiptInput =
+  | { rail: 'pay-sh-sandbox'; fixture: PayShSandboxEvidenceFixture }
+  | { rail: 'mpp-tempo'; fixture: MppTempoReceiptShapeFixture };
+
+export type RailNeutralPaymentReceiptErrorCode =
+  | 'malformed_receipt'
+  | 'unsupported_asset_network'
+  | 'policy_denied'
+  | 'unsupported_fixture_state'
+  | 'live_path_rejected';
+
+export type RailNeutralPaymentReceiptError = {
+  code: RailNeutralPaymentReceiptErrorCode;
+  path: string;
+  message: string;
+};
+
+export type RailNeutralPaymentReceiptResult =
+  | { ok: true; receipt: RailNeutralPaymentReceipt }
+  | { ok: false; errors: RailNeutralPaymentReceiptError[] };
+
+export const RAIL_NEUTRAL_PAYMENT_RECEIPT_GUARDRAILS: RailNeutralPaymentReceiptGuardrails = {
+  fixtureOnly: true,
+  livePaymentExecuted: false,
+  walletSigning: false,
+  rpcCall: false,
+  providerCall: false,
+  hostedRegistryWrite: false,
+  marketplacePublication: false,
+  trustUpgrade: false,
+  reputationMutation: false,
+  settlementProof: false,
+  custodyClaim: false,
+};
+
+const RECEIPT_V1_SUPPORTED_NETWORK_ASSETS = new Set([
+  'solana-devnet:USDC',
+  'solana-testnet:USDC',
+  'solana-mainnet-beta:USDC',
+]);
+const PAY_SH_SINGLE_CHARGE_MICRO_USD = '10000';
+
+export function createRailNeutralPaymentReceipt(
+  input: RailNeutralPaymentReceiptInput,
+  options: RailNeutralPaymentReceiptOptions = {},
+): RailNeutralPaymentReceipt {
+  const result = deriveRailNeutralPaymentReceipt(input, options);
+  if (!result.ok) {
+    throw new Error(`invalid_rail_neutral_payment_receipt:${result.errors.map((item) => `${item.code}:${item.path}`).join(',')}`);
+  }
+  return result.receipt;
+}
+
+export function deriveRailNeutralPaymentReceipt(
+  input: RailNeutralPaymentReceiptInput,
+  options: RailNeutralPaymentReceiptOptions = {},
+): RailNeutralPaymentReceiptResult {
+  const errors: RailNeutralPaymentReceiptError[] = [];
+  const policy = options.policy ?? {
+    allowed: true,
+    reasonCodes: ['allowed'],
+    auditNotes: ['Rail-neutral receipt normalization is fixture-only.'],
+  };
+
+  if (!policy.allowed) {
+    errors.push(error('policy_denied', '$.policy.allowed', 'policy denial blocks receipt/evidence binding normalization'));
+  }
+  if (!Array.isArray(policy.reasonCodes) || policy.reasonCodes.length === 0 || !policy.reasonCodes.every(isNonEmptyString)) {
+    errors.push(error('policy_denied', '$.policy.reasonCodes', 'policy reason codes are required'));
+  }
+
+  validateNoLivePath(input, errors);
+
+  const candidate = input.rail === 'pay-sh-sandbox'
+    ? fromPayShSandbox(input.fixture, options, errors)
+    : fromMppTempo(input.fixture, options, errors);
+
+  if (!candidate) return { ok: false, errors };
+
+  const networkAsset = `${candidate.payment.network}:${candidate.payment.asset}`;
+  if (!RECEIPT_V1_SUPPORTED_NETWORK_ASSETS.has(networkAsset)) {
+    errors.push(error('unsupported_asset_network', '$.payment', `${networkAsset} is not supported by Reddi receipt v1 binding`));
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    receipt: {
+      schemaVersion: RAIL_NEUTRAL_PAYMENT_RECEIPT_SCHEMA_VERSION,
+      rail: candidate.rail,
+      case: candidate.case,
+      supportState: 'receipt_binding_candidate',
+      source: candidate.source,
+      payment: candidate.payment,
+      bindingRefs: candidate.bindingRefs,
+      policy: {
+        allowed: true,
+        reasonCodes: policy.reasonCodes,
+        auditNotes: policy.auditNotes ?? [],
+      },
+      bindingIntegration: {
+        schemaVersion: 'reddi.receipt-evidence-binding.v1',
+        compatible: true,
+        requiredReceiptSchemaVersion: 'reddi.receipt.v1',
+      },
+      claimBoundary: candidate.claimBoundary,
+      guardrails: RAIL_NEUTRAL_PAYMENT_RECEIPT_GUARDRAILS,
+    },
+  };
+}
+
+function fromPayShSandbox(
+  fixture: PayShSandboxEvidenceFixture,
+  options: RailNeutralPaymentReceiptOptions,
+  errors: RailNeutralPaymentReceiptError[],
+): Omit<RailNeutralPaymentReceipt, 'schemaVersion' | 'supportState' | 'policy' | 'bindingIntegration' | 'guardrails'> | undefined {
+  if (fixture.status !== 'proven_single_charge' || fixture.case !== 'single_charge') {
+    errors.push(error('unsupported_fixture_state', '$.fixture.status', 'only proven Pay.sh sandbox single-charge evidence can become a binding candidate'));
+    return undefined;
+  }
+  if (!fixture.receipt || fixture.receipt.status !== 'success' || fixture.receipt.method !== 'solana' || !isNonEmptyString(fixture.bindingRefs.receiptRef)) {
+    errors.push(error('malformed_receipt', '$.fixture.receipt', 'Pay.sh sandbox single-charge evidence requires a successful Solana receipt ref'));
+    return undefined;
+  }
+  return {
+    rail: 'pay-sh-sandbox',
+    case: fixture.case,
+    source: fixture.bindingRefs.source,
+    payment: {
+      network: options.networkOverride ?? 'solana-devnet',
+      asset: options.assetOverride ?? 'USDC',
+      amount: PAY_SH_SINGLE_CHARGE_MICRO_USD,
+      unit: 'microusd',
+      paymentProofRef: fixture.bindingRefs.paymentProofRef,
+      receiptRef: fixture.bindingRefs.receiptRef,
+    },
+    bindingRefs: {
+      evidenceRef: fixture.bindingRefs.evidenceRef,
+      requestHash: fixture.bindingRefs.requestHash,
+      responseHash: fixture.bindingRefs.responseHash,
+      recipientRef: fixture.bindingRefs.recipientRef,
+      nonceRef: fixture.bindingRefs.nonceRef,
+      operatorApprovalRef: fixture.bindingRefs.operatorApprovalRef,
+    },
+    claimBoundary: [
+      ...fixture.claimBoundary,
+      'Rail-neutral normalization does not prove settlement finality, custody, trust, reputation, publication, provider execution, wallet signing, or RPC activity.',
+    ],
+  };
+}
+
+function fromMppTempo(
+  fixture: MppTempoReceiptShapeFixture,
+  options: RailNeutralPaymentReceiptOptions,
+  errors: RailNeutralPaymentReceiptError[],
+): Omit<RailNeutralPaymentReceipt, 'schemaVersion' | 'supportState' | 'policy' | 'bindingIntegration' | 'guardrails'> | undefined {
+  if (fixture.supportState !== 'binding_candidate' || fixture.case !== 'mpp_single_charge_tempo_candidate') {
+    errors.push(error('unsupported_fixture_state', '$.fixture.supportState', 'only MPP Tempo single-charge binding candidates can be normalized'));
+    return undefined;
+  }
+  if (!fixture.receipt || fixture.receipt.status !== 'success' || fixture.receipt.nonce !== fixture.challenge.nonce) {
+    errors.push(error('malformed_receipt', '$.fixture.receipt', 'MPP Tempo candidate requires a successful receipt bound to the challenge nonce'));
+    return undefined;
+  }
+  return {
+    rail: 'mpp-tempo',
+    case: fixture.case,
+    source: {
+      kind: 'static-fixture',
+      sourceId: fixture.bindingRefs.sourceId,
+      fixtureRef: fixture.artifactPath,
+      rawSnapshotRef: fixture.bindingRefs.challengeRef,
+    },
+    payment: {
+      network: options.networkOverride ?? fixture.challenge.network,
+      asset: options.assetOverride ?? fixture.challenge.asset,
+      amount: fixture.challenge.amount,
+      unit: fixture.challenge.unit,
+      paymentProofRef: fixture.bindingRefs.paymentProofRef,
+      receiptRef: fixture.receipt.receiptRef,
+    },
+    bindingRefs: {
+      evidenceRef: fixture.bindingRefs.evidenceRef,
+      requestHash: fixture.bindingRefs.requestHash,
+      responseHash: fixture.bindingRefs.responseHash,
+      recipientRef: fixture.bindingRefs.recipientRef,
+      nonceRef: fixture.bindingRefs.nonceRef,
+      operatorApprovalRef: fixture.bindingRefs.operatorApprovalRef,
+    },
+    claimBoundary: [
+      ...fixture.claimBoundary,
+      'Rail-neutral normalization does not accept Tempo as Reddi receipt v1 settlement proof until a separate verifier and network allowlist lane is approved.',
+    ],
+  };
+}
+
+function validateNoLivePath(input: RailNeutralPaymentReceiptInput, errors: RailNeutralPaymentReceiptError[]): void {
+  const serialized = JSON.stringify(input).toLowerCase();
+  const rejectedMarkers = [
+    'wallet_private_key',
+    'private_key',
+    'rpc_url',
+    'provider call completed',
+    'provider call performed',
+    'hosted-registry-write',
+    'hosted registry write completed',
+    'hosted registry write performed',
+    'marketplace publication completed',
+    'marketplace publication performed',
+    'trust upgrade completed',
+    'trust upgrade performed',
+    'reputation mutation completed',
+    'reputation mutation performed',
+    'custody accepted',
+    'settlement finality proven',
+    'live payment completed',
+    'live pay.sh activation',
+    'live tempo payment accepted',
+  ];
+  for (const marker of rejectedMarkers) {
+    if (serialized.includes(marker)) {
+      errors.push(error('live_path_rejected', '$', `rail-neutral receipt input contains rejected live-path marker: ${marker}`));
+    }
+  }
+}
+
+function error(code: RailNeutralPaymentReceiptErrorCode, path: string, message: string): RailNeutralPaymentReceiptError {
+  return { code, path, message };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/packages/agent-protocol/tests/rail-neutral-payment-receipts.test.ts
+++ b/packages/agent-protocol/tests/rail-neutral-payment-receipts.test.ts
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createEvidenceArchiveRecord,
+  createReceiptEvidenceBinding,
+  createReddiReceipt,
+  deriveRailNeutralPaymentReceipt,
+  mppTempoReceiptShapeFixtures,
+  payShSandboxEvidenceFixtures,
+  policyDecisionFromBudgetPolicyDecision,
+  RAIL_NEUTRAL_PAYMENT_RECEIPT_SCHEMA_VERSION,
+  type AuddPaymentPlanPreflightDecision,
+} from '../dist/index.js';
+
+const createdAt = '2026-06-22T04:30:00.000Z';
+
+test('normalizes Pay.sh sandbox single-charge evidence as a rail-neutral binding candidate', () => {
+  const result = deriveRailNeutralPaymentReceipt({
+    rail: 'pay-sh-sandbox',
+    fixture: payShSandboxEvidenceFixtures.singleCharge,
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  assert.equal(result.receipt.schemaVersion, RAIL_NEUTRAL_PAYMENT_RECEIPT_SCHEMA_VERSION);
+  assert.equal(result.receipt.rail, 'pay-sh-sandbox');
+  assert.equal(result.receipt.supportState, 'receipt_binding_candidate');
+  assert.equal(result.receipt.payment.network, 'solana-devnet');
+  assert.equal(result.receipt.payment.asset, 'USDC');
+  assert.equal(result.receipt.payment.amount, '10000');
+  assert.equal(result.receipt.bindingIntegration.compatible, true);
+  assert.equal(result.receipt.guardrails.fixtureOnly, true);
+  assert.equal(result.receipt.guardrails.livePaymentExecuted, false);
+  assert.equal(result.receipt.guardrails.walletSigning, false);
+  assert.equal(result.receipt.guardrails.rpcCall, false);
+  assert.equal(result.receipt.guardrails.providerCall, false);
+  assert.equal(result.receipt.guardrails.hostedRegistryWrite, false);
+  assert.equal(result.receipt.guardrails.marketplacePublication, false);
+  assert.equal(result.receipt.guardrails.trustUpgrade, false);
+  assert.equal(result.receipt.guardrails.reputationMutation, false);
+  assert.equal(result.receipt.guardrails.settlementProof, false);
+  assert.equal(result.receipt.guardrails.custodyClaim, false);
+});
+
+test('feeds normalized Pay.sh receipt metadata into receipt/evidence binding without live side effects', () => {
+  const normalized = deriveRailNeutralPaymentReceipt({
+    rail: 'pay-sh-sandbox',
+    fixture: payShSandboxEvidenceFixtures.singleCharge,
+  });
+  assert.equal(normalized.ok, true);
+  if (!normalized.ok) return;
+
+  const paymentProofRef = normalized.receipt.payment.paymentProofRef;
+  const policyDecision = policyDecisionFromBudgetPolicyDecision({
+    allowed: true,
+    reasonCodes: ['allowed'],
+    quotedAmount: {
+      amount: normalized.receipt.payment.amount,
+      asset: normalized.receipt.payment.asset,
+      network: normalized.receipt.payment.network,
+      source: normalized.receipt.source.sourceId,
+      specialist: 'pay-sh:reddi-x402-economic-demo',
+    },
+    remainingBudget: { perRequest: '20000' },
+    auditNotes: ['Allowed by fixture-only rail-neutral payment receipt normalizer.'],
+  });
+
+  const receipt = createReddiReceipt({
+    schemaVersion: 'reddi.receipt.v1',
+    job: { id: 'job:pay-sh-sandbox:single-charge', type: 'fixture-only-payment-normalization' },
+    source: {
+      id: normalized.receipt.source.sourceId,
+      type: normalized.receipt.source.kind,
+      uri: normalized.receipt.source.catalogRef,
+    },
+    payer: { id: 'buyer:fixture' },
+    specialist: { id: 'pay-sh:reddi-x402-economic-demo' },
+    protocol: { name: 'Reddi Agent Protocol', version: '0.1.0' },
+    payment: {
+      network: normalized.receipt.payment.network,
+      asset: normalized.receipt.payment.asset,
+      amount: normalized.receipt.payment.amount,
+      paymentProofRef,
+    },
+    requestHash: normalized.receipt.bindingRefs.requestHash,
+    responseHash: normalized.receipt.bindingRefs.responseHash,
+    evidenceRef: normalized.receipt.bindingRefs.evidenceRef,
+    policyDecision,
+    attestationStatus: 'not_requested',
+    createdAt,
+    metadata: {
+      rail: normalized.receipt.rail,
+      railNeutralReceiptSchema: normalized.receipt.schemaVersion,
+      operatorApprovalRef: normalized.receipt.bindingRefs.operatorApprovalRef,
+    },
+  });
+
+  const evidencePayload = {
+    request: { hash: normalized.receipt.bindingRefs.requestHash },
+    response: { hash: normalized.receipt.bindingRefs.responseHash },
+    payment: {
+      proofRef: paymentProofRef,
+      rail: normalized.receipt.rail,
+    },
+  };
+  const evidence = createEvidenceArchiveRecord({
+    id: 'evidence:pay-sh-sandbox:single-charge',
+    receiptId: receipt.job.id,
+    sourceId: normalized.receipt.source.sourceId,
+    requestHash: normalized.receipt.bindingRefs.requestHash,
+    responseHash: normalized.receipt.bindingRefs.responseHash,
+    evidenceRef: normalized.receipt.bindingRefs.evidenceRef,
+    evidencePayload,
+    createdAt,
+  });
+
+  const paymentPreflight: AuddPaymentPlanPreflightDecision = {
+    allowed: true,
+    reasonCodes: ['audd_payment_plan_allowed'],
+    paymentProofRef,
+    policyDecision,
+    paymentPlan: {
+      schemaVersion: 'reddi.audd-payment-plan.v1',
+      asset: normalized.receipt.payment.asset,
+      network: normalized.receipt.payment.network,
+      mint: 'AUDDdev111111111111111111111111111111111111',
+      payee: 'solana:payeeFixture111111111111111111111111111111',
+      settlementAccount: 'solana:settlementFixture1111111111111111111111',
+      amount: normalized.receipt.payment.amount,
+      quoteExpiresAt: '2026-06-22T05:30:00.000Z',
+      failurePolicy: { mode: 'no_charge_on_failure', description: 'Fixture-only normalization does not charge.' },
+      refundPolicy: { mode: 'manual_review', description: 'Refunds require manual review.' },
+      evidenceRequired: true,
+      paymentMode: 'dry-run',
+    },
+    auditNotes: ['Fixture-only payment proof ref accepted for binding integration.'],
+  } as unknown as AuddPaymentPlanPreflightDecision;
+
+  const binding = createReceiptEvidenceBinding({
+    id: 'binding:pay-sh-sandbox:single-charge',
+    source: normalized.receipt.source,
+    receipt,
+    evidence,
+    evidencePayload,
+    paymentPreflight,
+    createdAt,
+  });
+
+  assert.equal(binding.receipt.paymentProofRef, paymentProofRef);
+  assert.equal(binding.evidence.evidenceRef, normalized.receipt.bindingRefs.evidenceRef);
+  assert.equal(binding.guardrails.livePaymentExecuted, false);
+  assert.equal(binding.guardrails.walletSigning, false);
+  assert.equal(binding.guardrails.rpcCall, false);
+  assert.equal(binding.guardrails.reputationMutated, false);
+});
+
+test('fails closed for probe-only Pay.sh receipt metadata', () => {
+  const result = deriveRailNeutralPaymentReceipt({
+    rail: 'pay-sh-sandbox',
+    fixture: payShSandboxEvidenceFixtures.cappedSessionProbe,
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.ok(result.errors.some((item) => item.code === 'unsupported_fixture_state'));
+});
+
+test('fails closed for malformed receipt candidates', () => {
+  const malformed = structuredClone(payShSandboxEvidenceFixtures.singleCharge);
+  malformed.receipt = undefined;
+
+  const result = deriveRailNeutralPaymentReceipt({
+    rail: 'pay-sh-sandbox',
+    fixture: malformed,
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.ok(result.errors.some((item) => item.code === 'malformed_receipt'));
+});
+
+test('fails closed for unsupported asset or network before receipt/evidence binding', () => {
+  const payShUnsupported = deriveRailNeutralPaymentReceipt({
+    rail: 'pay-sh-sandbox',
+    fixture: payShSandboxEvidenceFixtures.singleCharge,
+  }, { networkOverride: 'base-mainnet' });
+
+  assert.equal(payShUnsupported.ok, false);
+  if (!payShUnsupported.ok) {
+    assert.ok(payShUnsupported.errors.some((item) => item.code === 'unsupported_asset_network'));
+  }
+
+  const tempoUnsupported = deriveRailNeutralPaymentReceipt({
+    rail: 'mpp-tempo',
+    fixture: mppTempoReceiptShapeFixtures.tempoSingleChargeCandidate,
+  });
+
+  assert.equal(tempoUnsupported.ok, false);
+  if (!tempoUnsupported.ok) {
+    assert.ok(tempoUnsupported.errors.some((item) => item.code === 'unsupported_asset_network'));
+  }
+});
+
+test('fails closed when policy denies receipt normalization', () => {
+  const result = deriveRailNeutralPaymentReceipt({
+    rail: 'pay-sh-sandbox',
+    fixture: payShSandboxEvidenceFixtures.singleCharge,
+  }, {
+    policy: {
+      allowed: false,
+      reasonCodes: ['operator_denied'],
+      auditNotes: ['Operator denied this payment receipt binding.'],
+    },
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.ok(result.errors.some((item) => item.code === 'policy_denied'));
+});
+
+test('rejects live-path overclaims embedded in imported rail metadata', () => {
+  const livePath = structuredClone(payShSandboxEvidenceFixtures.singleCharge);
+  livePath.claimBoundary = [
+    'provider call performed with hosted registry write completed, trust upgrade performed, reputation mutation performed, settlement finality proven, custody accepted, and live Pay.sh activation',
+  ];
+
+  const result = deriveRailNeutralPaymentReceipt({
+    rail: 'pay-sh-sandbox',
+    fixture: livePath,
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.ok(result.errors.some((item) => item.code === 'live_path_rejected'));
+});


### PR DESCRIPTION
## Summary
- add `@reddi/agent-protocol/rail-neutral-payment-receipts`
- normalize fixture-backed Pay.sh sandbox single-charge metadata into a conservative receipt/evidence binding candidate
- recognize MPP/Tempo receipt-shape candidates but fail closed while `tempo` remains outside Reddi receipt v1 network support
- reject probe-only, malformed, unsupported asset/network, policy-denied, and live-path-overclaim inputs
- wire package export, tracked dist output, and Bucket F BDD coverage

## Validation
- `npm test -- --test-name-pattern "rail-neutral|Pay.sh|MPP|Tempo"` in `packages/agent-protocol`
- `npm run release:dry-run` in `packages/agent-protocol`
- `npm run test:bdd:index`
- `npm run check:rap:naming`
- `git diff --check`

## Boundary
Fixture/static contract only. No Pay.sh CLI/setup, Circle call, Tempo wallet/key use, wallet signing, RPC, provider call, paid request, sandbox execution, hosted registry write, marketplace publication, trust/reputation mutation, custody claim, settlement-finality proof, or live payment.

Closes #456