### PR TITLE
Add OKF OpenKB static fixture corpus

### DIFF
--- a/data/okf-openkb-fixtures/okf-openkb-fixture-corpus.v1.json
+++ b/data/okf-openkb-fixtures/okf-openkb-fixture-corpus.v1.json
@@ -1,0 +1,185 @@
+{
+  "schemaVersion": "reddi.okf-openkb-fixture-corpus.v1",
+  "staticOnly": true,
+  "generatedAt": "2026-06-24T08:30:00.000Z",
+  "purpose": "Static fixture corpus for reviewing Google OKF-shaped and OpenKB-style knowledge bundles without installing, ingesting, executing, or trusting generated instructions.",
+  "formatBoundaries": {
+    "okf": "Treated as a static interchange format for markdown/frontmatter review.",
+    "openkb": "Treated as a possible producer/toolchain whose generated output remains untrusted until separate review.",
+    "runtimePolicy": "No imported bundle may install skills, run scripts, invoke tools, fetch URLs, call providers, write hosted registries, publish marketplace listings, onboard agents, activate payments, or mutate trust/reputation state."
+  },
+  "guardrails": {
+    "noOpenKbInstall": true,
+    "noUrlIngest": true,
+    "noLlmProviderCall": true,
+    "noGeneratedSkillInstall": true,
+    "noScriptExecution": true,
+    "noHostedWrite": true,
+    "noMarketplacePublication": true,
+    "noAgentOnboarding": true,
+    "noCredentialRead": true,
+    "noWalletRpc": true,
+    "noPaidCall": true,
+    "noTrustMutation": true,
+    "noReputationMutation": true
+  },
+  "fixtures": [
+    {
+      "id": "okf-minimal-concept-bundle",
+      "kind": "okf_interchange_fixture",
+      "source": {
+        "format": "google-okf",
+        "sourceUrl": "https://github.com/google/open-productivity-agent/tree/main/knowledge-format",
+        "checkedRef": "research/openkb-google-okf-comparison-2026-06-20.md",
+        "retrievedAt": "2026-06-20T00:00:00.000Z",
+        "provenanceNotes": [
+          "Fixture is curated from prior static research notes, not fetched at validation time.",
+          "OKF is represented as markdown/frontmatter interchange input only."
+        ]
+      },
+      "files": [
+        {
+          "path": "index.md",
+          "type": "index",
+          "contentClass": "static_markdown",
+          "trustBoundary": "untrusted_imported_context",
+          "contentPreview": "---\ntitle: Minimal RAP knowledge bundle\ntype: index\n---\n\n# Minimal RAP knowledge bundle\n\n- [[concepts/agent-marketplace]]\n- [[log]]"
+        },
+        {
+          "path": "concepts/agent-marketplace.md",
+          "type": "concept",
+          "contentClass": "static_markdown",
+          "trustBoundary": "untrusted_imported_context",
+          "contentPreview": "---\ntitle: Agent marketplace\ntype: concept\nsourceRefs:\n  - index.md\n---\n\nA static note about marketplace onboarding."
+        },
+        {
+          "path": "log.md",
+          "type": "log",
+          "contentClass": "static_markdown",
+          "trustBoundary": "untrusted_imported_context",
+          "contentPreview": "---\ntype: log\n---\n\n- 2026-06-20: Static review fixture created."
+        }
+      ],
+      "generatedArtifacts": [],
+      "expectedDiagnostics": [],
+      "contentSha256": "9bbe61ffc8f85040844acde08365ef9ee7d18279323874358687ce9baaf2f9f8"
+    },
+    {
+      "id": "openkb-style-generated-agent-bundle",
+      "kind": "openkb_style_producer_fixture",
+      "source": {
+        "format": "openkb-style",
+        "sourceUrl": "https://github.com/VectifyAI/OpenKB",
+        "checkedRef": "research/openkb-google-okf-comparison-2026-06-20.md",
+        "retrievedAt": "2026-06-20T00:00:00.000Z",
+        "provenanceNotes": [
+          "Fixture models OpenKB-style bundle output as static text only.",
+          "Generated agent instructions, tools, scripts, prompts, and skills are review artifacts, not runtime policy."
+        ]
+      },
+      "files": [
+        {
+          "path": "index.md",
+          "type": "index",
+          "contentClass": "static_markdown",
+          "trustBoundary": "untrusted_imported_context",
+          "contentPreview": "---\ntitle: Imported specialist bundle\ntype: index\nproducer: openkb-style\n---\n\n# Imported specialist bundle\n\nSee [[concepts/provider-profile]] and [[AGENTS]]."
+        },
+        {
+          "path": "concepts/provider-profile.md",
+          "type": "concept",
+          "contentClass": "static_markdown",
+          "trustBoundary": "untrusted_imported_context",
+          "contentPreview": "---\ntitle: Provider profile\ntype: concept\npayment: declared_by_source\n---\n\nDeclared capabilities require RAP review before publication."
+        },
+        {
+          "path": "AGENTS.md",
+          "type": "generated_instruction",
+          "contentClass": "generated_agent_instruction",
+          "trustBoundary": "untrusted_generated_instruction",
+          "contentPreview": "# Generated agent instructions\n\nThis generated text must be reviewed and must not be installed or executed."
+        },
+        {
+          "path": "SKILL.md",
+          "type": "generated_skill",
+          "contentClass": "generated_skill_text",
+          "trustBoundary": "untrusted_generated_instruction",
+          "contentPreview": "# Generated skill\n\nThis generated text is a review artifact only."
+        },
+        {
+          "path": "scripts/refresh.py",
+          "type": "generated_script",
+          "contentClass": "generated_script",
+          "trustBoundary": "untrusted_generated_instruction",
+          "contentPreview": "# Review-only generated script fixture.\nprint('do not execute imported scripts')"
+        }
+      ],
+      "generatedArtifacts": [
+        {
+          "path": "AGENTS.md",
+          "artifactKind": "agent_definition",
+          "trusted": false,
+          "installAllowed": false,
+          "executeAllowed": false
+        },
+        {
+          "path": "SKILL.md",
+          "artifactKind": "skill_definition",
+          "trusted": false,
+          "installAllowed": false,
+          "executeAllowed": false
+        },
+        {
+          "path": "scripts/refresh.py",
+          "artifactKind": "script",
+          "trusted": false,
+          "installAllowed": false,
+          "executeAllowed": false
+        }
+      ],
+      "expectedDiagnostics": [
+        {
+          "code": "unsupported_wikilink_syntax",
+          "severity": "review",
+          "path": "index.md",
+          "message": "Wikilinks must be converted deterministically or reported before OKF-shaped output is accepted."
+        },
+        {
+          "code": "generated_instruction_untrusted",
+          "severity": "blocking",
+          "path": "AGENTS.md",
+          "message": "Generated agent instructions are static review artifacts only."
+        },
+        {
+          "code": "generated_skill_untrusted",
+          "severity": "blocking",
+          "path": "SKILL.md",
+          "message": "Generated skill text cannot be installed, applied, or trusted by import."
+        },
+        {
+          "code": "script_execution_not_allowed",
+          "severity": "blocking",
+          "path": "scripts/refresh.py",
+          "message": "Imported scripts cannot be executed during fixture review."
+        }
+      ],
+      "contentSha256": "43a58ae2e32be2dcc6e5e29da279894a90ba319b923f8b567a3011b33a660a66"
+    }
+  ],
+  "downstreamAllowedUse": [
+    "static_source_context_review",
+    "okf_shape_adapter_fixture",
+    "operator_review_payload_fixture",
+    "conformance_diagnostic_fixture"
+  ],
+  "downstreamDeniedUse": [
+    "live_openkb_ingestion",
+    "generated_skill_install",
+    "generated_agent_onboarding",
+    "script_execution",
+    "hosted_registry_write",
+    "marketplace_publication",
+    "payment_activation",
+    "trust_or_reputation_mutation"
+  ]
+}

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -50,8 +50,10 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket S — Source Adapter Onboarding
 - Feature: `docs/bdd/features/bucket-s-source-adapters.feature`
 - Static agent-stack conformance reference: `docs/conformance/static-agent-stack/README.md`
