### PR TITLE
Add AUDD seller-wrapper rail-state fixtures

### DIFF
--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -18,3 +18,4 @@ export * from './pay-sh-sandbox-evidence.js';
 export * from './mpp-tempo-receipt-shapes.js';
 export * from './rail-neutral-payment-receipts.js';
 export * from './rail-neutral-proof-chain-fixture.js';
+export * from './seller-wrapper-rail-fixtures.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -18,3 +18,4 @@ export * from './pay-sh-sandbox-evidence.js';
 export * from './mpp-tempo-receipt-shapes.js';
 export * from './rail-neutral-payment-receipts.js';
 export * from './rail-neutral-proof-chain-fixture.js';
+export * from './seller-wrapper-rail-fixtures.js';

--- a/packages/agent-protocol/dist/seller-wrapper-rail-fixtures.d.ts
+++ b/packages/agent-protocol/dist/seller-wrapper-rail-fixtures.d.ts
@@ -1,0 +1,67 @@
+import { type AuddPaymentPlanPreflightDecision, type AuddSolanaPaymentPlan } from './audd-payment-plan.js';
+import { type SellerResponse } from './buyer-seller.js';
+export declare const SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION: "reddi.seller-wrapper-rail-fixture.v1";
+export type SellerWrapperRailState = 'fixture' | 'dry-run' | 'proof-metadata-only' | 'devnet-gated' | 'live-gated' | 'custody-supported' | 'unsupported';
+export type SellerWrapperRailConfig = {
+    id: string;
+    asset: 'SOL' | 'USDC' | 'AUDD';
+    network: string;
+    state: SellerWrapperRailState;
+    amountUnits: string;
+    payee: string;
+    settlementAccount?: string;
+    evidenceRequired: boolean;
+    approvalRequired: boolean;
+    livePaymentApproved: false;
+    custodySupported: boolean;
+    notes: string[];
+    auddPaymentPlan?: AuddSolanaPaymentPlan;
+};
+export type SellerWrapperEndpointFixture = {
+    kind: 'mcp' | 'http-openapi';
+    endpointId: string;
+    displayName: string;
+    transport: {
+        url: string;
+        auth: 'none';
+    };
+    rails: SellerWrapperRailConfig[];
+};
+export type SellerWrapperRailFixture = {
+    schemaVersion: typeof SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION;
+    issue: 529;
+    sourceContract: {
+        railParityIssue: 525;
+        railParityPullRequest: 528;
+        sellerWrapperIssue: 375;
+    };
+    endpoints: SellerWrapperEndpointFixture[];
+    guardrails: {
+        noSecrets: true;
+        noLivePayment: true;
+        noWalletSigning: true;
+        noRpcCall: true;
+        noCustodyClaim: true;
+        noSettlementFinalityClaim: true;
+    };
+};
+export type AuddSellerWrapperNoSpendFlow = {
+    fixture: SellerWrapperRailFixture;
+    auddRail: SellerWrapperRailConfig;
+    preflight: AuddPaymentPlanPreflightDecision;
+    sellerResponse: SellerResponse | undefined;
+    guardrails: SellerWrapperRailFixture['guardrails'];
+};
+export declare const sellerWrapperRailFixture: SellerWrapperRailFixture;
+export declare function sellerWrapperFixtureHasCredentialMaterial(value: unknown): boolean;
+export declare function getSellerWrapperRail(fixture: SellerWrapperRailFixture, asset: SellerWrapperRailConfig['asset'], network: string): SellerWrapperRailConfig | undefined;
+export declare function runAuddSellerWrapperNoSpendFlow(input?: {
+    fixture?: SellerWrapperRailFixture;
+    now?: string;
+    approvalState?: 'approved' | 'denied' | 'requires_operator_approval';
+    allowedMint?: string;
+    allowedPayee?: string;
+    allowedSettlementAccount?: string;
+    approveLivePayment?: boolean;
+    forceLiveChallenge?: boolean;
+}): Promise<AuddSellerWrapperNoSpendFlow>;

