### PR TITLE
Add Quasar package boundary guard

### DIFF
--- a/docs/QUASAR-SURFPOOL-DEVNET-PROMOTION-CHECKLIST.md
+++ b/docs/QUASAR-SURFPOOL-DEVNET-PROMOTION-CHECKLIST.md
@@ -6,6 +6,8 @@ This checklist is the approval boundary for any future Solana or Quasar instruct
 
 Package/read-model work does not need this gate. Examples include Quasar registry compatibility reports, hosted discovery/search read models, receipt/evidence bindings, off-chain reputation previews, documentation, and UI fixtures that do not build instructions, sign, submit, probe RPC, or mutate program state.
 
+Run `npm run check:quasar:boundary-guard` for package/read-model lanes that claim this metadata-only exemption. The guard runs without wallet, RPC, Surfpool, devnet, or deploy access; it scans configured package read-model paths by default and can also scan touched package/read-model files with `node scripts/check-quasar-boundary-guard.mjs --changed`, `--staged`, or explicit file paths.
+
 ## Promotion States
 
 | State | Allowed work | Required evidence | Wallet/RPC/deploy |
@@ -34,6 +36,22 @@ This checklist is not required for PRs that only:
 - update package docs/types without instruction builders
 - render disabled UI states or fixture-backed screenshots
 - update issue planning, runbooks, or non-live guardrails
+
+Package/read-model-only PRs lose this exemption when the boundary guard finds any forbidden Solana or Quasar mutation surface outside a declared program-boundary handoff. A deliberate handoff must move under a program-boundary path or include the marker `@quasar-program-boundary`, then use this promotion checklist before Surfpool/devnet evidence is requested.
+
+## Package/Read-Model Boundary Guard
+
+The lightweight guard for metadata-only lanes forbids:
+
+- instruction builders and transaction assembly
+- transaction signing, submission, wallet loading, or keypair loading
+- Solana RPC/client construction and account probes
+- Surfpool, devnet, and MagicBlock TEE network calls
+- program deploy, upgrade, and migration commands
+- PDA derivation, account-layout mutation, raw account serialization, and account metas
+- Quasar registry, escrow, reputation, attestation, PER, or vault state mutation
+
+If any of those surfaces are needed, the work is no longer package/read-model-only. Treat it as a program-boundary change, declare the scope explicitly, and follow this checklist before any local Surfpool or approved devnet activity.
 
 ## Program Inventory
 

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -90,6 +90,8 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 - Feature: `docs/bdd/features/bucket-m-magicblock-per.feature`
 - Verify:
   - `npm run test:bdd:index`
+  - `npm run test:quasar:boundary-guard`
+  - `npm run check:quasar:boundary-guard`
   - `npx jest lib/__tests__/quasar-demo-program-config.test.ts lib/__tests__/quasar-demo-agent-guard.test.ts lib/__tests__/quasar-agent-account-decoder.test.ts lib/__tests__/quasar-instructions.test.ts --runInBand`
   - `cargo test --manifest-path experiments/quasar-escrow-per/Cargo.toml`
   - `npm run test:surfpool:quasar-critical`

--- a/docs/bdd/features/bucket-m-magicblock-per.feature
+++ b/docs/bdd/features/bucket-m-magicblock-per.feature
@@ -29,3 +29,8 @@ Feature: Bucket M - Quasar-native MagicBlock PER escrow
     Then the phase records expected versus observed behavior
     And validation evidence is captured before moving on
     And the next phase plan is refined from the retrospective
+
+  Scenario: Package read models stay outside the Quasar program boundary
+    Given a package or read-model lane claims metadata-only Quasar scope
+    Then the Quasar boundary guard forbids instruction builders, wallet signing, RPC probes, Surfpool/devnet calls, deploy commands, PDA/account-layout mutations, and Quasar state mutation
+    And a forbidden surface requires an explicit program-boundary handoff before using the Surfpool/devnet promotion checklist

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "check:quasar:deployments": "node ./scripts/check-quasar-deployment-inventory.mjs",
     "check:quasar:demo-readiness": "node ./scripts/check-quasar-demo-readiness.mjs",
     "check:quasar:runtime-compatibility": "node ./scripts/check-quasar-runtime-compatibility.mjs",
