### PR TITLE
Add Solana external audit handoff packet

### DIFF
--- a/docs/SOLANA-EXTERNAL-AUDIT-HANDOFF-2026-06-24.md
+++ b/docs/SOLANA-EXTERNAL-AUDIT-HANDOFF-2026-06-24.md
@@ -1,0 +1,190 @@
+# Solana External Audit Handoff
+
+Date: 2026-06-24
+
+Issue: #530
+
+Input evidence:
+
+- #526 / PR #527: `docs/SOLANA-CONTRACT-AUDIT-READINESS-2026-06-24.md`
+- #531 / PR #532: `docs/SOLANA-CONTRACT-AUDIT-APPENDIX-2026-06-24.md`
+- #388 Solana/Quasar program boundary.
+- #441 Quasar/Surfpool/devnet promotion checklist.
+
+## Handoff Boundary
+
+This handoff package prepares evidence for an external Solana contract auditor.
+It does not select or pay an auditor, send external submissions, deploy
+programs, start Surfpool/devnet, call RPC, use wallets, does not approve transaction submission, activate live payments, claim mainnet readiness, expand custody, or claim settlement finality.
+
+Any paid auditor selection, external email/submission, spend, deploy,
+Surfpool/devnet run, wallet/RPC/provider call, transaction submission, live
+payment, mainnet, custody expansion, or settlement-finality claim requires explicit Nissan approval.
+
+## Auditor-Facing Scope
+
+In scope for handoff:
+
+- Active Quasar targets:
+  - `experiments/quasar-registry`
+  - `experiments/quasar-attestation`
+  - `experiments/quasar-reputation`
+  - `experiments/quasar-escrow-per`
+- Legacy/reference targets:
+  - `experiments/quasar-escrow`
+  - `programs/escrow`
+- Active client and instruction-builder surfaces:
+  - `lib/quasar/instruction-builders.ts`
+  - `lib/quasar/instructions.ts`
+  - `lib/register/registration-instruction.ts`
+  - `packages/demo-agents/src/registration-instruction.ts`
+  - `packages/per-client/src/client.ts`
+- Scripted proof lanes:
+  - `scripts/run-quasar-program-tests.sh`
+  - `scripts/check-quasar-boundary-guard.mjs`
+  - `scripts/check-quasar-runtime-compatibility.mjs`
+  - `scripts/check-quasar-deployment-inventory.mjs`
+  - `scripts/run-quasar-per-agent-vault-delegation-smoke.mjs`
+  - `scripts/run-quasar-per-agent-vault-settlement-smoke.mjs`
+  - `scripts/run-surfpool-critical-smoke.sh`
+
+Explicitly out of scope unless a later approved issue changes scope:
+
+- AUDD or USDC custody.
+- Mainnet deployment or mainnet readiness.
+- Settlement-finality proof.
+- Production Pay.sh activation or live payment.
+- Marketplace publication.
+- Trust/reputation mutation.
+- Any wallet/RPC/provider-backed execution.
+
+## Frozen Handoff Inputs
+
+- Handoff source commit: `3561dc5da0700367ed8ef95ab2dd091560280591`
+- Evidence pack: `docs/SOLANA-CONTRACT-AUDIT-READINESS-2026-06-24.md`
+- Account/PDA/ABI appendix: `docs/SOLANA-CONTRACT-AUDIT-APPENDIX-2026-06-24.md`
+- Current active escrow target for grant handoff: `experiments/quasar-escrow-per`
+- Current legacy escrow reference: `experiments/quasar-escrow`
+- Current Anchor reference: `programs/escrow`
+- Current AUDD posture: first-class payment-plan/proof metadata only.
+- Current USDC posture: package/proof/helper rail only, not Quasar or Anchor
+  custody.
+- Current SOL posture: lamports custody appears only in selected escrow/vault
+  program surfaces and remains promotion-gated.
+
+## Required Artifact Manifest
+
+Auditor packet must include:
+
+- Exact commit SHA and source tree pointer.
+- Program ids from the selected source files.
+- Account/PDA/layout matrix.
+- Instruction ABI and discriminator list.
+- Active client/instruction-builder inventory.
+- Scripted proof lane inventory.
+- Threat model and trust-boundary summary.
+- Known blockers and product decisions.
+- Latest test/smoke evidence.
+- Surfpool/devnet promotion state from #441.
+- Explicit non-goals for mainnet, custody expansion, live payment, external
+  submission, and settlement-finality claims.
+- Grant-facing reporting summary that separates readiness evidence from an
+  audit-complete claim.
+
+## Auditor Questions
+
+Expected questions and owner lanes:
+
+- Program target selection:
+  - Owner lane: #388 / #441.
+  - Required answer: which Quasar targets are active, which are legacy, and why.
+- ABI, PDA, and account layout:
+  - Owner lane: #531.
+  - Required answer: account names, discriminators, field order, byte sizes,
+    PDA seeds, signer/writable flags, and Anchor-vs-Quasar deltas.
+- PER and MagicBlock callback behavior:
+  - Owner lane: #388 / #441.
+  - Required answer: delegation accounts, callback expectations, approval gates,
+    and which evidence is local-only versus devnet-backed.
+- Payment rails:
+  - Owner lane: #338 / #334 / #525.
+  - Required answer: SOL custody scope, USDC proof scope, AUDD proof-metadata
+    scope, and no current AUDD/USDC custody.
+- Client handoff path:
+  - Owner lane: #526 / #531.
+  - Required answer: which builders assemble instruction data, which assemble
+    `TransactionInstruction` objects, and which scripts would require approval
+    before transaction submission.
+
+## Triage And Remediation Flow
+
+Severity handling:
+
+- Critical:
+  - Blocks audit handoff and any grant-facing audit-ready claim.
+  - Requires immediate issue, remediation PR, reviewer re-gate, and parent issue
+    refresh.
+- High:
+  - Blocks affected program/client surface from handoff.
+  - Requires remediation PR and targeted validation before re-review.
+- Medium:
+  - May proceed only if documented as an accepted audit caveat with issue owner,
+    risk, and follow-up.
+- Low:
+  - May be tracked as cleanup when it does not affect custody, authority,
+    transaction construction, or claim safety.
+
+Remediation PR flow:
+
+1. Open or update a GitHub issue with description, acceptance criteria,
+   dependencies, reverse dependencies, and boundary.
+2. Use an isolated worktree and feature branch.
+3. Patch only the affected program, client, proof-lane, or documentation surface.
+4. Run the validation set named by the issue and this handoff packet.
+5. Open a PR with validation evidence and explicit non-goals.
+6. Request read-only review.
+7. Merge only after review is ready to approve and GitHub checks are green.
+8. Refresh affected parent/dependency issues after merge.
+
+Re-review flow:
+
+- Reviewer findings must cite file/line references and severity.
+- Blockers require a remediation commit and a new review pass.
+- Non-blocking notes must either be accepted in the PR body or converted to a
+  follow-up issue before final handoff.
+- Any change touching UI must include screenshots and/or video evidence.
+
+## Grant-Facing Reporting
+
+Allowed grant-facing statement after this packet lands:
+
+- RAP has prepared a Solana contract audit-readiness handoff packet covering
+  active Quasar targets, legacy Anchor reference, account/PDA/ABI appendix,
+  client/instruction-builder surfaces, proof lanes, threat model, and known
+  blockers.
+
+Forbidden grant-facing statements until later approved evidence exists:
+
+- Contracts are audited.
+- Contracts are deployed or mainnet ready.
+- AUDD or USDC custody is supported by current Quasar or Anchor contracts.
+- Settlement finality is proven.
+- A live payment, wallet/RPC run, Surfpool/devnet execution, or external audit
+  submission has occurred.
+
+## Validation
+
+Run before handoff packet PR review:
+
+- `npm run check:solana:audit-handoff`
+- `npm run check:solana:audit-appendix`
+- `npm run check:rap:naming`
+- `git diff --check`
+
+If BDD docs change, also run:
+
+- `npm run test:bdd:index`
+
+If package/read-model files change, also run:
+
+- `npm run check:quasar:boundary-guard -- --changed`

