### PR TITLE
Add OSS v0.1 release smoke gate

### DIFF
--- a/docs/OSS-V0.1-RELEASE-SMOKE.md
+++ b/docs/OSS-V0.1-RELEASE-SMOKE.md
@@ -1,0 +1,70 @@
+# OSS v0.1 Release Smoke
+
+Issue: [#512](https://github.com/nissan/reddi-agent-protocol/issues/512)
+
+Status: no-publish, no-live-payment smoke gate.
+
+This runbook defines the clean-checkout command for the current OSS v0.1 package candidate set. It proves local package tests, import surfaces, no-spend examples, source/trust protocol inputs, and package artifact boundaries without publishing packages or calling hosted services, wallets, RPC endpoints, providers, Pay.sh, marketplaces, trust systems, or mainnet.
+
+## Package Scope
+
+Included:
+
+- `@reddi/agent-protocol`
+- `@reddi/x402-solana`
+
+Excluded from v0.1 smoke:
+
+- `@reddi/sendai-x402`
+- `@reddi/eliza-plugin-x402`
+
+The SendAI and Eliza adapters are deferred experimental repo-local packages per [x402 Adapter Retention Decision](./X402-ADAPTER-RETENTION-DECISION-2026-06-24.md). They must not appear in public v0.1 release claims, npm publication plans, or supported integration matrices unless a later promotion issue adds package metadata, README docs, stable smoke tests, and claim-boundary review.
+
+## Clean-Checkout Command
+
+From a fresh checkout after installing dependencies:
+
+```bash
+npm run check:oss-release-smoke
+```
+
+The script runs:
+
+- `@reddi/agent-protocol` tests.
+- `@reddi/agent-protocol` ARD no-spend example.
+- `@reddi/agent-protocol` import smoke for root, receipt, policy, provider-trust, source-diagnostics, discovery-source, and proof-chain surfaces.
+- `@reddi/x402-solana` tests.
+- `@reddi/x402-solana` build.
+- `@reddi/x402-solana` import smoke for root, budget-policy, client, Jupiter, middleware, nonce, and payment surfaces.
+- Package `npm pack --dry-run --json` inspection from each package directory.
+- RAP naming guard.
+- Claim-boundary scan for stale x402 package comments and adapter-retention scope.
+
+## Artifact Rules
+
+The package dry-run fails if a candidate package includes:
+
+- `node_modules/`, `.next/`, `coverage/`, `artifacts/`, `ingests/`, `research/`, `programs/`, `third_party/`, app UI files, or config files.
+- `.env` files, wallet/keypair files, private-key shaped paths, logs, or tarballs.
+- Missing `package.json`, `README.md`, or `dist/` output.
+
+`npm pack --dry-run` must be executed with the package directory as the working directory. In this repo, `npm --prefix packages/<pkg> pack --dry-run` can accidentally inspect the root app package instead of the target package.
+
+## Success Boundary
+
+Passing this smoke means:
+
+- The current local package candidate set can build, test, import, and produce bounded dry-run package contents from a clean checkout.
+- `@reddi/agent-protocol` no-spend ARD/RAP examples work locally.
+- `@reddi/x402-solana` remains a repo-local OSS candidate with explicit x402/Solana package boundaries.
+
+Passing this smoke does not mean:
+
+- Any package was published to npm.
+- Hosted marketplace/facilitator paths are ready.
+- Pay.sh is activated.
+- A wallet, RPC endpoint, provider, marketplace, trust/reputation system, mainnet, custody flow, or settlement-finality path was exercised.
+
+## Next Gate
+
+After this smoke is stable, #521 can add a no-publish package-readiness dry-run for the wider RAP package set. Real publication still requires a separate approved issue and explicit operator approval.

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "ingest:circle-x402": "node ./scripts/ingest-circle-x402-discovery.mjs",
     "ingest:pay-sh": "node ./scripts/ingest-pay-sh-catalog.mjs",
     "inspect:pay-sh:mcp": "node ./scripts/inspect-pay-sh-mcp.mjs",
-    "check:rap:naming": "node ./scripts/check-rap-naming.mjs"
+    "check:rap:naming": "node ./scripts/check-rap-naming.mjs",
+    "check:oss-release-smoke": "node ./scripts/check-oss-release-smoke.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/packages/x402-solana/dist/index.d.ts
+++ b/packages/x402-solana/dist/index.d.ts
@@ -1,8 +1,9 @@
 /**
- * @reddi/x402-solana — HTTP 402 Payment Middleware for Solana
+ * @reddi/x402-solana - HTTP 402 primitives for Solana-oriented RAP workflows.
  *
- * Enables trustless micropayment flows between agents using x402 standard
- * and Solana's on-chain escrow (Phase 0: Anchor program)
+ * Repo-local v0.1 OSS candidate. Clean-checkout smoke must stay local and
+ * must not imply npm publication, live payment, custody, mainnet, or
+ * settlement-finality readiness.
  */
 export * from './types';
 export * from './nonce';

--- a/packages/x402-solana/dist/index.js
+++ b/packages/x402-solana/dist/index.js
@@ -1,9 +1,10 @@
 "use strict";
 /**
- * @reddi/x402-solana — HTTP 402 Payment Middleware for Solana
+ * @reddi/x402-solana - HTTP 402 primitives for Solana-oriented RAP workflows.
  *
- * Enables trustless micropayment flows between agents using x402 standard
- * and Solana's on-chain escrow (Phase 0: Anchor program)
+ * Repo-local v0.1 OSS candidate. Clean-checkout smoke must stay local and
+ * must not imply npm publication, live payment, custody, mainnet, or
+ * settlement-finality readiness.
  */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;

--- a/packages/x402-solana/package.json
+++ b/packages/x402-solana/package.json
@@ -3,10 +3,59 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./budget-policy": {
+      "types": "./dist/budget-policy.d.ts",
+      "import": "./dist/budget-policy.js",
+      "require": "./dist/budget-policy.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.js",
+      "require": "./dist/client.js"
+    },
+    "./jupiter": {
+      "types": "./dist/jupiter.d.ts",
+      "import": "./dist/jupiter.js",
+      "require": "./dist/jupiter.js"
+    },
+    "./middleware": {
+      "types": "./dist/middleware.d.ts",
+      "import": "./dist/middleware.js",
+      "require": "./dist/middleware.js"
+    },
+    "./nonce": {
+      "types": "./dist/nonce.d.ts",
+      "import": "./dist/nonce.js",
+      "require": "./dist/nonce.js"
+    },
+    "./payment": {
+      "types": "./dist/payment.d.ts",
+      "import": "./dist/payment.js",
+      "require": "./dist/payment.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "import": "./dist/types.js",
+      "require": "./dist/types.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
   "scripts": {
     "build": "node ./node_modules/typescript/lib/tsc.js",
     "test": "jest",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "release:dry-run": "npm run clean && npm run build && npm test -- --runInBand && npm pack --dry-run"
   },
   "dependencies": {
     "@solana/spl-token": "^0.4.14",

--- a/packages/x402-solana/src/index.ts
+++ b/packages/x402-solana/src/index.ts
@@ -1,8 +1,9 @@
 /**
- * @reddi/x402-solana — HTTP 402 Payment Middleware for Solana
+ * @reddi/x402-solana - HTTP 402 primitives for Solana-oriented RAP workflows.
  *
- * Enables trustless micropayment flows between agents using x402 standard
- * and Solana's on-chain escrow (Phase 0: Anchor program)
+ * Repo-local v0.1 OSS candidate. Clean-checkout smoke must stay local and
+ * must not imply npm publication, live payment, custody, mainnet, or
+ * settlement-finality readiness.
  */
 
 export * from './types';

--- a/scripts/check-oss-release-smoke.mjs
+++ b/scripts/check-oss-release-smoke.mjs
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const packageSet = [
+  {
+    name: "@reddi/agent-protocol",
+    dir: "packages/agent-protocol",
+    commands: [
+      ["npm", ["test"]],
+      ["npm", ["run", "example:ard:no-spend"]],
+    ],
+    importSmoke: [
+      "index.js",
+      "receipts.js",
+      "policy.js",
+      "provider-trust.js",
+      "source-diagnostics.js",
+      "discovery-source.js",
+      "rail-neutral-proof-chain-fixture.js",
+    ],
+  },
+  {
+    name: "@reddi/x402-solana",
+    dir: "packages/x402-solana",
+    commands: [
+      ["npm", ["test", "--", "--runInBand"]],
+      ["npm", ["run", "build"]],
+    ],
+    importSmoke: [
+      "index.js",
+      "budget-policy.js",
+      "client.js",
+      "jupiter.js",
+      "middleware.js",
+      "nonce.js",
+      "payment.js",
+    ],
+  },
+];
+
+const excludedPackages = new Set([
+  "@reddi/sendai-x402",
+  "@reddi/eliza-plugin-x402",
+]);
+
+const forbiddenPackPathPatterns = [
+  /^node_modules\//,
+  /^artifacts\//,
+  /^coverage\//,
+  /^\.next\//,
+  /^ingests\//,
+  /^research\//,
+  /^programs\//,
+  /^third_party\//,
+  /^app\//,
+  /^components\//,
+  /^config\//,
+  /^\.env($|\.)/,
+  /(^|\/)\.env($|\.)/,
+  /(^|\/)(id_rsa|id_ed25519|wallet|keypair).*\.json$/i,
+  /(^|\/).*secret.*$/i,
+  /(^|\/).*private-key.*$/i,
+  /(^|\/).*\.log$/i,
+  /(^|\/).*\.tgz$/i,
+];
+
+const staleClaimPatterns = [
+  {
+    pattern: /trustless micropayment/i,
+    reason: "stale trustless micropayment claim",
+  },
+  {
+    pattern: /on-chain escrow \(Phase 0/i,
+    reason: "stale on-chain escrow phase claim",
+  },
+];
+
+const overclaimPatterns = [
+  {
+    pattern: /published (?:on )?npm|npm[- ]published|publicly published/i,
+    reason: "npm publication claim",
+  },
+  {
+    pattern: /generally installable|npm install @reddi\/x402-solana/i,
+    reason: "general installability claim",
+  },
+  {
+    pattern: /production[- ]ready settlement|production settlement|settlement[- ]finality|settlement finality/i,
+    reason: "settlement-finality claim",
+  },
+  {
+    pattern: /mainnet support|mainnet[- ]ready|mainnet readiness/i,
+    reason: "mainnet readiness claim",
+  },
+  {
+    pattern: /custody|escrow[- ]finality|escrow finality/i,
+    reason: "custody or escrow-finality claim",
+  },
+  {
+    pattern: /default live payment|live payment|live\/devnet payment|devnet payment/i,
+    reason: "live/devnet payment claim",
+  },
+  {
+    pattern: /pay\.sh activation|pay\.sh activated|default pay\.sh/i,
+    reason: "Pay.sh activation claim",
+  },
+  {
+    pattern: /hosted marketplace publication|marketplace publication/i,
+    reason: "marketplace publication claim",
+  },
+  {
+    pattern: /trust\/reputation mutation|trust mutation|reputation mutation/i,
+    reason: "trust/reputation mutation claim",
+  },
+];
+
+const claimScanFiles = [
+  "packages/x402-solana/README.md",
+  "packages/x402-solana/src/index.ts",
+  "packages/x402-solana/dist/index.js",
+  "packages/x402-solana/dist/index.d.ts",
+  "packages/x402-solana/package.json",
+  "docs/X402-SOLANA-PACKAGE-SURFACE-DECISION.md",
+  "docs/X402-ADAPTER-RETENTION-DECISION-2026-06-24.md",
+  "docs/OSS-V0.1-RELEASE-SMOKE.md",
+];
+
+const failures = [];
+const passed = [];
+
+function run(label, command, args, options = {}) {
+  const cwd = options.cwd ?? ROOT;
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    shell: false,
+    stdio: options.capture ? "pipe" : "inherit",
+    env: {
+      ...process.env,
+      CI: process.env.CI ?? "1",
+      REDDI_RELEASE_SMOKE: "no-publish-no-live-payment",
+    },
+  });
+
+  if (result.status !== 0) {
+    failures.push(`${label} failed with exit ${result.status}`);
+  } else {
+    passed.push(label);
+  }
+
+  return result;
+}
+
+function parseJsonOutput(label, result) {
+  if (result.status !== 0) return undefined;
+  const stdout = result.stdout?.trim() ?? "";
+  const start = stdout.indexOf("[");
+  if (start < 0) {
+    failures.push(`${label} did not emit npm pack JSON`);
+    return undefined;
+  }
+  try {
+    return JSON.parse(stdout.slice(start));
+  } catch (error) {
+    failures.push(`${label} emitted invalid JSON: ${error.message}`);
+    return undefined;
+  }
+}
+
+function checkPackageManifest(pkg) {
+  const manifestPath = join(ROOT, pkg.dir, "package.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+  if (manifest.name !== pkg.name) {
+    failures.push(`${pkg.dir}/package.json name mismatch: ${manifest.name}`);
+  }
+  if (!manifest.main || !manifest.types) {
+    failures.push(`${pkg.name} must declare main and types`);
+  }
+  if (!Array.isArray(manifest.files) || !manifest.files.includes("dist") || !manifest.files.includes("README.md")) {
+    failures.push(`${pkg.name} must restrict package files to dist plus README.md`);
+  }
+  if (excludedPackages.has(manifest.name)) {
+    failures.push(`${manifest.name} is excluded from OSS v0.1 smoke`);
+  }
+}
+
+function checkPackContents(pkg) {
+  const result = run(
+    `${pkg.name} npm pack dry-run`,
+    "npm",
+    ["pack", "--dry-run", "--json"],
+    { cwd: join(ROOT, pkg.dir), capture: true },
+  );
+  const parsed = parseJsonOutput(`${pkg.name} npm pack dry-run`, result);
+  if (!parsed?.[0]?.files) return;
+
+  const files = parsed[0].files.map((file) => file.path);
+  for (const required of ["package.json", "README.md"]) {
+    if (!files.includes(required)) {
+      failures.push(`${pkg.name} package dry-run missing ${required}`);
+    }
+  }
+  if (!files.some((path) => path.startsWith("dist/"))) {
+    failures.push(`${pkg.name} package dry-run missing dist output`);
+  }
+  for (const path of files) {
+    for (const pattern of forbiddenPackPathPatterns) {
+      if (pattern.test(path)) {
+        failures.push(`${pkg.name} package dry-run includes forbidden path: ${path}`);
+      }
+    }
+  }
+}
+
+async function checkImportSmoke(pkg) {
+  const distDir = join(ROOT, pkg.dir, "dist");
+  for (const file of pkg.importSmoke) {
+    const modulePath = join(distDir, file);
+    if (!existsSync(modulePath)) {
+      failures.push(`${pkg.name} import smoke missing ${relative(ROOT, modulePath)}`);
+      continue;
+    }
+    try {
+      await import(`file://${modulePath}`);
+    } catch (error) {
+      failures.push(`${pkg.name} import smoke failed for ${file}: ${error.message}`);
+    }
+  }
+  passed.push(`${pkg.name} import smoke`);
+}
+
+function checkClaimBoundaries() {
+  for (const file of claimScanFiles) {
+    const path = join(ROOT, file);
+    if (!existsSync(path)) continue;
+    const text = readFileSync(path, "utf8");
+    for (const { pattern, reason } of staleClaimPatterns) {
+      if (pattern.test(text)) {
+        failures.push(`${file}: ${reason}`);
+      }
+    }
+    checkOverclaimBoundaries(file, text);
+  }
+
+  const retention = readFileSync(join(ROOT, "docs/X402-ADAPTER-RETENTION-DECISION-2026-06-24.md"), "utf8");
+  for (const packageName of excludedPackages) {
+    const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (!new RegExp(`${escaped}[\\s\\S]{0,240}(defer|deferred|excluded)`, "i").test(retention)) {
+      failures.push(`adapter retention doc must explicitly defer/exclude ${packageName}`);
+    }
+  }
+
+  passed.push("claim boundary scan");
+}
+
+function checkOverclaimBoundaries(file, text) {
+  const lines = text.split("\n");
+  let boundaryContext = "";
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const normalized = line.toLowerCase();
+    if (/^(#{1,6}\s*)?(forbidden claims|explicit non-claims|success boundary|boundaries|what this does not prove|passing this smoke does not mean|excluded from v0\.1 smoke)/i.test(line.trim())) {
+      boundaryContext = normalized;
+    } else if (/^#{1,6}\s+/.test(line.trim())) {
+      boundaryContext = "";
+    }
+
+    for (const { pattern, reason } of overclaimPatterns) {
+      if (!pattern.test(line)) continue;
+      if (isAllowedBoundaryLine([lines[index - 1] ?? "", line, lines[index + 1] ?? ""].join(" "), boundaryContext)) continue;
+      failures.push(`${file}:${index + 1}: ${reason}: ${line.trim()}`);
+    }
+  }
+}
+
+function isAllowedBoundaryLine(line, boundaryContext) {
+  const normalized = line.toLowerCase();
+  if (boundaryContext) return true;
+  return [
+    " not ",
+    " not yet ",
+    " no ",
+    " no-",
+    " non-",
+    "never ",
+    "must not",
+    "should not",
+    "do not",
+    "does not",
+    "without ",
+    "outside ",
+    "excluded",
+    "exclude ",
+    "deferred",
+    "forbidden",
+    "blocked",
+    "fail ",
+    "fails ",
+    "rejected",
+    "disabled",
+    "requires explicit",
+    "until ",
+    "unless ",
+    "separately proven",
+    "must stay local",
+    "must not imply",
+    "overclaim",
+    "mock",
+    "behind explicit",
+    "separate spend policy",
+    "human-approved",
+  ].some((marker) => normalized.includes(marker));
+}
+
+function checkRootPackageScript() {
+  const manifest = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+  if (manifest.scripts?.["check:oss-release-smoke"] !== "node ./scripts/check-oss-release-smoke.mjs") {
+    failures.push("root package.json missing check:oss-release-smoke script");
+  } else {
+    passed.push("root smoke script registration");
+  }
+}
+
+for (const pkg of packageSet) {
+  checkPackageManifest(pkg);
+  for (const [command, args] of pkg.commands) {
+    run(`${pkg.name}: ${command} ${args.join(" ")}`, command, args, { cwd: join(ROOT, pkg.dir) });
+  }
+  await checkImportSmoke(pkg);
+  checkPackContents(pkg);
+}
+
+run("RAP naming guard", "npm", ["run", "check:rap:naming"]);
+checkClaimBoundaries();
+checkRootPackageScript();
+
+console.log("");
+console.log("[oss-release-smoke] passed checks:");
+for (const item of passed) {
+  console.log(`- ${item}`);
+}
+
+if (failures.length > 0) {
+  console.error("");
+  console.error("[oss-release-smoke] failures:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("");
+console.log("[oss-release-smoke] OK: clean-checkout smoke stayed no-publish and no-live-payment");


### PR DESCRIPTION
## Summary
- adds `npm run check:oss-release-smoke` as the clean-checkout no-publish/no-live-payment gate for #512
- documents the OSS v0.1 smoke runbook and package scope in `docs/OSS-V0.1-RELEASE-SMOKE.md`
- tightens `@reddi/x402-solana` package metadata with export subpaths, bounded `files`, `sideEffects: false`, and a package-local `release:dry-run`
- removes stale trustless/on-chain-escrow wording from the x402 package entrypoint and regenerated dist comments

## Scope
Included in the smoke:
- `@reddi/agent-protocol`
- `@reddi/x402-solana`

Explicitly excluded per #519:
- `@reddi/sendai-x402`
- `@reddi/eliza-plugin-x402`

## Validation
- `npm install --ignore-scripts` in `packages/x402-solana`
- `npm install --ignore-scripts` in `packages/agent-protocol`
- `npm run check:oss-release-smoke`
  - `@reddi/agent-protocol` tests: 163/163 pass
  - `@reddi/agent-protocol` ARD no-spend example: pass
  - `@reddi/agent-protocol` import smoke: pass
  - `@reddi/agent-protocol` package dry-run inspection: pass
  - `@reddi/x402-solana` tests: 45/45 pass
  - `@reddi/x402-solana` build: pass
  - `@reddi/x402-solana` import smoke: pass
  - `@reddi/x402-solana` package dry-run inspection: pass
  - RAP naming guard: pass
  - claim-boundary scan: pass
- `npm run test:bdd:index`
- `git diff --check`

## Notes
- The first local probe showed `npm --prefix packages/x402-solana pack --dry-run --json` can inspect the root app package instead of the target package. The checker runs `npm pack --dry-run --json` with `cwd` set to each package directory to avoid that false pass.
- The x402 test/build output still prints the known `bigint-buffer` pure-JS warning; tests and build pass.

## Boundary
No npm publish, live/devnet payment, wallet/RPC/provider call, Pay.sh activation, hosted write, marketplace publication, trust/reputation mutation, mainnet, custody, settlement-finality claim, or UI change occurred.

Closes #512.