+    "check:quasar:boundary-guard": "node ./scripts/check-quasar-boundary-guard.mjs",
+    "test:quasar:boundary-guard": "node --test ./scripts/__tests__/check-quasar-boundary-guard.test.mjs",
     "check:quasar:submission": "npm run check:quasar:runtime-compatibility && npm run check:quasar:deployments && npm run check:quasar:demo-readiness && npm run check:quasar:critical-success",
     "check:quasar:critical-success": "node ./scripts/check-quasar-critical-success.mjs",
     "check:quasar:per-abi": "node ./scripts/check-quasar-per-abi.mjs",

--- a/scripts/__tests__/check-quasar-boundary-guard.test.mjs
+++ b/scripts/__tests__/check-quasar-boundary-guard.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { checkFiles } from "../check-quasar-boundary-guard.mjs";
+
+const fixture = (name) => `scripts/fixtures/quasar-boundary-guard/${name}`;
+
+test("allows read-model files that keep Quasar state off-chain", () => {
+  const result = checkFiles([fixture("allowed-read-model.ts")]);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.failures.length, 0);
+});
+
+test("rejects instruction builder imports in package/read-model lanes", () => {
+  const result = checkFiles([fixture("forbidden-instruction-builder.ts")]);
+
+  assert.equal(result.ok, false);
+  assert.match(result.failures.map((finding) => finding.surface).join(","), /instruction-builder/);
+});
+
+test("rejects wallet loading and RPC probes", () => {
+  const result = checkFiles([fixture("forbidden-wallet-rpc.ts")]);
+
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((finding) => finding.surface === "transaction-signing"));
+  assert.ok(result.failures.some((finding) => finding.surface === "rpc-client-probe"));
+});
+
+test("rejects deploy and migration command references", () => {
+  const result = checkFiles([fixture("forbidden-deploy-migration.ts")]);
+
+  assert.equal(result.ok, false);
+  assert.ok(result.failures.some((finding) => finding.surface === "program-deploy-migration"));
+});
+
+test("records explicit program-boundary handoffs without failing package/read-model guard", () => {
+  const result = checkFiles([fixture("program-boundary-handoff.ts")]);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.failures.length, 0);
+  assert.ok(result.handoffs.some((finding) => finding.surface === "instruction-builder"));
+});

