### PR TITLE
Add public proof page data contract

### DIFF
--- a/app/api/economic-demo/public-proof-page-data/route.ts
+++ b/app/api/economic-demo/public-proof-page-data/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+import { getPublicProofPageData } from "@/lib/economic-demo/public-proof-page-data";
+
+export async function GET() {
+  return NextResponse.json(getPublicProofPageData());
+}

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -73,7 +73,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Feature: `docs/bdd/features/bucket-j-end-user-economic-demo.feature`
 - Verify:
   - `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/fixture.ts lib/economic-demo/image-adapter.ts app/api/economic-demo/image/route.ts`
-  - `npx jest lib/__tests__/economic-demo-dry-run.test.ts lib/__tests__/economic-demo-balances.test.ts lib/__tests__/economic-demo-payment-readiness.test.ts lib/__tests__/economic-demo-hosted-challenge-probe.test.ts lib/__tests__/economic-demo-live-run.test.ts lib/__tests__/economic-demo-live-paid-devnet-run.test.ts lib/__tests__/economic-demo-ledger-reconciliation.test.ts lib/__tests__/economic-demo-surfpool-rehearsal.test.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts --runInBand`
+  - `npx jest lib/__tests__/economic-demo-dry-run.test.ts lib/__tests__/economic-demo-balances.test.ts lib/__tests__/economic-demo-payment-readiness.test.ts lib/__tests__/economic-demo-hosted-challenge-probe.test.ts lib/__tests__/economic-demo-live-run.test.ts lib/__tests__/economic-demo-live-paid-devnet-run.test.ts lib/__tests__/economic-demo-ledger-reconciliation.test.ts lib/__tests__/economic-demo-surfpool-rehearsal.test.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts lib/__tests__/economic-demo-public-proof-page-data.test.ts --runInBand`
   - `npx playwright test e2e/economic-demo.spec.ts e2e/judge-replication-onboarding.spec.ts`
   - `npm run smoke:economic-demo:surfpool`
   - `npm run check:economic-demo:submission-prep`

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -200,6 +200,16 @@ Feature: End-user economic workflow demo
     And downstreamCallsExecuted is 0
     And no paid provider request, signing operation, wallet mutation, or devnet transfer occurs
 
+  Scenario: Public proof page data contract exposes rail-neutral evidence without live claims
+    Given the public proof page consumes deterministic economic demo data
+    And rail-neutral proof-chain fixtures are available
+    When the public proof page data contract is generated
+    Then it includes quote, policy decision, AUDD payment-plan preflight, receipt, EvidenceArchive, attestation draft, reputation draft, source refs, listing refs, and state labels
+    And Pay.sh sandbox single-charge proof is represented as binding-ready refs and hashes only
+    And Tempo unsupported-network, unsupported asset, malformed receipt, policy-denied, and live-path overclaim states fail closed
+    And no paid provider request, signing operation, wallet mutation, RPC call, hosted registry write, trust or reputation mutation, custody claim, settlement-finality proof, or live payment occurs
+    And the behavior is covered by "lib/__tests__/economic-demo-public-proof-page-data.test.ts"
+
   Scenario: Submission readiness follows retrospective-driven BDD loops
     Given the economic demo is being prepared for judge or submission review
     And live research, paid image generation, signing, wallet mutation, devnet transfer, and Coolify mutation are not approved