--- a/packages/agent-protocol/dist/seller-wrapper-rail-fixtures.js
+++ b/packages/agent-protocol/dist/seller-wrapper-rail-fixtures.js
@@ -1,0 +1,185 @@
+import { createAuddPaymentChallenge, createAuddSolanaPaymentPlan, evaluateAuddPaymentPlanPreflight, } from './audd-payment-plan.js';
+import { handlePaidSpecialistRequest } from './buyer-seller.js';
+export const SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION = 'reddi.seller-wrapper-rail-fixture.v1';
+const AUDD_DEVNET_MINT = 'AUDDdev111111111111111111111111111111111111';
+const SELLER_PAYEE = 'solana:SellerWrapperDemoPayee111111111111111111111';
+const SELLER_SETTLEMENT_ACCOUNT = 'solana:SellerWrapperDemoSettlement11111111111111111';
+const auddPaymentPlan = createAuddSolanaPaymentPlan({
+    network: 'solana-devnet',
+    mint: AUDD_DEVNET_MINT,
+    payee: SELLER_PAYEE,
+    settlementAccount: SELLER_SETTLEMENT_ACCOUNT,
+    amount: '2500000',
+    quoteExpiresAt: '2026-07-01T00:00:00.000Z',
+    failurePolicy: {
+        mode: 'no_charge_on_failure',
+        description: 'Dry-run seller-wrapper failures do not charge the buyer.',
+    },
+    refundPolicy: {
+        mode: 'manual_review',
+        description: 'Future live refunds require operator review before settlement.',
+    },
+    evidenceRequired: true,
+    paymentMode: 'dry-run',
+});
+export const sellerWrapperRailFixture = {
+    schemaVersion: SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION,
+    issue: 529,
+    sourceContract: {
+        railParityIssue: 525,
+        railParityPullRequest: 528,
+        sellerWrapperIssue: 375,
+    },
+    endpoints: [
+        {
+            kind: 'http-openapi',
+            endpointId: 'seller-wrapper:listing-writer:http',
+            displayName: 'Listing writer seller wrapper fixture',
+            transport: {
+                url: 'http://localhost:4021/specialist/listing-writer',
+                auth: 'none',
+            },
+            rails: [
+                {
+                    id: 'rail:solana-devnet-sol',
+                    asset: 'SOL',
+                    network: 'solana-devnet',
+                    state: 'devnet-gated',
+                    amountUnits: 'lamports',
+                    payee: 'solana:SellerWrapperDemoSolPayee111111111111111111',
+                    evidenceRequired: true,
+                    approvalRequired: true,
+                    livePaymentApproved: false,
+                    custodySupported: true,
+                    notes: ['SOL custody exists only through audited/promotion-gated contract lanes.'],
+                },
+                {
+                    id: 'rail:solana-devnet-usdc',
+                    asset: 'USDC',
+                    network: 'solana-devnet',
+                    state: 'dry-run',
+                    amountUnits: 'base-units',
+                    payee: 'solana:SellerWrapperDemoUsdcPayee11111111111111111',
+                    settlementAccount: 'solana:SellerWrapperDemoUsdcSettlement111111111111',
+                    evidenceRequired: true,
+                    approvalRequired: true,
+                    livePaymentApproved: false,
+                    custodySupported: false,
+                    notes: ['USDC is represented as quote/receipt/proof metadata in this fixture.'],
+                },
+                {
+                    id: 'rail:solana-devnet-audd',
+                    asset: 'AUDD',
+                    network: 'solana-devnet',
+                    state: 'proof-metadata-only',
+                    amountUnits: 'base-units',
+                    payee: SELLER_PAYEE,
+                    settlementAccount: SELLER_SETTLEMENT_ACCOUNT,
+                    evidenceRequired: true,
+                    approvalRequired: true,
+                    livePaymentApproved: false,
+                    custodySupported: false,
+                    auddPaymentPlan,
+                    notes: [
+                        'AUDD is first-class payment-plan/proof metadata beside SOL and USDC.',
+                        'AUDD custody or settlement-finality claims require a later audited custody workstream.',
+                    ],
+                },
+            ],
+        },
+    ],
+    guardrails: {
+        noSecrets: true,
+        noLivePayment: true,
+        noWalletSigning: true,
+        noRpcCall: true,
+        noCustodyClaim: true,
+        noSettlementFinalityClaim: true,
+    },
+};
+const CREDENTIAL_KEYS = new Set([
+    'api_key',
+    'apikey',
+    'access_token',
+    'auth_token',
+    'authorization',
+    'bearer',
+    'credential',
+    'mnemonic',
+    'password',
+    'private_key',
+    'secret',
+    'seed',
+    'token',
+]);
+const CREDENTIAL_VALUE_PATTERN = /bearer\s+[a-z0-9._-]+|-----BEGIN [A-Z ]*PRIVATE KEY-----|sk-[a-z0-9_-]+/i;
+function normalizedKey(value) {
+    return value.replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`).replace(/[-\s]+/g, '_').replace(/^_+/, '').toLowerCase();
+}
+export function sellerWrapperFixtureHasCredentialMaterial(value) {
+    if (typeof value === 'string')
+        return CREDENTIAL_VALUE_PATTERN.test(value);
+    if (!value || typeof value !== 'object')
+        return false;
+    if (Array.isArray(value))
+        return value.some(sellerWrapperFixtureHasCredentialMaterial);
+    return Object.entries(value).some(([key, item]) => (CREDENTIAL_KEYS.has(normalizedKey(key)) || sellerWrapperFixtureHasCredentialMaterial(item)));
+}
+export function getSellerWrapperRail(fixture, asset, network) {
+    return fixture.endpoints
+        .flatMap((endpoint) => endpoint.rails)
+        .find((rail) => rail.asset === asset && rail.network === network);
+}
+export async function runAuddSellerWrapperNoSpendFlow(input = {}) {
+    const fixture = input.fixture ?? sellerWrapperRailFixture;
+    if (sellerWrapperFixtureHasCredentialMaterial(fixture)) {
+        throw new Error('seller_wrapper_fixture_contains_credentials');
+    }
+    const auddRail = getSellerWrapperRail(fixture, 'AUDD', 'solana-devnet');
+    if (!auddRail?.auddPaymentPlan)
+        throw new Error('audd_seller_wrapper_rail_missing');
+    const paymentPlan = input.forceLiveChallenge
+        ? createAuddSolanaPaymentPlan({ ...auddRail.auddPaymentPlan, paymentMode: 'live' })
+        : auddRail.auddPaymentPlan;
+    const challenge = createAuddPaymentChallenge({
+        mode: paymentPlan.paymentMode,
+        paymentPlan,
+        quote: {
+            source: 'source:seller-wrapper-fixture',
+            specialist: 'specialist:listing-writer',
+        },
+        nonce: 'audd-seller-wrapper-001',
+        endpoint: fixture.endpoints[0].transport.url,
+    });
+    const preflight = evaluateAuddPaymentPlanPreflight(challenge, {
+        allowedNetworks: ['solana-devnet'],
+        allowedMints: [input.allowedMint ?? paymentPlan.mint],
+        allowedPayees: [input.allowedPayee ?? paymentPlan.payee],
+        allowedSettlementAccounts: [input.allowedSettlementAccount ?? paymentPlan.settlementAccount],
+        maxAmount: paymentPlan.amount,
+        requireEvidence: true,
+        approvalState: input.approvalState ?? 'approved',
+        approveLivePayment: input.approveLivePayment,
+        paymentProofRef: 'dry-run:audd-seller-wrapper-001',
+        now: input.now ?? '2026-06-24T00:00:00.000Z',
+    });
+    const sellerResponse = preflight.allowed
+        ? await handlePaidSpecialistRequest({
+            challenge,
+            request: {
+                body: { task: 'draft-listing', rail: 'AUDD' },
+                paymentProofRef: preflight.paymentProofRef,
+            },
+            policyDecision: preflight.policyDecision,
+            createdAt: '2026-06-24T00:01:00.000Z',
+            specialist: (body) => ({ ok: true, body, mode: 'mocked-invocation' }),
+        })
+        : undefined;
+    return {
+        fixture,
+        auddRail,
+        preflight,
+        sellerResponse,
+        guardrails: fixture.guardrails,
+    };
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -90,6 +90,10 @@
       "types": "./dist/rail-neutral-proof-chain-fixture.d.ts",
       "import": "./dist/rail-neutral-proof-chain-fixture.js"
     },
+    "./seller-wrapper-rail-fixtures": {
+      "types": "./dist/seller-wrapper-rail-fixtures.d.ts",
+      "import": "./dist/seller-wrapper-rail-fixtures.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -18,3 +18,4 @@ export * from './pay-sh-sandbox-evidence.js';
 export * from './mpp-tempo-receipt-shapes.js';
 export * from './rail-neutral-payment-receipts.js';
 export * from './rail-neutral-proof-chain-fixture.js';
+export * from './seller-wrapper-rail-fixtures.js';

--- a/packages/agent-protocol/src/seller-wrapper-rail-fixtures.ts
+++ b/packages/agent-protocol/src/seller-wrapper-rail-fixtures.ts
@@ -1,0 +1,278 @@
+import {
+  createAuddPaymentChallenge,
+  createAuddSolanaPaymentPlan,
+  evaluateAuddPaymentPlanPreflight,
+  type AuddPaymentPlanPreflightDecision,
+  type AuddSolanaPaymentPlan,
+} from './audd-payment-plan.js';
+import { handlePaidSpecialistRequest, type SellerResponse } from './buyer-seller.js';
+
+export const SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION = 'reddi.seller-wrapper-rail-fixture.v1' as const;
+
+export type SellerWrapperRailState =
+  | 'fixture'
+  | 'dry-run'
+  | 'proof-metadata-only'
+  | 'devnet-gated'
+  | 'live-gated'
+  | 'custody-supported'
+  | 'unsupported';
+
+export type SellerWrapperRailConfig = {
+  id: string;
+  asset: 'SOL' | 'USDC' | 'AUDD';
+  network: string;
+  state: SellerWrapperRailState;
+  amountUnits: string;
+  payee: string;
+  settlementAccount?: string;
+  evidenceRequired: boolean;
+  approvalRequired: boolean;
+  livePaymentApproved: false;
+  custodySupported: boolean;
+  notes: string[];
+  auddPaymentPlan?: AuddSolanaPaymentPlan;
+};
+
+export type SellerWrapperEndpointFixture = {
+  kind: 'mcp' | 'http-openapi';
+  endpointId: string;
+  displayName: string;
+  transport: {
+    url: string;
+    auth: 'none';
+  };
+  rails: SellerWrapperRailConfig[];
+};
+
+export type SellerWrapperRailFixture = {
+  schemaVersion: typeof SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION;
+  issue: 529;
+  sourceContract: {
+    railParityIssue: 525;
+    railParityPullRequest: 528;
+    sellerWrapperIssue: 375;
+  };
+  endpoints: SellerWrapperEndpointFixture[];
+  guardrails: {
+    noSecrets: true;
+    noLivePayment: true;
+    noWalletSigning: true;
+    noRpcCall: true;
+    noCustodyClaim: true;
+    noSettlementFinalityClaim: true;
+  };
+};
+
+export type AuddSellerWrapperNoSpendFlow = {
+  fixture: SellerWrapperRailFixture;
+  auddRail: SellerWrapperRailConfig;
+  preflight: AuddPaymentPlanPreflightDecision;
+  sellerResponse: SellerResponse | undefined;
+  guardrails: SellerWrapperRailFixture['guardrails'];
+};
+
+const AUDD_DEVNET_MINT = 'AUDDdev111111111111111111111111111111111111';
+const SELLER_PAYEE = 'solana:SellerWrapperDemoPayee111111111111111111111';
+const SELLER_SETTLEMENT_ACCOUNT = 'solana:SellerWrapperDemoSettlement11111111111111111';
+
+const auddPaymentPlan = createAuddSolanaPaymentPlan({
+  network: 'solana-devnet',
+  mint: AUDD_DEVNET_MINT,
+  payee: SELLER_PAYEE,
+  settlementAccount: SELLER_SETTLEMENT_ACCOUNT,
+  amount: '2500000',
+  quoteExpiresAt: '2026-07-01T00:00:00.000Z',
+  failurePolicy: {
+    mode: 'no_charge_on_failure',
+    description: 'Dry-run seller-wrapper failures do not charge the buyer.',
+  },
+  refundPolicy: {
+    mode: 'manual_review',
+    description: 'Future live refunds require operator review before settlement.',
+  },
+  evidenceRequired: true,
+  paymentMode: 'dry-run',
+});
+
+export const sellerWrapperRailFixture: SellerWrapperRailFixture = {
+  schemaVersion: SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION,
+  issue: 529,
+  sourceContract: {
+    railParityIssue: 525,
+    railParityPullRequest: 528,
+    sellerWrapperIssue: 375,
+  },
+  endpoints: [
+    {
+      kind: 'http-openapi',
+      endpointId: 'seller-wrapper:listing-writer:http',
+      displayName: 'Listing writer seller wrapper fixture',
+      transport: {
+        url: 'http://localhost:4021/specialist/listing-writer',
+        auth: 'none',
+      },
+      rails: [
+        {
+          id: 'rail:solana-devnet-sol',
+          asset: 'SOL',
+          network: 'solana-devnet',
+          state: 'devnet-gated',
+          amountUnits: 'lamports',
+          payee: 'solana:SellerWrapperDemoSolPayee111111111111111111',
+          evidenceRequired: true,
+          approvalRequired: true,
+          livePaymentApproved: false,
+          custodySupported: true,
+          notes: ['SOL custody exists only through audited/promotion-gated contract lanes.'],
+        },
+        {
+          id: 'rail:solana-devnet-usdc',
+          asset: 'USDC',
+          network: 'solana-devnet',
+          state: 'dry-run',
+          amountUnits: 'base-units',
+          payee: 'solana:SellerWrapperDemoUsdcPayee11111111111111111',
+          settlementAccount: 'solana:SellerWrapperDemoUsdcSettlement111111111111',
+          evidenceRequired: true,
+          approvalRequired: true,
+          livePaymentApproved: false,
+          custodySupported: false,
+          notes: ['USDC is represented as quote/receipt/proof metadata in this fixture.'],
+        },
+        {
+          id: 'rail:solana-devnet-audd',
+          asset: 'AUDD',
+          network: 'solana-devnet',
+          state: 'proof-metadata-only',
+          amountUnits: 'base-units',
+          payee: SELLER_PAYEE,
+          settlementAccount: SELLER_SETTLEMENT_ACCOUNT,
+          evidenceRequired: true,
+          approvalRequired: true,
+          livePaymentApproved: false,
+          custodySupported: false,
+          auddPaymentPlan,
+          notes: [
+            'AUDD is first-class payment-plan/proof metadata beside SOL and USDC.',
+            'AUDD custody or settlement-finality claims require a later audited custody workstream.',
+          ],
+        },
+      ],
+    },
+  ],
+  guardrails: {
+    noSecrets: true,
+    noLivePayment: true,
+    noWalletSigning: true,
+    noRpcCall: true,
+    noCustodyClaim: true,
+    noSettlementFinalityClaim: true,
+  },
+};
+
+const CREDENTIAL_KEYS = new Set([
+  'api_key',
+  'apikey',
+  'access_token',
+  'auth_token',
+  'authorization',
+  'bearer',
+  'credential',
+  'mnemonic',
+  'password',
+  'private_key',
+  'secret',
+  'seed',
+  'token',
+]);
+const CREDENTIAL_VALUE_PATTERN = /bearer\s+[a-z0-9._-]+|-----BEGIN [A-Z ]*PRIVATE KEY-----|sk-[a-z0-9_-]+/i;
+
+function normalizedKey(value: string): string {
+  return value.replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`).replace(/[-\s]+/g, '_').replace(/^_+/, '').toLowerCase();
+}
+
+export function sellerWrapperFixtureHasCredentialMaterial(value: unknown): boolean {
+  if (typeof value === 'string') return CREDENTIAL_VALUE_PATTERN.test(value);
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some(sellerWrapperFixtureHasCredentialMaterial);
+  return Object.entries(value).some(([key, item]) => (
+    CREDENTIAL_KEYS.has(normalizedKey(key)) || sellerWrapperFixtureHasCredentialMaterial(item)
+  ));
+}
+
+export function getSellerWrapperRail(
+  fixture: SellerWrapperRailFixture,
+  asset: SellerWrapperRailConfig['asset'],
+  network: string,
+): SellerWrapperRailConfig | undefined {
+  return fixture.endpoints
+    .flatMap((endpoint) => endpoint.rails)
+    .find((rail) => rail.asset === asset && rail.network === network);
+}
+
+export async function runAuddSellerWrapperNoSpendFlow(input: {
+  fixture?: SellerWrapperRailFixture;
+  now?: string;
+  approvalState?: 'approved' | 'denied' | 'requires_operator_approval';
+  allowedMint?: string;
+  allowedPayee?: string;
+  allowedSettlementAccount?: string;
+  approveLivePayment?: boolean;
+  forceLiveChallenge?: boolean;
+} = {}): Promise<AuddSellerWrapperNoSpendFlow> {
+  const fixture = input.fixture ?? sellerWrapperRailFixture;
+  if (sellerWrapperFixtureHasCredentialMaterial(fixture)) {
+    throw new Error('seller_wrapper_fixture_contains_credentials');
+  }
+
+  const auddRail = getSellerWrapperRail(fixture, 'AUDD', 'solana-devnet');
+  if (!auddRail?.auddPaymentPlan) throw new Error('audd_seller_wrapper_rail_missing');
+
+  const paymentPlan = input.forceLiveChallenge
+    ? createAuddSolanaPaymentPlan({ ...auddRail.auddPaymentPlan, paymentMode: 'live' })
+    : auddRail.auddPaymentPlan;
+  const challenge = createAuddPaymentChallenge({
+    mode: paymentPlan.paymentMode,
+    paymentPlan,
+    quote: {
+      source: 'source:seller-wrapper-fixture',
+      specialist: 'specialist:listing-writer',
+    },
+    nonce: 'audd-seller-wrapper-001',
+    endpoint: fixture.endpoints[0].transport.url,
+  });
+  const preflight = evaluateAuddPaymentPlanPreflight(challenge, {
+    allowedNetworks: ['solana-devnet'],
+    allowedMints: [input.allowedMint ?? paymentPlan.mint],
+    allowedPayees: [input.allowedPayee ?? paymentPlan.payee],
+    allowedSettlementAccounts: [input.allowedSettlementAccount ?? paymentPlan.settlementAccount],
+    maxAmount: paymentPlan.amount,
+    requireEvidence: true,
+    approvalState: input.approvalState ?? 'approved',
+    approveLivePayment: input.approveLivePayment,
+    paymentProofRef: 'dry-run:audd-seller-wrapper-001',
+    now: input.now ?? '2026-06-24T00:00:00.000Z',
+  });
+
+  const sellerResponse = preflight.allowed
+    ? await handlePaidSpecialistRequest({
+      challenge,
+      request: {
+        body: { task: 'draft-listing', rail: 'AUDD' },
+        paymentProofRef: preflight.paymentProofRef,
+      },
+      policyDecision: preflight.policyDecision,
+      createdAt: '2026-06-24T00:01:00.000Z',
+      specialist: (body) => ({ ok: true, body, mode: 'mocked-invocation' }),
+    })
+    : undefined;
+
+  return {
+    fixture,
+    auddRail,
+    preflight,
+    sellerResponse,
+    guardrails: fixture.guardrails,
+  };
+}

