### PR TITLE
Polish public no-spend quickstart proof output

### DIFF
--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -73,6 +73,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Feature: `docs/bdd/features/bucket-j-end-user-economic-demo.feature`
 - Verify:
   - `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/fixture.ts lib/economic-demo/image-adapter.ts app/api/economic-demo/image/route.ts`
+  - `cd packages/agent-protocol && npm test -- --test-name-pattern "ARD no-spend demo"`
   - `npx jest lib/__tests__/economic-demo-dry-run.test.ts lib/__tests__/economic-demo-balances.test.ts lib/__tests__/economic-demo-payment-readiness.test.ts lib/__tests__/economic-demo-hosted-challenge-probe.test.ts lib/__tests__/economic-demo-live-run.test.ts lib/__tests__/economic-demo-live-paid-devnet-run.test.ts lib/__tests__/economic-demo-ledger-reconciliation.test.ts lib/__tests__/economic-demo-surfpool-rehearsal.test.ts lib/__tests__/economic-demo-webpage-live-workflow-evidence.test.ts lib/__tests__/economic-demo-public-proof-page-data.test.ts lib/__tests__/economic-demo-paid-workflow-proof-ui-fixtures.test.ts --runInBand`
   - `npx playwright test e2e/economic-demo.spec.ts e2e/judge-replication-onboarding.spec.ts`
   - `npm run smoke:economic-demo:surfpool`

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -200,6 +200,16 @@ Feature: End-user economic workflow demo
     And downstreamCallsExecuted is 0
     And no paid provider request, signing operation, wallet mutation, or devnet transfer occurs
 
+  Scenario: Public local no-spend quickstart links proof contracts without live claims
+    Given the ARD no-spend package quickstart runs from local fixtures
+    When the Discover Decide Prove example emits its JSON output
+    Then it includes receipt, EvidenceArchive, receipt/evidence binding, attestation draft, reputation update, AUDD dry-run preflight, source diagnostics, and rail-neutral proof-chain refs
+    And it links the public proof page data contract and paid workflow proof UI fixture pack schema versions
+    And it labels the output as fixture zero-spend, planned dry-run, simulated, devnet proof metadata, live-gated, and production/live disabled
+    And policy denial, malformed challenge, missing evidence, missing payment setup, unsupported rail/network, and unsafe metadata states fail closed
+    And no hosted service, paid provider request, signing operation, wallet mutation, RPC call, SPL transfer, Quasar custody claim, settlement-finality proof, trust or reputation mutation, marketplace publication, or live payment occurs
+    And the behavior is covered by "packages/agent-protocol/tests/ard-no-spend-demo.test.ts"
+
   Scenario: Public proof page data contract exposes rail-neutral evidence without live claims
     Given the public proof page consumes deterministic economic demo data
     And rail-neutral proof-chain fixtures are available

--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -419,13 +419,33 @@ AUDD/Solana payment plans are metadata and policy-preflight helpers for RAP buye
 
 ## ARD No-Spend Quickstart
 
+From a fresh checkout, the local proof path should complete in under five minutes:
+
 ```bash
+git clone https://github.com/nissan/reddi-agent-protocol.git
+cd reddi-agent-protocol/packages/agent-protocol
+npm ci
 npm run example:ard:no-spend
 ```
 
-The ARD no-spend example is a deterministic Discover -> Decide -> Prove workflow. It starts from `examples/ard-no-spend-ai-catalog.json`, validates the AI Catalog fixture, creates a discovery candidate, runs source-aware diagnostics, evaluates local policy/trust/payment gates, executes a bounded dry-run specialist function, and emits receipt, evidence, attestation, and reputation output.
+The ARD no-spend example is a deterministic Discover -> Decide -> Prove workflow. It starts from `examples/ard-no-spend-ai-catalog.json`, validates the AI Catalog fixture, creates a discovery candidate, runs source-aware diagnostics, evaluates local policy/trust/payment gates, executes a bounded dry-run specialist function, and emits receipt, EvidenceArchive, attestation draft, reputation update, AUDD dry-run payment-plan/preflight, and source diagnostics output.
 
