### PR TITLE
Add Pay.sh devnet approval validator

### DIFF
--- a/docs/PAY-SH-LIVE-ACTIVATION-GATES-AND-SPEND-POLICY.md
+++ b/docs/PAY-SH-LIVE-ACTIVATION-GATES-AND-SPEND-POLICY.md
@@ -58,6 +58,26 @@ The approval record must include:
 
 Missing, stale, or ambiguous approval means no-go.
 
+For Pay.sh/devnet paid-run review, the approval record is machine-checkable with:
+
+```bash
+npm run check:pay-sh:devnet-approval -- --approval <approval.json> --request <request.json> --receipt <receipt.json> --verifier <verifier.json>
+```
+
+The validator is an offline docs/process checker only. It does not run Pay.sh setup, wallet setup, wallet top-up, RPC/Solana/provider calls, paid requests, hosted registry writes, catalog submissions, trust/reputation mutation, mainnet, production activation, or default auto-pay. Passing the validator means only that the supplied approval, request, receipt, and verifier artifacts are internally consistent for review. It does not authorize execution, and Nissan approval is still required before any paid command is run.
+
+The approval JSON must use schema `reddi.pay-sh.devnet-paid-run-approval.v1` and include, at minimum:
+
+- `status: "approved"`, `approver`, `approvedAt`, and `expiresAt`;
+- `environment`, `network: "solana-devnet"`, and `asset: "USDC"`;
+- exact `payer`, `recipientPayee`, and HTTPS `endpoint`;
+- `caps.singleRunUsdc` and `caps.sessionUsdc`;
+- explicit `retryPolicy.allowed` and `retryPolicy.maxRetries`;
+- exact `exactCommand`, `evidencePath`, `rollbackOwner`, and `scope: "single-use"`;
+- `autoPay: false` and `defaultLive: false`.
+
+The checker fails closed when the approval is missing or expired, when payer, payee, endpoint, network, asset, cap, receipt, or verifier artifacts drift from approval, or when the approval/request text implies auto-pay, default-live, production, or mainnet activation.
+
 ## Spend Policy
 
 Default policy:
@@ -194,6 +214,7 @@ No-spend and docs/process validation:
 ```bash
 npm run check:superteam:devnet-demo
 npm run check:economic-demo:live-payment-gate
+npm run test:pay-sh:devnet-approval
 npm run verify:economic-demo:devnet-usdc-receipt
 npm run check:rap:naming
 npm run test:bdd:index
@@ -201,6 +222,8 @@ git diff --check
 ```
 
 The default `check:economic-demo:live-payment-gate` and `verify:economic-demo:devnet-usdc-receipt` modes are expected to fail closed or block without the explicit confirmation inputs. Passing those default blocked modes is safety evidence, not payment evidence.
+
+The default `check:pay-sh:devnet-approval` mode also fails closed without an approval record. Use `test:pay-sh:devnet-approval` for the offline positive and negative fixture suite.
 
 ## Related Documents
 

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -74,6 +74,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket J — End-User Economic Demo
 - Feature: `docs/bdd/features/bucket-j-end-user-economic-demo.feature`
 - Paid workflow route state contract: `docs/PAID-WORKFLOW-ROUTE-STATE-CONTRACT.md`
+- Pay.sh/devnet paid-run approval validator maps #502 to #476, #471, #338, and #334.
 - Verify:
   - `npm run lint -- app/economic-demo/page.tsx lib/economic-demo/fixture.ts lib/economic-demo/image-adapter.ts app/api/economic-demo/image/route.ts`
   - `cd packages/agent-protocol && npm test -- --test-name-pattern "ARD no-spend demo"`
@@ -82,6 +83,7 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
   - `npm run smoke:economic-demo:surfpool`
   - `npm run check:economic-demo:submission-prep`
   - `npm run check:superteam:devnet-demo`
+  - `npm run test:pay-sh:devnet-approval`
   - `npm run generate:economic-demo:submission-prep`
   - `npm run build`
   - Devnet cycle, when fresh devnet validation is explicitly approved: `npm run run:economic-demo:devnet-signed-action`, `npm run smoke:economic-demo:jupiter-quote`, `npm run check:economic-demo:live-payment-gate`, `npm run verify:economic-demo:devnet-usdc-receipt`, `npm run plan:economic-demo:devnet-usdc-sender`, `node scripts/judge-replication-check.mjs`