+- OKF/OpenKB static fixture reference: `docs/conformance/okf-openkb/README.md`
 - Verify:
   - `npm run check:rap:naming`
+  - `npm run check:okf-openkb:fixtures`
   - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts lib/__tests__/source-adapter-circle-x402-profile.test.ts lib/__tests__/circle-x402-catalog-route.test.ts lib/__tests__/circle-x402-quote-preview-route.test.ts lib/__tests__/source-adapter-pay-sh-profile.test.ts lib/__tests__/pay-sh-catalog-route.test.ts lib/__tests__/pay-sh-quote-preview-route.test.ts lib/__tests__/pay-sh-mcp-inspection.test.ts lib/__tests__/pay-sh-policy-plan.test.ts lib/__tests__/pay-sh-policy-plan-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
   - `npm run test:source:conformance`
   - `./scripts/run-source-conformance.sh --source hermes --mode smoke`

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -147,3 +147,11 @@ Feature: Bucket S Source Adapter Onboarding
     And the draft recipe and profile distinguish declared Solana capability from reviewed RAP readiness
     And payment readiness remains disabled pending operator review
     And no wallet RPC SPL transfer live payment AUDD custody Quasar custody or marketplace publication is implied
+
+  @S5.15 @conformance @okf-openkb @static-fixture
+  Scenario: OKF and OpenKB-style knowledge bundles remain static review fixtures
+    When an OKF-shaped or OpenKB-style knowledge bundle fixture is added for RAP review
+    Then source provenance and imported-context trust boundaries are recorded
+    And generated AGENTS SKILL prompt tool script and agent definition artifacts are marked untrusted
+    And fixture validation rejects generated install execution hosted publication payment trust mutation and reputation mutation paths
+    And no OpenKB install URL ingestion provider call MCP call wallet RPC paid call marketplace publication or agent onboarding occurs

