### PR TITLE
Add paid workflow proof UI fixtures

### DIFF
--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -73,7 +73,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Feature: `docs/bdd/features/bucket-j-end-user-economic-demo.feature`
 - Verify:
   - `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/fixture.ts lib/economic-demo/image-adapter.ts app/api/economic-demo/image/route.ts`
-  - `npx jest lib/__tests__/economic-demo-dry-run.test.ts lib/__tests__/economic-demo-balances.test.ts lib/__tests__/economic-demo-payment-readiness.test.ts lib/__tests__/economic-demo-hosted-challenge-probe.test.ts lib/__tests__/economic-demo-live-run.test.ts lib/__tests__/economic-demo-live-paid-devnet-run.test.ts lib/__tests__/economic-demo-ledger-reconciliation.test.ts lib/__tests__/economic-demo-surfpool-rehearsal.test.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts lib/__tests__/economic-demo-public-proof-page-data.test.ts --runInBand`
+  - `npx jest lib/__tests__/economic-demo-dry-run.test.ts lib/__tests__/economic-demo-balances.test.ts lib/__tests__/economic-demo-payment-readiness.test.ts lib/__tests__/economic-demo-hosted-challenge-probe.test.ts lib/__tests__/economic-demo-live-run.test.ts lib/__tests__/economic-demo-live-paid-devnet-run.test.ts lib/__tests__/economic-demo-ledger-reconciliation.test.ts lib/__tests__/economic-demo-surfpool-rehearsal.test.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts lib/__tests__/economic-demo-public-proof-page-data.test.ts lib/__tests__/economic-demo-paid-workflow-proof-ui-fixtures.test.ts --runInBand`
   - `npx playwright test e2e/economic-demo.spec.ts e2e/judge-replication-onboarding.spec.ts`
   - `npm run smoke:economic-demo:surfpool`
   - `npm run check:economic-demo:submission-prep`

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -210,6 +210,16 @@ Feature: End-user economic workflow demo
     And no paid provider request, signing operation, wallet mutation, RPC call, hosted registry write, trust or reputation mutation, custody claim, settlement-finality proof, or live payment occurs
     And the behavior is covered by "lib/__tests__/economic-demo-public-proof-page-data.test.ts"
 
+  Scenario: Paid workflow proof-chain UI fixture pack covers responsive render states
+    Given the public proof page data contract is available
+    When the paid workflow proof-chain UI fixture pack is generated
+    Then it includes quote, budget ledger, result, receipt, evidence, attestation preview, and reputation preview sections
+    And it provides mobile, tablet, and desktop fixture expectations for every case
+    And Pay.sh sandbox single-charge proof is represented as a no-network no-spend happy path with refs and hashes only
+    And Tempo unsupported-network, unsupported asset, malformed receipt, policy-denied, and live-path overclaim states stay blocked for downstream rendering
+    And no UI implementation, paid provider request, signing operation, wallet mutation, RPC call, hosted registry write, trust or reputation mutation, custody claim, settlement-finality proof, or live payment occurs
+    And the behavior is covered by "lib/__tests__/economic-demo-paid-workflow-proof-ui-fixtures.test.ts"
+
   Scenario: Submission readiness follows retrospective-driven BDD loops
     Given the economic demo is being prepared for judge or submission review
     And live research, paid image generation, signing, wallet mutation, devnet transfer, and Coolify mutation are not approved