-The example also prints expected failure states for policy denial, malformed challenge, missing evidence, and unsupported AUDD/Solana network. It does not start a server, fetch an ARD registry, call hosted Reddi infrastructure, use secrets, invoke a paid provider, access a wallet, submit RPC/SPL transfers, or claim AUDD escrow custody.
+The JSON output labels the run as fixture-only and no-spend:
+
+- `payment.mode` is `dry-run`, with `paymentProofRef` set to a local `dry-run:*` ref.
+- `receiptEvidenceBinding` links the receipt, EvidenceArchive record, payment proof ref, request hash, response hash, and evidence ref using `bindingMode: "local_fixture_refs_only"`.
+- `railNeutralProofChain` includes the #489 rail-neutral proof-chain fixture bridge: the Pay.sh sandbox single-charge fixture is `binding_ready` by refs/hashes only, while Tempo unsupported network, unsupported asset/network, malformed receipt, policy denied, and live-path overclaim cases fail closed.
+- `downstreamPublicProofContracts` names the app-level public proof data contract (`reddi.economic-demo.public-proof-page-data.v1`) and paid workflow proof UI fixture pack (`reddi.economic-demo.paid-workflow-proof-ui-fixture-pack.v1`) so downstream pages can consume the same proof states without inventing another schema.
+- `downstreamPublicProofContracts.stateLabels` includes `fixture_zero_spend`, `planned_dry_run`, `simulated`, `devnet_proof_metadata`, `live_gated`, and `production_live_disabled`.
+- `boundaries` keeps hosted service, paid provider, wallet access, RPC call, SPL transfer, Quasar custody, settlement-finality proof, trust upgrade, reputation mutation, and live payment flags false.
+
+The example also prints expected failure states for policy denial, malformed challenge, missing evidence, missing operator/payment setup, unsupported AUDD/Solana network, and unsafe/credential-shaped evidence metadata. It does not start a server, fetch an ARD registry, call hosted Reddi infrastructure, use secrets, invoke a paid provider, access a wallet, submit RPC/SPL transfers, mutate trust or reputation state, publish to a marketplace, claim AUDD escrow custody, prove settlement finality, or perform a live payment.
+
+Run the deterministic conformance check for this quickstart:
+
+```bash
+npm test -- --test-name-pattern "ARD no-spend demo"
+```
 
 ## Local Validation
 

--- a/packages/agent-protocol/examples/ard-no-spend-demo.mjs
+++ b/packages/agent-protocol/examples/ard-no-spend-demo.mjs
@@ -25,6 +25,7 @@ import {
   createAttestationRecord,
   createInitialReputationState,
 } from '../dist/attestation-reputation.js';
+import { railNeutralProofChainFixtures } from '../dist/rail-neutral-proof-chain-fixture.js';
 
 const createdAt = '2026-06-19T07:45:00.000Z';
 const nonce = 'ard-no-spend-001';
@@ -221,6 +222,36 @@ const malformedChallenge = evaluateBuyerPaymentChallenge({
   quote: { amount: 2500000 },
 });
 const missingEvidence = validateEvidenceArchiveRecord(specialistResponse.evidence);