--- a/docs/bdd/features/bucket-j-end-user-economic-demo.feature
+++ b/docs/bdd/features/bucket-j-end-user-economic-demo.feature
@@ -60,6 +60,17 @@ Feature: End-user economic workflow demo
     And it rejects missing signatures, mainnet routes, wrong assets, missing recipients, and over-cap transfers
     And it does not sign, submit, swap, transfer, or mutate a wallet
 
+  Scenario: Pay.sh devnet paid-run approval record fails closed before execution
+    Given a Pay.sh/devnet paid-run approval record is supplied for review under #502, #476, #471, #338, and #334
+    When the approval validator compares the approval, request, receipt, and verifier artifacts
+    Then it requires environment, asset, payer, recipient/payee, endpoint, cap, retry policy, exact command, evidence path, rollback owner, and expiry
+    And it rejects missing or expired approval records
+    And it rejects payer, payee, endpoint, network, asset, cap, receipt, and verifier mismatches
+    And it rejects auto-pay or default-live ambiguity
+    And passing validation does not authorize execution without Nissan approval
+    And no payment execution, Pay.sh setup, wallet setup, wallet top-up, RPC call, provider call, hosted write, catalog submission, trust mutation, reputation mutation, mainnet activation, production activation, or default auto-pay occurs
+    And the behavior is covered by "scripts/test-pay-sh-devnet-approval-validator.mjs"
+
   Scenario: Upfront evidence pack preserves proof hierarchy boundaries
     Given local Surfpool evidence, live Jupiter quote proof, and devnet USDC receipt verification artifacts may exist
     When the upfront payment evidence pack is generated

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "run:economic-demo:devnet-wallet-backed-jupiter-swap": "node ./scripts/run-economic-demo-devnet-wallet-backed-jupiter-swap.mjs",
     "check:product:naming": "node ./scripts/check-product-naming.mjs",
     "check:pay-sh:provider-spec": "node ./scripts/check-pay-sh-provider-spec.mjs",
+    "check:pay-sh:devnet-approval": "node ./scripts/check-pay-sh-devnet-approval-record.mjs",
+    "test:pay-sh:devnet-approval": "node ./scripts/test-pay-sh-devnet-approval-validator.mjs",
     "evidence:pay-sh:reddi-x402": "node ./scripts/generate-pay-sh-reddi-x402-evidence.mjs",
     "check:pay-skills:registry": "node ./scripts/check-pay-skills-registry.mjs",
     "check:submission:claim-boundaries": "node ./scripts/check-submission-claim-boundaries.mjs",