--- a/docs/SOLANA-EXTERNAL-AUDIT-HANDOFF-2026-06-24.md
+++ b/docs/SOLANA-EXTERNAL-AUDIT-HANDOFF-2026-06-24.md
@@ -60,9 +60,13 @@ Explicitly out of scope unless a later approved issue changes scope:
 
 ## Frozen Handoff Inputs
 
-- Handoff source commit: `3561dc5da0700367ed8ef95ab2dd091560280591`
-- Evidence pack: `docs/SOLANA-CONTRACT-AUDIT-READINESS-2026-06-24.md`
-- Account/PDA/ABI appendix: `docs/SOLANA-CONTRACT-AUDIT-APPENDIX-2026-06-24.md`
+- Input evidence commit: `3561dc5da0700367ed8ef95ab2dd091560280591`
+- Evidence pack at input evidence commit:
+  `docs/SOLANA-CONTRACT-AUDIT-READINESS-2026-06-24.md`
+- Account/PDA/ABI appendix at input evidence commit:
+  `docs/SOLANA-CONTRACT-AUDIT-APPENDIX-2026-06-24.md`
+- Final handoff source commit: the merge commit for PR #534, to be recorded in
+  #530 before any external auditor submission.
 - Current active escrow target for grant handoff: `experiments/quasar-escrow-per`
 - Current legacy escrow reference: `experiments/quasar-escrow`
 - Current Anchor reference: `programs/escrow`
