### PR TITLE
feat: expose seller-wrapper config onboarding API

### DIFF
--- a/app/api/onboarding/seller-wrapper-config/route.ts
+++ b/app/api/onboarding/seller-wrapper-config/route.ts
@@ -1,0 +1,20 @@
+import { getOnboardingSellerWrapperConfig } from "@/lib/onboarding/seller-wrapper-config";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    return Response.json({
+      ok: true,
+      result: getOnboardingSellerWrapperConfig(),
+    });
+  } catch (error) {
+    return Response.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : "Seller wrapper config generation failed",
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/lib/__tests__/onboarding-routes-wrappers.test.ts
+++ b/lib/__tests__/onboarding-routes-wrappers.test.ts
@@ -56,6 +56,39 @@ describe("onboarding wrapper routes", () => {
     expect(overrideBody.slippage_bps).toBe(80);
   });
 
+  it("GET /api/onboarding/seller-wrapper-config returns no-spend wrapper config", async () => {
+    const { GET } = await import("@/app/api/onboarding/seller-wrapper-config/route");
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.result.schemaVersion).toBe("reddi.onboarding-seller-wrapper-config.v1");
+    expect(body.result.mode).toBe("no-spend-config-preview");
+    expect(body.result.validation.valid).toBe(true);
+    expect(body.result.boundaries).toMatchObject({
+      networkCalls: false,
+      livePayment: false,
+      walletSigning: false,
+      rpcCalls: false,
+      providerInvocation: false,
+      hostedWrites: false,
+      custodyExpansion: false,
+      settlementFinalityClaim: false,
+    });
+
+    const endpointKinds = body.result.config.endpoints.map((endpoint: { kind: string }) => endpoint.kind).sort();
+    expect(endpointKinds).toEqual(["http-openapi", "mcp"]);
+
+    const rails = body.result.config.endpoints[0].rails;
+    const audd = rails.find((rail: { asset: string }) => rail.asset === "AUDD");
+    expect(rails.map((rail: { asset: string }) => rail.asset).sort()).toEqual(["AUDD", "SOL", "USDC"]);
+    expect(audd.runtimeState).toBe("proof-metadata-only");
+    expect(audd.audd.mint).toBe("AUDDdev111111111111111111111111111111111111");
+    expect(audd.livePaymentApproved).toBe(false);
+    expect(audd.custodySupported).toBe(false);
+  });
+
   it("/api/onboarding/planner/execute GET lists runs and POST executes", async () => {
     const { listPlannerRuns, executePlannerSpecialistCall } = await import("@/lib/onboarding/planner-execution");
     (listPlannerRuns as jest.Mock).mockReturnValue({ ok: true, runs: [{ runId: "r1" }] });

--- a/lib/onboarding/seller-wrapper-config.ts
+++ b/lib/onboarding/seller-wrapper-config.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import {
+  generateSellerWrapperConfigExamples,
+  validateSellerWrapperConfigExamples,
+} from "../../packages/agent-protocol/dist/seller-wrapper-config.js";
+
+export const ONBOARDING_SELLER_WRAPPER_CONFIG_SCHEMA_VERSION =
+  "reddi.onboarding-seller-wrapper-config.v1" as const;
+
+export function getOnboardingSellerWrapperConfig() {
+  const config = generateSellerWrapperConfigExamples();
+  const validation = validateSellerWrapperConfigExamples(config);
+
+  if (!validation.valid) {
+    throw new Error(`Seller wrapper config validation failed: ${validation.reasonCodes.join(",")}`);
+  }
+
+  return {
+    schemaVersion: ONBOARDING_SELLER_WRAPPER_CONFIG_SCHEMA_VERSION,
+    mode: "no-spend-config-preview",
+    config,
+    validation,
+    boundaries: {
+      networkCalls: false,
+      livePayment: false,
+      walletSigning: false,
+      rpcCalls: false,
+      providerInvocation: false,
+      hostedWrites: false,
+      custodyExpansion: false,
+      settlementFinalityClaim: false,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- closes #537
- adds `GET /api/onboarding/seller-wrapper-config` as a no-network onboarding API surface for #535 seller-wrapper config examples
- wraps `@reddi/agent-protocol` seller-wrapper config output with onboarding mode, validation result, guardrails, and explicit no-live/no-network boundaries
- adds targeted route coverage for MCP + HTTP/OpenAPI endpoints, SOL/USDC/AUDD rails, AUDD payment-plan metadata, and disabled live/custody/RPC states

## Validation
- `npm install --ignore-scripts`
- `npx jest lib/__tests__/onboarding-routes-wrappers.test.ts --runInBand` (6/6)
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `git diff --check`
- `npm run build`

Notes: root `npm install --ignore-scripts` reported existing dependency audit findings (95 vulnerabilities: 20 low, 48 moderate, 26 high, 1 critical). No dependency changes were made in this PR.

## Boundaries
- No UI changes, so no screenshots/video required.
- No npm publish, live/devnet payment, wallet/RPC/provider call, Pay.sh activation, external audit submission, spend, hosted write, marketplace publication, mainnet, custody expansion, or settlement-finality claim.