+const missingPaymentSetup = evaluateAuddPaymentPlanPreflight(challenge, {
+  allowedNetworks: ['solana-devnet'],
+  allowedMints: [auddMint],
+  allowedPayees: [payee],
+  allowedSettlementAccounts: [settlementAccount],
+  maxAmount: '3000000',
+  requireEvidence: true,
+  approvalState: 'pending',
+  now: '2026-06-19T07:45:01.000Z',
+});
+const unsafeMetadata = validateEvidenceArchiveRecord({
+  ...specialistResponse.evidence,
+  metadata: {
+    publicLabel: 'unsafe metadata fixture',
+    api_key: 'redacted',
+  },
+}, {
+  resultRef: specialistResponse.evidence.evidenceRef,
+});
+
+const railNeutralProofCases = Object.values(railNeutralProofChainFixtures).map((item) => ({
+  case: item.case,
+  status: item.status,
+  rail: item.sourceRef.rail,
+  sourceId: item.sourceRef.sourceId,
+  paymentProofRef: item.bindingRefs.paymentProofRef,
+  evidenceRef: item.bindingRefs.evidenceRef,
+  blockedBy: item.blockedBy?.map((error) => error.code) ?? [],
+  claimBoundaryLabels: item.claimBoundaryLabels,
+}));
 
 console.log(JSON.stringify({
   ok: true,
@@ -270,6 +301,15 @@ console.log(JSON.stringify({
     responseHash: specialistResponse.receipt.responseHash,
     archiveHasEvidence: archive.has(specialistResponse.evidence.id),
   },
+  receiptEvidenceBinding: {
+    receiptId: specialistResponse.receipt.job.id,
+    evidenceId: specialistResponse.evidence.id,
+    paymentProofRef: auddDecision.paymentProofRef,
+    requestHash: specialistResponse.receipt.requestHash,
+    responseHash: specialistResponse.receipt.responseHash,
+    evidenceRef: specialistResponse.evidence.evidenceRef,
+    bindingMode: 'local_fixture_refs_only',
+  },
   attestation: {
     id: attestation.id,
     verdict: attestation.verdict,
@@ -290,10 +330,48 @@ console.log(JSON.stringify({
       ok: missingEvidence.ok,
       errorCodes: missingEvidence.ok ? [] : missingEvidence.errors.map((item) => item.code),
     },
+    missingPaymentSetup: {
+      allowed: missingPaymentSetup.allowed,
+      reasonCodes: missingPaymentSetup.reasonCodes,
+    },
     unsupportedRailNetwork: {
       allowed: unsupportedNetwork.allowed,
       reasonCodes: unsupportedNetwork.reasonCodes,
     },
+    unsafeMetadata: {
+      ok: unsafeMetadata.ok,
+      errorCodes: unsafeMetadata.ok ? [] : unsafeMetadata.errors.map((item) => item.code),
+    },
+  },
+  railNeutralProofChain: {
+    schemaVersion: 'reddi.rail-neutral-proof-chain-fixture.v1',
+    bindingReadyCase: railNeutralProofCases.find((item) => item.status === 'binding_ready')?.case,
+    blockedCases: railNeutralProofCases.filter((item) => item.status === 'blocked').map((item) => item.case),
+    cases: railNeutralProofCases,
+  },
+  downstreamPublicProofContracts: {
+    publicProofPageData: 'reddi.economic-demo.public-proof-page-data.v1',
+    paidWorkflowProofUiFixturePack: 'reddi.economic-demo.paid-workflow-proof-ui-fixture-pack.v1',
+    stateLabels: [
+      'fixture_zero_spend',
+      'planned_dry_run',
+      'simulated',
+      'devnet_proof_metadata',
+      'live_gated',
+      'production_live_disabled',
+    ],
+  },
+  boundaries: {
+    hostedService: false,
+    paidProvider: false,
+    walletAccess: false,
+    rpcCall: false,
+    splTransfer: false,
+    quasarCustody: false,
+    settlementFinalityProof: false,
+    trustUpgrade: false,
+    reputationMutation: false,
+    livePayment: false,
   },
   hashes: {
     request: hashJson(requestBody),

--- a/packages/agent-protocol/tests/ard-no-spend-demo.test.ts
+++ b/packages/agent-protocol/tests/ard-no-spend-demo.test.ts
@@ -51,6 +51,13 @@ describe('ARD no-spend demo', () => {
     assert.equal(output.execution.receiptId, 'job:ard-no-spend-001');
     assert.equal(output.execution.evidenceId, 'evidence:ard-no-spend-001');
     assert.equal(output.execution.archiveHasEvidence, true);
+    assert.equal(output.receiptEvidenceBinding.bindingMode, 'local_fixture_refs_only');
+    assert.equal(output.receiptEvidenceBinding.receiptId, output.execution.receiptId);
+    assert.equal(output.receiptEvidenceBinding.evidenceId, output.execution.evidenceId);
+    assert.equal(output.receiptEvidenceBinding.paymentProofRef, output.payment.paymentProofRef);
+    assert.equal(output.receiptEvidenceBinding.requestHash, output.execution.requestHash);
+    assert.equal(output.receiptEvidenceBinding.responseHash, output.execution.responseHash);
+    assert.equal(output.receiptEvidenceBinding.evidenceRef, output.execution.evidenceRef);
     assert.equal(output.attestation.verdict, 'passed');
     assert.equal(output.failures.policyDenial.allowed, false);
     assert.ok(output.failures.policyDenial.reasonCodes.includes('over_budget'));
@@ -58,7 +65,56 @@ describe('ARD no-spend demo', () => {
     assert.ok(output.failures.malformedChallenge.reasonCodes.includes('challenge_malformed'));
     assert.equal(output.failures.missingEvidence.ok, false);
     assert.ok(output.failures.missingEvidence.errorCodes.includes('evidence_missing'));
+    assert.equal(output.failures.missingPaymentSetup.allowed, false);
+    assert.ok(output.failures.missingPaymentSetup.reasonCodes.includes('operator_approval_required'));
     assert.equal(output.failures.unsupportedRailNetwork.allowed, false);
     assert.ok(output.failures.unsupportedRailNetwork.reasonCodes.includes('wrong_network'));
+    assert.equal(output.failures.unsafeMetadata.ok, false);
+    assert.ok(output.failures.unsafeMetadata.errorCodes.includes('credential_leakage_rejected'));
+    assert.equal(output.railNeutralProofChain.schemaVersion, 'reddi.rail-neutral-proof-chain-fixture.v1');
+    assert.equal(output.railNeutralProofChain.bindingReadyCase, 'pay_sh_sandbox_single_charge_binding');
+    assert.deepEqual(output.railNeutralProofChain.blockedCases, [
+      'mpp_tempo_unsupported_network',
+      'unsupported_asset_network',
+      'malformed_receipt',
+      'policy_denied',
+      'live_path_overclaim',
+    ]);
+    assert.equal(output.railNeutralProofChain.cases.length, 6);
+    const bindingReady = (output.railNeutralProofChain.cases as Array<{
+      case: string;
+      status: string;
+      rail: string;
+      paymentProofRef: string;
+      evidenceRef: string;
+      claimBoundaryLabels: string[];
+    }>).find((item) => item.case === 'pay_sh_sandbox_single_charge_binding');
+    assert.ok(bindingReady);
+    assert.equal(bindingReady.status, 'binding_ready');
+    assert.equal(bindingReady.rail, 'pay-sh-sandbox');
+    assert.ok(bindingReady.paymentProofRef.startsWith('pay-sh-sandbox-receipt:'));
+    assert.ok(bindingReady.evidenceRef.startsWith('file://artifacts/pay-sh-reddi-x402/'));
+    for (const item of output.railNeutralProofChain.cases as Array<{ claimBoundaryLabels: string[] }>) {
+      assert.ok(item.claimBoundaryLabels.every((label) => !/settlement finality is proven|custody is proven|trust upgrade applied|reputation mutation applied|live payment completed/i.test(label)));
+    }
+    assert.equal(output.downstreamPublicProofContracts.publicProofPageData, 'reddi.economic-demo.public-proof-page-data.v1');
+    assert.equal(output.downstreamPublicProofContracts.paidWorkflowProofUiFixturePack, 'reddi.economic-demo.paid-workflow-proof-ui-fixture-pack.v1');
+    assert.ok(output.downstreamPublicProofContracts.stateLabels.includes('fixture_zero_spend'));
+    assert.ok(output.downstreamPublicProofContracts.stateLabels.includes('planned_dry_run'));
+    assert.ok(output.downstreamPublicProofContracts.stateLabels.includes('devnet_proof_metadata'));
+    assert.ok(output.downstreamPublicProofContracts.stateLabels.includes('live_gated'));
+    assert.ok(output.downstreamPublicProofContracts.stateLabels.includes('production_live_disabled'));
+    assert.deepEqual(output.boundaries, {
+      hostedService: false,
+      paidProvider: false,
+      walletAccess: false,
+      rpcCall: false,
+      splTransfer: false,
+      quasarCustody: false,
+      settlementFinalityProof: false,
+      trustUpgrade: false,
+      reputationMutation: false,
+      livePayment: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- expands the ARD no-spend quickstart output with receipt/evidence binding refs, rail-neutral proof-chain fixture cases, downstream public proof schema names, state labels, and explicit false boundary flags
- documents the under-five-minute local install/build/run path plus deterministic conformance command
- adds Bucket J BDD coverage and pins fail-closed states for policy denial, malformed challenge, missing evidence, missing payment setup, unsupported rail/network, and unsafe metadata

## Validation
- cd packages/agent-protocol && npm run example:ard:no-spend
- cd packages/agent-protocol && npm test -- --test-name-pattern "ARD no-spend demo" (163/163)
- cd packages/agent-protocol && npm run release:dry-run (163/163 + pack dry run)
- npm run test:bdd:index
- npm run check:rap:naming
- git diff --check

## UI evidence
No UI files changed; screenshots/video are not required for this data/docs/conformance PR. Downstream #458/#448 UI rendering still requires mobile/tablet/desktop screenshots plus video or trace.

Closes #357