--- a/scripts/check-pay-sh-devnet-approval-record.mjs
+++ b/scripts/check-pay-sh-devnet-approval-record.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMA_VERSION = "reddi.pay-sh.devnet-paid-run-approval.v1";
+const APPROVED_STATUS = "approved";
+const VERIFIED_STATUS = "verified";
+const ALLOWED_ENVIRONMENTS = new Set(["pay-sh-sandbox", "sandbox-localnet", "solana-devnet"]);
+const ALLOWED_NETWORKS = new Set(["solana-devnet"]);
+const ALLOWED_ASSETS = new Set(["USDC"]);
+const AMBIGUOUS_LIVE_PATTERNS = [
+  /auto[-_]?pay/i,
+  /default[-_]?live/i,
+  /live[-_]?enabled/i,
+  /\bmainnet\b/i,
+  /\bproduction\b/i,
+];
+
+function parseArgs(argv) {
+  const args = {
+    approval: process.env.PAY_SH_DEVNET_APPROVAL_RECORD || "",
+    request: process.env.PAY_SH_DEVNET_RUN_REQUEST || "",
+    receipt: process.env.PAY_SH_DEVNET_RECEIPT || "",
+    verifier: process.env.PAY_SH_DEVNET_VERIFIER || "",
+    now: process.env.PAY_SH_DEVNET_APPROVAL_NOW || "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--approval") {
+      args.approval = next ?? "";
+      index += 1;
+    } else if (arg === "--request") {
+      args.request = next ?? "";
+      index += 1;
+    } else if (arg === "--receipt") {
+      args.receipt = next ?? "";
+      index += 1;
+    } else if (arg === "--verifier") {
+      args.verifier = next ?? "";
+      index += 1;
+    } else if (arg === "--now") {
+      args.now = next ?? "";
+      index += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else if (!arg.startsWith("--") && !args.approval) {
+      args.approval = arg;
+    } else {
+      args.unknown = arg;
+      break;
+    }
+  }
+
+  return args;
+}
+
+function resolveRepoPath(path) {
+  if (!path) return "";
+  return isAbsolute(path) ? path : join(rootDir, path);
+}
+
+function readJson(path, label, failures) {
+  const fullPath = resolveRepoPath(path);
+  if (!path || !existsSync(fullPath)) {
+    failures.push({ id: `${label}_present`, ok: false, summary: `${label} JSON file must exist` });
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileSync(fullPath, "utf8"));
+  } catch (error) {
+    failures.push({ id: `${label}_json_parseable`, ok: false, summary: `${label} JSON must parse: ${error.message}` });
+    return null;
+  }
+}
+
+function present(value) {
+  return typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined;
+}
+
+function exactPublicReference(value) {
+  return typeof value === "string" && /^[1-9A-HJ-NP-Za-km-z]{32,64}$/.test(value);
+}
+
+function exactHttpsEndpoint(value) {
+  if (typeof value !== "string" || value.includes("*") || /\s/.test(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hash === "" && url.username === "" && url.password === "";
+  } catch {
+    return false;
+  }
+}
+
+function finitePositiveNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function getCapUsdc(record) {
+  return record?.capUsdc ?? record?.caps?.singleRunUsdc ?? null;
+}
+
+function getSessionCapUsdc(record) {
+  return record?.sessionCapUsdc ?? record?.caps?.sessionUsdc ?? null;
+}
+
+function getRetryAllowed(record) {
+  return record?.retryAllowed ?? record?.retryPolicy?.allowed ?? null;
+}
+
+function getRetryCount(record) {
+  return record?.retryCount ?? record?.retryPolicy?.maxRetries ?? record?.retryPolicy?.count ?? null;
+}
+
+function hasAmbiguousLiveText(record) {
+  const text = [
+    record?.exactCommand,
+    record?.paymentMode,
+    record?.activationState,
+    record?.notes,
+    record?.summary,
+  ]
+    .filter((value) => typeof value === "string")
+    .join("\n");
+
+  return AMBIGUOUS_LIVE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function addCheck(checks, id, ok, summary) {
+  checks.push({ id, ok: Boolean(ok), summary });
+}
+
+function compareField(checks, actual, expected, fieldName, label) {
+  addCheck(checks, `${label}_${fieldName}_matches_approval`, actual === expected, `${label}.${fieldName} must exactly match approval.${fieldName}`);
+}
+
+function validateApprovalRecord(approval, now) {
+  const checks = [];
+  addCheck(checks, "schema_version", approval?.schemaVersion === SCHEMA_VERSION, `schemaVersion must equal ${SCHEMA_VERSION}`);
+  addCheck(checks, "approval_status", approval?.status === APPROVED_STATUS, "approval status must be approved");
+  addCheck(checks, "approver_present", present(approval?.approver), "approver must be present");
+  addCheck(checks, "approved_at_present", Number.isFinite(Date.parse(approval?.approvedAt ?? "")), "approvedAt must be an ISO timestamp");
+  addCheck(checks, "environment_allowed", ALLOWED_ENVIRONMENTS.has(approval?.environment), "environment must be pay-sh-sandbox, sandbox-localnet, or solana-devnet");
+  addCheck(checks, "network_devnet", ALLOWED_NETWORKS.has(approval?.network), "network must be solana-devnet for this checker");
+  addCheck(checks, "asset_usdc", ALLOWED_ASSETS.has(approval?.asset), "asset must be USDC for Pay.sh/devnet paid-run validation");
+  addCheck(checks, "payer_exact", exactPublicReference(approval?.payer), "payer must be an exact public key/reference, not a default or wildcard");
+  addCheck(checks, "recipient_payee_exact", exactPublicReference(approval?.recipientPayee), "recipientPayee must be an exact public key/reference, not a default or wildcard");
+  addCheck(checks, "endpoint_exact_https", exactHttpsEndpoint(approval?.endpoint), "endpoint must be one exact HTTPS URL without wildcard or credentials");
+  addCheck(checks, "single_run_cap_present", finitePositiveNumber(getCapUsdc(approval)), "single-run cap must be a positive USDC number");
+  addCheck(checks, "session_cap_present", finitePositiveNumber(getSessionCapUsdc(approval)), "session cap must be a positive USDC number");
+  addCheck(checks, "session_cap_covers_single_run", getSessionCapUsdc(approval) >= getCapUsdc(approval), "session cap must be >= single-run cap");
+  addCheck(checks, "retry_policy_explicit", typeof getRetryAllowed(approval) === "boolean" && Number.isInteger(getRetryCount(approval)) && getRetryCount(approval) >= 0, "retry policy must explicitly set allowed and maxRetries/count");
+  addCheck(checks, "retry_policy_bounded", getRetryAllowed(approval) === false ? getRetryCount(approval) === 0 : getRetryCount(approval) > 0 && getRetryCount(approval) <= 2, "retries must be disabled with 0 retries or explicitly bounded to <=2");
+  addCheck(checks, "exact_command_present", present(approval?.exactCommand), "exact command must be present");
+  addCheck(checks, "evidence_path_present", present(approval?.evidencePath), "evidence path must be present");
+  addCheck(checks, "rollback_owner_present", present(approval?.rollbackOwner), "rollback/suspend owner must be present");
+  addCheck(checks, "expiry_present", Number.isFinite(Date.parse(approval?.expiresAt ?? "")), "expiresAt must be an ISO timestamp");
+  addCheck(checks, "not_expired", Number.isFinite(Date.parse(approval?.expiresAt ?? "")) && Date.parse(approval.expiresAt) > now.getTime(), "approval must not be expired");
+  addCheck(checks, "single_use_scope", approval?.scope === "single-use", "approval scope must be single-use");
+  addCheck(checks, "auto_pay_disabled", approval?.autoPay === false, "autoPay must be false");
+  addCheck(checks, "default_live_disabled", approval?.defaultLive === false, "defaultLive must be false");
+  addCheck(checks, "no_auto_pay_or_default_live_ambiguity", !hasAmbiguousLiveText(approval), "approval text/command must not imply auto-pay, default-live, production, mainnet, or live-enabled mode");
+  return checks;
+}
+
+function validateRequest(checks, request, approval) {
+  if (!request) return;
+  compareField(checks, request.environment, approval.environment, "environment", "request");
+  compareField(checks, request.network, approval.network, "network", "request");
+  compareField(checks, request.asset, approval.asset, "asset", "request");
+  compareField(checks, request.payer, approval.payer, "payer", "request");
+  compareField(checks, request.recipientPayee, approval.recipientPayee, "recipientPayee", "request");
+  compareField(checks, request.endpoint, approval.endpoint, "endpoint", "request");
+  compareField(checks, request.exactCommand, approval.exactCommand, "exactCommand", "request");
+  compareField(checks, request.evidencePath, approval.evidencePath, "evidencePath", "request");
+  addCheck(checks, "request_cap_within_approval", finitePositiveNumber(request.capUsdc) && request.capUsdc <= getCapUsdc(approval), "request cap must be positive and <= approval single-run cap");
+  addCheck(checks, "request_retry_policy_matches", getRetryAllowed(request) === getRetryAllowed(approval) && getRetryCount(request) === getRetryCount(approval), "request retry policy must match approval retry policy");
+  addCheck(checks, "request_auto_pay_disabled", request.autoPay === false, "request autoPay must be false");
+  addCheck(checks, "request_default_live_disabled", request.defaultLive === false, "request defaultLive must be false");
+  addCheck(checks, "request_no_auto_pay_or_default_live_ambiguity", !hasAmbiguousLiveText(request), "request text/command must not imply auto-pay, default-live, production, mainnet, or live-enabled mode");
+}
+
+function validateReceipt(checks, receipt, approval) {
+  if (!receipt) return;
+  addCheck(checks, "receipt_status_present", present(receipt.status), "receipt status must be present when a receipt is supplied");
+  compareField(checks, receipt.network, approval.network, "network", "receipt");
+  compareField(checks, receipt.asset, approval.asset, "asset", "receipt");
+  compareField(checks, receipt.payer, approval.payer, "payer", "receipt");
+  compareField(checks, receipt.recipientPayee, approval.recipientPayee, "recipientPayee", "receipt");
+  compareField(checks, receipt.endpoint, approval.endpoint, "endpoint", "receipt");
+  addCheck(checks, "receipt_amount_within_cap", finitePositiveNumber(receipt.amountUsdc) && receipt.amountUsdc <= getCapUsdc(approval), "receipt amount must be positive and <= approval single-run cap");
+  addCheck(checks, "receipt_evidence_path_matches_approval", receipt.evidencePath === approval.evidencePath, "receipt evidence path must match approval evidence path");
+}
+
+function validateVerifier(checks, verifier, approval, receipt) {
+  if (!verifier) return;
+  addCheck(checks, "verifier_status_verified", verifier.status === VERIFIED_STATUS, "verifier status must be verified when a verifier artifact is supplied");
+  compareField(checks, verifier.network, approval.network, "network", "verifier");
+  compareField(checks, verifier.asset, approval.asset, "asset", "verifier");
+  compareField(checks, verifier.payer, approval.payer, "payer", "verifier");
+  compareField(checks, verifier.recipientPayee, approval.recipientPayee, "recipientPayee", "verifier");
+  compareField(checks, verifier.endpoint, approval.endpoint, "endpoint", "verifier");
+  addCheck(checks, "verifier_cap_matches_approval", verifier.capUsdc === getCapUsdc(approval), "verifier cap must equal approval single-run cap");
+  addCheck(checks, "verifier_evidence_path_matches_approval", verifier.evidencePath === approval.evidencePath, "verifier evidence path must match approval evidence path");
+  if (receipt) {
+    addCheck(checks, "verifier_receipt_path_matches_receipt", verifier.receiptEvidencePath === receipt.evidencePath, "verifier receiptEvidencePath must match supplied receipt evidencePath");
+    addCheck(checks, "verifier_amount_matches_receipt", verifier.amountUsdc === receipt.amountUsdc, "verifier amount must match supplied receipt amount");
+  }
+}
+
+function help() {
+  return [
+    "Usage: node scripts/check-pay-sh-devnet-approval-record.mjs --approval <approval.json> [--request <request.json>] [--receipt <receipt.json>] [--verifier <verifier.json>] [--now <iso>]",
+    "",
+    "Offline fail-closed validator for Pay.sh/devnet paid-run approval records.",
+    "It does not execute payments, call Pay.sh, read wallets, or query Solana RPC.",
+  ].join("\n");
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help) {
+  console.log(help());
+  process.exit(0);
+}
+
+if (args.unknown) {
+  console.error(`[pay-sh-devnet-approval] unknown argument: ${args.unknown}`);
+  console.error(help());
+  process.exit(1);
+}
+
+const loadFailures = [];
+const approval = readJson(args.approval, "approval_record", loadFailures);
+const request = args.request ? readJson(args.request, "request", loadFailures) : null;
+const receipt = args.receipt ? readJson(args.receipt, "receipt", loadFailures) : null;
+const verifier = args.verifier ? readJson(args.verifier, "verifier", loadFailures) : null;
+const now = args.now && Number.isFinite(Date.parse(args.now)) ? new Date(args.now) : new Date();
+
+const checks = [...loadFailures];
+if (approval) {
+  checks.push(...validateApprovalRecord(approval, now));
+  validateRequest(checks, request, approval);
+  validateReceipt(checks, receipt, approval);
+  validateVerifier(checks, verifier, approval, receipt);
+}
+
+const status = checks.every((check) => check.ok) ? "approved_for_review" : "blocked";
+const artifact = {
+  schemaVersion: "reddi.pay-sh.devnet-approval-validation.v1",
+  generatedAt: new Date().toISOString(),
+  status,
+  inputs: {
+    approval: args.approval ? relative(rootDir, resolveRepoPath(args.approval)) : null,
+    request: args.request ? relative(rootDir, resolveRepoPath(args.request)) : null,
+    receipt: args.receipt ? relative(rootDir, resolveRepoPath(args.receipt)) : null,
+    verifier: args.verifier ? relative(rootDir, resolveRepoPath(args.verifier)) : null,
+    now: now.toISOString(),
+  },
+  checks,
+  blockers: checks.filter((check) => !check.ok).map((check) => check.id),
+  guardrails: [
+    "Offline validator only: no payment, Pay.sh setup, wallet setup, wallet top-up, RPC call, provider call, catalog submission, hosted write, trust mutation, or reputation mutation occurs.",
+    "Passing validation only proves the supplied records are internally consistent for review.",
+    "Passing validation does not authorize execution; Nissan approval is still required before any paid run.",
+  ],
+};
+
+console.log(JSON.stringify(artifact, null, 2));
+process.exit(status === "approved_for_review" ? 0 : 1);

--- a/scripts/fixtures/pay-sh-devnet-approval/approval.expired.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/approval.expired.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "reddi.pay-sh.devnet-paid-run-approval.v1",
+  "status": "approved",
+  "issue": "https://github.com/nissan/reddi-agent-protocol/issues/502",
+  "approver": "Nissan",
+  "approvedAt": "2026-06-20T00:00:00.000Z",
+  "expiresAt": "2026-06-21T00:00:00.000Z",
+  "environment": "solana-devnet",
+  "network": "solana-devnet",
+  "asset": "USDC",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "22222222222222222222222222222222",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/pay-sh-smoke",
+  "caps": {
+    "singleRunUsdc": 0.06,
+    "sessionUsdc": 0.06
+  },
+  "retryPolicy": {
+    "allowed": false,
+    "maxRetries": 0
+  },
+  "exactCommand": "ECONOMIC_DEMO_LIVE_PAYMENT_CONFIRM=RUN_ECONOMIC_DEMO_LIVE_PAYMENT_RECEIPT_LANE npm run check:economic-demo:live-payment-gate",
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json",
+  "rollbackOwner": "Nissan",
+  "scope": "single-use",
+  "autoPay": false,
+  "defaultLive": false
+}

--- a/scripts/fixtures/pay-sh-devnet-approval/approval.valid.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/approval.valid.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "reddi.pay-sh.devnet-paid-run-approval.v1",
+  "status": "approved",
+  "issue": "https://github.com/nissan/reddi-agent-protocol/issues/502",
+  "approver": "Nissan",
+  "approvedAt": "2026-06-24T00:00:00.000Z",
+  "expiresAt": "2026-06-25T00:00:00.000Z",
+  "environment": "solana-devnet",
+  "network": "solana-devnet",
+  "asset": "USDC",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "22222222222222222222222222222222",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/pay-sh-smoke",
+  "caps": {
+    "singleRunUsdc": 0.06,
+    "sessionUsdc": 0.06
+  },
+  "retryPolicy": {
+    "allowed": false,
+    "maxRetries": 0
+  },
+  "exactCommand": "ECONOMIC_DEMO_LIVE_PAYMENT_CONFIRM=RUN_ECONOMIC_DEMO_LIVE_PAYMENT_RECEIPT_LANE npm run check:economic-demo:live-payment-gate",
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json",
+  "rollbackOwner": "Nissan",
+  "scope": "single-use",
+  "autoPay": false,
+  "defaultLive": false,
+  "notes": "Fixture only. Passing the validator does not authorize execution."
+}

