### PR TITLE
Document x402 Solana package release boundary

### DIFF
--- a/docs/X402-SOLANA-PACKAGE-SURFACE-DECISION.md
+++ b/docs/X402-SOLANA-PACKAGE-SURFACE-DECISION.md
@@ -1,0 +1,103 @@
+# `@reddi/x402-solana` Package Surface Decision
+
+Issue: [#518](https://github.com/nissan/reddi-agent-protocol/issues/518)
+
+Status: v0.1 OSS candidate, not yet a public/published package claim.
+
+The `@reddi/x402-solana` package exists at `packages/x402-solana` and remains the Solana/x402 rail primitive underneath RAP. It is not published on npm at the time of this decision, and it must not be described as generally installable or production-ready until #512 proves a clean-checkout release smoke and a later package-publication gate approves publication.
+
+## Current Inventory
+
+- Package path: `packages/x402-solana`
+- Package name: `@reddi/x402-solana`
+- Version: `0.1.0`
+- Main export: `dist/index.js`
+- Type export: `dist/index.d.ts`
+- Source exports:
+  - `types`
+  - `nonce`
+  - `payment`
+  - `middleware`
+  - `jupiter`
+  - `client`
+  - `budget-policy`
+- Tests:
+  - `tests/payment.test.ts`
+  - `tests/client.test.ts`
+  - `tests/budget-policy.test.ts`
+
+## Surface Classification
+
+### v0.1 public candidate
+
+These APIs are candidates for #512 clean-checkout OSS smoke if package tests, build, README claim boundaries, and package dry-run checks pass:
+
+- Header and challenge parsing: `parseX402Header`, `buildX402Challenge`, `challengeFromX402RequestHeader`.
+- Nonce replay protection: in-memory nonce helpers and `MemoryNonceReplayStore`.
+- Demo-only receipt verification: `DemoPaymentVerifier`, `verifyDemoPaymentReceipt`.
+- Local buyer preflight: `evaluateBudgetPolicy`, `assetNetworkKey`, budget policy types.
+- Pure validation helpers: `isValidSolanaPublicKey`, `isValidPaymentAddress`, USDC amount/cap parsing helpers.
+
+### Gated devnet candidate
+
+These APIs stay gated and must not be presented as default OSS success criteria:
+
+- `prepareDevnetUsdcPayment`
+- `executeDevnetUsdcPayment`
+- `createSolanaDevnetUsdcPaymentClient`
+- `SolanaReceiptVerifier` with `allowRealPayment: true`
+
+They require explicit approval records, endpoint allowlists, spend caps, wallet scope, receipt verification, and the #502/#515 approval-record validator before any fresh devnet or live execution issue can proceed.
+
+### Internal or demo-only until further review
+
+- Express middleware examples are docs-only until a clean no-spend seller/buyer example proves the integration path without implying payment execution.
+- Jupiter helpers remain auxiliary; they are not a default v0.1 release claim unless #512 includes a no-network validation path.
+- Dist artifacts are generated outputs and must match source before package release smoke claims success.
+
+## Relationship To RAP Surfaces
+
+`@reddi/x402-solana` is not the whole RAP product surface. It owns Solana/x402 rail primitives. Product-level policy, receipts, evidence, attestations, reputation previews, and rail-neutral proof chains are increasingly represented in `@reddi/agent-protocol`.
+
+Current relationship:
+
+- `@reddi/x402-solana`: x402/Solana parsing, local budget preflight, demo receipts, gated devnet USDC client helpers.
+- `@reddi/agent-protocol`: RAP receipts, policy/evidence/trust metadata, rail-neutral receipt candidates, proof-chain fixtures.
+- `@reddi/rap-mcp-bridge`: consumes `@reddi/x402-solana` for x402 specialist-call preparation/execution/verification flows behind devnet approval gates.
+
+## Claim Boundaries
+
+Allowed claims:
+
+- Repo-local package candidate for Solana/x402 rail primitives.
+- Mock-friendly tests and demo-only receipt verification exist.
+- Local budget preflight can run before any payment authorization.
+- Devnet USDC payment helpers exist but are gated and not default release behavior.
+
+Forbidden claims until separately proven:
+
+- Published npm package.
+- Production-ready settlement.
+- Mainnet support.
+- Custody or escrow finality.
+- Default live payment.
+- Default Pay.sh activation.
+- Hosted marketplace publication.
+- Trust or reputation mutation.
+- Wallet/RPC/provider calls during clean-checkout OSS smoke.
+
+## Release Smoke Requirements For #512
+
+If #512 includes `@reddi/x402-solana`, it should verify:
+
+- `npm --prefix packages/x402-solana test -- --runInBand`
+- `npm --prefix packages/x402-solana run build`
+- Package export/import smoke from a clean checkout.
+- README/package metadata scan for npm/publication, live payment, custody, mainnet, or settlement-finality overclaims.
+- `npm pack --dry-run` or equivalent package artifact inspection.
+
+It should not require wallet material, RPC, Pay.sh, hosted Reddi, live providers, marketplace publication, trust/reputation mutation, mainnet, or paid calls.
+
+## Decision
+
+Keep `@reddi/x402-solana` alive as a v0.1 OSS candidate, but do not publish or market it as a public package until #512 and a later package-publication gate prove the release artifact and claim boundaries.

--- a/packages/x402-solana/README.md
+++ b/packages/x402-solana/README.md
@@ -1,10 +1,12 @@
 # @reddi/x402-solana
 
-HTTP 402 Payment Middleware for Solana. Enables trustless micropayment flows between agents using the x402 standard and Solana's on-chain escrow.
+HTTP 402 payment primitives for Solana-oriented RAP workflows.
+
+This package is currently a repo-local v0.1 OSS candidate. It is not yet published on npm, and it should not be treated as production payment, custody, escrow-finality, or mainnet infrastructure.
 
 ## Overview
 
-**x402** is an HTTP status code indicating that payment is required. This package implements the middleware to handle x402 payment flows on Solana, supporting agent-to-agent micropayments without central intermediaries.
+**x402** is an HTTP status code indicating that payment is required. This package implements local parsing, policy, middleware, demo receipt, and gated devnet-helper primitives for Solana/x402 workflows.
 
 ### Core Features
 
@@ -13,11 +15,15 @@ HTTP 402 Payment Middleware for Solana. Enables trustless micropayment flows bet
 - **Local buyer budget preflight** — evaluates spend/call limits before payment authorization
 - **Modular design** — nonce store, payment logic, and middleware are separately testable
 - **Mock-friendly** — tests don't require Solana devnet access
+- **Fail-closed devnet helpers** — any real devnet payment path is explicit, capped, allowlisted, and outside default OSS smoke
 
 ## Installation
 
+The package is repo-local until the OSS release smoke and package-publication gates are complete:
+
 ```bash
-npm install @reddi/x402-solana @solana/web3.js
+npm --prefix packages/x402-solana test -- --runInBand
+npm --prefix packages/x402-solana run build
 ```
 
 ## Usage
@@ -66,8 +72,8 @@ Returns an Express middleware that:
 1. Checks for `x402-request` header
 2. Parses and validates payment details
 3. Checks nonce for replay attacks
-4. Initiates payment transfer
-5. Sets `x402-payment` response header with receipt
+4. Verifies demo or explicitly approved payment receipts according to configured policy
+5. Sets `x402-payment` response header with receipt metadata when verification succeeds
 
 **Errors:**
 - `400` — Invalid request (bad JSON, missing fields)
@@ -97,7 +103,7 @@ if (checkAndStoreNonce(nonce)) {
 
 ### `sendPayment(request: X402Request): Promise<PaymentReceipt>`
 
-Sends the payment and returns a receipt.
+Legacy demo helper for local tests. Do not use it as a production payment path.
 
 ```typescript
 const receipt = await sendPayment(request);
@@ -172,18 +178,22 @@ payment.ts (parse + validate)
     ↓
 nonce.ts (replay check)
     ↓
-sendPayment (transfer SOL)
+payment verifier or explicitly approved devnet helper
     ↓
 x402-payment (response receipt)
 ```
 
 ## Phases
 
-- **Phase 0** (✅ done): Anchor 1.0.0 escrow program on devnet
-- **Phase 1** (this): x402 middleware library (header parsing, nonce, validation)
-- **Phase 2**: Full payment flow (actual Solana transfer via Phase 0 escrow)
-- **Phase 3**: ElizaOS plugin + SendAI integration
-- **Phase 4**: MagicBlock Private Ephemeral Rollup for private settlement
+- **Phase 0**: Historical devnet/escrow research exists, but is not a current release claim
+- **Phase 1**: x402 primitives (header parsing, nonce, validation, demo receipts, local budget preflight)
+- **Phase 2**: Gated devnet USDC helpers behind explicit approval records and spend caps
+- **Phase 3**: Framework adapters only after #519 decides retention/deprecation scope
+- **Phase 4**: Future private/Quasar settlement work only behind separate program-boundary approval
+
+## Boundaries
+
+Clean-checkout OSS success must not require wallet material, RPC calls, Pay.sh activation, hosted Reddi, paid providers, marketplace publication, trust/reputation mutation, mainnet, custody, or settlement-finality claims.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add a package-surface decision for repo-local `@reddi/x402-solana`
- classify public-candidate, gated-devnet, and demo/internal surfaces before v0.1 release claims
- tighten README claims so it no longer implies npm publication, production settlement, custody, or mainnet readiness

Closes #518.

## Validation
- `npm --prefix packages/x402-solana test -- --runInBand`
- `npm --prefix packages/x402-solana run build`
- `npm run check:rap:naming`
- `git diff --check`

## Notes
- `npm install` in `packages/x402-solana` was needed in the fresh worktree to run package tests/build.
- npm audit reported existing package dependency warnings in that package: 29 total, 4 high. This PR does not change dependencies; it records the release boundary.

## Safety
Docs/package README only. No npm publish, live payment, wallet/RPC/provider call, Pay.sh activation, hosted write, marketplace publication, trust/reputation mutation, mainnet, custody, or settlement-finality path.
