### PR TITLE
feat: add seller-wrapper config examples

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -38,6 +38,27 @@ const policyDecision = policyDecisionFromBudgetPolicyDecision({
 
 Use payment-rail packages to settle and verify payment-specific proofs. RAP receipts record the policy, payment-proof reference, evidence reference, and trust metadata around the paid agent workflow.
 
+## Seller Wrapper Config Examples
+
+```typescript
+import {
+  generateSellerWrapperConfigExamples,
+  runSellerWrapperConfigNoSpendCheck,
+} from '@reddi/agent-protocol/seller-wrapper-config';
+
+const config = generateSellerWrapperConfigExamples();
+console.log(config.endpoints[0].wrapper.quoteRoute); // /seller-wrapper/listing-writer-http/quote
+console.log(config.endpoints[0].rails.map((rail) => rail.asset)); // SOL, USDC, AUDD
+
+const check = await runSellerWrapperConfigNoSpendCheck();
+console.log(check.validation.valid); // true
+console.log(check.auddFlow.preflight.allowed); // true for the local no-spend AUDD flow
+```
+
+Seller-wrapper config examples turn the local rail-state fixture into MCP and HTTP/OpenAPI wrapper metadata: quote route, policy preflight route, mocked invocation route, receipt hook, evidence hook, and SOL/USDC/AUDD rail states. AUDD is represented as first-class payment-plan/proof metadata with mint, payee, settlement account, expiry, failure policy, refund policy, and evidence requirements.
+
+The helper is no-spend and non-secret. It rejects credential-shaped metadata, live-payment approval, wallet/RPC/signing/transfer instructions, custody claims, and settlement-finality claims. It does not publish packages, invoke providers, call wallets/RPC endpoints, submit Pay.sh payments, or activate live rails.
+
 ## AI Catalog Ingestion
 
 ```typescript

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -19,3 +19,4 @@ export * from './mpp-tempo-receipt-shapes.js';
 export * from './rail-neutral-payment-receipts.js';
 export * from './rail-neutral-proof-chain-fixture.js';
 export * from './seller-wrapper-rail-fixtures.js';
+export * from './seller-wrapper-config.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -19,3 +19,4 @@ export * from './mpp-tempo-receipt-shapes.js';
 export * from './rail-neutral-payment-receipts.js';
 export * from './rail-neutral-proof-chain-fixture.js';
 export * from './seller-wrapper-rail-fixtures.js';
+export * from './seller-wrapper-config.js';

--- a/packages/agent-protocol/dist/seller-wrapper-config.d.ts
+++ b/packages/agent-protocol/dist/seller-wrapper-config.d.ts
@@ -1,0 +1,88 @@
+import type { AuddSolanaPaymentPlan } from './audd-payment-plan.js';
+import { SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION, type SellerWrapperEndpointFixture, type SellerWrapperRailConfig, type SellerWrapperRailFixture, type SellerWrapperRailState } from './seller-wrapper-rail-fixtures.js';
+export declare const SELLER_WRAPPER_CONFIG_SCHEMA_VERSION: "reddi.seller-wrapper-config.v1";
+export type SellerWrapperRuntimeState = 'local-dry-run' | 'devnet-gated' | 'proof-metadata-only' | 'live-gated' | 'custody-supported' | 'unsupported' | 'live-payment-approved';
+export type SellerWrapperRailConfigExample = {
+    id: string;
+    asset: SellerWrapperRailConfig['asset'];
+    network: string;
+    fixtureState: SellerWrapperRailState;
+    runtimeState: SellerWrapperRuntimeState;
+    amountUnits: string;
+    payee: string;
+    settlementAccount?: string;
+    evidenceRequired: boolean;
+    approvalRequired: boolean;
+    livePaymentApproved: boolean;
+    custodySupported: boolean;
+    quote: {
+        amount: string;
+        expiresAt?: string;
+        paymentMode: 'dry-run' | 'live';
+    };
+    audd?: {
+        mint: string;
+        failurePolicy: AuddSolanaPaymentPlan['failurePolicy'];
+        refundPolicy: AuddSolanaPaymentPlan['refundPolicy'];
+    };
+    notes: string[];
+};
+export type SellerWrapperEndpointConfigExample = {
+    kind: SellerWrapperEndpointFixture['kind'];
+    endpointId: string;
+    displayName: string;
+    transport: SellerWrapperEndpointFixture['transport'];
+    wrapper: {
+        quoteRoute: string;
+        policyPreflightRoute: string;
+        invocationRoute: string;
+        receiptHook: string;
+        evidenceHook: string;
+    };
+    rails: SellerWrapperRailConfigExample[];
+};
+export type SellerWrapperConfigExamples = {
+    schemaVersion: typeof SELLER_WRAPPER_CONFIG_SCHEMA_VERSION;
+    issue: 535;
+    sourceContract: SellerWrapperRailFixture['sourceContract'] & {
+        configIssue: 535;
+        railFixtureIssue: SellerWrapperRailFixture['issue'];
+        railFixtureSchemaVersion: typeof SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION;
+    };
+    generatedMode: 'no-spend-config-examples';
+    endpoints: SellerWrapperEndpointConfigExample[];
+    guardrails: SellerWrapperRailFixture['guardrails'] & {
+        noSecrets: true;
+        noProviderCredentials: true;
+        noLivePaymentInstructions: true;
+    };
+};
+export type SellerWrapperConfigValidationReasonCode = 'seller_wrapper_config_valid' | 'config_malformed' | 'fixture_contains_credentials' | 'config_contains_credentials' | 'missing_audd_rail' | 'missing_audd_payment_plan' | 'missing_wrapper_hooks' | 'live_payment_not_approved' | 'live_payment_instruction_rejected' | 'custody_claim_rejected' | 'settlement_finality_claim_rejected';
+export type SellerWrapperConfigValidationResult = {
+    valid: boolean;
+    reasonCodes: SellerWrapperConfigValidationReasonCode[];
+    auditNotes: string[];
+};
+export declare function generateSellerWrapperConfigExamples(input?: {
+    fixture?: SellerWrapperRailFixture;
+}): SellerWrapperConfigExamples;
+export declare function validateSellerWrapperConfigExamples(config: unknown): SellerWrapperConfigValidationResult;
+export declare function runSellerWrapperConfigNoSpendCheck(input?: {
+    fixture?: SellerWrapperRailFixture;
+}): Promise<{
+    config: SellerWrapperConfigExamples;
+    validation: SellerWrapperConfigValidationResult;
+    auddFlow: import("./seller-wrapper-rail-fixtures.js").AuddSellerWrapperNoSpendFlow;
+    guardrails: {
+        noSecrets: true;
+        noLivePayment: true;
+        noWalletSigning: true;
+        noRpcCall: true;
+        noCustodyClaim: true;
+        noSettlementFinalityClaim: true;
+    } & {
+        noSecrets: true;
+        noProviderCredentials: true;
+        noLivePaymentInstructions: true;
+    };
+}>;

--- a/packages/agent-protocol/dist/seller-wrapper-config.js
+++ b/packages/agent-protocol/dist/seller-wrapper-config.js
@@ -1,0 +1,221 @@
+import { SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION, getSellerWrapperRail, runAuddSellerWrapperNoSpendFlow, sellerWrapperFixtureHasCredentialMaterial, sellerWrapperRailFixture, } from './seller-wrapper-rail-fixtures.js';
+export const SELLER_WRAPPER_CONFIG_SCHEMA_VERSION = 'reddi.seller-wrapper-config.v1';
+const REQUIRED_WRAPPER_HOOKS = [
+    'quoteRoute',
+    'policyPreflightRoute',
+    'invocationRoute',
+    'receiptHook',
+    'evidenceHook',
+];
+const LIVE_PAYMENT_INSTRUCTION_PATTERN = /\b(submit|sign|transfer|settle|broadcast)\b.*\b(transaction|payment|audd|usdc|sol)\b|\bwallet\s+sign|\brpc\b/i;
+const CUSTODY_CLAIM_PATTERN = /\b(audd|usdc|sol)\b.*\b(is|are|was|were|will be|held|escrowed)\b.*\b(custody|custodied|escrowed|held)\b|\bheld\s+in\s+custody\b/i;
+const SETTLEMENT_FINALITY_PATTERN = /\bsettlement\s+finality\b|\bfinal\s+settlement\b/i;
+function endpointSlug(endpointId) {
+    return endpointId.replace(/^seller-wrapper:/, '').replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').toLowerCase();
+}
+function amountForRail(rail) {
+    if (rail.auddPaymentPlan)
+        return rail.auddPaymentPlan.amount;
+    if (rail.asset === 'SOL')
+        return '1000000';
+    return '2500000';
+}
+function runtimeStateForRail(rail) {
+    if (rail.livePaymentApproved)
+        return 'live-payment-approved';
+    if (rail.state === 'dry-run' || rail.state === 'fixture')
+        return 'local-dry-run';
+    if (rail.state === 'custody-supported')
+        return 'custody-supported';
+    if (rail.state === 'proof-metadata-only')
+        return 'proof-metadata-only';
+    if (rail.state === 'devnet-gated')
+        return 'devnet-gated';
+    if (rail.state === 'live-gated')
+        return 'live-gated';
+    return 'unsupported';
+}
+function railConfigExample(rail) {
+    return {
+        id: rail.id,
+        asset: rail.asset,
+        network: rail.network,
+        fixtureState: rail.state,
+        runtimeState: runtimeStateForRail(rail),
+        amountUnits: rail.amountUnits,
+        payee: rail.payee,
+        settlementAccount: rail.settlementAccount,
+        evidenceRequired: rail.evidenceRequired,
+        approvalRequired: rail.approvalRequired,
+        livePaymentApproved: rail.livePaymentApproved,
+        custodySupported: rail.custodySupported,
+        quote: {
+            amount: amountForRail(rail),
+            expiresAt: rail.auddPaymentPlan?.quoteExpiresAt,
+            paymentMode: rail.auddPaymentPlan?.paymentMode ?? 'dry-run',
+        },
+        audd: rail.auddPaymentPlan
+            ? {
+                mint: rail.auddPaymentPlan.mint,
+                failurePolicy: rail.auddPaymentPlan.failurePolicy,
+                refundPolicy: rail.auddPaymentPlan.refundPolicy,
+            }
+            : undefined,
+        notes: rail.notes,
+    };
+}
+function endpointConfigExample(endpoint) {
+    const slug = endpointSlug(endpoint.endpointId);
+    return {
+        kind: endpoint.kind,
+        endpointId: endpoint.endpointId,
+        displayName: endpoint.displayName,
+        transport: endpoint.transport,
+        wrapper: {
+            quoteRoute: `/seller-wrapper/${slug}/quote`,
+            policyPreflightRoute: `/seller-wrapper/${slug}/policy-preflight`,
+            invocationRoute: `/seller-wrapper/${slug}/invoke-mock`,
+            receiptHook: `/seller-wrapper/${slug}/receipt`,
+            evidenceHook: `/seller-wrapper/${slug}/evidence`,
+        },
+        rails: endpoint.rails.map(railConfigExample),
+    };
+}
+function generatedEndpoints(fixture) {
+    if (fixture.endpoints.some((endpoint) => endpoint.kind === 'mcp'))
+        return fixture.endpoints;
+    const first = fixture.endpoints[0];
+    if (!first)
+        return [];
+    return [
+        ...fixture.endpoints,
+        {
+            ...first,
+            kind: 'mcp',
+            endpointId: `${first.endpointId}:mcp`,
+            displayName: `${first.displayName} MCP bridge`,
+            transport: {
+                url: 'mcp://local/seller-wrapper/listing-writer',
+                auth: 'none',
+            },
+        },
+    ];
+}
+function textContains(value, pattern) {
+    if (typeof value === 'string')
+        return pattern.test(value);
+    if (!value || typeof value !== 'object')
+        return false;
+    if (Array.isArray(value))
+        return value.some((item) => textContains(item, pattern));
+    return Object.values(value).some((item) => textContains(item, pattern));
+}
+function configLooksStructured(config) {
+    if (!config || typeof config !== 'object' || Array.isArray(config))
+        return false;
+    const candidate = config;
+    return candidate.schemaVersion === SELLER_WRAPPER_CONFIG_SCHEMA_VERSION
+        && candidate.issue === 535
+        && candidate.generatedMode === 'no-spend-config-examples'
+        && Array.isArray(candidate.endpoints)
+        && !!candidate.guardrails
+        && typeof candidate.guardrails === 'object';
+}
+export function generateSellerWrapperConfigExamples(input = {}) {
+    const fixture = input.fixture ?? sellerWrapperRailFixture;
+    if (sellerWrapperFixtureHasCredentialMaterial(fixture)) {
+        throw new Error('seller_wrapper_fixture_contains_credentials');
+    }
+    const auddRail = getSellerWrapperRail(fixture, 'AUDD', 'solana-devnet');
+    if (!auddRail)
+        throw new Error('seller_wrapper_config_missing_audd_rail');
+    if (!auddRail.auddPaymentPlan)
+        throw new Error('seller_wrapper_config_missing_audd_payment_plan');
+    const config = {
+        schemaVersion: SELLER_WRAPPER_CONFIG_SCHEMA_VERSION,
+        issue: 535,
+        sourceContract: {
+            ...fixture.sourceContract,
+            configIssue: 535,
+            railFixtureIssue: fixture.issue,
+            railFixtureSchemaVersion: SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION,
+        },
+        generatedMode: 'no-spend-config-examples',
+        endpoints: generatedEndpoints(fixture).map(endpointConfigExample),
+        guardrails: {
+            ...fixture.guardrails,
+            noProviderCredentials: true,
+            noLivePaymentInstructions: true,
+        },
+    };
+    const validation = validateSellerWrapperConfigExamples(config);
+    if (!validation.valid) {
+        throw new Error(`seller_wrapper_config_invalid:${validation.reasonCodes.join(',')}`);
+    }
+    return config;
+}
+export function validateSellerWrapperConfigExamples(config) {
+    const reasonCodes = [];
+    const auditNotes = [];
+    if (!configLooksStructured(config)) {
+        return {
+            valid: false,
+            reasonCodes: ['config_malformed'],
+            auditNotes: ['Denied: seller-wrapper config is malformed.'],
+        };
+    }
+    if (sellerWrapperFixtureHasCredentialMaterial(config)) {
+        reasonCodes.push('config_contains_credentials');
+        auditNotes.push('Denied: generated config contains credential-like material.');
+    }
+    const auddRail = config.endpoints.flatMap((endpoint) => endpoint.rails).find((rail) => (rail.asset === 'AUDD' && rail.network === 'solana-devnet'));
+    if (!auddRail) {
+        reasonCodes.push('missing_audd_rail');
+        auditNotes.push('Denied: AUDD solana-devnet rail is missing from generated config.');
+    }
+    else if (!auddRail.audd) {
+        reasonCodes.push('missing_audd_payment_plan');
+        auditNotes.push('Denied: AUDD payment-plan metadata is missing from generated config.');
+    }
+    const missingHooks = config.endpoints.some((endpoint) => REQUIRED_WRAPPER_HOOKS.some((hook) => (typeof endpoint.wrapper[hook] !== 'string' || endpoint.wrapper[hook].trim().length === 0)));
+    if (missingHooks) {
+        reasonCodes.push('missing_wrapper_hooks');
+        auditNotes.push('Denied: quote, policy, invocation, receipt, and evidence hooks are all required.');
+    }
+    if (config.endpoints.some((endpoint) => endpoint.rails.some((rail) => rail.livePaymentApproved))) {
+        reasonCodes.push('live_payment_not_approved');
+        auditNotes.push('Denied: generated examples must not approve live payment.');
+    }
+    if (textContains(config, LIVE_PAYMENT_INSTRUCTION_PATTERN)) {
+        reasonCodes.push('live_payment_instruction_rejected');
+        auditNotes.push('Denied: generated examples must not include wallet, RPC, signing, transfer, broadcast, or settlement instructions.');
+    }
+    if (textContains(config, CUSTODY_CLAIM_PATTERN)) {
+        reasonCodes.push('custody_claim_rejected');
+        auditNotes.push('Denied: generated examples must not claim AUDD/USDC/SOL custody.');
+    }
+    if (textContains(config, SETTLEMENT_FINALITY_PATTERN)) {
+        reasonCodes.push('settlement_finality_claim_rejected');
+        auditNotes.push('Denied: generated examples must not claim settlement finality.');
+    }
+    if (reasonCodes.length > 0) {
+        return { valid: false, reasonCodes, auditNotes };
+    }
+    return {
+        valid: true,
+        reasonCodes: ['seller_wrapper_config_valid'],
+        auditNotes: ['Allowed: seller-wrapper config examples are non-secret, no-spend, and include required wrapper hooks.'],
+    };
+}
+export async function runSellerWrapperConfigNoSpendCheck(input = {}) {
+    const fixture = input.fixture ?? sellerWrapperRailFixture;
+    const config = generateSellerWrapperConfigExamples({ fixture });
+    const validation = validateSellerWrapperConfigExamples(config);
+    const auddFlow = await runAuddSellerWrapperNoSpendFlow({ fixture });
+    return {
+        config,
+        validation,
+        auddFlow,
+        guardrails: config.guardrails,
+    };
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -94,6 +94,10 @@
       "types": "./dist/seller-wrapper-rail-fixtures.d.ts",
       "import": "./dist/seller-wrapper-rail-fixtures.js"
     },
+    "./seller-wrapper-config": {
+      "types": "./dist/seller-wrapper-config.d.ts",
+      "import": "./dist/seller-wrapper-config.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -19,3 +19,4 @@ export * from './mpp-tempo-receipt-shapes.js';
 export * from './rail-neutral-payment-receipts.js';
 export * from './rail-neutral-proof-chain-fixture.js';
 export * from './seller-wrapper-rail-fixtures.js';
+export * from './seller-wrapper-config.js';

--- a/packages/agent-protocol/src/seller-wrapper-config.ts
+++ b/packages/agent-protocol/src/seller-wrapper-config.ts
@@ -1,0 +1,332 @@
+import type { AuddSolanaPaymentPlan } from './audd-payment-plan.js';
+import {
+  SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION,
+  getSellerWrapperRail,
+  runAuddSellerWrapperNoSpendFlow,
+  sellerWrapperFixtureHasCredentialMaterial,
+  sellerWrapperRailFixture,
+  type SellerWrapperEndpointFixture,
+  type SellerWrapperRailConfig,
+  type SellerWrapperRailFixture,
+  type SellerWrapperRailState,
+} from './seller-wrapper-rail-fixtures.js';
+
+export const SELLER_WRAPPER_CONFIG_SCHEMA_VERSION = 'reddi.seller-wrapper-config.v1' as const;
+
+export type SellerWrapperRuntimeState =
+  | 'local-dry-run'
+  | 'devnet-gated'
+  | 'proof-metadata-only'
+  | 'live-gated'
+  | 'custody-supported'
+  | 'unsupported'
+  | 'live-payment-approved';
+
+export type SellerWrapperRailConfigExample = {
+  id: string;
+  asset: SellerWrapperRailConfig['asset'];
+  network: string;
+  fixtureState: SellerWrapperRailState;
+  runtimeState: SellerWrapperRuntimeState;
+  amountUnits: string;
+  payee: string;
+  settlementAccount?: string;
+  evidenceRequired: boolean;
+  approvalRequired: boolean;
+  livePaymentApproved: boolean;
+  custodySupported: boolean;
+  quote: {
+    amount: string;
+    expiresAt?: string;
+    paymentMode: 'dry-run' | 'live';
+  };
+  audd?: {
+    mint: string;
+    failurePolicy: AuddSolanaPaymentPlan['failurePolicy'];
+    refundPolicy: AuddSolanaPaymentPlan['refundPolicy'];
+  };
+  notes: string[];
+};
+
+export type SellerWrapperEndpointConfigExample = {
+  kind: SellerWrapperEndpointFixture['kind'];
+  endpointId: string;
+  displayName: string;
+  transport: SellerWrapperEndpointFixture['transport'];
+  wrapper: {
+    quoteRoute: string;
+    policyPreflightRoute: string;
+    invocationRoute: string;
+    receiptHook: string;
+    evidenceHook: string;
+  };
+  rails: SellerWrapperRailConfigExample[];
+};
+
+export type SellerWrapperConfigExamples = {
+  schemaVersion: typeof SELLER_WRAPPER_CONFIG_SCHEMA_VERSION;
+  issue: 535;
+  sourceContract: SellerWrapperRailFixture['sourceContract'] & {
+    configIssue: 535;
+    railFixtureIssue: SellerWrapperRailFixture['issue'];
+    railFixtureSchemaVersion: typeof SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION;
+  };
+  generatedMode: 'no-spend-config-examples';
+  endpoints: SellerWrapperEndpointConfigExample[];
+  guardrails: SellerWrapperRailFixture['guardrails'] & {
+    noSecrets: true;
+    noProviderCredentials: true;
+    noLivePaymentInstructions: true;
+  };
+};
+
+export type SellerWrapperConfigValidationReasonCode =
+  | 'seller_wrapper_config_valid'
+  | 'config_malformed'
+  | 'fixture_contains_credentials'
+  | 'config_contains_credentials'
+  | 'missing_audd_rail'
+  | 'missing_audd_payment_plan'
+  | 'missing_wrapper_hooks'
+  | 'live_payment_not_approved'
+  | 'live_payment_instruction_rejected'
+  | 'custody_claim_rejected'
+  | 'settlement_finality_claim_rejected';
+
+export type SellerWrapperConfigValidationResult = {
+  valid: boolean;
+  reasonCodes: SellerWrapperConfigValidationReasonCode[];
+  auditNotes: string[];
+};
+
+const REQUIRED_WRAPPER_HOOKS = [
+  'quoteRoute',
+  'policyPreflightRoute',
+  'invocationRoute',
+  'receiptHook',
+  'evidenceHook',
+] as const;
+
+const LIVE_PAYMENT_INSTRUCTION_PATTERN = /\b(submit|sign|transfer|settle|broadcast)\b.*\b(transaction|payment|audd|usdc|sol)\b|\bwallet\s+sign|\brpc\b/i;
+const CUSTODY_CLAIM_PATTERN = /\b(audd|usdc|sol)\b.*\b(is|are|was|were|will be|held|escrowed)\b.*\b(custody|custodied|escrowed|held)\b|\bheld\s+in\s+custody\b/i;
+const SETTLEMENT_FINALITY_PATTERN = /\bsettlement\s+finality\b|\bfinal\s+settlement\b/i;
+
+function endpointSlug(endpointId: string): string {
+  return endpointId.replace(/^seller-wrapper:/, '').replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').toLowerCase();
+}
+
+function amountForRail(rail: SellerWrapperRailConfig): string {
+  if (rail.auddPaymentPlan) return rail.auddPaymentPlan.amount;
+  if (rail.asset === 'SOL') return '1000000';
+  return '2500000';
+}
+
+function runtimeStateForRail(rail: SellerWrapperRailConfig): SellerWrapperRuntimeState {
+  if (rail.livePaymentApproved) return 'live-payment-approved';
+  if (rail.state === 'dry-run' || rail.state === 'fixture') return 'local-dry-run';
+  if (rail.state === 'custody-supported') return 'custody-supported';
+  if (rail.state === 'proof-metadata-only') return 'proof-metadata-only';
+  if (rail.state === 'devnet-gated') return 'devnet-gated';
+  if (rail.state === 'live-gated') return 'live-gated';
+  return 'unsupported';
+}
+
+function railConfigExample(rail: SellerWrapperRailConfig): SellerWrapperRailConfigExample {
+  return {
+    id: rail.id,
+    asset: rail.asset,
+    network: rail.network,
+    fixtureState: rail.state,
+    runtimeState: runtimeStateForRail(rail),
+    amountUnits: rail.amountUnits,
+    payee: rail.payee,
+    settlementAccount: rail.settlementAccount,
+    evidenceRequired: rail.evidenceRequired,
+    approvalRequired: rail.approvalRequired,
+    livePaymentApproved: rail.livePaymentApproved,
+    custodySupported: rail.custodySupported,
+    quote: {
+      amount: amountForRail(rail),
+      expiresAt: rail.auddPaymentPlan?.quoteExpiresAt,
+      paymentMode: rail.auddPaymentPlan?.paymentMode ?? 'dry-run',
+    },
+    audd: rail.auddPaymentPlan
+      ? {
+        mint: rail.auddPaymentPlan.mint,
+        failurePolicy: rail.auddPaymentPlan.failurePolicy,
+        refundPolicy: rail.auddPaymentPlan.refundPolicy,
+      }
+      : undefined,
+    notes: rail.notes,
+  };
+}
+
+function endpointConfigExample(endpoint: SellerWrapperEndpointFixture): SellerWrapperEndpointConfigExample {
+  const slug = endpointSlug(endpoint.endpointId);
+  return {
+    kind: endpoint.kind,
+    endpointId: endpoint.endpointId,
+    displayName: endpoint.displayName,
+    transport: endpoint.transport,
+    wrapper: {
+      quoteRoute: `/seller-wrapper/${slug}/quote`,
+      policyPreflightRoute: `/seller-wrapper/${slug}/policy-preflight`,
+      invocationRoute: `/seller-wrapper/${slug}/invoke-mock`,
+      receiptHook: `/seller-wrapper/${slug}/receipt`,
+      evidenceHook: `/seller-wrapper/${slug}/evidence`,
+    },
+    rails: endpoint.rails.map(railConfigExample),
+  };
+}
+
+function generatedEndpoints(fixture: SellerWrapperRailFixture): SellerWrapperEndpointFixture[] {
+  if (fixture.endpoints.some((endpoint) => endpoint.kind === 'mcp')) return fixture.endpoints;
+  const first = fixture.endpoints[0];
+  if (!first) return [];
+  return [
+    ...fixture.endpoints,
+    {
+      ...first,
+      kind: 'mcp',
+      endpointId: `${first.endpointId}:mcp`,
+      displayName: `${first.displayName} MCP bridge`,
+      transport: {
+        url: 'mcp://local/seller-wrapper/listing-writer',
+        auth: 'none',
+      },
+    },
+  ];
+}
+
+function textContains(value: unknown, pattern: RegExp): boolean {
+  if (typeof value === 'string') return pattern.test(value);
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some((item) => textContains(item, pattern));
+  return Object.values(value).some((item) => textContains(item, pattern));
+}
+
+function configLooksStructured(config: unknown): config is SellerWrapperConfigExamples {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return false;
+  const candidate = config as Partial<SellerWrapperConfigExamples>;
+  return candidate.schemaVersion === SELLER_WRAPPER_CONFIG_SCHEMA_VERSION
+    && candidate.issue === 535
+    && candidate.generatedMode === 'no-spend-config-examples'
+    && Array.isArray(candidate.endpoints)
+    && !!candidate.guardrails
+    && typeof candidate.guardrails === 'object';
+}
+
+export function generateSellerWrapperConfigExamples(input: {
+  fixture?: SellerWrapperRailFixture;
+} = {}): SellerWrapperConfigExamples {
+  const fixture = input.fixture ?? sellerWrapperRailFixture;
+  if (sellerWrapperFixtureHasCredentialMaterial(fixture)) {
+    throw new Error('seller_wrapper_fixture_contains_credentials');
+  }
+
+  const auddRail = getSellerWrapperRail(fixture, 'AUDD', 'solana-devnet');
+  if (!auddRail) throw new Error('seller_wrapper_config_missing_audd_rail');
+  if (!auddRail.auddPaymentPlan) throw new Error('seller_wrapper_config_missing_audd_payment_plan');
+
+  const config: SellerWrapperConfigExamples = {
+    schemaVersion: SELLER_WRAPPER_CONFIG_SCHEMA_VERSION,
+    issue: 535,
+    sourceContract: {
+      ...fixture.sourceContract,
+      configIssue: 535,
+      railFixtureIssue: fixture.issue,
+      railFixtureSchemaVersion: SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION,
+    },
+    generatedMode: 'no-spend-config-examples',
+    endpoints: generatedEndpoints(fixture).map(endpointConfigExample),
+    guardrails: {
+      ...fixture.guardrails,
+      noProviderCredentials: true,
+      noLivePaymentInstructions: true,
+    },
+  };
+
+  const validation = validateSellerWrapperConfigExamples(config);
+  if (!validation.valid) {
+    throw new Error(`seller_wrapper_config_invalid:${validation.reasonCodes.join(',')}`);
+  }
+  return config;
+}
+
+export function validateSellerWrapperConfigExamples(config: unknown): SellerWrapperConfigValidationResult {
+  const reasonCodes: SellerWrapperConfigValidationReasonCode[] = [];
+  const auditNotes: string[] = [];
+
+  if (!configLooksStructured(config)) {
+    return {
+      valid: false,
+      reasonCodes: ['config_malformed'],
+      auditNotes: ['Denied: seller-wrapper config is malformed.'],
+    };
+  }
+
+  if (sellerWrapperFixtureHasCredentialMaterial(config)) {
+    reasonCodes.push('config_contains_credentials');
+    auditNotes.push('Denied: generated config contains credential-like material.');
+  }
+
+  const auddRail = config.endpoints.flatMap((endpoint) => endpoint.rails).find((rail) => (
+    rail.asset === 'AUDD' && rail.network === 'solana-devnet'
+  ));
+  if (!auddRail) {
+    reasonCodes.push('missing_audd_rail');
+    auditNotes.push('Denied: AUDD solana-devnet rail is missing from generated config.');
+  } else if (!auddRail.audd) {
+    reasonCodes.push('missing_audd_payment_plan');
+    auditNotes.push('Denied: AUDD payment-plan metadata is missing from generated config.');
+  }
+
+  const missingHooks = config.endpoints.some((endpoint) => REQUIRED_WRAPPER_HOOKS.some((hook) => (
+    typeof endpoint.wrapper[hook] !== 'string' || endpoint.wrapper[hook].trim().length === 0
+  )));
+  if (missingHooks) {
+    reasonCodes.push('missing_wrapper_hooks');
+    auditNotes.push('Denied: quote, policy, invocation, receipt, and evidence hooks are all required.');
+  }
+
+  if (config.endpoints.some((endpoint) => endpoint.rails.some((rail) => rail.livePaymentApproved))) {
+    reasonCodes.push('live_payment_not_approved');
+    auditNotes.push('Denied: generated examples must not approve live payment.');
+  }
+  if (textContains(config, LIVE_PAYMENT_INSTRUCTION_PATTERN)) {
+    reasonCodes.push('live_payment_instruction_rejected');
+    auditNotes.push('Denied: generated examples must not include wallet, RPC, signing, transfer, broadcast, or settlement instructions.');
+  }
+  if (textContains(config, CUSTODY_CLAIM_PATTERN)) {
+    reasonCodes.push('custody_claim_rejected');
+    auditNotes.push('Denied: generated examples must not claim AUDD/USDC/SOL custody.');
+  }
+  if (textContains(config, SETTLEMENT_FINALITY_PATTERN)) {
+    reasonCodes.push('settlement_finality_claim_rejected');
+    auditNotes.push('Denied: generated examples must not claim settlement finality.');
+  }
+
+  if (reasonCodes.length > 0) {
+    return { valid: false, reasonCodes, auditNotes };
+  }
+  return {
+    valid: true,
+    reasonCodes: ['seller_wrapper_config_valid'],
+    auditNotes: ['Allowed: seller-wrapper config examples are non-secret, no-spend, and include required wrapper hooks.'],
+  };
+}
+
+export async function runSellerWrapperConfigNoSpendCheck(input: {
+  fixture?: SellerWrapperRailFixture;
+} = {}) {
+  const fixture = input.fixture ?? sellerWrapperRailFixture;
+  const config = generateSellerWrapperConfigExamples({ fixture });
+  const validation = validateSellerWrapperConfigExamples(config);
+  const auddFlow = await runAuddSellerWrapperNoSpendFlow({ fixture });
+  return {
+    config,
+    validation,
+    auddFlow,
+    guardrails: config.guardrails,
+  };
+}

--- a/packages/agent-protocol/tests/seller-wrapper-config.test.ts
+++ b/packages/agent-protocol/tests/seller-wrapper-config.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  generateSellerWrapperConfigExamples,
+  runSellerWrapperConfigNoSpendCheck,
+  sellerWrapperRailFixture,
+  validateSellerWrapperConfigExamples,
+  type SellerWrapperConfigExamples,
+  type SellerWrapperRailFixture,
+} from '../dist/index.js';
+
+describe('seller-wrapper config examples', () => {
+  it('generates non-secret MCP and HTTP/OpenAPI wrapper config examples from rail fixtures', () => {
+    const config = generateSellerWrapperConfigExamples();
+
+    assert.equal(config.schemaVersion, 'reddi.seller-wrapper-config.v1');
+    assert.equal(config.issue, 535);
+    assert.equal(config.sourceContract.sellerWrapperIssue, 375);
+    assert.equal(config.sourceContract.railFixtureIssue, 529);
+    assert.equal(config.sourceContract.railParityIssue, 525);
+    assert.equal(config.guardrails.noSecrets, true);
+    assert.equal(config.guardrails.noProviderCredentials, true);
+    assert.equal(config.guardrails.noLivePaymentInstructions, true);
+    assert.equal(config.guardrails.noLivePayment, true);
+    assert.equal(config.guardrails.noWalletSigning, true);
+    assert.equal(config.guardrails.noRpcCall, true);
+
+    assert.deepEqual(config.endpoints.map((endpoint) => endpoint.kind).sort(), ['http-openapi', 'mcp']);
+
+    const endpoint = config.endpoints.find((item) => item.kind === 'http-openapi');
+    assert.ok(endpoint);
+    assert.equal(endpoint.kind, 'http-openapi');
+    assert.equal(endpoint.wrapper.quoteRoute, '/seller-wrapper/listing-writer-http/quote');
+    assert.equal(endpoint.wrapper.policyPreflightRoute, '/seller-wrapper/listing-writer-http/policy-preflight');
+    assert.equal(endpoint.wrapper.invocationRoute, '/seller-wrapper/listing-writer-http/invoke-mock');
+    assert.equal(endpoint.wrapper.receiptHook, '/seller-wrapper/listing-writer-http/receipt');
+    assert.equal(endpoint.wrapper.evidenceHook, '/seller-wrapper/listing-writer-http/evidence');
+
+    const mcpEndpoint = config.endpoints.find((item) => item.kind === 'mcp');
+    assert.ok(mcpEndpoint);
+    assert.equal(mcpEndpoint.transport.url, 'mcp://local/seller-wrapper/listing-writer');
+    assert.equal(mcpEndpoint.wrapper.invocationRoute, '/seller-wrapper/listing-writer-http-mcp/invoke-mock');
+
+    const statesByAsset = new Map(endpoint.rails.map((rail) => [rail.asset, rail.runtimeState]));
+    assert.deepEqual([...statesByAsset.keys()].sort(), ['AUDD', 'SOL', 'USDC']);
+    assert.equal(statesByAsset.get('AUDD'), 'proof-metadata-only');
+    assert.equal(statesByAsset.get('USDC'), 'local-dry-run');
+    assert.equal(statesByAsset.get('SOL'), 'devnet-gated');
+
+    const audd = endpoint.rails.find((rail) => rail.asset === 'AUDD');
+    assert.ok(audd);
+    assert.equal(audd.audd?.mint, 'AUDDdev111111111111111111111111111111111111');
+    assert.equal(audd.payee, 'solana:SellerWrapperDemoPayee111111111111111111111');
+    assert.equal(audd.settlementAccount, 'solana:SellerWrapperDemoSettlement11111111111111111');
+    assert.equal(audd.quote.expiresAt, '2026-07-01T00:00:00.000Z');
+    assert.equal(audd.audd?.failurePolicy.mode, 'no_charge_on_failure');
+    assert.equal(audd.audd?.refundPolicy.mode, 'manual_review');
+    assert.equal(audd.livePaymentApproved, false);
+    assert.equal(audd.custodySupported, false);
+  });
+
+  it('keeps generated config tied to the no-spend AUDD preflight and receipt/evidence flow', async () => {
+    const check = await runSellerWrapperConfigNoSpendCheck();
+
+    assert.equal(check.validation.valid, true);
+    assert.deepEqual(check.validation.reasonCodes, ['seller_wrapper_config_valid']);
+    assert.equal(check.auddFlow.preflight.allowed, true);
+    assert.equal(check.auddFlow.sellerResponse?.status, 200);
+    if (check.auddFlow.sellerResponse?.status === 200) {
+      assert.equal(check.auddFlow.sellerResponse.receipt.payment.asset, 'AUDD');
+      assert.equal(check.auddFlow.sellerResponse.evidence.schemaVersion, 'reddi.evidence-archive.v1');
+    }
+  });
+
+  it('fails closed for credential-bearing fixtures and unsafe generated config claims', () => {
+    const credentialFixture = structuredClone(sellerWrapperRailFixture) as SellerWrapperRailFixture & {
+      providerSecret?: string;
+    };
+    credentialFixture.providerSecret = 'sk-test-secret';
+    assert.throws(
+      () => generateSellerWrapperConfigExamples({ fixture: credentialFixture }),
+      /seller_wrapper_fixture_contains_credentials/,
+    );
+
+    const configWithToken = structuredClone(generateSellerWrapperConfigExamples()) as SellerWrapperConfigExamples & {
+      apiKey?: string;
+    };
+    configWithToken.apiKey = 'sk-test-secret';
+    assert.deepEqual(validateSellerWrapperConfigExamples(configWithToken).reasonCodes, ['config_contains_credentials']);
+
+    const configWithLivePayment = structuredClone(generateSellerWrapperConfigExamples());
+    configWithLivePayment.endpoints[0].rails[0].livePaymentApproved = true;
+    assert.deepEqual(validateSellerWrapperConfigExamples(configWithLivePayment).reasonCodes, ['live_payment_not_approved']);
+
+    const configWithRpcInstruction = structuredClone(generateSellerWrapperConfigExamples());
+    configWithRpcInstruction.endpoints[0].rails[0].notes.push('Submit the transaction through RPC after wallet sign.');
+    assert.deepEqual(validateSellerWrapperConfigExamples(configWithRpcInstruction).reasonCodes, ['live_payment_instruction_rejected']);
+
+    const configWithCustodyClaim = structuredClone(generateSellerWrapperConfigExamples());
+    configWithCustodyClaim.endpoints[0].rails[2].notes.push('AUDD is held in custody by the wrapper.');
+    assert.deepEqual(validateSellerWrapperConfigExamples(configWithCustodyClaim).reasonCodes, ['custody_claim_rejected']);
+
+    const configWithoutHook = structuredClone(generateSellerWrapperConfigExamples());
+    configWithoutHook.endpoints[0].wrapper.receiptHook = '';
+    assert.deepEqual(validateSellerWrapperConfigExamples(configWithoutHook).reasonCodes, ['missing_wrapper_hooks']);
+  });
+});


### PR DESCRIPTION
## Summary
- closes #535
- adds exported seller-wrapper config examples for MCP and HTTP/OpenAPI wrapper surfaces derived from the merged #529 rail-state fixtures
- carries SOL/USDC/AUDD rail state, AUDD mint/payee/settlement/expiry/failure/refund/evidence metadata, wrapper routes, receipt/evidence hooks, and no-spend guardrails
- adds fail-closed validation for credential-shaped metadata, live-payment approval, wallet/RPC/signing/transfer instructions, custody claims, settlement-finality claims, and missing wrapper hooks
- documents the package export in `@reddi/agent-protocol` README

## Validation
- `npm --prefix packages/agent-protocol install --ignore-scripts`
- `npm --prefix packages/agent-protocol test -- --runInBand` (170/170)
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `git diff --check`

## Boundaries
- No UI changes, so no screenshots/video required.
- No npm publish, live/devnet payment, wallet/RPC/provider call, Pay.sh activation, external audit submission, spend, hosted write, marketplace publication, mainnet, custody expansion, or settlement-finality claim.