--- a/scripts/fixtures/pay-sh-devnet-approval/receipt.payee-mismatch.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/receipt.payee-mismatch.json
@@ -1,0 +1,10 @@
+{
+  "status": "recorded",
+  "network": "solana-devnet",
+  "asset": "USDC",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "33333333333333333333333333333333",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/pay-sh-smoke",
+  "amountUsdc": 0.06,
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json"
+}

--- a/scripts/fixtures/pay-sh-devnet-approval/receipt.valid.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/receipt.valid.json
@@ -1,0 +1,10 @@
+{
+  "status": "recorded",
+  "network": "solana-devnet",
+  "asset": "USDC",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "22222222222222222222222222222222",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/pay-sh-smoke",
+  "amountUsdc": 0.06,
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json"
+}

--- a/scripts/fixtures/pay-sh-devnet-approval/request.auto-pay.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/request.auto-pay.json
@@ -1,0 +1,17 @@
+{
+  "environment": "solana-devnet",
+  "network": "solana-devnet",
+  "asset": "USDC",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "22222222222222222222222222222222",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/pay-sh-smoke",
+  "capUsdc": 0.06,
+  "retryPolicy": {
+    "allowed": false,
+    "maxRetries": 0
+  },
+  "exactCommand": "PAY_SH_AUTO_PAY=true ECONOMIC_DEMO_LIVE_PAYMENT_CONFIRM=RUN_ECONOMIC_DEMO_LIVE_PAYMENT_RECEIPT_LANE npm run check:economic-demo:live-payment-gate",
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json",
+  "autoPay": false,
+  "defaultLive": false
+}