--- a/lib/__tests__/economic-demo-paid-workflow-proof-ui-fixtures.test.ts
+++ b/lib/__tests__/economic-demo-paid-workflow-proof-ui-fixtures.test.ts
@@ -1,0 +1,90 @@
+import {
+  getPaidWorkflowProofUiFixturePack,
+  PAID_WORKFLOW_PROOF_UI_FIXTURE_PACK_SCHEMA_VERSION,
+} from "@/lib/economic-demo/paid-workflow-proof-ui-fixtures";
+import { PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION } from "@/lib/economic-demo/public-proof-page-data";
+
+describe("economic demo paid workflow proof UI fixture pack", () => {
+  it("builds a UI fixture pack that consumes the #417 public proof page data contract", () => {
+    const pack = getPaidWorkflowProofUiFixturePack();
+
+    expect(pack.schemaVersion).toBe(PAID_WORKFLOW_PROOF_UI_FIXTURE_PACK_SCHEMA_VERSION);
+    expect(pack.consumes.publicProofPageDataSchemaVersion).toBe(PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION);
+    expect(pack.happyPathCaseId).toBe("pay_sh_sandbox_single_charge_binding_ready");
+    expect(pack.cases.map((item) => item.id)).toContain(pack.happyPathCaseId);
+    expect(pack.cases.every((item) => item.stateLabels.includes("planned_dry_run"))).toBe(true);
+    expect(pack.cases.every((item) => item.stateLabels.includes("devnet_proof_metadata"))).toBe(true);
+    expect(pack.cases.every((item) => item.stateLabels.includes("live_gated"))).toBe(true);
+    expect(pack.cases.every((item) => item.stateLabels.includes("production_live_disabled"))).toBe(true);
+    expect(pack.copyBoundaries.join(" ")).toContain("UI fixtures are deterministic no-network/no-spend data");
+  });
+
+  it("covers mobile tablet and desktop fixture expectations for every case", () => {
+    const pack = getPaidWorkflowProofUiFixturePack();
+    const requiredSections = [
+      "quote",
+      "budget_ledger",
+      "result",
+      "receipt",
+      "evidence",
+      "attestation_preview",
+      "reputation_preview",
+    ];
+
+    expect(pack.viewports.map((item) => item.viewport)).toEqual(["mobile", "tablet", "desktop"]);
+    expect(pack.cases.length).toBeGreaterThanOrEqual(6);
+    for (const item of pack.cases) {
+      expect(item.viewports.map((viewport) => viewport.viewport)).toEqual(["mobile", "tablet", "desktop"]);
+      expect(item.sections.map((section) => section.key)).toEqual(requiredSections);
+      expect(item.viewports.every((viewport) => viewport.requiredSections.join("|") === requiredSections.join("|"))).toBe(true);
+    }
+  });
+
+  it("represents the no-network no-spend happy path with refs and hashes only", () => {
+    const pack = getPaidWorkflowProofUiFixturePack();
+    const happy = pack.cases.find((item) => item.id === pack.happyPathCaseId);
+
+    expect(happy).toMatchObject({
+      status: "no_network_no_spend_happy_path",
+      rail: "pay-sh-sandbox",
+      supportState: "receipt_binding_candidate",
+      paymentProofLabel: "refs_hashes_only",
+    });
+    expect(happy?.sections.find((section) => section.key === "receipt")).toMatchObject({
+      state: "binding_ready",
+      primaryLabel: "Receipt binding ready",
+    });
+    expect(happy?.sections.find((section) => section.key === "evidence")?.refs).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^evidence:/), expect.any(String)]),
+    );
+    expect(JSON.stringify(happy)).not.toContain("rawPrompt");
+    expect(JSON.stringify(happy)).not.toContain("providerResponseBody");
+  });
+
+  it("keeps blocked variants fail-closed for downstream rendering", () => {
+    const pack = getPaidWorkflowProofUiFixturePack();
+    const blocked = pack.cases.filter((item) => item.status === "blocked");
+
+    expect(pack.blockedCaseIds.sort()).toEqual([
+      "live_path_overclaim_blocked",
+      "malformed_receipt_blocked",
+      "mpp_tempo_unsupported_network_blocked",
+      "policy_denied_blocked",
+      "unsupported_asset_network_blocked",
+    ]);
+    expect(blocked).toHaveLength(5);
+    expect(blocked.every((item) => item.paymentProofLabel === "fail_closed")).toBe(true);
+    expect(blocked.every((item) => item.blockedBy.length > 0)).toBe(true);
+    expect(blocked.every((item) => item.sections.find((section) => section.key === "receipt")?.state === "blocked")).toBe(true);
+    expect(JSON.stringify(blocked)).not.toContain("provider call performed");
+  });
+
+  it("keeps all live and sensitive boundaries disabled", () => {
+    const pack = getPaidWorkflowProofUiFixturePack();
+
+    expect(Object.values(pack.boundaryFlags).every((value) => value === false)).toBe(true);
+    expect(pack.cases.every((item) => Object.values(item.boundaryFlags).every((value) => value === false))).toBe(true);
+    expect(pack.cases.every((item) => item.sections.find((section) => section.key === "attestation_preview")?.state === "draft")).toBe(true);
+    expect(pack.cases.every((item) => item.sections.find((section) => section.key === "reputation_preview")?.primaryLabel === "No mutation")).toBe(true);
+  });
+});