--- a/scripts/check-quasar-boundary-guard.mjs
+++ b/scripts/check-quasar-boundary-guard.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = process.cwd();
+const CHECK_NAME = "quasar-boundary-guard";
+const PROGRAM_BOUNDARY_MARKER = "@quasar-program-boundary";
+
+const DEFAULT_PROTECTED_PATHS = [
+  "packages/agent-protocol/src",
+];
+
+const PROGRAM_BOUNDARY_PATHS = [
+  "experiments/",
+  "lib/program.ts",
+  "lib/register/",
+  "packages/demo-agents/",
+  "packages/per-client/",
+  "scripts/check-devnet-agent-pdas.ts",
+  "scripts/run-quasar-",
+  "scripts/run-surfpool-",
+];
+
+const SCANNABLE_EXTENSIONS = new Set([
+  ".cjs",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".mts",
+  ".sh",
+  ".ts",
+  ".tsx",
+]);
+
+const FORBIDDEN_SURFACES = [
+  {
+    id: "instruction-builder",
+    description: "Solana/Quasar instruction builders or transaction assembly",
+    patterns: [
+      /\bTransactionInstruction\b/,
+      /\b(AccountMeta|SystemProgram|ComputeBudgetProgram)\b/,
+      /\b(create|build|make)[A-Za-z0-9_]*(Instruction|Transaction)\b/,
+      /\b(add|compile|serialize)\s*\([^)]*\b(Transaction|Instruction)\b/,
+      /from\s+["'](?:@solana\/web3\.js|@solana\/spl-token|@coral-xyz\/anchor)["']/,
+    ],
+  },
+  {
+    id: "transaction-signing",
+    description: "transaction signing, sending, or wallet/keypair loading",
+    patterns: [
+      /\bKeypair\.(fromSecretKey|generate)\b/,
+      /\b(load|read|parse)[A-Za-z0-9_]*(Keypair|Wallet|Secret)\b/,
+      /\b(sign|partialSign|signTransaction|signAllTransactions)\b/,
+      /\b(sendAndConfirmTransaction|sendRawTransaction|sendTransaction)\b/,
+    ],
+  },
+  {
+    id: "rpc-client-probe",
+    description: "Solana RPC/client construction or account probes",
+    patterns: [
+      /\bnew\s+Connection\s*\(/,
+      /\b(connection|client)\.(getAccountInfo|getBalance|getLatestBlockhash|getProgramAccounts|getSignatureStatuses|getTransaction|requestAirdrop|simulateTransaction)\s*\(/,
+      /\b(clusterApiUrl|RpcClient|rpcUrl|rpcEndpoint)\b/,
+      /from\s+["'](?:@solana\/web3\.js|@magicblock-labs\/ephemeral-rollups-sdk)["']/,
+    ],
+  },
+  {
+    id: "surfpool-devnet-call",
+    description: "Surfpool/devnet/MagicBlock network calls",
+    patterns: [
+      /\bsurfpool\s+(?:start|run|scenario|smoke|test)\b/i,
+      /\bdevnet-tee\.magicblock\.app\b/i,
+      /\bapi\.devnet\.solana\.com\b/i,
+      /\bsolana\s+(?:airdrop|balance|cluster-version|confirm|program|transfer)\b/,
+      /\b(smoke|run):quasar:per-devnet\b/,
+    ],
+  },
+  {
+    id: "program-deploy-migration",
+    description: "program deploy, upgrade, or migration command path",
+    patterns: [
+      /\bsolana\s+program\s+(?:deploy|write-buffer|set-upgrade-authority)\b/,
+      /\b(anchor|quasar)\s+(?:deploy|migrate|upgrade|build)\b/,
+      /\b(BPFUpgradeableLoader|upgradeAuthority|migration)\b/,
+      /\bdeploy[A-Za-z0-9_]*(Program|Quasar|Escrow|Registry|Reputation|Attestation)\b/,
+    ],
+  },
+  {
+    id: "pda-account-layout-mutation",
+    description: "PDA derivation, account-layout mutation, or raw account serialization",
+    patterns: [
+      /\b(PublicKey\.)?(findProgramAddressSync|findProgramAddress|createProgramAddressSync|createProgramAddress)\b/,
+      /\b(BufferLayout|borsh|AccountLayout|MintLayout|TOKEN_PROGRAM_ID)\b/,
+      /\b(writeBigUInt64LE|writeUInt8|writeInt32LE|Buffer\.alloc)\b/,
+      /\b(accountMetas|accountLayout)\b/,
+    ],
+  },
+  {
+    id: "quasar-state-mutation",
+    description: "Quasar registry, escrow, reputation, attestation, or PER state mutation",
+    patterns: [
+      /\b(register|update|close|settle|commit|reveal|attest|dispute|delegate|undelegate)[A-Za-z0-9_]*(Agent|Listing|Escrow|Reputation|Attestation|Vault|Per|PER|Quasar)\b/,
+      /\bquasar[A-Za-z0-9_]*\.(?:register|update|settle|commit|reveal|attest|dispute|delegate|undelegate|send|deploy)\b/,
+      /\b(reputationMutated|quasarInstructionBuilt)\s*:\s*true\b/,
+      /\b(instructionFlow|registrationIntent)\s*:\s*["'](?:built|register|update)["']/,
+    ],
+  },
+];
+
+function usage() {
+  return [
+    "Usage: node scripts/check-quasar-boundary-guard.mjs [--changed|--staged] [path ...]",
+    "",
+    "Default scans configured package/read-model protected paths.",
+    "--changed/--staged scan touched files only when they are under configured package/read-model protected paths.",
+    `Files with forbidden surfaces fail unless they live in a program-boundary path or contain ${PROGRAM_BOUNDARY_MARKER}.`,
+  ].join("\n");
+}
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function isScannableFile(filePath) {
+  return SCANNABLE_EXTENSIONS.has(path.extname(filePath)) && fs.existsSync(path.join(repoRoot, filePath));
+}
+
+function walkFiles(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  if (!fs.existsSync(absolutePath)) return [];
+  const stat = fs.statSync(absolutePath);
+  if (stat.isFile()) return [normalizePath(relativePath)].filter(isScannableFile);
+  if (!stat.isDirectory()) return [];
+
+  const entries = fs.readdirSync(absolutePath, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name === "dist-tests") return [];
+    return walkFiles(path.join(relativePath, entry.name));
+  });
+}
+
+function filesFromGit(args) {
+  const output = execFileSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+  return output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+function isProtectedSourceFile(filePath) {
+  return DEFAULT_PROTECTED_PATHS.some((scope) => filePath === scope || filePath.startsWith(`${scope}/`));
+}
+
+function resolveTargets(argv) {
+  const args = [...argv];
+  if (args.includes("--help") || args.includes("-h")) {
+    return { help: true, files: [] };
+  }
+
+  const useChanged = args.includes("--changed");
+  const useStaged = args.includes("--staged");
+  const explicitPaths = args.filter((arg) => !arg.startsWith("--"));
+  const unknownFlags = args.filter((arg) => arg.startsWith("--") && !["--changed", "--staged"].includes(arg));
+  if (unknownFlags.length) {
+    throw new Error(`unknown option(s): ${unknownFlags.join(", ")}`);
+  }
+
+  if (useChanged && useStaged) {
+    throw new Error("choose only one of --changed or --staged");
+  }
+
+  if (explicitPaths.length > 0) {
+    return {
+      mode: "explicit",
+      files: unique(explicitPaths.flatMap((target) => walkFiles(normalizePath(target)))),
+    };
+  }
+
+  if (useStaged) {
+    return {
+      mode: "staged",
+      files: unique(filesFromGit(["diff", "--name-only", "--cached"])
+        .map(normalizePath)
+        .filter((file) => isProtectedSourceFile(file) && isScannableFile(file))),
+    };
+  }
+
+  if (useChanged) {
+    let changed = [];
+    try {
+      changed = filesFromGit(["diff", "--name-only", "origin/main...HEAD"]);
+    } catch {
+      changed = filesFromGit(["diff", "--name-only", "HEAD"]);
+    }
+    const untracked = filesFromGit(["ls-files", "--others", "--exclude-standard"]);
+    return {
+      mode: "changed",
+      files: unique([...changed, ...untracked]
+        .map(normalizePath)
+        .filter((file) => isProtectedSourceFile(file) && isScannableFile(file))),
+    };
+  }
+
+  return {
+    mode: "default",
+    files: unique(DEFAULT_PROTECTED_PATHS.flatMap((target) => walkFiles(target))),
+  };
+}
+
+function isProgramBoundaryPath(filePath) {
+  return PROGRAM_BOUNDARY_PATHS.some((scope) => (
+    scope.endsWith("/") ? filePath.startsWith(scope) : filePath === scope || filePath.startsWith(scope)
+  ));
+}
+
+function scanFile(filePath) {
+  const absolutePath = path.join(repoRoot, filePath);
+  const source = fs.readFileSync(absolutePath, "utf8");
+  const programBoundary = isProgramBoundaryPath(filePath) || source.includes(PROGRAM_BOUNDARY_MARKER);
+  const lines = source.split(/\r?\n/);
+  const findings = [];
+
+  for (const surface of FORBIDDEN_SURFACES) {
+    for (const pattern of surface.patterns) {
+      for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index];
+        pattern.lastIndex = 0;
+        if (pattern.test(line)) {
+          findings.push({
+            file: filePath,
+            line: index + 1,
+            surface: surface.id,
+            description: surface.description,
+            snippet: line.trim().slice(0, 180),
+            programBoundary,
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
+export function checkFiles(files) {
+  const findings = unique(files).flatMap(scanFile);
+  const failures = findings.filter((finding) => !finding.programBoundary);
+  const handoffs = findings.filter((finding) => finding.programBoundary);
+  return {
+    ok: failures.length === 0,
+    filesScanned: unique(files).length,
+    failures,
+    handoffs,
+    forbiddenSurfaces: FORBIDDEN_SURFACES.map(({ id, description }) => ({ id, description })),
+    protectedPaths: DEFAULT_PROTECTED_PATHS,
+    programBoundaryMarker: PROGRAM_BOUNDARY_MARKER,
+  };
+}
+
+function formatFinding(finding) {
+  return [
+    `- ${finding.file}:${finding.line} [${finding.surface}] ${finding.description}`,
+    `  ${finding.snippet}`,
+  ].join("\n");
+}
+
+function unique(items) {
+  return [...new Set(items)];
+}
+
+function main() {
+  let targets;
+  try {
+    targets = resolveTargets(process.argv.slice(2));
+  } catch (error) {
+    console.error(`[${CHECK_NAME}] FAIL: ${error.message}`);
+    console.error(usage());
+    process.exit(1);
+  }
+
+  if (targets.help) {
+    console.log(usage());
+    return;
+  }
+
+  const result = checkFiles(targets.files);
+  if (!result.ok) {
+    console.error(`[${CHECK_NAME}] FAIL: forbidden Solana/Quasar mutation surfaces found in package/read-model lane`);
+    console.error(result.failures.map(formatFinding).join("\n"));
+    console.error(`Declare ${PROGRAM_BOUNDARY_MARKER} or move the change under a program-boundary path, then use the #441 promotion checklist.`);
+    process.exit(1);
+  }
+
+  console.log(`[${CHECK_NAME}] OK: scanned ${result.filesScanned} file(s); no package/read-model boundary violations`);
+  if (result.handoffs.length) {
+    console.log(`[${CHECK_NAME}] program-boundary handoffs: ${result.handoffs.length}`);
+  }
+}
+
+const executedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (executedPath === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/fixtures/quasar-boundary-guard/allowed-read-model.ts
+++ b/scripts/fixtures/quasar-boundary-guard/allowed-read-model.ts
@@ -1,0 +1,25 @@
+export type QuasarReadModelProjection = {
+  listingId: string;
+  backing: "metadata_only" | "offchain_preview";
+  guardrails: {
+    instructionBuilt: false;
+    walletSigning: false;
+    rpcCall: false;
+    programDeploy: false;
+    reputationMutated: false;
+  };
+};
+
+export function projectQuasarReadModel(listingId: string): QuasarReadModelProjection {
+  return {
+    listingId,
+    backing: "metadata_only",
+    guardrails: {
+      instructionBuilt: false,
+      walletSigning: false,
+      rpcCall: false,
+      programDeploy: false,
+      reputationMutated: false,
+    },
+  };
+}

--- a/scripts/fixtures/quasar-boundary-guard/forbidden-deploy-migration.ts
+++ b/scripts/fixtures/quasar-boundary-guard/forbidden-deploy-migration.ts
@@ -1,0 +1,4 @@
+export const releaseRunbook = {
+  command: "solana program deploy target/deploy/quasar_registry.so",
+  rollback: "anchor migrate --provider.cluster devnet",
+};

--- a/scripts/fixtures/quasar-boundary-guard/forbidden-instruction-builder.ts
+++ b/scripts/fixtures/quasar-boundary-guard/forbidden-instruction-builder.ts
@@ -1,0 +1,5 @@
+import { TransactionInstruction } from "@solana/web3.js";
+
+export function buildRegisterAgentInstruction(): TransactionInstruction {
+  throw new Error("fixture only");
+}

--- a/scripts/fixtures/quasar-boundary-guard/forbidden-wallet-rpc.ts
+++ b/scripts/fixtures/quasar-boundary-guard/forbidden-wallet-rpc.ts
@@ -1,0 +1,7 @@
+import { Connection, Keypair } from "@solana/web3.js";
+
+export async function unsafeProbe(secret: Uint8Array): Promise<number> {
+  const signer = Keypair.fromSecretKey(secret);
+  const connection = new Connection("https://api.devnet.solana.com");
+  return connection.getBalance(signer.publicKey);
+}

--- a/scripts/fixtures/quasar-boundary-guard/program-boundary-handoff.ts
+++ b/scripts/fixtures/quasar-boundary-guard/program-boundary-handoff.ts
@@ -1,0 +1,7 @@
+// @quasar-program-boundary
+// This fixture represents a deliberate handoff to the #441 promotion checklist.
+import { TransactionInstruction } from "@solana/web3.js";
+
+export function buildQuasarEscrowInstruction(): TransactionInstruction {
+  throw new Error("program boundary fixture only");
+}


### PR DESCRIPTION
## Summary
- add a package/read-model boundary guard for Quasar/Solana mutation surfaces
- add fixture-backed node tests for allowed read models, forbidden instruction/wallet/RPC/deploy paths, and explicit program-boundary handoffs
- document the guard in the Quasar promotion checklist and map it into Bucket M BDD/index coverage

Closes #508.

## Validation
- npm run test:quasar:boundary-guard
- npm run check:quasar:boundary-guard
- node scripts/check-quasar-boundary-guard.mjs --changed
- npm run test:bdd:index
- npm run check:rap:naming
- git diff --check origin/main...HEAD

## Scope note
The guard defaults to scanning configured package/read-model protected paths: packages/agent-protocol/src. The --changed mode only scans changed files inside those protected paths, so this PR's --changed run reports 0 scanned files because the PR adds the checker/docs/BDD mapping rather than modifying protected package sources. The default package scan covered 21 files.

## Safety
This is a checker/docs/fixture change only. It does not run Surfpool/devnet, build instructions, sign or submit transactions, call wallets/RPC, mutate Quasar state, deploy programs, publish marketplace listings, or mutate trust/reputation state.