--- a/scripts/fixtures/pay-sh-devnet-approval/request.endpoint-mismatch.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/request.endpoint-mismatch.json
@@ -1,0 +1,17 @@
+{
+  "environment": "solana-devnet",
+  "network": "solana-devnet",
+  "asset": "USDC",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "22222222222222222222222222222222",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/other-provider",
+  "capUsdc": 0.06,
+  "retryPolicy": {
+    "allowed": false,
+    "maxRetries": 0
+  },
+  "exactCommand": "ECONOMIC_DEMO_LIVE_PAYMENT_CONFIRM=RUN_ECONOMIC_DEMO_LIVE_PAYMENT_RECEIPT_LANE npm run check:economic-demo:live-payment-gate",
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json",
+  "autoPay": false,
+  "defaultLive": false
+}

--- a/scripts/fixtures/pay-sh-devnet-approval/request.over-cap.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/request.over-cap.json
@@ -1,0 +1,17 @@
+{
+  "environment": "solana-devnet",
+  "network": "solana-devnet",
+  "asset": "USDC",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "22222222222222222222222222222222",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/pay-sh-smoke",
+  "capUsdc": 0.07,
+  "retryPolicy": {
+    "allowed": false,
+    "maxRetries": 0
+  },
+  "exactCommand": "ECONOMIC_DEMO_LIVE_PAYMENT_CONFIRM=RUN_ECONOMIC_DEMO_LIVE_PAYMENT_RECEIPT_LANE npm run check:economic-demo:live-payment-gate",
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json",
+  "autoPay": false,
+  "defaultLive": false
+}

