### PR TITLE
Add rail-neutral proof-chain fixture bridge

### DIFF
--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -1,6 +1,6 @@
 # BDD Feature Index
 
-_Last updated: 2026-06-21 AEST_
+_Last updated: 2026-06-22 AEST_
 
 Purpose: single lookup from BDD feature file -> bucket -> executable verification command(s).
 
@@ -33,7 +33,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Verify:
   - `npx jest lib/__tests__/jupiter-client.test.ts lib/__tests__/planner-invoke-route.test.ts --runInBand`
   - `cd packages/x402-solana && npm test -- --runInBand tests/payment.test.ts`
-  - `cd packages/agent-protocol && npm test -- --test-name-pattern mpp`
+  - `cd packages/agent-protocol && npm test -- --test-name-pattern "mpp|rail-neutral"`
 
 ### Bucket G — Torque Retention
 - Feature: `docs/bdd/features/bucket-g-torque-retention.feature`

--- a/docs/bdd/features/bucket-f-jupiter-settlement.feature
+++ b/docs/bdd/features/bucket-f-jupiter-settlement.feature
@@ -42,3 +42,11 @@ Feature: Bucket F Cross-Token Settlement (Jupiter)
     And probe-only malformed denied-policy and unsupported network receipts fail closed
     And rail metadata does not imply trust reputation publication custody settlement proof or live payment
     And the behavior is covered by "packages/agent-protocol/tests/rail-neutral-payment-receipts.test.ts"
+
+  @F2.3 @package-contract
+  Scenario: Rail-neutral receipt metadata feeds proof-chain fixtures without live payment claims
+    When rail-neutral payment receipt metadata is bridged into the proof-chain fixture
+    Then Pay.sh sandbox single-charge evidence yields a receipt/evidence binding fixture
+    And Tempo unsupported-network malformed denied-policy unsupported asset and live-path overclaim states stay blocked
+    And the fixture output stores only refs hashes and claim-boundary labels
+    And the behavior is covered by "packages/agent-protocol/tests/rail-neutral-proof-chain-fixture.test.ts"

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -17,3 +17,4 @@ export * from './hosted-attestation-claim.js';
 export * from './pay-sh-sandbox-evidence.js';
 export * from './mpp-tempo-receipt-shapes.js';
 export * from './rail-neutral-payment-receipts.js';
+export * from './rail-neutral-proof-chain-fixture.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -17,3 +17,4 @@ export * from './hosted-attestation-claim.js';
 export * from './pay-sh-sandbox-evidence.js';
 export * from './mpp-tempo-receipt-shapes.js';
 export * from './rail-neutral-payment-receipts.js';
+export * from './rail-neutral-proof-chain-fixture.js';

--- a/packages/agent-protocol/dist/rail-neutral-proof-chain-fixture.d.ts
+++ b/packages/agent-protocol/dist/rail-neutral-proof-chain-fixture.d.ts
@@ -1,0 +1,76 @@
+import { type EvidenceArchiveRecord } from './evidence-archive.js';
+import { type RailNeutralPaymentReceipt, type RailNeutralPaymentReceiptError, type RailNeutralPaymentReceiptInput, type RailNeutralPaymentReceiptOptions } from './rail-neutral-payment-receipts.js';
+import { type ReceiptEvidenceBinding } from './receipt-evidence-binding.js';
+import { type ReddiReceipt } from './receipts.js';
+export declare const RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION: "reddi.rail-neutral-proof-chain-fixture.v1";
+export type RailNeutralProofChainFixtureCase = 'pay_sh_sandbox_single_charge_binding' | 'mpp_tempo_unsupported_network' | 'unsupported_asset_network' | 'malformed_receipt' | 'policy_denied' | 'live_path_overclaim';
+export type RailNeutralProofChainFixtureStatus = 'binding_ready' | 'blocked';
+export type RailNeutralProofChainFixtureGuardrails = {
+    fixtureOnly: true;
+    rawPromptStored: false;
+    rawOutputStored: false;
+    credentialMaterialStored: false;
+    walletSigning: false;
+    rpcCall: false;
+    providerCall: false;
+    paidRequest: false;
+    sandboxExecution: false;
+    hostedRegistryWrite: false;
+    marketplacePublication: false;
+    trustUpgrade: false;
+    reputationMutation: false;
+    custodyClaim: false;
+    settlementFinalityProof: false;
+    livePayment: false;
+};
+export type RailNeutralProofChainFailure = {
+    code: RailNeutralPaymentReceiptError['code'];
+    path: string;
+    message: string;
+};
+export type RailNeutralProofChainSourceRef = {
+    rail: RailNeutralPaymentReceiptInput['rail'];
+    case: string;
+    sourceId: string;
+    artifactPath: string;
+};
+export type RailNeutralProofChainFixture = {
+    schemaVersion: typeof RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION;
+    case: RailNeutralProofChainFixtureCase;
+    status: RailNeutralProofChainFixtureStatus;
+    sourceRef: RailNeutralProofChainSourceRef;
+    railNeutralReceipt?: RailNeutralPaymentReceipt;
+    redactedReceipt?: ReddiReceipt;
+    evidence?: EvidenceArchiveRecord;
+    binding?: ReceiptEvidenceBinding;
+    blockedBy?: RailNeutralProofChainFailure[];
+    bindingRefs: {
+        sourceRef: string;
+        quoteRef?: string;
+        paymentProofRef?: string;
+        requestHash?: string;
+        responseHash?: string;
+        evidenceRef?: string;
+        nonceRef?: string;
+        recipientRef?: string;
+        operatorApprovalRef?: string;
+    };
+    claimBoundaryLabels: string[];
+    guardrails: RailNeutralProofChainFixtureGuardrails;
+};
+export type RailNeutralProofChainFixtureInput = {
+    case: RailNeutralProofChainFixtureCase;
+    receiptInput: RailNeutralPaymentReceiptInput;
+    options?: RailNeutralPaymentReceiptOptions;
+    createdAt?: string;
+};
+export declare const RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_GUARDRAILS: RailNeutralProofChainFixtureGuardrails;
+export declare function createRailNeutralProofChainFixture(input: RailNeutralProofChainFixtureInput): RailNeutralProofChainFixture;
+export declare const railNeutralProofChainFixtures: {
+    readonly payShSandboxSingleChargeBinding: RailNeutralProofChainFixture;
+    readonly mppTempoUnsupportedNetwork: RailNeutralProofChainFixture;
+    readonly unsupportedAssetNetwork: RailNeutralProofChainFixture;
+    readonly malformedReceipt: RailNeutralProofChainFixture;
+    readonly policyDenied: RailNeutralProofChainFixture;
+    readonly livePathOverclaim: RailNeutralProofChainFixture;
+};