--- a/lib/economic-demo/paid-workflow-proof-ui-fixtures.ts
+++ b/lib/economic-demo/paid-workflow-proof-ui-fixtures.ts
@@ -1,0 +1,315 @@
+import {
+  getPublicProofPageData,
+  PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION,
+  type PublicProofPageData,
+  type PublicProofPageRailNeutralCase,
+} from "@/lib/economic-demo/public-proof-page-data";
+
+export const PAID_WORKFLOW_PROOF_UI_FIXTURE_PACK_SCHEMA_VERSION =
+  "reddi.economic-demo.paid-workflow-proof-ui-fixture-pack.v1" as const;
+
+export type PaidWorkflowProofUiViewport = "mobile" | "tablet" | "desktop";
+
+export type PaidWorkflowProofUiSectionKey =
+  | "quote"
+  | "budget_ledger"
+  | "result"
+  | "receipt"
+  | "evidence"
+  | "attestation_preview"
+  | "reputation_preview";
+
+export type PaidWorkflowProofUiCaseStatus = "no_network_no_spend_happy_path" | "blocked";
+
+export type PaidWorkflowProofUiViewportFixture = {
+  viewport: PaidWorkflowProofUiViewport;
+  width: number;
+  height: number;
+  density: "single_column" | "split_panels" | "dashboard_grid";
+  requiredSections: PaidWorkflowProofUiSectionKey[];
+  layoutNotes: string[];
+};
+
+export type PaidWorkflowProofUiSectionFixture = {
+  key: PaidWorkflowProofUiSectionKey;
+  title: string;
+  state:
+    | "ready"
+    | "planned"
+    | "draft"
+    | "binding_ready"
+    | "blocked"
+    | "live_gated"
+    | "production_live_disabled";
+  primaryLabel: string;
+  detail: string;
+  refs: string[];
+};
+
+export type PaidWorkflowProofUiCaseFixture = {
+  id: string;
+  sourceCase: string;
+  status: PaidWorkflowProofUiCaseStatus;
+  rail: string;
+  supportState: string;
+  stateLabels: PublicProofPageData["stateLabels"];
+  paymentProofLabel: "refs_hashes_only" | "fail_closed";
+  viewports: PaidWorkflowProofUiViewportFixture[];
+  sections: PaidWorkflowProofUiSectionFixture[];
+  blockedBy: PublicProofPageRailNeutralCase["blockedBy"];
+  boundaryLabels: string[];
+  boundaryFlags: PublicProofPageData["boundaryFlags"];
+};
+
+export type PaidWorkflowProofUiFixturePack = {
+  schemaVersion: typeof PAID_WORKFLOW_PROOF_UI_FIXTURE_PACK_SCHEMA_VERSION;
+  generatedAt: string;
+  consumes: {
+    publicProofPageDataSchemaVersion: typeof PUBLIC_PROOF_PAGE_DATA_SCHEMA_VERSION;
+    publicProofPageGeneratedAt: string;
+  };
+  viewports: PaidWorkflowProofUiViewportFixture[];
+  cases: PaidWorkflowProofUiCaseFixture[];
+  happyPathCaseId: "pay_sh_sandbox_single_charge_binding_ready";
+  blockedCaseIds: string[];
+  copyBoundaries: string[];
+  boundaryFlags: PublicProofPageData["boundaryFlags"];
+};
+
+const GENERATED_AT = "2026-06-22T13:20:00.000Z";
+
+const REQUIRED_SECTIONS: PaidWorkflowProofUiSectionKey[] = [
+  "quote",
+  "budget_ledger",
+  "result",
+  "receipt",
+  "evidence",
+  "attestation_preview",
+  "reputation_preview",
+];
+
+const VIEWPORTS: PaidWorkflowProofUiViewportFixture[] = [
+  {
+    viewport: "mobile",
+    width: 390,
+    height: 844,
+    density: "single_column",
+    requiredSections: REQUIRED_SECTIONS,
+    layoutNotes: [
+      "Render sections as a stable single-column stack.",
+      "Keep quote total, receipt/evidence state, and blocked reason labels visible without horizontal scrolling.",
+    ],
+  },
+  {
+    viewport: "tablet",
+    width: 820,
+    height: 1180,
+    density: "split_panels",
+    requiredSections: REQUIRED_SECTIONS,
+    layoutNotes: [
+      "Render quote/budget and receipt/evidence as two readable groups.",
+      "Keep attestation and reputation previews visually subordinate to proof state labels.",
+    ],
+  },
+  {
+    viewport: "desktop",
+    width: 1440,
+    height: 960,
+    density: "dashboard_grid",
+    requiredSections: REQUIRED_SECTIONS,
+    layoutNotes: [
+      "Render quote, ledger, receipt, evidence, result, attestation, and reputation panels in scan-friendly dashboard groups.",
+      "Blocked variants must keep fail-closed reason and no-live-payment boundary labels visible.",
+    ],
+  },
+];
+
+export function getPaidWorkflowProofUiFixturePack(
+  publicProofPageData: PublicProofPageData = getPublicProofPageData(),
+): PaidWorkflowProofUiFixturePack {
+  const cases = publicProofPageData.railNeutralProofChain.cases.map((item) =>
+    item.status === "binding_ready"
+      ? buildHappyPathCase(publicProofPageData, item)
+      : buildBlockedCase(publicProofPageData, item),
+  );
+
+  return {
+    schemaVersion: PAID_WORKFLOW_PROOF_UI_FIXTURE_PACK_SCHEMA_VERSION,
+    generatedAt: GENERATED_AT,
+    consumes: {
+      publicProofPageDataSchemaVersion: publicProofPageData.schemaVersion,
+      publicProofPageGeneratedAt: publicProofPageData.generatedAt,
+    },
+    viewports: VIEWPORTS,
+    cases,
+    happyPathCaseId: "pay_sh_sandbox_single_charge_binding_ready",
+    blockedCaseIds: cases.filter((item) => item.status === "blocked").map((item) => item.id),
+    copyBoundaries: [
+      ...publicProofPageData.copyBoundaries,
+      "UI fixtures are deterministic no-network/no-spend data for rendering only.",
+      "Viewport coverage proves downstream render states exist; it is not visual evidence of a UI implementation.",
+    ],
+    boundaryFlags: publicProofPageData.boundaryFlags,
+  };
+}
+
+function buildHappyPathCase(
+  publicProofPageData: PublicProofPageData,
+  proofCase: PublicProofPageRailNeutralCase,
+): PaidWorkflowProofUiCaseFixture {
+  return {
+    id: "pay_sh_sandbox_single_charge_binding_ready",
+    sourceCase: proofCase.case,
+    status: "no_network_no_spend_happy_path",
+    rail: proofCase.sourceRef.rail,
+    supportState: proofCase.receipt?.supportState ?? "receipt_binding_candidate",
+    stateLabels: publicProofPageData.stateLabels,
+    paymentProofLabel: "refs_hashes_only",
+    viewports: VIEWPORTS,
+    sections: [
+      quoteSection(publicProofPageData),
+      budgetLedgerSection(publicProofPageData),
+      resultSection(publicProofPageData, "ready", "Ready fixture result"),
+      receiptSection(proofCase, "binding_ready", "Receipt binding ready"),
+      evidenceSection(proofCase, "ready", "Evidence refs ready"),
+      attestationPreviewSection(publicProofPageData),
+      reputationPreviewSection(publicProofPageData),
+    ],
+    blockedBy: [],
+    boundaryLabels: proofCase.claimBoundaryLabels,
+    boundaryFlags: publicProofPageData.boundaryFlags,
+  };
+}
+
+function buildBlockedCase(
+  publicProofPageData: PublicProofPageData,
+  proofCase: PublicProofPageRailNeutralCase,
+): PaidWorkflowProofUiCaseFixture {
+  const reason = proofCase.blockedBy[0]?.message ?? "Proof-chain fixture failed closed.";
+
+  return {
+    id: `${proofCase.case}_blocked`,
+    sourceCase: proofCase.case,
+    status: "blocked",
+    rail: proofCase.sourceRef.rail,
+    supportState: "fail_closed",
+    stateLabels: publicProofPageData.stateLabels,
+    paymentProofLabel: "fail_closed",
+    viewports: VIEWPORTS,
+    sections: [
+      quoteSection(publicProofPageData),
+      budgetLedgerSection(publicProofPageData),
+      resultSection(publicProofPageData, "blocked", "Blocked before result release"),
+      receiptSection(proofCase, "blocked", "Receipt unavailable"),
+      evidenceSection(proofCase, "blocked", reason),
+      attestationPreviewSection(publicProofPageData),
+      reputationPreviewSection(publicProofPageData),
+    ],
+    blockedBy: proofCase.blockedBy,
+    boundaryLabels: proofCase.claimBoundaryLabels,
+    boundaryFlags: publicProofPageData.boundaryFlags,
+  };
+}
+
+function quoteSection(publicProofPageData: PublicProofPageData): PaidWorkflowProofUiSectionFixture {
+  return {
+    key: "quote",
+    title: "Quote",
+    state: "ready",
+    primaryLabel: `${publicProofPageData.quote.totalUsdc.toFixed(6)} ${publicProofPageData.quote.currency}`,
+    detail: `${publicProofPageData.quote.downstreamFeesUsdc.toFixed(2)} downstream + ${publicProofPageData.quote.attestorFeesUsdc.toFixed(2)} attestor + ${publicProofPageData.quote.orchestratorMarkupUsdc.toFixed(2)} markup + ${publicProofPageData.quote.protocolRailFeeBps} bps rail fee.`,
+    refs: [publicProofPageData.railNeutralProofChain.bindingReadyCase],
+  };
+}
+
+function budgetLedgerSection(publicProofPageData: PublicProofPageData): PaidWorkflowProofUiSectionFixture {
+  return {
+    key: "budget_ledger",
+    title: "Budget ledger",
+    state: "planned",
+    primaryLabel: "Planned dry-run ledger",
+    detail: `${publicProofPageData.sourceListingRefs.dryRunPlan.downstreamProfileIds.length} downstream profiles; downstream calls executed: ${publicProofPageData.sourceListingRefs.dryRunPlan.downstreamCallsExecuted}.`,
+    refs: publicProofPageData.sourceListingRefs.dryRunPlan.downstreamProfileIds,
+  };
+}
+
+function resultSection(
+  publicProofPageData: PublicProofPageData,
+  state: PaidWorkflowProofUiSectionFixture["state"],
+  primaryLabel: string,
+): PaidWorkflowProofUiSectionFixture {
+  return {
+    key: "result",
+    title: "Result",
+    state,
+    primaryLabel,
+    detail: publicProofPageData.publicWorkflowEvidence.limitations[0] ?? "Fixture result is bounded by public proof data.",
+    refs: [publicProofPageData.publicWorkflowEvidence.sourceArtifactPath],
+  };
+}
+
+function receiptSection(
+  proofCase: PublicProofPageRailNeutralCase,
+  state: PaidWorkflowProofUiSectionFixture["state"],
+  primaryLabel: string,
+): PaidWorkflowProofUiSectionFixture {
+  return {
+    key: "receipt",
+    title: "Receipt",
+    state,
+    primaryLabel,
+    detail: proofCase.receipt
+      ? `${proofCase.receipt.supportState}; ${proofCase.payment?.asset ?? "unknown asset"} on ${proofCase.payment?.network ?? "unknown network"}.`
+      : proofCase.blockedBy[0]?.message ?? "No receipt is available for this fail-closed state.",
+    refs: [
+      proofCase.receipt?.id,
+      proofCase.bindingRefs.paymentProofRef,
+      proofCase.bindingRefs.nonceRef,
+      proofCase.bindingRefs.recipientRef,
+    ].filter((item): item is string => Boolean(item)),
+  };
+}
+
+function evidenceSection(
+  proofCase: PublicProofPageRailNeutralCase,
+  state: PaidWorkflowProofUiSectionFixture["state"],
+  primaryLabel: string,
+): PaidWorkflowProofUiSectionFixture {
+  return {
+    key: "evidence",
+    title: "Evidence",
+    state,
+    primaryLabel,
+    detail: proofCase.evidenceArchive
+      ? "EvidenceArchive refs are available without raw prompt, output, credential, provider, wallet, or RPC material."
+      : "EvidenceArchive binding is withheld because the proof-chain case failed closed.",
+    refs: [
+      proofCase.evidenceArchive?.id,
+      proofCase.evidenceArchive?.evidenceRef,
+      proofCase.evidenceArchive?.requestHash,
+      proofCase.evidenceArchive?.responseHash,
+    ].filter((item): item is string => Boolean(item)),
+  };
+}
+
+function attestationPreviewSection(publicProofPageData: PublicProofPageData): PaidWorkflowProofUiSectionFixture {
+  return {
+    key: "attestation_preview",
+    title: "Attestation preview",
+    state: "draft",
+    primaryLabel: "Draft only",
+    detail: `${publicProofPageData.attestationDraft.attestorProfileId} has not submitted an attestation.`,
+    refs: [publicProofPageData.attestationDraft.evidenceRef].filter((item): item is string => Boolean(item)),
+  };
+}
+
+function reputationPreviewSection(publicProofPageData: PublicProofPageData): PaidWorkflowProofUiSectionFixture {
+  return {
+    key: "reputation_preview",
+    title: "Reputation preview",
+    state: "draft",
+    primaryLabel: "No mutation",
+    detail: `${publicProofPageData.reputationDraft.profileId} reputation mutation is disabled for this fixture pack.`,
+    refs: [],
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `reddi.economic-demo.paid-workflow-proof-ui-fixture-pack.v1` as a data-only fixture pack for #457.
- Consumes #417's `reddi.economic-demo.public-proof-page-data.v1` contract instead of introducing a second public proof schema.
- Provides mobile/tablet/desktop fixture expectations for quote, budget ledger, result, receipt, evidence, attestation preview, and reputation preview sections.

## Fixture coverage
- Pay.sh sandbox single-charge is represented as a no-network/no-spend happy path with refs/hashes only.
- Tempo unsupported network, unsupported asset/network, malformed receipt, policy denied, and live-path overclaim states remain blocked/fail-closed for downstream rendering.
- Dry-run, devnet proof metadata, live-gated, and production/live-disabled labels are asserted across all cases.
- All live/sensitive boundary flags remain false: no UI implementation, paid provider request, signing, wallet mutation, RPC, hosted registry write, trust/reputation mutation, custody claim, settlement-finality proof, or live payment.

## Validation
- `npx jest --runTestsByPath lib/__tests__/economic-demo-paid-workflow-proof-ui-fixtures.test.ts lib/__tests__/economic-demo-public-proof-page-data.test.ts --runInBand` — PASS 9/9
- `npm run test:bdd:index` — PASS
- `npm run check:rap:naming` — PASS
- `npm run lint -- lib/economic-demo/paid-workflow-proof-ui-fixtures.ts lib/__tests__/economic-demo-paid-workflow-proof-ui-fixtures.test.ts` — PASS
- `npm run build` — PASS
- `git diff --check` — PASS

## UI evidence
No UI files were changed in this PR. Screenshots/video are not required for #457 while it remains data-only. Downstream #458/#448 UI rendering must still include mobile/tablet/desktop screenshots plus video or Playwright trace.

Closes #457.