--- a/scripts/fixtures/pay-sh-devnet-approval/request.valid.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/request.valid.json
@@ -1,0 +1,17 @@
+{
+  "environment": "solana-devnet",
+  "network": "solana-devnet",
+  "asset": "USDC",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "22222222222222222222222222222222",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/pay-sh-smoke",
+  "capUsdc": 0.06,
+  "retryPolicy": {
+    "allowed": false,
+    "maxRetries": 0
+  },
+  "exactCommand": "ECONOMIC_DEMO_LIVE_PAYMENT_CONFIRM=RUN_ECONOMIC_DEMO_LIVE_PAYMENT_RECEIPT_LANE npm run check:economic-demo:live-payment-gate",
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json",
+  "autoPay": false,
+  "defaultLive": false
+}

--- a/scripts/fixtures/pay-sh-devnet-approval/verifier.asset-mismatch.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/verifier.asset-mismatch.json
@@ -1,0 +1,12 @@
+{
+  "status": "verified",
+  "network": "solana-devnet",
+  "asset": "SOL",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "22222222222222222222222222222222",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/pay-sh-smoke",
+  "capUsdc": 0.06,
+  "amountUsdc": 0.06,
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json",
+  "receiptEvidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json"
+}

--- a/scripts/fixtures/pay-sh-devnet-approval/verifier.valid.json
+++ b/scripts/fixtures/pay-sh-devnet-approval/verifier.valid.json
@@ -1,0 +1,12 @@
+{
+  "status": "verified",
+  "network": "solana-devnet",
+  "asset": "USDC",
+  "payer": "11111111111111111111111111111111",
+  "recipientPayee": "22222222222222222222222222222222",
+  "endpoint": "https://pay-sh.example.test/api/economic-demo/reddi-x402/pay-sh-smoke",
+  "capUsdc": 0.06,
+  "amountUsdc": 0.06,
+  "evidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json",
+  "receiptEvidencePath": "artifacts/economic-demo-devnet-usdc-receipt/approval-fixture/receipt-verification.json"
+}