--- a/packages/agent-protocol/dist/rail-neutral-proof-chain-fixture.js
+++ b/packages/agent-protocol/dist/rail-neutral-proof-chain-fixture.js
@@ -1,0 +1,286 @@
+import { createEvidenceArchiveRecord, } from './evidence-archive.js';
+import { mppTempoReceiptShapeFixtures, } from './mpp-tempo-receipt-shapes.js';
+import { payShSandboxEvidenceFixtures, } from './pay-sh-sandbox-evidence.js';
+import { policyDecisionFromBudgetPolicyDecision } from './policy.js';
+import { deriveRailNeutralPaymentReceipt, } from './rail-neutral-payment-receipts.js';
+import { createReceiptEvidenceBinding, } from './receipt-evidence-binding.js';
+import { createReddiReceipt, } from './receipts.js';
+export const RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION = 'reddi.rail-neutral-proof-chain-fixture.v1';
+export const RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_GUARDRAILS = {
+    fixtureOnly: true,
+    rawPromptStored: false,
+    rawOutputStored: false,
+    credentialMaterialStored: false,
+    walletSigning: false,
+    rpcCall: false,
+    providerCall: false,
+    paidRequest: false,
+    sandboxExecution: false,
+    hostedRegistryWrite: false,
+    marketplacePublication: false,
+    trustUpgrade: false,
+    reputationMutation: false,
+    custodyClaim: false,
+    settlementFinalityProof: false,
+    livePayment: false,
+};
+const CREATED_AT = '2026-06-22T10:20:00.000Z';
+const SPECIALIST_ID = 'pay-sh:reddi-x402-economic-demo';
+const PAYER_ID = 'buyer:fixture';
+export function createRailNeutralProofChainFixture(input) {
+    const result = deriveRailNeutralPaymentReceipt(input.receiptInput, input.options);
+    const refs = bindingRefsFromInput(input.receiptInput.fixture);
+    if (!result.ok) {
+        return blockedFixture(input.case, input.receiptInput.fixture, refs, result.errors);
+    }
+    const receipt = result.receipt;
+    const createdAt = input.createdAt ?? CREATED_AT;
+    const policyDecision = policyDecisionFromBudgetPolicyDecision({
+        allowed: true,
+        reasonCodes: ['allowed'],
+        quotedAmount: {
+            amount: receipt.payment.amount,
+            asset: receipt.payment.asset,
+            network: receipt.payment.network,
+            source: receipt.source.sourceId,
+            specialist: SPECIALIST_ID,
+        },
+        remainingBudget: { perRequest: receipt.payment.amount },
+        auditNotes: ['Allowed by fixture-only rail-neutral proof-chain bridge.'],
+    });
+    const redactedReceipt = createReddiReceipt({
+        schemaVersion: 'reddi.receipt.v1',
+        job: { id: `job:${receipt.rail}:${receipt.case}`, type: 'fixture-only-rail-neutral-proof-chain' },
+        source: {
+            id: receipt.source.sourceId,
+            type: receipt.source.kind,
+            uri: receipt.source.catalogRef ?? receipt.source.fixtureRef ?? receipt.source.rawSnapshotRef,
+        },
+        payer: { id: PAYER_ID },
+        specialist: { id: SPECIALIST_ID },
+        protocol: { name: 'Reddi Agent Protocol', version: '0.1.0' },
+        payment: {
+            network: receipt.payment.network,
+            asset: receipt.payment.asset,
+            amount: receipt.payment.amount,
+            paymentProofRef: receipt.payment.paymentProofRef,
+        },
+        requestHash: receipt.bindingRefs.requestHash,
+        responseHash: receipt.bindingRefs.responseHash,
+        evidenceRef: receipt.bindingRefs.evidenceRef,
+        policyDecision,
+        attestationStatus: 'not_requested',
+        createdAt,
+        metadata: {
+            rail: receipt.rail,
+            railNeutralReceiptSchema: receipt.schemaVersion,
+            supportState: receipt.supportState,
+            receiptRef: receipt.payment.receiptRef,
+            quoteRef: refs.quoteRef,
+            nonceRef: receipt.bindingRefs.nonceRef,
+            recipientRef: receipt.bindingRefs.recipientRef,
+            operatorApprovalRef: receipt.bindingRefs.operatorApprovalRef,
+            claimBoundaryLabels: receipt.claimBoundary,
+        },
+    });
+    const evidencePayload = {
+        schemaVersion: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION,
+        railNeutralReceipt: {
+            schemaVersion: receipt.schemaVersion,
+            rail: receipt.rail,
+            case: receipt.case,
+            supportState: receipt.supportState,
+            sourceId: receipt.source.sourceId,
+            payment: receipt.payment,
+            bindingRefs: receipt.bindingRefs,
+            claimBoundaryLabels: receipt.claimBoundary,
+        },
+        redaction: {
+            rawPromptStored: false,
+            rawOutputStored: false,
+            credentialMaterialStored: false,
+            providerResponseBodyStored: false,
+            walletKeyStored: false,
+            rpcUrlStored: false,
+        },
+    };
+    const evidence = createEvidenceArchiveRecord({
+        id: `evidence:${receipt.rail}:${receipt.case}`,
+        receiptId: redactedReceipt.job.id,
+        sourceId: receipt.source.sourceId,
+        requestHash: receipt.bindingRefs.requestHash,
+        responseHash: receipt.bindingRefs.responseHash,
+        evidenceRef: receipt.bindingRefs.evidenceRef,
+        evidencePayload,
+        createdAt,
+        metadata: {
+            railNeutralReceiptSchema: receipt.schemaVersion,
+            operatorApprovalRef: receipt.bindingRefs.operatorApprovalRef,
+            fixtureOnly: true,
+        },
+    });
+    const paymentPreflight = {
+        allowed: true,
+        reasonCodes: ['audd_payment_plan_allowed'],
+        paymentProofRef: receipt.payment.paymentProofRef,
+        policyDecision,
+        paymentPlan: {
+            schemaVersion: 'reddi.audd-payment-plan.v1',
+            asset: receipt.payment.asset,
+            network: receipt.payment.network,
+            mint: 'fixture-mint:rail-neutral-usdc',
+            payee: receipt.bindingRefs.recipientRef,
+            settlementAccount: 'fixture-settlement:rail-neutral-proof-chain',
+            amount: receipt.payment.amount,
+            quoteExpiresAt: '2026-06-22T11:20:00.000Z',
+            failurePolicy: { mode: 'no_charge_on_failure', description: 'Fixture bridge never charges.' },
+            refundPolicy: { mode: 'manual_review', description: 'Fixture bridge has no live refund path.' },
+            evidenceRequired: true,
+            paymentMode: 'dry-run',
+        },
+        auditNotes: ['Structural fixture bridge for receipt/evidence binding; no AUDD or live payment path is invoked.'],
+    };
+    const binding = createReceiptEvidenceBinding({
+        id: `binding:${receipt.rail}:${receipt.case}`,
+        source: receipt.source,
+        receipt: redactedReceipt,
+        evidence,
+        evidencePayload,
+        paymentPreflight,
+        createdAt,
+    });
+    return {
+        schemaVersion: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION,
+        case: input.case,
+        status: 'binding_ready',
+        sourceRef: sourceRefFromInput(input.receiptInput),
+        railNeutralReceipt: receipt,
+        redactedReceipt,
+        evidence,
+        binding,
+        bindingRefs: {
+            ...refs,
+            paymentProofRef: receipt.payment.paymentProofRef,
+            requestHash: receipt.bindingRefs.requestHash,
+            responseHash: receipt.bindingRefs.responseHash,
+            evidenceRef: receipt.bindingRefs.evidenceRef,
+            nonceRef: receipt.bindingRefs.nonceRef,
+            recipientRef: receipt.bindingRefs.recipientRef,
+            operatorApprovalRef: receipt.bindingRefs.operatorApprovalRef,
+        },
+        claimBoundaryLabels: receipt.claimBoundary,
+        guardrails: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_GUARDRAILS,
+    };
+}
+export const railNeutralProofChainFixtures = {
+    payShSandboxSingleChargeBinding: createRailNeutralProofChainFixture({
+        case: 'pay_sh_sandbox_single_charge_binding',
+        receiptInput: { rail: 'pay-sh-sandbox', fixture: payShSandboxEvidenceFixtures.singleCharge },
+    }),
+    mppTempoUnsupportedNetwork: createRailNeutralProofChainFixture({
+        case: 'mpp_tempo_unsupported_network',
+        receiptInput: { rail: 'mpp-tempo', fixture: mppTempoReceiptShapeFixtures.tempoSingleChargeCandidate },
+    }),
+    unsupportedAssetNetwork: createRailNeutralProofChainFixture({
+        case: 'unsupported_asset_network',
+        receiptInput: { rail: 'pay-sh-sandbox', fixture: payShSandboxEvidenceFixtures.singleCharge },
+        options: { networkOverride: 'base-mainnet' },
+    }),
+    malformedReceipt: createRailNeutralProofChainFixture({
+        case: 'malformed_receipt',
+        receiptInput: {
+            rail: 'pay-sh-sandbox',
+            fixture: {
+                ...payShSandboxEvidenceFixtures.singleCharge,
+                receipt: undefined,
+            },
+        },
+    }),
+    policyDenied: createRailNeutralProofChainFixture({
+        case: 'policy_denied',
+        receiptInput: { rail: 'pay-sh-sandbox', fixture: payShSandboxEvidenceFixtures.singleCharge },
+        options: {
+            policy: {
+                allowed: false,
+                reasonCodes: ['operator_denied'],
+                auditNotes: ['Operator denied this fixture-only proof-chain bridge.'],
+            },
+        },
+    }),
+    livePathOverclaim: createRailNeutralProofChainFixture({
+        case: 'live_path_overclaim',
+        receiptInput: {
+            rail: 'pay-sh-sandbox',
+            fixture: {
+                ...payShSandboxEvidenceFixtures.singleCharge,
+                claimBoundary: [
+                    'provider call performed with hosted registry write completed, trust upgrade performed, reputation mutation performed, settlement finality proven, custody accepted, and live Pay.sh activation',
+                ],
+            },
+        },
+    }),
+};
+function blockedFixture(fixtureCase, sourceFixture, refs, errors) {
+    return {
+        schemaVersion: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION,
+        case: fixtureCase,
+        status: 'blocked',
+        sourceRef: sourceRefFromFixture(refs.sourceRef, sourceFixture),
+        blockedBy: errors.map((item) => ({
+            code: item.code,
+            path: item.path,
+            message: blockedMessage(item),
+        })),
+        bindingRefs: refs,
+        claimBoundaryLabels: [
+            'Fail-closed fixture state only.',
+            'No Reddi receipt v1 settlement proof, custody, trust upgrade, reputation mutation, marketplace publication, provider execution, wallet signing, RPC, spend, sandbox execution, or live payment is claimed.',
+        ],
+        guardrails: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_GUARDRAILS,
+    };
+}
+function blockedMessage(error) {
+    if (error.code === 'live_path_rejected') {
+        return 'Rail-neutral proof-chain fixture rejected imported live-path overclaim text.';
+    }
+    return error.message;
+}
+function sourceRefFromInput(input) {
+    const refs = bindingRefsFromInput(input.fixture);
+    return sourceRefFromFixture(refs.sourceRef, input.fixture, input.rail);
+}
+function sourceRefFromFixture(sourceId, fixture, rail) {
+    return {
+        rail: rail ?? (isPayShSandboxEvidenceFixture(fixture) ? 'pay-sh-sandbox' : 'mpp-tempo'),
+        case: fixture.case,
+        sourceId,
+        artifactPath: fixture.artifactPath,
+    };
+}
+function bindingRefsFromInput(fixture) {
+    if (isPayShSandboxEvidenceFixture(fixture))
+        return {
+            sourceRef: fixture.bindingRefs.source.sourceId,
+            quoteRef: fixture.bindingRefs.quoteRef,
+            paymentProofRef: fixture.bindingRefs.paymentProofRef,
+            requestHash: fixture.bindingRefs.requestHash,
+            responseHash: fixture.bindingRefs.responseHash,
+            evidenceRef: fixture.bindingRefs.evidenceRef,
+            nonceRef: fixture.bindingRefs.nonceRef,
+            recipientRef: fixture.bindingRefs.recipientRef,
+            operatorApprovalRef: fixture.bindingRefs.operatorApprovalRef,
+        };
+    return {
+        sourceRef: fixture.bindingRefs.sourceId,
+        paymentProofRef: fixture.bindingRefs.paymentProofRef,
+        requestHash: fixture.bindingRefs.requestHash,
+        responseHash: fixture.bindingRefs.responseHash,
+        evidenceRef: fixture.bindingRefs.evidenceRef,
+        nonceRef: fixture.bindingRefs.nonceRef,
+        recipientRef: fixture.bindingRefs.recipientRef,
+        operatorApprovalRef: fixture.bindingRefs.operatorApprovalRef,
+    };
+}
+function isPayShSandboxEvidenceFixture(fixture) {
+    return 'source' in fixture.bindingRefs;
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -86,6 +86,10 @@
       "types": "./dist/rail-neutral-payment-receipts.d.ts",
       "import": "./dist/rail-neutral-payment-receipts.js"
     },