--- a/docs/conformance/okf-openkb/README.md
+++ b/docs/conformance/okf-openkb/README.md
@@ -1,0 +1,38 @@
+# OKF/OpenKB Static Fixture Corpus
+
+Issue: [#503](https://github.com/nissan/reddi-agent-protocol/issues/503)
+
+This corpus gives RAP a static, no-network fixture lane for reviewing Google OKF-shaped and OpenKB-style knowledge bundles. It is an evidence input for future diagnostics and adapter work, not a runtime ingestion path.
+
+The fixture corpus is stored at `data/okf-openkb-fixtures/okf-openkb-fixture-corpus.v1.json` and is checked by `npm run check:okf-openkb:fixtures`.
+Each fixture carries a `contentSha256` digest over its static file path, role, content class, trust boundary, and preview text. The checker recomputes those digests so fixture review inputs cannot drift silently.
+
+## Boundaries
+
+OKF is treated as a markdown/frontmatter interchange shape. OpenKB is treated as a possible producer of bundle-shaped output. Neither one is trusted as runtime policy by import.
+
+The corpus must not:
+
+- Install OpenKB or any generated skill.
+- Fetch arbitrary URLs or ingest live repositories.
+- Invoke LLM/provider APIs, MCP tools, wallets, RPC providers, or paid endpoints.
+- Execute imported scripts, hooks, prompts, tools, or agent definitions.
+- Write hosted registries, publish marketplace listings, onboard agents, activate payments, or mutate trust/reputation state.
+
+Generated `AGENTS.md`, `SKILL.md`, prompts, scripts, tools, and agent definitions are review artifacts only. They may be preserved as static text so reviewers and future checkers can report diagnostics, but they cannot become trusted instructions by import.
+
+## Fixtures
+
+### `okf-minimal-concept-bundle`
+
+Models a small OKF-shaped markdown/frontmatter bundle with `index.md`, a concept note, and `log.md`. It proves RAP can carry source provenance, file roles, and untrusted imported-context boundaries without relying on live fetches.
+
+### `openkb-style-generated-agent-bundle`
+
+Models an OpenKB-style producer output that includes wikilinks plus generated agent instructions, generated skill text, and a generated script. It intentionally expects blocking diagnostics for generated instructions and execution-not-allowed artifacts.
+
+## Downstream Use
+
+Allowed downstream use is limited to static review, deterministic OKF-shaped adapter fixtures, operator review payload fixtures, and conformance diagnostics.
+
+This corpus does not claim OKF/OpenKB support in RAP v0.1. That decision remains a product decision after the #503/#504/#505 evidence and adapter spike work are reviewed.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:surfpool:jupiter-invoke": "./scripts/run-surfpool-jupiter-invoke-smoke.sh",
     "test:source:conformance": "./scripts/run-source-conformance.sh --source openclaw --mode smoke",
     "test:source:matrix": "./scripts/run-source-conformance-matrix.sh",
+    "check:okf-openkb:fixtures": "node ./scripts/check-okf-openkb-fixture-corpus.mjs",
     "test:tunnel:rca": "node ./scripts/run-cloudflare-rca-matrix.mjs",
     "test:tunnel:rca:evaluate": "node ./scripts/evaluate-cloudflare-rca.mjs",
     "dev:rca:x402-fixture": "node ./scripts/run-rca-x402-fixture.mjs",

--- a/scripts/check-okf-openkb-fixture-corpus.mjs
+++ b/scripts/check-okf-openkb-fixture-corpus.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const corpusPath = path.join(root, 'data/okf-openkb-fixtures/okf-openkb-fixture-corpus.v1.json');
+const forbiddenPattern = /(api[_-]?key|private[_-]?key)\s*[:=]\s*['"]?[A-Za-z0-9_./+=-]{12,}|seed phrase\s*[:=]|bearer\s+[A-Za-z0-9_./+=-]{16,}|BEGIN PRIVATE KEY|xox[baprs]-[A-Za-z0-9-]{10,}|sk-[A-Za-z0-9_-]{20,}/i;
+
+function fail(message) {
+  console.error(`OKF/OpenKB fixture corpus check failed: ${message}`);
+  process.exit(1);
+}
+
+function requireBoolean(value, expected, pathLabel) {
+  if (value !== expected) {
+    fail(`${pathLabel} must be ${expected}`);
+  }
+}
+
+function requireNonEmptyString(value, pathLabel) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    fail(`${pathLabel} must be a non-empty string`);
+  }
+}
+
+function scanText(value, pathLabel) {
+  if (typeof value === 'string' && forbiddenPattern.test(value)) {
+    fail(`${pathLabel} contains credential-shaped content`);
+  }
+}
+
+function fixtureContentHash(files) {
+  const hashInput = JSON.stringify(files.map((file) => ({
+    path: file.path,
+    type: file.type,
+    contentClass: file.contentClass,
+    trustBoundary: file.trustBoundary,
+    contentPreview: file.contentPreview,
+  })), null, 2);
+
+  return createHash('sha256').update(hashInput).digest('hex');
+}
+
+const raw = await readFile(corpusPath, 'utf8');
+scanText(raw, corpusPath);
+
+let corpus;
+try {
+  corpus = JSON.parse(raw);
+} catch (error) {
+  fail(`invalid JSON: ${error.message}`);
+}
+
+if (corpus.schemaVersion !== 'reddi.okf-openkb-fixture-corpus.v1') {
+  fail('schemaVersion must be reddi.okf-openkb-fixture-corpus.v1');
+}
+
+requireBoolean(corpus.staticOnly, true, '$.staticOnly');
+
+const guardrails = corpus.guardrails ?? {};
+for (const key of [
+  'noOpenKbInstall',
+  'noUrlIngest',
+  'noLlmProviderCall',
+  'noGeneratedSkillInstall',
+  'noScriptExecution',
+  'noHostedWrite',
+  'noMarketplacePublication',
+  'noAgentOnboarding',
+  'noCredentialRead',
+  'noWalletRpc',
+  'noPaidCall',
+  'noTrustMutation',
+  'noReputationMutation',
+]) {
+  requireBoolean(guardrails[key], true, `$.guardrails.${key}`);
+}
+
+if (!Array.isArray(corpus.fixtures) || corpus.fixtures.length < 2) {
+  fail('$.fixtures must include at least two fixture classes');
+}
+
+const requiredKinds = new Set(['okf_interchange_fixture', 'openkb_style_producer_fixture']);
+for (const fixture of corpus.fixtures) {
+  requireNonEmptyString(fixture.id, '$.fixtures[].id');
+  requiredKinds.delete(fixture.kind);
+  requireNonEmptyString(fixture.source?.sourceUrl, `$.fixtures[${fixture.id}].source.sourceUrl`);
+  requireNonEmptyString(fixture.source?.checkedRef, `$.fixtures[${fixture.id}].source.checkedRef`);
+  requireNonEmptyString(fixture.source?.retrievedAt, `$.fixtures[${fixture.id}].source.retrievedAt`);
+
+  if (!Array.isArray(fixture.files) || fixture.files.length === 0) {
+    fail(`$.fixtures[${fixture.id}].files must be non-empty`);
+  }
+  requireNonEmptyString(fixture.contentSha256, `$.fixtures[${fixture.id}].contentSha256`);
+
+  for (const file of fixture.files) {
+    requireNonEmptyString(file.path, `$.fixtures[${fixture.id}].files[].path`);
+    requireNonEmptyString(file.type, `$.fixtures[${fixture.id}].files[${file.path}].type`);
+    requireNonEmptyString(file.trustBoundary, `$.fixtures[${fixture.id}].files[${file.path}].trustBoundary`);
+    scanText(file.contentPreview, `$.fixtures[${fixture.id}].files[${file.path}].contentPreview`);
+
+    if (file.type.startsWith('generated_') && file.trustBoundary !== 'untrusted_generated_instruction') {
+      fail(`generated file ${file.path} must use untrusted_generated_instruction boundary`);
+    }
+  }
+
+  const expectedHash = fixtureContentHash(fixture.files);
+  if (fixture.contentSha256 !== expectedHash) {
+    fail(`$.fixtures[${fixture.id}].contentSha256 must equal ${expectedHash}`);
+  }
+
+  for (const artifact of fixture.generatedArtifacts ?? []) {
+    requireBoolean(artifact.trusted, false, `$.fixtures[${fixture.id}].generatedArtifacts[${artifact.path}].trusted`);
+    requireBoolean(artifact.installAllowed, false, `$.fixtures[${fixture.id}].generatedArtifacts[${artifact.path}].installAllowed`);
+    requireBoolean(artifact.executeAllowed, false, `$.fixtures[${fixture.id}].generatedArtifacts[${artifact.path}].executeAllowed`);
+  }
+}
+
+if (requiredKinds.size > 0) {
+  fail(`missing fixture kinds: ${Array.from(requiredKinds).join(', ')}`);
+}
+
+for (const deniedUse of [
+  'live_openkb_ingestion',
+  'generated_skill_install',
+  'generated_agent_onboarding',
+  'script_execution',
+  'hosted_registry_write',
+  'marketplace_publication',
+  'payment_activation',
+  'trust_or_reputation_mutation',
+]) {
+  if (!corpus.downstreamDeniedUse?.includes(deniedUse)) {
+    fail(`$.downstreamDeniedUse must include ${deniedUse}`);
+  }
+}
+
+console.log(`OKF/OpenKB fixture corpus check passed: ${corpus.fixtures.length} fixtures`);


### PR DESCRIPTION
## Summary
- add a static OKF/OpenKB fixture corpus with provenance and trust-boundary metadata
- add an offline corpus checker and package script
- document the no-network/no-execution fixture lane and add Bucket S BDD/index coverage

Closes #503.

## Validation
- npm run check:okf-openkb:fixtures
- npm run test:bdd:index
- npm run check:rap:naming
- git diff --check origin/main...HEAD

## Safety
Static fixtures/checker/docs only. This does not install OpenKB, fetch arbitrary URLs, invoke LLM/provider APIs, call MCP tools, execute imported scripts, install generated skills, onboard generated agents, call wallets/RPC, activate payments, write hosted registries, publish marketplace listings, or mutate trust/reputation state.