--- a/scripts/test-pay-sh-devnet-approval-validator.mjs
+++ b/scripts/test-pay-sh-devnet-approval-validator.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureDir = join(rootDir, "scripts", "fixtures", "pay-sh-devnet-approval");
+const checker = join(rootDir, "scripts", "check-pay-sh-devnet-approval-record.mjs");
+const now = "2026-06-24T12:00:00.000Z";
+
+const validArgs = [
+  "--approval",
+  join(fixtureDir, "approval.valid.json"),
+  "--request",
+  join(fixtureDir, "request.valid.json"),
+  "--receipt",
+  join(fixtureDir, "receipt.valid.json"),
+  "--verifier",
+  join(fixtureDir, "verifier.valid.json"),
+  "--now",
+  now,
+];
+
+const cases = [
+  {
+    name: "valid approval/request/receipt/verifier passes",
+    args: validArgs,
+    expectStatus: "approved_for_review",
+    expectExit: 0,
+  },
+  {
+    name: "missing approval record fails closed",
+    args: ["--approval", join(fixtureDir, "missing.json"), "--now", now],
+    expectStatus: "blocked",
+    expectExit: 1,
+    expectBlocker: "approval_record_present",
+  },
+  {
+    name: "expired approval fails closed",
+    args: ["--approval", join(fixtureDir, "approval.expired.json"), "--now", now],
+    expectStatus: "blocked",
+    expectExit: 1,
+    expectBlocker: "not_expired",
+  },
+  {
+    name: "over-cap request fails closed",
+    args: [
+      "--approval",
+      join(fixtureDir, "approval.valid.json"),
+      "--request",
+      join(fixtureDir, "request.over-cap.json"),
+      "--now",
+      now,
+    ],
+    expectStatus: "blocked",
+    expectExit: 1,
+    expectBlocker: "request_cap_within_approval",
+  },
+  {
+    name: "endpoint drift fails closed",
+    args: [
+      "--approval",
+      join(fixtureDir, "approval.valid.json"),
+      "--request",
+      join(fixtureDir, "request.endpoint-mismatch.json"),
+      "--now",
+      now,
+    ],
+    expectStatus: "blocked",
+    expectExit: 1,
+    expectBlocker: "request_endpoint_matches_approval",
+  },
+  {
+    name: "auto-pay ambiguity fails closed",
+    args: [
+      "--approval",
+      join(fixtureDir, "approval.valid.json"),
+      "--request",
+      join(fixtureDir, "request.auto-pay.json"),
+      "--now",
+      now,
+    ],
+    expectStatus: "blocked",
+    expectExit: 1,
+    expectBlocker: "request_no_auto_pay_or_default_live_ambiguity",
+  },
+  {
+    name: "receipt payee mismatch fails closed",
+    args: [
+      "--approval",
+      join(fixtureDir, "approval.valid.json"),
+      "--receipt",
+      join(fixtureDir, "receipt.payee-mismatch.json"),
+      "--now",
+      now,
+    ],
+    expectStatus: "blocked",
+    expectExit: 1,
+    expectBlocker: "receipt_recipientPayee_matches_approval",
+  },
+  {
+    name: "verifier asset mismatch fails closed",
+    args: [
+      "--approval",
+      join(fixtureDir, "approval.valid.json"),
+      "--verifier",
+      join(fixtureDir, "verifier.asset-mismatch.json"),
+      "--now",
+      now,
+    ],
+    expectStatus: "blocked",
+    expectExit: 1,
+    expectBlocker: "verifier_asset_matches_approval",
+  },
+];
+
+const failures = [];
+
+for (const testCase of cases) {
+  const result = spawnSync(process.execPath, [checker, ...testCase.args], {
+    cwd: rootDir,
+    encoding: "utf8",
+  });
+
+  let artifact = null;
+  try {
+    artifact = JSON.parse(result.stdout);
+  } catch (error) {
+    failures.push(`${testCase.name}: output did not parse as JSON: ${error.message}`);
+    continue;
+  }
+
+  if (result.status !== testCase.expectExit) {
+    failures.push(`${testCase.name}: expected exit ${testCase.expectExit}, got ${result.status}`);
+  }
+  if (artifact.status !== testCase.expectStatus) {
+    failures.push(`${testCase.name}: expected status ${testCase.expectStatus}, got ${artifact.status}`);
+  }
+  if (testCase.expectBlocker && !artifact.blockers.includes(testCase.expectBlocker)) {
+    failures.push(`${testCase.name}: missing expected blocker ${testCase.expectBlocker}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("[pay-sh-devnet-approval-validator-test] FAIL");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(`[pay-sh-devnet-approval-validator-test] OK: ${cases.length} cases`);


### PR DESCRIPTION
## Summary
- add an offline Pay.sh/devnet paid-run approval-record validator and fixture test harness
- document approval JSON requirements and non-authorization language in the live activation policy
- add Bucket J BDD/index coverage for fail-closed approval validation

Closes #502.

## Validation
- npm run test:pay-sh:devnet-approval
- npm run test:bdd:index
- npm run check:rap:naming
- git diff --check origin/main...HEAD

## Safety
Docs/checker/fixture work only. This does not execute Pay.sh setup, wallet setup/top-up, RPC/Solana calls, provider calls, paid requests, hosted registry writes, catalog submissions, trust/reputation mutation, mainnet, production Pay.sh activation, or default auto-pay.