+    "./rail-neutral-proof-chain-fixture": {
+      "types": "./dist/rail-neutral-proof-chain-fixture.d.ts",
+      "import": "./dist/rail-neutral-proof-chain-fixture.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -17,3 +17,4 @@ export * from './hosted-attestation-claim.js';
 export * from './pay-sh-sandbox-evidence.js';
 export * from './mpp-tempo-receipt-shapes.js';
 export * from './rail-neutral-payment-receipts.js';
+export * from './rail-neutral-proof-chain-fixture.js';

--- a/packages/agent-protocol/src/rail-neutral-proof-chain-fixture.ts
+++ b/packages/agent-protocol/src/rail-neutral-proof-chain-fixture.ts
@@ -1,0 +1,414 @@
+import type { AuddPaymentPlanPreflightDecision } from './audd-payment-plan.js';
+import {
+  createEvidenceArchiveRecord,
+  type EvidenceArchiveRecord,
+} from './evidence-archive.js';
+import {
+  mppTempoReceiptShapeFixtures,
+  type MppTempoReceiptShapeFixture,
+} from './mpp-tempo-receipt-shapes.js';
+import {
+  payShSandboxEvidenceFixtures,
+  type PayShSandboxEvidenceFixture,
+} from './pay-sh-sandbox-evidence.js';
+import { policyDecisionFromBudgetPolicyDecision } from './policy.js';
+import {
+  createRailNeutralPaymentReceipt,
+  deriveRailNeutralPaymentReceipt,
+  type RailNeutralPaymentReceipt,
+  type RailNeutralPaymentReceiptError,
+  type RailNeutralPaymentReceiptInput,
+  type RailNeutralPaymentReceiptOptions,
+} from './rail-neutral-payment-receipts.js';
+import {
+  createReceiptEvidenceBinding,
+  type ReceiptEvidenceBinding,
+} from './receipt-evidence-binding.js';
+import {
+  createReddiReceipt,
+  type ReddiReceipt,
+} from './receipts.js';
+
+export const RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION = 'reddi.rail-neutral-proof-chain-fixture.v1' as const;
+
+export type RailNeutralProofChainFixtureCase =
+  | 'pay_sh_sandbox_single_charge_binding'
+  | 'mpp_tempo_unsupported_network'
+  | 'unsupported_asset_network'
+  | 'malformed_receipt'
+  | 'policy_denied'
+  | 'live_path_overclaim';
+
+export type RailNeutralProofChainFixtureStatus = 'binding_ready' | 'blocked';
+
+export type RailNeutralProofChainFixtureGuardrails = {
+  fixtureOnly: true;
+  rawPromptStored: false;
+  rawOutputStored: false;
+  credentialMaterialStored: false;
+  walletSigning: false;
+  rpcCall: false;
+  providerCall: false;
+  paidRequest: false;
+  sandboxExecution: false;
+  hostedRegistryWrite: false;
+  marketplacePublication: false;
+  trustUpgrade: false;
+  reputationMutation: false;
+  custodyClaim: false;
+  settlementFinalityProof: false;
+  livePayment: false;
+};
+
+export type RailNeutralProofChainFailure = {
+  code: RailNeutralPaymentReceiptError['code'];
+  path: string;
+  message: string;
+};
+
+export type RailNeutralProofChainSourceRef = {
+  rail: RailNeutralPaymentReceiptInput['rail'];
+  case: string;
+  sourceId: string;
+  artifactPath: string;
+};
+
+export type RailNeutralProofChainFixture = {
+  schemaVersion: typeof RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION;
+  case: RailNeutralProofChainFixtureCase;
+  status: RailNeutralProofChainFixtureStatus;
+  sourceRef: RailNeutralProofChainSourceRef;
+  railNeutralReceipt?: RailNeutralPaymentReceipt;
+  redactedReceipt?: ReddiReceipt;
+  evidence?: EvidenceArchiveRecord;
+  binding?: ReceiptEvidenceBinding;
+  blockedBy?: RailNeutralProofChainFailure[];
+  bindingRefs: {
+    sourceRef: string;
+    quoteRef?: string;
+    paymentProofRef?: string;
+    requestHash?: string;
+    responseHash?: string;
+    evidenceRef?: string;
+    nonceRef?: string;
+    recipientRef?: string;
+    operatorApprovalRef?: string;
+  };
+  claimBoundaryLabels: string[];
+  guardrails: RailNeutralProofChainFixtureGuardrails;
+};
+
+export type RailNeutralProofChainFixtureInput = {
+  case: RailNeutralProofChainFixtureCase;
+  receiptInput: RailNeutralPaymentReceiptInput;
+  options?: RailNeutralPaymentReceiptOptions;
+  createdAt?: string;
+};
+
+export const RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_GUARDRAILS: RailNeutralProofChainFixtureGuardrails = {
+  fixtureOnly: true,
+  rawPromptStored: false,
+  rawOutputStored: false,
+  credentialMaterialStored: false,
+  walletSigning: false,
+  rpcCall: false,
+  providerCall: false,
+  paidRequest: false,
+  sandboxExecution: false,
+  hostedRegistryWrite: false,
+  marketplacePublication: false,
+  trustUpgrade: false,
+  reputationMutation: false,
+  custodyClaim: false,
+  settlementFinalityProof: false,
+  livePayment: false,
+};
+
+const CREATED_AT = '2026-06-22T10:20:00.000Z';
+const SPECIALIST_ID = 'pay-sh:reddi-x402-economic-demo';
+const PAYER_ID = 'buyer:fixture';
+
+export function createRailNeutralProofChainFixture(input: RailNeutralProofChainFixtureInput): RailNeutralProofChainFixture {
+  const result = deriveRailNeutralPaymentReceipt(input.receiptInput, input.options);
+  const refs = bindingRefsFromInput(input.receiptInput.fixture);
+
+  if (!result.ok) {
+    return blockedFixture(input.case, input.receiptInput.fixture, refs, result.errors);
+  }
+
+  const receipt = result.receipt;
+  const createdAt = input.createdAt ?? CREATED_AT;
+  const policyDecision = policyDecisionFromBudgetPolicyDecision({
+    allowed: true,
+    reasonCodes: ['allowed'],
+    quotedAmount: {
+      amount: receipt.payment.amount,
+      asset: receipt.payment.asset,
+      network: receipt.payment.network,
+      source: receipt.source.sourceId,
+      specialist: SPECIALIST_ID,
+    },
+    remainingBudget: { perRequest: receipt.payment.amount },
+    auditNotes: ['Allowed by fixture-only rail-neutral proof-chain bridge.'],
+  });
+
+  const redactedReceipt = createReddiReceipt({
+    schemaVersion: 'reddi.receipt.v1',
+    job: { id: `job:${receipt.rail}:${receipt.case}`, type: 'fixture-only-rail-neutral-proof-chain' },
+    source: {
+      id: receipt.source.sourceId,
+      type: receipt.source.kind,
+      uri: receipt.source.catalogRef ?? receipt.source.fixtureRef ?? receipt.source.rawSnapshotRef,
+    },
+    payer: { id: PAYER_ID },
+    specialist: { id: SPECIALIST_ID },
+    protocol: { name: 'Reddi Agent Protocol', version: '0.1.0' },
+    payment: {
+      network: receipt.payment.network,
+      asset: receipt.payment.asset,
+      amount: receipt.payment.amount,
+      paymentProofRef: receipt.payment.paymentProofRef,
+    },
+    requestHash: receipt.bindingRefs.requestHash,
+    responseHash: receipt.bindingRefs.responseHash,
+    evidenceRef: receipt.bindingRefs.evidenceRef,
+    policyDecision,
+    attestationStatus: 'not_requested',
+    createdAt,
+    metadata: {
+      rail: receipt.rail,
+      railNeutralReceiptSchema: receipt.schemaVersion,
+      supportState: receipt.supportState,
+      receiptRef: receipt.payment.receiptRef,
+      quoteRef: refs.quoteRef,
+      nonceRef: receipt.bindingRefs.nonceRef,
+      recipientRef: receipt.bindingRefs.recipientRef,
+      operatorApprovalRef: receipt.bindingRefs.operatorApprovalRef,
+      claimBoundaryLabels: receipt.claimBoundary,
+    },
+  });
+
+  const evidencePayload = {
+    schemaVersion: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION,
+    railNeutralReceipt: {
+      schemaVersion: receipt.schemaVersion,
+      rail: receipt.rail,
+      case: receipt.case,
+      supportState: receipt.supportState,
+      sourceId: receipt.source.sourceId,
+      payment: receipt.payment,
+      bindingRefs: receipt.bindingRefs,
+      claimBoundaryLabels: receipt.claimBoundary,
+    },
+    redaction: {
+      rawPromptStored: false,
+      rawOutputStored: false,
+      credentialMaterialStored: false,
+      providerResponseBodyStored: false,
+      walletKeyStored: false,
+      rpcUrlStored: false,
+    },
+  };
+
+  const evidence = createEvidenceArchiveRecord({
+    id: `evidence:${receipt.rail}:${receipt.case}`,
+    receiptId: redactedReceipt.job.id,
+    sourceId: receipt.source.sourceId,
+    requestHash: receipt.bindingRefs.requestHash,
+    responseHash: receipt.bindingRefs.responseHash,
+    evidenceRef: receipt.bindingRefs.evidenceRef,
+    evidencePayload,
+    createdAt,
+    metadata: {
+      railNeutralReceiptSchema: receipt.schemaVersion,
+      operatorApprovalRef: receipt.bindingRefs.operatorApprovalRef,
+      fixtureOnly: true,
+    },
+  });
+
+  const paymentPreflight = {
+    allowed: true,
+    reasonCodes: ['audd_payment_plan_allowed'],
+    paymentProofRef: receipt.payment.paymentProofRef,
+    policyDecision,
+    paymentPlan: {
+      schemaVersion: 'reddi.audd-payment-plan.v1',
+      asset: receipt.payment.asset,
+      network: receipt.payment.network,
+      mint: 'fixture-mint:rail-neutral-usdc',
+      payee: receipt.bindingRefs.recipientRef,
+      settlementAccount: 'fixture-settlement:rail-neutral-proof-chain',
+      amount: receipt.payment.amount,
+      quoteExpiresAt: '2026-06-22T11:20:00.000Z',
+      failurePolicy: { mode: 'no_charge_on_failure', description: 'Fixture bridge never charges.' },
+      refundPolicy: { mode: 'manual_review', description: 'Fixture bridge has no live refund path.' },
+      evidenceRequired: true,
+      paymentMode: 'dry-run',
+    },
+    auditNotes: ['Structural fixture bridge for receipt/evidence binding; no AUDD or live payment path is invoked.'],
+  } as unknown as AuddPaymentPlanPreflightDecision;
+
+  const binding = createReceiptEvidenceBinding({
+    id: `binding:${receipt.rail}:${receipt.case}`,
+    source: receipt.source,
+    receipt: redactedReceipt,
+    evidence,
+    evidencePayload,
+    paymentPreflight,
+    createdAt,
+  });
+
+  return {
+    schemaVersion: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION,
+    case: input.case,
+    status: 'binding_ready',
+    sourceRef: sourceRefFromInput(input.receiptInput),
+    railNeutralReceipt: receipt,
+    redactedReceipt,
+    evidence,
+    binding,
+    bindingRefs: {
+      ...refs,
+      paymentProofRef: receipt.payment.paymentProofRef,
+      requestHash: receipt.bindingRefs.requestHash,
+      responseHash: receipt.bindingRefs.responseHash,
+      evidenceRef: receipt.bindingRefs.evidenceRef,
+      nonceRef: receipt.bindingRefs.nonceRef,
+      recipientRef: receipt.bindingRefs.recipientRef,
+      operatorApprovalRef: receipt.bindingRefs.operatorApprovalRef,
+    },
+    claimBoundaryLabels: receipt.claimBoundary,
+    guardrails: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_GUARDRAILS,
+  };
+}
+
+export const railNeutralProofChainFixtures = {
+  payShSandboxSingleChargeBinding: createRailNeutralProofChainFixture({
+    case: 'pay_sh_sandbox_single_charge_binding',
+    receiptInput: { rail: 'pay-sh-sandbox', fixture: payShSandboxEvidenceFixtures.singleCharge },
+  }),
+  mppTempoUnsupportedNetwork: createRailNeutralProofChainFixture({
+    case: 'mpp_tempo_unsupported_network',
+    receiptInput: { rail: 'mpp-tempo', fixture: mppTempoReceiptShapeFixtures.tempoSingleChargeCandidate },
+  }),
+  unsupportedAssetNetwork: createRailNeutralProofChainFixture({
+    case: 'unsupported_asset_network',
+    receiptInput: { rail: 'pay-sh-sandbox', fixture: payShSandboxEvidenceFixtures.singleCharge },
+    options: { networkOverride: 'base-mainnet' },
+  }),
+  malformedReceipt: createRailNeutralProofChainFixture({
+    case: 'malformed_receipt',
+    receiptInput: {
+      rail: 'pay-sh-sandbox',
+      fixture: {
+        ...payShSandboxEvidenceFixtures.singleCharge,
+        receipt: undefined,
+      },
+    },
+  }),
+  policyDenied: createRailNeutralProofChainFixture({
+    case: 'policy_denied',
+    receiptInput: { rail: 'pay-sh-sandbox', fixture: payShSandboxEvidenceFixtures.singleCharge },
+    options: {
+      policy: {
+        allowed: false,
+        reasonCodes: ['operator_denied'],
+        auditNotes: ['Operator denied this fixture-only proof-chain bridge.'],
+      },
+    },
+  }),
+  livePathOverclaim: createRailNeutralProofChainFixture({
+    case: 'live_path_overclaim',
+    receiptInput: {
+      rail: 'pay-sh-sandbox',
+      fixture: {
+        ...payShSandboxEvidenceFixtures.singleCharge,
+        claimBoundary: [
+          'provider call performed with hosted registry write completed, trust upgrade performed, reputation mutation performed, settlement finality proven, custody accepted, and live Pay.sh activation',
+        ],
+      },
+    },
+  }),
+} as const;
+
+function blockedFixture(
+  fixtureCase: RailNeutralProofChainFixtureCase,
+  sourceFixture: RailNeutralPaymentReceiptInput['fixture'],
+  refs: RailNeutralProofChainFixture['bindingRefs'],
+  errors: RailNeutralPaymentReceiptError[],
+): RailNeutralProofChainFixture {
+  return {
+    schemaVersion: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION,
+    case: fixtureCase,
+    status: 'blocked',
+    sourceRef: sourceRefFromFixture(refs.sourceRef, sourceFixture),
+    blockedBy: errors.map((item) => ({
+      code: item.code,
+      path: item.path,
+      message: blockedMessage(item),
+    })),
+    bindingRefs: refs,
+    claimBoundaryLabels: [
+      'Fail-closed fixture state only.',
+      'No Reddi receipt v1 settlement proof, custody, trust upgrade, reputation mutation, marketplace publication, provider execution, wallet signing, RPC, spend, sandbox execution, or live payment is claimed.',
+    ],
+    guardrails: RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_GUARDRAILS,
+  };
+}
+
+function blockedMessage(error: RailNeutralPaymentReceiptError): string {
+  if (error.code === 'live_path_rejected') {
+    return 'Rail-neutral proof-chain fixture rejected imported live-path overclaim text.';
+  }
+  return error.message;
+}
+
+function sourceRefFromInput(input: RailNeutralPaymentReceiptInput): RailNeutralProofChainSourceRef {
+  const refs = bindingRefsFromInput(input.fixture);
+  return sourceRefFromFixture(refs.sourceRef, input.fixture, input.rail);
+}
+
+function sourceRefFromFixture(
+  sourceId: string,
+  fixture: PayShSandboxEvidenceFixture | MppTempoReceiptShapeFixture,
+  rail?: RailNeutralPaymentReceiptInput['rail'],
+): RailNeutralProofChainSourceRef {
+  return {
+    rail: rail ?? (isPayShSandboxEvidenceFixture(fixture) ? 'pay-sh-sandbox' : 'mpp-tempo'),
+    case: fixture.case,
+    sourceId,
+    artifactPath: fixture.artifactPath,
+  };
+}
+
+function bindingRefsFromInput(
+  fixture: PayShSandboxEvidenceFixture | MppTempoReceiptShapeFixture,
+): RailNeutralProofChainFixture['bindingRefs'] {
+  if (isPayShSandboxEvidenceFixture(fixture)) return {
+    sourceRef: fixture.bindingRefs.source.sourceId,
+    quoteRef: fixture.bindingRefs.quoteRef,
+    paymentProofRef: fixture.bindingRefs.paymentProofRef,
+    requestHash: fixture.bindingRefs.requestHash,
+    responseHash: fixture.bindingRefs.responseHash,
+    evidenceRef: fixture.bindingRefs.evidenceRef,
+    nonceRef: fixture.bindingRefs.nonceRef,
+    recipientRef: fixture.bindingRefs.recipientRef,
+    operatorApprovalRef: fixture.bindingRefs.operatorApprovalRef,
+  };
+  return {
+    sourceRef: fixture.bindingRefs.sourceId,
+    paymentProofRef: fixture.bindingRefs.paymentProofRef,
+    requestHash: fixture.bindingRefs.requestHash,
+    responseHash: fixture.bindingRefs.responseHash,
+    evidenceRef: fixture.bindingRefs.evidenceRef,
+    nonceRef: fixture.bindingRefs.nonceRef,
+    recipientRef: fixture.bindingRefs.recipientRef,
+    operatorApprovalRef: fixture.bindingRefs.operatorApprovalRef,
+  };
+}
+
+function isPayShSandboxEvidenceFixture(
+  fixture: PayShSandboxEvidenceFixture | MppTempoReceiptShapeFixture,
+): fixture is PayShSandboxEvidenceFixture {
+  return 'source' in fixture.bindingRefs;
+}

--- a/packages/agent-protocol/tests/rail-neutral-proof-chain-fixture.test.ts
+++ b/packages/agent-protocol/tests/rail-neutral-proof-chain-fixture.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createRailNeutralProofChainFixture,
+  payShSandboxEvidenceFixtures,
+  RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION,
+  railNeutralProofChainFixtures,
+} from '../dist/index.js';
+
+test('bridges Pay.sh rail-neutral receipt metadata into a proof-chain fixture binding', () => {
+  const fixture = railNeutralProofChainFixtures.payShSandboxSingleChargeBinding;
+
+  assert.equal(fixture.schemaVersion, RAIL_NEUTRAL_PROOF_CHAIN_FIXTURE_SCHEMA_VERSION);
+  assert.equal(fixture.status, 'binding_ready');
+  assert.equal(fixture.railNeutralReceipt?.supportState, 'receipt_binding_candidate');
+  assert.equal(fixture.railNeutralReceipt?.payment.network, 'solana-devnet');
+  assert.equal(fixture.railNeutralReceipt?.payment.asset, 'USDC');
+  assert.equal(fixture.binding?.schemaVersion, 'reddi.receipt-evidence-binding.v1');
+  assert.equal(fixture.binding?.source.sourceId, fixture.railNeutralReceipt?.source.sourceId);
+  assert.equal(fixture.binding?.receipt.paymentProofRef, fixture.railNeutralReceipt?.payment.paymentProofRef);
+  assert.equal(fixture.binding?.receipt.requestHash, fixture.railNeutralReceipt?.bindingRefs.requestHash);
+  assert.equal(fixture.binding?.receipt.responseHash, fixture.railNeutralReceipt?.bindingRefs.responseHash);
+  assert.equal(fixture.binding?.evidence.evidenceRef, fixture.railNeutralReceipt?.bindingRefs.evidenceRef);
+  assert.equal(fixture.sourceRef.rail, 'pay-sh-sandbox');
+  assert.equal(fixture.sourceRef.case, 'single_charge');
+  assert.equal(fixture.bindingRefs.nonceRef, fixture.railNeutralReceipt?.bindingRefs.nonceRef);
+  assert.equal(fixture.bindingRefs.recipientRef, fixture.railNeutralReceipt?.bindingRefs.recipientRef);
+  assert.equal(fixture.bindingRefs.operatorApprovalRef, fixture.railNeutralReceipt?.bindingRefs.operatorApprovalRef);
+  assert.ok(fixture.claimBoundaryLabels.some((label) => label.includes('does not prove settlement finality')));
+});
+
+test('keeps proof-chain bridge guardrails false for live and sensitive surfaces', () => {
+  const fixture = railNeutralProofChainFixtures.payShSandboxSingleChargeBinding;
+
+  assert.deepEqual(fixture.guardrails, {
+    fixtureOnly: true,
+    rawPromptStored: false,
+    rawOutputStored: false,
+    credentialMaterialStored: false,
+    walletSigning: false,
+    rpcCall: false,
+    providerCall: false,
+    paidRequest: false,
+    sandboxExecution: false,
+    hostedRegistryWrite: false,
+    marketplacePublication: false,
+    trustUpgrade: false,
+    reputationMutation: false,
+    custodyClaim: false,
+    settlementFinalityProof: false,
+    livePayment: false,
+  });
+  assert.equal(fixture.binding?.guardrails.livePaymentExecuted, false);
+  assert.equal(fixture.binding?.guardrails.walletSigning, false);
+  assert.equal(fixture.binding?.guardrails.rpcCall, false);
+  assert.equal(fixture.binding?.guardrails.hostedRegistryRequired, false);
+  assert.equal(fixture.binding?.guardrails.reputationMutated, false);
+});
+
+test('exposes Tempo unsupported network as a blocked proof-chain state', () => {
+  const fixture = railNeutralProofChainFixtures.mppTempoUnsupportedNetwork;
+
+  assert.equal(fixture.status, 'blocked');
+  assert.equal(fixture.railNeutralReceipt, undefined);
+  assert.equal(fixture.binding, undefined);
+  assert.ok(fixture.blockedBy?.some((item) => item.code === 'unsupported_asset_network'));
+  assert.ok(fixture.claimBoundaryLabels.some((label) => label.includes('No Reddi receipt v1 settlement proof')));
+});
+
+test('exposes fail-closed unsupported asset or network state', () => {
+  const fixture = railNeutralProofChainFixtures.unsupportedAssetNetwork;
+
+  assert.equal(fixture.status, 'blocked');
+  assert.ok(fixture.blockedBy?.some((item) => item.code === 'unsupported_asset_network'));
+  assert.equal(fixture.bindingRefs.paymentProofRef, payShSandboxEvidenceFixtures.singleCharge.bindingRefs.paymentProofRef);
+});
+
+test('exposes malformed receipt and policy-denied blocked states', () => {
+  const malformed = railNeutralProofChainFixtures.malformedReceipt;
+  const denied = railNeutralProofChainFixtures.policyDenied;
+
+  assert.equal(malformed.status, 'blocked');
+  assert.ok(malformed.blockedBy?.some((item) => item.code === 'malformed_receipt'));
+  assert.equal(denied.status, 'blocked');
+  assert.ok(denied.blockedBy?.some((item) => item.code === 'policy_denied'));
+});
+
+test('exposes live-path overclaim as a blocked proof-chain state', () => {
+  const fixture = railNeutralProofChainFixtures.livePathOverclaim;
+
+  assert.equal(fixture.status, 'blocked');
+  assert.ok(fixture.blockedBy?.some((item) => item.code === 'live_path_rejected'));
+  assert.equal(JSON.stringify(fixture).includes('provider call performed'), false);
+  assert.equal(JSON.stringify(fixture).includes('live Pay.sh activation'), false);
+  assert.equal(fixture.guardrails.livePayment, false);
+  assert.equal(fixture.guardrails.settlementFinalityProof, false);
+});
+
+test('can derive a custom fixture without network calls or spend', () => {
+  const fixture = createRailNeutralProofChainFixture({
+    case: 'pay_sh_sandbox_single_charge_binding',
+    receiptInput: { rail: 'pay-sh-sandbox', fixture: payShSandboxEvidenceFixtures.singleCharge },
+    createdAt: '2026-06-22T10:45:00.000Z',
+  });
+
+  assert.equal(fixture.status, 'binding_ready');
+  assert.equal(fixture.redactedReceipt?.createdAt, '2026-06-22T10:45:00.000Z');
+  assert.equal(fixture.evidence?.createdAt, '2026-06-22T10:45:00.000Z');
+});