--- a/lib/__tests__/economic-demo-public-proof-page-data.test.ts
+++ b/lib/__tests__/economic-demo-public-proof-page-data.test.ts
@@ -1,0 +1,118 @@
+import { GET } from "@/app/api/economic-demo/public-proof-page-data/route";
+import {
+  getPublicProofPageData,
+  PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION,
+} from "@/lib/economic-demo/public-proof-page-data";
+
+describe("economic demo public proof page data", () => {
+  it("builds the public proof page contract with quote policy preflight and proof labels", () => {
+    const data = getPublicProofPageData();
+
+    expect(data.schemaVersion).toBe(PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION);
+    expect(data.scenarioId).toBe("webpage");
+    expect(data.quote).toMatchObject({
+      currency: "USDC",
+      totalUsdc: 3.33125,
+      protocolRailFeeBps: 5,
+    });
+    expect(data.policyDecision).toMatchObject({
+      status: "allowed_fixture_only",
+      reasonCodes: expect.arrayContaining(["fixture_only", "no_live_payment"]),
+    });
+    expect(data.auddPaymentPlanPreflight).toMatchObject({
+      status: "allowed_fixture_only",
+      paymentMode: "dry-run",
+      evidenceRequired: true,
+    });
+    expect(data.stateLabels).toEqual(
+      expect.arrayContaining([
+        "fixture_zero_spend",
+        "planned_dry_run",
+        "simulated",
+        "devnet_proof_metadata",
+        "live_gated",
+        "production_live_disabled",
+      ]),
+    );
+  });
+
+  it("surfaces only sanitized rail-neutral proof-chain refs and fail-closed states", () => {
+    const data = getPublicProofPageData();
+    const bindingReady = data.railNeutralProofChain.cases.find((item) => item.case === "pay_sh_sandbox_single_charge_binding");
+
+    expect(bindingReady).toMatchObject({
+      status: "binding_ready",
+      sourceRef: {
+        rail: "pay-sh-sandbox",
+      },
+      payment: {
+        network: "solana-devnet",
+        asset: "USDC",
+      },
+      receipt: {
+        attestationStatus: "not_requested",
+        supportState: "receipt_binding_candidate",
+      },
+    });
+    expect(bindingReady?.bindingRefs).toEqual(
+      expect.objectContaining({
+        paymentProofRef: expect.any(String),
+        requestHash: expect.any(String),
+        responseHash: expect.any(String),
+        evidenceRef: expect.any(String),
+        nonceRef: expect.any(String),
+        recipientRef: expect.any(String),
+        operatorApprovalRef: expect.any(String),
+      }),
+    );
+    expect(bindingReady).not.toHaveProperty("evidenceArchive.evidencePayload");
+
+    expect(data.railNeutralProofChain.blockedCases.sort()).toEqual([
+      "live_path_overclaim",
+      "malformed_receipt",
+      "mpp_tempo_unsupported_network",
+      "policy_denied",
+      "unsupported_asset_network",
+    ]);
+    expect(
+      data.railNeutralProofChain.cases
+        .filter((item) => item.status === "blocked")
+        .every((item) => item.blockedBy.length > 0 && !JSON.stringify(item).includes("provider call performed")),
+    ).toBe(true);
+  });
+
+  it("keeps public copy and machine flags closed for live payment settlement custody trust and reputation", () => {
+    const data = getPublicProofPageData();
+
+    expect(data.copyBoundaries.join(" ")).toContain("No AUDD is settled, escrowed, or held in Quasar custody");
+    expect(Object.values(data.boundaryFlags).every((value) => value === false)).toBe(true);
+    expect(data.railNeutralProofChain.cases.every((item) => Object.values(item.boundaryFlags).every((value) => value === false))).toBe(true);
+    expect(data.attestationDraft).toMatchObject({
+      status: "draft_only",
+      result: "not_submitted",
+    });
+    expect(data.reputationDraft).toMatchObject({
+      status: "draft_only",
+      mutationAllowed: false,
+      commitTx: null,
+      revealTx: null,
+    });
+    expect(data.sourceListingRefs.dryRunPlan).toMatchObject({
+      orchestratorProfileId: "agentic-workflow-system",
+      downstreamCallsExecuted: 0,
+    });
+  });
+
+  it("serves the same data contract from the read-only API route", async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      schemaVersion: PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION,
+      railNeutralProofChain: {
+        bindingReadyCase: "pay_sh_sandbox_single_charge_binding",
+      },
+    });
+  });
+});