@@ -76,7 +80,7 @@ Explicitly out of scope unless a later approved issue changes scope:
 
 Auditor packet must include:
 
-- Exact commit SHA and source tree pointer.
+- Exact input evidence commit SHA and final handoff source tree pointer.
 - Program ids from the selected source files.
 - Account/PDA/layout matrix.
 - Instruction ABI and discriminator list.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "check:quasar:runtime-compatibility": "node ./scripts/check-quasar-runtime-compatibility.mjs",
     "check:quasar:boundary-guard": "node ./scripts/check-quasar-boundary-guard.mjs",
     "check:solana:audit-appendix": "node ./scripts/check-solana-audit-appendix.mjs",
+    "check:solana:audit-handoff": "node ./scripts/check-solana-audit-handoff.mjs",
     "test:quasar:boundary-guard": "node --test ./scripts/__tests__/check-quasar-boundary-guard.test.mjs",
     "check:quasar:submission": "npm run check:quasar:runtime-compatibility && npm run check:quasar:deployments && npm run check:quasar:demo-readiness && npm run check:quasar:critical-success",
     "check:quasar:critical-success": "node ./scripts/check-quasar-critical-success.mjs",

--- a/scripts/check-solana-audit-handoff.mjs
+++ b/scripts/check-solana-audit-handoff.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const handoffPath = path.join(repoRoot, "docs/SOLANA-EXTERNAL-AUDIT-HANDOFF-2026-06-24.md");
+
+const requiredHeadings = [
+  "# Solana External Audit Handoff",
+  "## Handoff Boundary",
+  "## Auditor-Facing Scope",
+  "## Frozen Handoff Inputs",
+  "## Required Artifact Manifest",
+  "## Auditor Questions",
+  "## Triage And Remediation Flow",
+  "## Grant-Facing Reporting",
+  "## Validation",
+];
+
+const requiredReferences = [
+  "docs/SOLANA-CONTRACT-AUDIT-READINESS-2026-06-24.md",
+  "docs/SOLANA-CONTRACT-AUDIT-APPENDIX-2026-06-24.md",
+  "experiments/quasar-registry",
+  "experiments/quasar-attestation",
+  "experiments/quasar-reputation",
+  "experiments/quasar-escrow-per",
+  "experiments/quasar-escrow",
+  "programs/escrow",
+  "lib/quasar/instruction-builders.ts",
+  "lib/quasar/instructions.ts",
+  "lib/register/registration-instruction.ts",
+  "packages/demo-agents/src/registration-instruction.ts",
+  "packages/per-client/src/client.ts",
+  "scripts/run-quasar-program-tests.sh",
+  "scripts/check-quasar-boundary-guard.mjs",
+  "scripts/check-quasar-runtime-compatibility.mjs",
+  "scripts/check-quasar-deployment-inventory.mjs",
+  "scripts/run-quasar-per-agent-vault-delegation-smoke.mjs",
+  "scripts/run-quasar-per-agent-vault-settlement-smoke.mjs",
+  "scripts/run-surfpool-critical-smoke.sh",
+];
+
+const requiredArtifactTerms = [
+  "Exact commit SHA",
+  "Program ids",
+  "Account/PDA/layout matrix",
+  "Instruction ABI and discriminator list",
+  "Threat model and trust-boundary summary",
+  "Known blockers and product decisions",
+  "Latest test/smoke evidence",
+  "Surfpool/devnet promotion state",
+  "Grant-facing reporting summary",
+];
+
+const requiredBoundaryPhrases = [
+  "does not select or pay an auditor",
+  "does not approve transaction submission",
+  "requires explicit Nissan approval",
+  "AUDD or USDC custody",
+  "Settlement-finality proof",
+  "Contracts are audited.",
+  "Settlement finality is proven.",
+];
+
+function fail(message, details = []) {
+  console.error(`[solana-audit-handoff] FAIL: ${message}`);
+  for (const detail of details) console.error(`- ${detail}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(handoffPath)) {
+  fail("handoff file is missing", [path.relative(repoRoot, handoffPath)]);
+}
+
+const source = fs.readFileSync(handoffPath, "utf8");
+
+const missingHeadings = requiredHeadings.filter((heading) => !source.includes(heading));
+if (missingHeadings.length) fail("required headings are missing", missingHeadings);
+
+const missingReferences = requiredReferences.filter((reference) => !source.includes(reference));
+if (missingReferences.length) fail("required references are missing", missingReferences);
+
+const missingFiles = requiredReferences
+  .filter((reference) => reference.includes("/") && !reference.startsWith("#"))
+  .filter((reference) => !fs.existsSync(path.join(repoRoot, reference)));
+if (missingFiles.length) fail("referenced files/directories are missing", missingFiles);
+
+const missingArtifactTerms = requiredArtifactTerms.filter((term) => !source.includes(term));
+if (missingArtifactTerms.length) fail("required artifact terms are missing", missingArtifactTerms);
+
+const missingBoundaryPhrases = requiredBoundaryPhrases.filter((phrase) => !source.includes(phrase));
+if (missingBoundaryPhrases.length) fail("required boundary phrases are missing", missingBoundaryPhrases);
+
+console.log(`[solana-audit-handoff] OK: ${requiredHeadings.length} headings, ${requiredReferences.length} references, ${requiredArtifactTerms.length} artifact terms, and ${requiredBoundaryPhrases.length} boundary phrases verified`);

--- a/scripts/check-solana-audit-handoff.mjs
+++ b/scripts/check-solana-audit-handoff.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 
 const repoRoot = process.cwd();
 const handoffPath = path.join(repoRoot, "docs/SOLANA-EXTERNAL-AUDIT-HANDOFF-2026-06-24.md");
@@ -41,7 +42,8 @@ const requiredReferences = [
 ];
 
 const requiredArtifactTerms = [
-  "Exact commit SHA",
+  "Exact input evidence commit SHA",
+  "final handoff source tree pointer",
   "Program ids",
   "Account/PDA/layout matrix",
   "Instruction ABI and discriminator list",
@@ -60,6 +62,12 @@ const requiredBoundaryPhrases = [
   "Settlement-finality proof",
   "Contracts are audited.",
   "Settlement finality is proven.",
+  "Final handoff source commit: the merge commit for PR #534",
+];
+
+const inputEvidencePaths = [
+  "docs/SOLANA-CONTRACT-AUDIT-READINESS-2026-06-24.md",
+  "docs/SOLANA-CONTRACT-AUDIT-APPENDIX-2026-06-24.md",
 ];
 
 function fail(message, details = []) {
@@ -91,4 +99,31 @@ if (missingArtifactTerms.length) fail("required artifact terms are missing", mis
 const missingBoundaryPhrases = requiredBoundaryPhrases.filter((phrase) => !source.includes(phrase));
 if (missingBoundaryPhrases.length) fail("required boundary phrases are missing", missingBoundaryPhrases);
 
-console.log(`[solana-audit-handoff] OK: ${requiredHeadings.length} headings, ${requiredReferences.length} references, ${requiredArtifactTerms.length} artifact terms, and ${requiredBoundaryPhrases.length} boundary phrases verified`);
+const inputCommitMatch = source.match(/Input evidence commit: `([0-9a-f]{40})`/);
+if (!inputCommitMatch) fail("input evidence commit SHA is missing or malformed");
+
+const inputCommit = inputCommitMatch[1];
+try {
+  execFileSync("git", ["cat-file", "-e", `${inputCommit}^{commit}`], { cwd: repoRoot, stdio: "ignore" });
+} catch {
+  fail("input evidence commit does not exist in git", [inputCommit]);
+}
+
+const missingInputEvidence = inputEvidencePaths.filter((sourcePath) => {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${inputCommit}:${sourcePath}`], { cwd: repoRoot, stdio: "ignore" });
+    return false;
+  } catch {
+    return true;
+  }
+});
+if (missingInputEvidence.length) {
+  fail("input evidence commit does not contain required evidence files", missingInputEvidence);
+}
+
+const staleHandoffSha = source.match(/Handoff source commit: `([0-9a-f]{40})`/);
+if (staleHandoffSha) {
+  fail("handoff source commit must not be a pre-merge stale SHA", [staleHandoffSha[1]]);
+}
+
+console.log(`[solana-audit-handoff] OK: ${requiredHeadings.length} headings, ${requiredReferences.length} references, ${requiredArtifactTerms.length} artifact terms, ${requiredBoundaryPhrases.length} boundary phrases, and input evidence commit ${inputCommit} verified`);


### PR DESCRIPTION
Closes #530.

## Summary
- adds the external Solana contract audit handoff packet using #526/#527 and #531/#532 as inputs
- defines active Quasar targets, legacy references, client/instruction-builder scope, proof lanes, explicit non-goals, artifact manifest, auditor questions, triage/remediation flow, re-review flow, and grant-facing reporting language
- adds `npm run check:solana:audit-handoff` to verify required headings, references, artifact terms, and boundary phrases

## Validation
- `npm run check:solana:audit-handoff`
- `npm run check:solana:audit-appendix`
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `git diff --check`

## Boundary
Docs/checker only. No paid auditor selection, external email/submission, spend, program deploy, Surfpool/devnet start, wallet/RPC/provider call, transaction submission approval, live payment, mainnet, custody expansion, or settlement-finality claim.