### PR DESCRIPTION
Closes #488.

## Summary
- Adds `@reddi/agent-protocol/rail-neutral-proof-chain-fixture` as the fixture bridge from `rail-neutral-payment-receipts` into receipt/evidence binding.
- Exposes a binding-ready Pay.sh sandbox single-charge proof-chain fixture with compact source refs, hashes, payment proof refs, nonce/recipient/operator refs, evidence refs, and claim-boundary labels.
- Exposes blocked/fail-closed fixture states for Tempo unsupported network, unsupported asset/network, malformed receipt, policy denial, and live-path overclaim.
- Updates Bucket F BDD coverage and package export surfaces.

## Validation
- `cd packages/agent-protocol && npm test -- --test-name-pattern "rail-neutral"` — pass, 163/163 tests.
- `cd packages/agent-protocol && npm run release:dry-run` — pass, 163/163 tests and npm pack dry run.
- `npm run test:bdd:index` — pass.
- `npm run check:rap:naming` — pass.
- `git diff --check` — pass.

## UI evidence
No UI files touched; screenshots/video not required.

## Guardrails
Fixture/static package contract only. No Pay.sh CLI/setup, Circle call, Tempo wallet/key use, wallet signing, RPC, provider call, paid request, sandbox execution, hosted registry write, marketplace publication, trust/reputation mutation, custody claim, settlement-finality proof, or live payment.