--- a/packages/agent-protocol/tests/seller-wrapper-rail-fixtures.test.ts
+++ b/packages/agent-protocol/tests/seller-wrapper-rail-fixtures.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  getSellerWrapperRail,
+  runAuddSellerWrapperNoSpendFlow,
+  sellerWrapperFixtureHasCredentialMaterial,
+  sellerWrapperRailFixture,
+  type SellerWrapperRailFixture,
+} from '../dist/index.js';
+
+describe('seller-wrapper rail-state fixtures', () => {
+  it('declares SOL, USDC, and AUDD rails without secrets or live approval', () => {
+    assert.equal(sellerWrapperRailFixture.schemaVersion, 'reddi.seller-wrapper-rail-fixture.v1');
+    assert.equal(sellerWrapperRailFixture.sourceContract.railParityIssue, 525);
+    assert.equal(sellerWrapperRailFixture.sourceContract.railParityPullRequest, 528);
+    assert.equal(sellerWrapperFixtureHasCredentialMaterial(sellerWrapperRailFixture), false);
+
+    const rails = sellerWrapperRailFixture.endpoints.flatMap((endpoint) => endpoint.rails);
+    assert.deepEqual(rails.map((rail) => rail.asset).sort(), ['AUDD', 'SOL', 'USDC']);
+    assert.equal(rails.every((rail) => rail.livePaymentApproved === false), true);
+    assert.equal(rails.every((rail) => rail.evidenceRequired === true), true);
+
+    const audd = getSellerWrapperRail(sellerWrapperRailFixture, 'AUDD', 'solana-devnet');
+    assert.ok(audd);
+    assert.equal(audd.state, 'proof-metadata-only');
+    assert.equal(audd.custodySupported, false);
+    assert.equal(audd.auddPaymentPlan?.asset, 'AUDD');
+    assert.equal(audd.auddPaymentPlan?.network, 'solana-devnet');
+    assert.equal(audd.auddPaymentPlan?.mint, 'AUDDdev111111111111111111111111111111111111');
+    assert.equal(audd.auddPaymentPlan?.payee, audd.payee);
+    assert.equal(audd.auddPaymentPlan?.settlementAccount, audd.settlementAccount);
+    assert.equal(audd.auddPaymentPlan?.evidenceRequired, true);
+    assert.equal(audd.auddPaymentPlan?.failurePolicy.mode, 'no_charge_on_failure');
+    assert.equal(audd.auddPaymentPlan?.refundPolicy.mode, 'manual_review');
+  });
+
+  it('runs a no-spend AUDD quote to buyer preflight to mocked seller invocation to receipt/evidence flow', async () => {
+    const flow = await runAuddSellerWrapperNoSpendFlow();
+
+    assert.equal(flow.guardrails.noLivePayment, true);
+    assert.equal(flow.guardrails.noWalletSigning, true);
+    assert.equal(flow.guardrails.noRpcCall, true);
+    assert.equal(flow.guardrails.noCustodyClaim, true);
+    assert.equal(flow.guardrails.noSettlementFinalityClaim, true);
+    assert.equal(flow.preflight.allowed, true);
+    assert.deepEqual(flow.preflight.reasonCodes, ['audd_payment_plan_allowed']);
+    assert.equal(flow.preflight.paymentPlan?.asset, 'AUDD');
+    assert.equal(flow.preflight.paymentProofRef, 'dry-run:audd-seller-wrapper-001');
+
+    assert.equal(flow.sellerResponse?.status, 200);
+    if (flow.sellerResponse?.status === 200) {
+      assert.equal(flow.sellerResponse.receipt.payment.asset, 'AUDD');
+      assert.equal(flow.sellerResponse.receipt.payment.network, 'solana-devnet');
+      assert.equal(flow.sellerResponse.receipt.payment.paymentProofRef, 'dry-run:audd-seller-wrapper-001');
+      assert.equal(flow.sellerResponse.receipt.policyDecision.allowed, true);
+      assert.equal(flow.sellerResponse.evidence.schemaVersion, 'reddi.evidence-archive.v1');
+      assert.equal(Object.prototype.hasOwnProperty.call(flow.sellerResponse.evidence, 'evidencePayload'), false);
+      assert.equal(flow.sellerResponse.result && typeof flow.sellerResponse.result === 'object', true);
+    }
+  });
+
+  it('fails closed for missing approval, expired quote, bad mint, bad payee, bad settlement account, and live mode', async () => {
+    assert.deepEqual(
+      (await runAuddSellerWrapperNoSpendFlow({ approvalState: 'requires_operator_approval' })).preflight.reasonCodes,
+      ['operator_approval_required'],
+    );
+    assert.equal((await runAuddSellerWrapperNoSpendFlow({ approvalState: 'requires_operator_approval' })).sellerResponse, undefined);
+
+    assert.deepEqual(
+      (await runAuddSellerWrapperNoSpendFlow({ now: '2026-07-01T00:00:00.000Z' })).preflight.reasonCodes,
+      ['quote_expired'],
+    );
+
+    assert.deepEqual(
+      (await runAuddSellerWrapperNoSpendFlow({ allowedMint: 'wrong-audd-mint' })).preflight.reasonCodes,
+      ['wrong_mint'],
+    );
+
+    assert.deepEqual(
+      (await runAuddSellerWrapperNoSpendFlow({ allowedPayee: 'solana:wrong-payee' })).preflight.reasonCodes,
+      ['missing_payee'],
+    );
+
+    assert.deepEqual(
+      (await runAuddSellerWrapperNoSpendFlow({ allowedSettlementAccount: 'solana:wrong-settlement' })).preflight.reasonCodes,
+      ['missing_payee'],
+    );
+
+    assert.deepEqual(
+      (await runAuddSellerWrapperNoSpendFlow({ forceLiveChallenge: true })).preflight.reasonCodes,
+      ['live_payment_not_approved'],
+    );
+  });
+
+  it('rejects credential-bearing seller-wrapper fixture metadata before any seller invocation', async () => {
+    const credentialFixture = structuredClone(sellerWrapperRailFixture) as SellerWrapperRailFixture & {
+      operatorToken?: string;
+    };
+    credentialFixture.operatorToken = 'Bearer secret-token';
+    assert.equal(sellerWrapperFixtureHasCredentialMaterial(credentialFixture), true);
+
+    await assert.rejects(
+      () => runAuddSellerWrapperNoSpendFlow({ fixture: credentialFixture }),
+      /seller_wrapper_fixture_contains_credentials/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #529.

## Summary
- adds exported seller-wrapper rail-state fixtures for SOL, USDC, and AUDD
- marks AUDD as first-class proof-metadata-only alongside SOL/USDC while preserving no-custody/no-finality boundaries
- adds a no-spend AUDD flow: quote/payment-plan -> buyer preflight -> mocked seller invocation -> RAP receipt/evidence
- adds fail-closed tests for missing approval, expired quote, bad mint, bad payee, bad settlement account, live mode, and credential-bearing fixture metadata

## Validation
- `npm --prefix packages/agent-protocol install --ignore-scripts`
- `npm --prefix packages/agent-protocol test -- --runInBand` (167/167)
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `git diff --check`

## UI evidence
No UI changed; screenshots/video are not required.

## Boundary
No live/devnet payment, wallet/RPC/provider call, Pay.sh activation, Surfpool/devnet start, program deploy, hosted write, marketplace publication, trust/reputation mutation, mainnet, custody expansion, or settlement-finality claim.