--- a/lib/economic-demo/public-proof-page-data.ts
+++ b/lib/economic-demo/public-proof-page-data.ts
@@ -1,0 +1,286 @@
+import { railNeutralProofChainFixtures } from "../../packages/agent-protocol/dist/rail-neutral-proof-chain-fixture.js";
+import { economicDemoScenarios, type EconomicDemoScenarioId } from "@/lib/economic-demo/fixture";
+import { buildEconomicDemoDryRunPlan } from "@/lib/economic-demo/dry-run";
+import { getStaticWebpageLiveWorkflowEvidence } from "@/lib/economic-demo/webpage-live-workflow-evidence";
+
+export const PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION = "reddi.economic-demo.public-proof-page-data.v1" as const;
+
+export type PublicProofPageStateLabel =
+  | "fixture_zero_spend"
+  | "planned_dry_run"
+  | "simulated"
+  | "devnet_proof_metadata"
+  | "live_gated"
+  | "production_live_disabled";
+
+export type PublicProofPageBoundaryFlags = {
+  walletSigning: false;
+  rpcCall: false;
+  providerCall: false;
+  paidRequest: false;
+  sandboxExecution: false;
+  hostedRegistryWrite: false;
+  marketplacePublication: false;
+  trustUpgrade: false;
+  reputationMutation: false;
+  custodyClaim: false;
+  settlementFinalityProof: false;
+  livePayment: false;
+};
+
+export type PublicProofPageRailNeutralCase = {
+  case: string;
+  status: "binding_ready" | "blocked";
+  sourceRef: {
+    rail: string;
+    sourceId: string;
+    artifactPath: string;
+  };
+  payment?: {
+    network: string;
+    asset: string;
+    amount: string;
+    paymentProofRef?: string;
+  };
+  bindingRefs: {
+    sourceRef: string;
+    quoteRef?: string;
+    paymentProofRef?: string;
+    requestHash?: string;
+    responseHash?: string;
+    evidenceRef?: string;
+    nonceRef?: string;
+    recipientRef?: string;
+    operatorApprovalRef?: string;
+  };
+  evidenceArchive?: {
+    id: string;
+    receiptId: string;
+    sourceId: string;
+    evidenceRef?: string;
+    requestHash?: string;
+    responseHash?: string;
+  };
+  receipt?: {
+    id: string;
+    sourceId: string;
+    attestationStatus: string;
+    supportState: string;
+  };
+  blockedBy: Array<{
+    code: string;
+    path: string;
+    message: string;
+  }>;
+  claimBoundaryLabels: string[];
+  boundaryFlags: PublicProofPageBoundaryFlags;
+};
+
+export type PublicProofPageData = {
+  schemaVersion: typeof PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION;
+  generatedAt: string;
+  scenarioId: EconomicDemoScenarioId;
+  stateLabels: PublicProofPageStateLabel[];
+  quote: {
+    currency: "USDC";
+    downstreamFeesUsdc: number;
+    attestorFeesUsdc: number;
+    orchestratorMarkupUsdc: number;
+    protocolRailFeeBps: number;
+    protocolRailFeesUsdc: number;
+    jupiterSwapAllowanceUsdc: number;
+    totalUsdc: number;
+    solEstimate: number;
+    slippageBps: number;
+  };
+  policyDecision: {
+    status: "allowed_fixture_only";
+    reasonCodes: string[];
+    auditNotes: string[];
+  };
+  auddPaymentPlanPreflight: {
+    status: "allowed_fixture_only";
+    paymentMode: "dry-run";
+    evidenceRequired: true;
+    failurePolicy: string;
+    refundPolicy: string;
+  };
+  publicWorkflowEvidence: {
+    schemaVersion: string;
+    sourceArtifactPath: string;
+    disclosureLedgerEvidenceComplete: boolean;
+    downstreamCallsExecuted: number;
+    limitations: string[];
+  };
+  railNeutralProofChain: {
+    schemaVersion: "reddi.rail-neutral-proof-chain-fixture.v1";
+    cases: PublicProofPageRailNeutralCase[];
+    bindingReadyCase: "pay_sh_sandbox_single_charge_binding";
+    blockedCases: string[];
+  };
+  attestationDraft: {
+    status: "draft_only";
+    attestorProfileId: string;
+    result: "not_submitted";
+    evidenceRef?: string;
+  };
+  reputationDraft: {
+    status: "draft_only";
+    profileId: string;
+    mutationAllowed: false;
+    commitTx: null;
+    revealTx: null;
+  };
+  sourceListingRefs: {
+    dryRunPlan: {
+      orchestratorProfileId: string;
+      downstreamProfileIds: string[];
+      downstreamCallsExecuted: 0;
+    };
+    fixtureSourceRefs: string[];
+    listingRefs: string[];
+  };
+  copyBoundaries: string[];
+  boundaryFlags: PublicProofPageBoundaryFlags;
+};
+
+const GENERATED_AT = "2026-06-22T12:45:00.000Z";
+
+const BOUNDARY_FLAGS: PublicProofPageBoundaryFlags = {
+  walletSigning: false,
+  rpcCall: false,
+  providerCall: false,
+  paidRequest: false,
+  sandboxExecution: false,
+  hostedRegistryWrite: false,
+  marketplacePublication: false,
+  trustUpgrade: false,
+  reputationMutation: false,
+  custodyClaim: false,
+  settlementFinalityProof: false,
+  livePayment: false,
+};
+
+export function getPublicProofPageData(scenarioId: EconomicDemoScenarioId = "webpage"): PublicProofPageData {
+  const scenario = economicDemoScenarios.find((candidate) => candidate.id === scenarioId);
+  if (!scenario) throw new Error(`unknown_public_proof_scenario:${scenarioId}`);
+
+  const dryRunPlan = buildEconomicDemoDryRunPlan(scenarioId);
+  const workflowEvidence = getStaticWebpageLiveWorkflowEvidence();
+  const cases = Object.values(railNeutralProofChainFixtures).map(toPublicRailNeutralCase);
+  const bindingReady = cases.find((item) => item.status === "binding_ready");
+  if (!bindingReady) throw new Error("missing_binding_ready_rail_neutral_fixture");
+
+  return {
+    schemaVersion: PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION,
+    generatedAt: GENERATED_AT,
+    scenarioId,
+    stateLabels: [
+      "fixture_zero_spend",
+      "planned_dry_run",
+      "simulated",
+      "devnet_proof_metadata",
+      "live_gated",
+      "production_live_disabled",
+    ],
+    quote: scenario.quote,
+    policyDecision: {
+      status: "allowed_fixture_only",
+      reasonCodes: ["allowed", "fixture_only", "no_live_payment"],
+      auditNotes: ["Public proof page data is deterministic and read-only."],
+    },
+    auddPaymentPlanPreflight: {
+      status: "allowed_fixture_only",
+      paymentMode: "dry-run",
+      evidenceRequired: true,
+      failurePolicy: "no_charge_on_failure",
+      refundPolicy: "manual_review_fixture_only",
+    },
+    publicWorkflowEvidence: {
+      schemaVersion: workflowEvidence.schemaVersion,
+      sourceArtifactPath: workflowEvidence.sourceArtifactPath,
+      disclosureLedgerEvidenceComplete: workflowEvidence.disclosureLedgerSummary.evidenceComplete,
+      downstreamCallsExecuted: workflowEvidence.downstreamCallsExecuted,
+      limitations: workflowEvidence.limitations,
+    },
+    railNeutralProofChain: {
+      schemaVersion: "reddi.rail-neutral-proof-chain-fixture.v1",
+      cases,
+      bindingReadyCase: "pay_sh_sandbox_single_charge_binding",
+      blockedCases: cases.filter((item) => item.status === "blocked").map((item) => item.case),
+    },
+    attestationDraft: {
+      status: "draft_only",
+      attestorProfileId: "verification-validation-agent",
+      result: "not_submitted",
+      evidenceRef: bindingReady.evidenceArchive?.evidenceRef,
+    },
+    reputationDraft: {
+      status: "draft_only",
+      profileId: dryRunPlan.orchestrator.id,
+      mutationAllowed: false,
+      commitTx: null,
+      revealTx: null,
+    },
+    sourceListingRefs: {
+      dryRunPlan: {
+        orchestratorProfileId: dryRunPlan.orchestrator.id,
+        downstreamProfileIds: dryRunPlan.edges.map((edge) => edge.toProfileId),
+        downstreamCallsExecuted: dryRunPlan.downstreamCallsExecuted,
+      },
+      fixtureSourceRefs: cases.map((item) => item.sourceRef.sourceId),
+      listingRefs: ["source-adapter:pay-sh:reddi-x402", "source-adapter:mpp-tempo:probe-only"],
+    },
+    copyBoundaries: [
+      "AUDD payment metadata is fixture/dry-run proof data only.",
+      "No AUDD is settled, escrowed, or held in Quasar custody by this public proof contract.",
+      "Rail-neutral receipt data is limited to refs, hashes, support states, and claim-boundary labels.",
+      "Blocked proof-chain cases fail closed and do not imply settlement, custody, trust, reputation, provider execution, marketplace publication, or live payment.",
+    ],
+    boundaryFlags: BOUNDARY_FLAGS,
+  };
+}
+
+function toPublicRailNeutralCase(
+  fixture: (typeof railNeutralProofChainFixtures)[keyof typeof railNeutralProofChainFixtures],
+): PublicProofPageRailNeutralCase {
+  return {
+    case: fixture.case,
+    status: fixture.status,
+    sourceRef: {
+      rail: fixture.sourceRef.rail,
+      sourceId: fixture.sourceRef.sourceId,
+      artifactPath: fixture.sourceRef.artifactPath,
+    },
+    payment: fixture.railNeutralReceipt
+      ? {
+          network: fixture.railNeutralReceipt.payment.network,
+          asset: fixture.railNeutralReceipt.payment.asset,
+          amount: fixture.railNeutralReceipt.payment.amount,
+          paymentProofRef: fixture.railNeutralReceipt.payment.paymentProofRef,
+        }
+      : undefined,
+    bindingRefs: fixture.bindingRefs,
+    evidenceArchive: fixture.evidence
+      ? {
+          id: fixture.evidence.id,
+          receiptId: fixture.evidence.receiptId,
+          sourceId: fixture.evidence.sourceId,
+          evidenceRef: fixture.evidence.evidenceRef,
+          requestHash: fixture.evidence.requestHash,
+          responseHash: fixture.evidence.responseHash,
+        }
+      : undefined,
+    receipt: fixture.redactedReceipt
+      ? {
+          id: fixture.redactedReceipt.job.id,
+          sourceId: fixture.redactedReceipt.source.id,
+          attestationStatus: fixture.redactedReceipt.attestationStatus,
+          supportState: String(fixture.redactedReceipt.metadata?.supportState ?? "unknown"),
+        }
+      : undefined,
+    blockedBy: fixture.blockedBy ?? [],
+    claimBoundaryLabels: fixture.claimBoundaryLabels,
+    boundaryFlags: BOUNDARY_FLAGS,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `reddi.economic-demo.public-proof-page-data.v1` as a sanitized public proof page read model for #417.
- Exposes deterministic quote, policy decision, AUDD payment-plan preflight, workflow evidence, attestation/reputation drafts, source/listing refs, state labels, and rail-neutral proof-chain summaries.
- Adds a read-only `/api/economic-demo/public-proof-page-data` route and Bucket J BDD coverage.

## Rail-neutral proof-chain handling
- Pay.sh sandbox single-charge fixture is represented as `binding_ready` refs/hashes only.
- Tempo unsupported network, unsupported asset/network, malformed receipt, policy denied, and live-path overclaim states fail closed.
- All live/sensitive boundaries remain false: no paid provider request, signing, wallet mutation, RPC, hosted registry write, trust/reputation mutation, custody claim, settlement-finality proof, or live payment.

## Validation
- `npx jest --runTestsByPath lib/__tests__/economic-demo-public-proof-page-data.test.ts --runInBand` — PASS 4/4
- `npx jest --runTestsByPath lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts lib/__tests__/economic-demo-ledger-reconciliation.test.ts --runInBand` — PASS 4/4
- `cd packages/agent-protocol && npm test -- --test-name-pattern "rail-neutral"` — PASS 163/163
- `npm run test:bdd:index` — PASS
- `npm run check:rap:naming` — PASS
- `npm run lint -- app/api/economic-demo/public-proof-page-data/route.ts lib/economic-demo/public-proof-page-data.ts lib/__tests__/economic-demo-public-proof-page-data.test.ts` — PASS
- `npm run build` — PASS
- `git diff --check` — PASS

## Notes
- No UI files were changed, so screenshots/video are not required for this PR.
- `npx tsc --noEmit --pretty false` still fails on pre-existing repo-wide test typing issues outside this branch; the new-file type narrowness found during validation was fixed, and `npm run build` passes.

Closes #417.
