### PR TITLE
feat: add buyer authority policy examples

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -59,6 +59,31 @@ Seller-wrapper config examples turn the local rail-state fixture into MCP and HT
 
 The helper is no-spend and non-secret. It rejects credential-shaped metadata, live-payment approval, wallet/RPC/signing/transfer instructions, custody claims, and settlement-finality claims. It does not publish packages, invoke providers, call wallets/RPC endpoints, submit Pay.sh payments, or activate live rails.
 
+## Buyer Authority Policy Examples
+
+```typescript
+import {
+  buyerAuthorityPolicyExamples,
+  evaluateBuyerAuthorityPolicy,
+} from '@reddi/agent-protocol/buyer-authority-policy';
+
+const example = buyerAuthorityPolicyExamples.allow;
+const result = evaluateBuyerAuthorityPolicy(example.policy, example.request);
+console.log(result.allowed); // true in local no-live fixture mode
+
+const denied = evaluateBuyerAuthorityPolicy(
+  buyerAuthorityPolicyExamples.missingEvidenceRequirement.policy,
+  buyerAuthorityPolicyExamples.missingEvidenceRequirement.request,
+);
+console.log(denied.reasonCodes); // evidence_requirement_missing
+```
+
+Buyer authority policy examples make an agent's spending authority explicit before it discovers, quotes, preflights, invokes, or simulates payment for another agent. The static contract covers spend caps, allowed rails and currencies, seller allowlists, expiry, receipt/evidence requirements, refund/failure policy, operator approval thresholds, and support-state constraints.
+
+The built-in examples cover allow, deny, expired, approval-required, unsupported rail/currency, seller-not-allowlisted, and missing-evidence states. AUDD/SOL/USDC remain proof, preflight, and support metadata only unless a separate audited custody or settlement workstream is approved.
+
+The helper is no-spend and non-secret. It rejects credential-shaped metadata, live-payment approval, wallet/RPC/provider-call material, signing/transfer instructions, custody claims, and settlement-finality claims. It does not contact Airwallex, invoke providers, call wallets/RPC endpoints, transfer SPL tokens, activate Pay.sh, or settle funds.
+
 ## AI Catalog Ingestion
 
 ```typescript

--- a/packages/agent-protocol/dist/buyer-authority-policy.d.ts
+++ b/packages/agent-protocol/dist/buyer-authority-policy.d.ts
@@ -1,0 +1,85 @@
+export declare const BUYER_AUTHORITY_POLICY_SCHEMA_VERSION: "reddi.buyer-authority-policy.v1";
+export type BuyerAuthorityAsset = 'SOL' | 'USDC' | 'AUDD';
+export type BuyerAuthoritySupportState = 'fixture' | 'dry-run' | 'proof-metadata-only' | 'devnet-gated' | 'live-gated';
+export type BuyerAuthorityOperatorApprovalState = 'approved' | 'denied' | 'requires_operator_approval' | 'not_required';
+export type BuyerAuthorityPolicyMode = 'allow' | 'deny' | 'approval-required';
+export type BuyerAuthoritySpendCap = {
+    asset: BuyerAuthorityAsset;
+    network: string;
+    maxAmountUnits: string;
+    window: 'per_request' | 'daily' | 'monthly';
+    approvalRequiredAboveUnits?: string;
+};
+export type BuyerAuthorityRailPermission = {
+    asset: BuyerAuthorityAsset;
+    network: string;
+    supportStates: BuyerAuthoritySupportState[];
+};
+export type BuyerAuthorityPolicy = {
+    schemaVersion: typeof BUYER_AUTHORITY_POLICY_SCHEMA_VERSION;
+    issue: 549;
+    policyId: string;
+    mode: BuyerAuthorityPolicyMode;
+    buyerAgentId: string;
+    expiresAt: string;
+    allowedRails: BuyerAuthorityRailPermission[];
+    allowedCurrencies: BuyerAuthorityAsset[];
+    spendCaps: BuyerAuthoritySpendCap[];
+    sellerAllowlist: {
+        sellerIds: string[];
+        endpointIds: string[];
+    };
+    receiptEvidence: {
+        receiptRequired: boolean;
+        evidenceRequired: boolean;
+        evidenceArchiveRequired: boolean;
+    };
+    refundFailurePolicy: {
+        failureMode: 'no_charge_on_failure' | 'manual_review_required';
+        refundMode: 'manual_review' | 'not_applicable';
+        operatorReviewRequired: boolean;
+    };
+    operatorApproval: {
+        required: boolean;
+        approvalState: BuyerAuthorityOperatorApprovalState;
+        thresholdAmountUnits?: string;
+    };
+    supportStateConstraints: {
+        allowLivePayment: false;
+        allowedRuntimeStates: BuyerAuthoritySupportState[];
+        forbidCustody: true;
+        forbidSettlementFinality: true;
+    };
+    notes: string[];
+};
+export type BuyerAuthorityPolicyEvaluationRequest = {
+    sellerId: string;
+    endpointId: string;
+    asset: string;
+    network: string;
+    amountUnits: string;
+    supportState: string;
+    receiptPresented: boolean;
+    evidencePresented: boolean;
+    now: string;
+    operatorApprovalState?: BuyerAuthorityOperatorApprovalState;
+};
+export type BuyerAuthorityPolicyReasonCode = 'buyer_authority_policy_valid' | 'policy_malformed' | 'policy_contains_credentials' | 'policy_denied' | 'policy_expired' | 'unsupported_rail_currency' | 'seller_not_allowlisted' | 'spend_cap_exceeded' | 'receipt_requirement_missing' | 'evidence_requirement_missing' | 'operator_approval_required' | 'operator_approval_denied' | 'live_payment_rejected' | 'wallet_rpc_provider_call_rejected' | 'transfer_instruction_rejected' | 'custody_claim_rejected' | 'settlement_finality_claim_rejected';
+export type BuyerAuthorityPolicyEvaluation = {
+    allowed: boolean;
+    reasonCodes: BuyerAuthorityPolicyReasonCode[];
+    auditNotes: string[];
+};
+export type BuyerAuthorityPolicyExampleKey = 'allow' | 'deny' | 'expired' | 'approvalRequired' | 'unsupportedRailCurrency' | 'sellerNotAllowlisted' | 'missingEvidenceRequirement';
+export type BuyerAuthorityPolicyExampleCase = {
+    key: BuyerAuthorityPolicyExampleKey;
+    description: string;
+    policy: BuyerAuthorityPolicy;
+    request: BuyerAuthorityPolicyEvaluationRequest;
+    expectedAllowed: boolean;
+    expectedReasonCodes: BuyerAuthorityPolicyReasonCode[];
+};
+export declare function validateBuyerAuthorityPolicy(policy: unknown): BuyerAuthorityPolicyEvaluation;
+export declare function evaluateBuyerAuthorityPolicy(policy: unknown, request: BuyerAuthorityPolicyEvaluationRequest): BuyerAuthorityPolicyEvaluation;
+export declare const buyerAuthorityPolicyExamples: Record<BuyerAuthorityPolicyExampleKey, BuyerAuthorityPolicyExampleCase>;
+export declare function listBuyerAuthorityPolicyExamples(): BuyerAuthorityPolicyExampleCase[];

--- a/packages/agent-protocol/dist/buyer-authority-policy.js
+++ b/packages/agent-protocol/dist/buyer-authority-policy.js
@@ -1,0 +1,376 @@
+import { sellerWrapperFixtureHasCredentialMaterial } from './seller-wrapper-rail-fixtures.js';
+export const BUYER_AUTHORITY_POLICY_SCHEMA_VERSION = 'reddi.buyer-authority-policy.v1';
+const BASE_EXPIRES_AT = '2026-07-01T00:00:00.000Z';
+const DEFAULT_REQUEST = {
+    sellerId: 'seller:listing-writer',
+    endpointId: 'seller-wrapper:listing-writer:http',
+    asset: 'AUDD',
+    network: 'solana-devnet',
+    amountUnits: '2500000',
+    supportState: 'proof-metadata-only',
+    receiptPresented: true,
+    evidencePresented: true,
+    now: '2026-06-27T00:00:00.000Z',
+    operatorApprovalState: 'approved',
+};
+const UNSAFE_LIVE_PATTERN = /\bhttps?:\/\/[^\s"]*(rpc|alchemy|helius|quicknode|api\.(mainnet-beta|devnet|testnet)\.solana\.com)[^\s"]*|\b(provider\s+credential|wallet\s+sign|signing\s+authority)\b/i;
+const TRANSFER_INSTRUCTION_PATTERN = /\b(submit|sign|transfer|broadcast)\b.*\b(transaction|payment|audd|usdc|sol)\b/i;
+const CUSTODY_CLAIM_PATTERN = /\b(audd|usdc|sol)\b.*\b(custody|custodied|escrowed|held)\b|\bheld\s+in\s+custody\b/i;
+const SETTLEMENT_FINALITY_PATTERN = /\bsettlement\s+finality\b|\bfinal\s+settlement\b/i;
+function basePolicy(overrides = {}) {
+    return {
+        schemaVersion: BUYER_AUTHORITY_POLICY_SCHEMA_VERSION,
+        issue: 549,
+        policyId: 'buyer-authority:listing-writer:audd',
+        mode: 'allow',
+        buyerAgentId: 'buyer-agent:planning-demo',
+        expiresAt: BASE_EXPIRES_AT,
+        allowedRails: [
+            {
+                asset: 'AUDD',
+                network: 'solana-devnet',
+                supportStates: ['proof-metadata-only', 'dry-run'],
+            },
+            {
+                asset: 'USDC',
+                network: 'solana-devnet',
+                supportStates: ['dry-run'],
+            },
+            {
+                asset: 'SOL',
+                network: 'solana-devnet',
+                supportStates: ['devnet-gated'],
+            },
+        ],
+        allowedCurrencies: ['AUDD', 'USDC', 'SOL'],
+        spendCaps: [
+            {
+                asset: 'AUDD',
+                network: 'solana-devnet',
+                maxAmountUnits: '2500000',
+                window: 'per_request',
+                approvalRequiredAboveUnits: '1000000',
+            },
+        ],
+        sellerAllowlist: {
+            sellerIds: ['seller:listing-writer'],
+            endpointIds: ['seller-wrapper:listing-writer:http'],
+        },
+        receiptEvidence: {
+            receiptRequired: true,
+            evidenceRequired: true,
+            evidenceArchiveRequired: true,
+        },
+        refundFailurePolicy: {
+            failureMode: 'no_charge_on_failure',
+            refundMode: 'manual_review',
+            operatorReviewRequired: true,
+        },
+        operatorApproval: {
+            required: true,
+            approvalState: 'approved',
+            thresholdAmountUnits: '1000000',
+        },
+        supportStateConstraints: {
+            allowLivePayment: false,
+            allowedRuntimeStates: ['proof-metadata-only', 'dry-run', 'devnet-gated'],
+            forbidCustody: true,
+            forbidSettlementFinality: true,
+        },
+        notes: [
+            'AUDD, SOL, and USDC are proof/preflight metadata in this policy.',
+            'Live settlement requires a separate approved and audited workstream.',
+        ],
+        ...overrides,
+    };
+}
+function clonePolicy(policy) {
+    return structuredClone(policy);
+}
+function textContains(value, pattern) {
+    if (typeof value === 'string')
+        return pattern.test(value);
+    if (!value || typeof value !== 'object')
+        return false;
+    if (Array.isArray(value))
+        return value.some((item) => textContains(item, pattern));
+    return Object.values(value).some((item) => textContains(item, pattern));
+}
+function isRecord(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+function isStringArray(value) {
+    return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+function isStructuredPolicy(value) {
+    if (!isRecord(value))
+        return false;
+    const candidate = value;
+    const sellerAllowlist = candidate.sellerAllowlist;
+    const receiptEvidence = candidate.receiptEvidence;
+    const refundFailurePolicy = candidate.refundFailurePolicy;
+    const operatorApproval = candidate.operatorApproval;
+    const supportStateConstraints = candidate.supportStateConstraints;
+    return candidate.schemaVersion === BUYER_AUTHORITY_POLICY_SCHEMA_VERSION
+        && candidate.issue === 549
+        && typeof candidate.policyId === 'string'
+        && typeof candidate.buyerAgentId === 'string'
+        && typeof candidate.expiresAt === 'string'
+        && candidate.mode !== undefined
+        && ['allow', 'deny', 'approval-required'].includes(candidate.mode)
+        && Array.isArray(candidate.allowedRails)
+        && candidate.allowedRails.every((rail) => isRecord(rail)
+            && ['SOL', 'USDC', 'AUDD'].includes(String(rail.asset))
+            && typeof rail.network === 'string'
+            && isStringArray(rail.supportStates))
+        && Array.isArray(candidate.allowedCurrencies)
+        && candidate.allowedCurrencies.every((asset) => ['SOL', 'USDC', 'AUDD'].includes(asset))
+        && Array.isArray(candidate.spendCaps)
+        && candidate.spendCaps.every((cap) => isRecord(cap)
+            && ['SOL', 'USDC', 'AUDD'].includes(String(cap.asset))
+            && typeof cap.network === 'string'
+            && typeof cap.maxAmountUnits === 'string'
+            && ['per_request', 'daily', 'monthly'].includes(String(cap.window)))
+        && isRecord(sellerAllowlist)
+        && isStringArray(sellerAllowlist.sellerIds)
+        && isStringArray(sellerAllowlist.endpointIds)
+        && isRecord(receiptEvidence)
+        && typeof receiptEvidence.receiptRequired === 'boolean'
+        && typeof receiptEvidence.evidenceRequired === 'boolean'
+        && typeof receiptEvidence.evidenceArchiveRequired === 'boolean'
+        && isRecord(refundFailurePolicy)
+        && ['no_charge_on_failure', 'manual_review_required'].includes(String(refundFailurePolicy.failureMode))
+        && ['manual_review', 'not_applicable'].includes(String(refundFailurePolicy.refundMode))
+        && typeof refundFailurePolicy.operatorReviewRequired === 'boolean'
+        && isRecord(operatorApproval)
+        && typeof operatorApproval.required === 'boolean'
+        && ['approved', 'denied', 'requires_operator_approval', 'not_required'].includes(String(operatorApproval.approvalState))
+        && isRecord(supportStateConstraints)
+        && typeof supportStateConstraints.allowLivePayment === 'boolean'
+        && isStringArray(supportStateConstraints.allowedRuntimeStates)
+        && typeof supportStateConstraints.forbidCustody === 'boolean'
+        && typeof supportStateConstraints.forbidSettlementFinality === 'boolean'
+        && isStringArray(candidate.notes);
+}
+function amountGreaterThan(amount, maxAmount) {
+    try {
+        return BigInt(amount) > BigInt(maxAmount);
+    }
+    catch {
+        return true;
+    }
+}
+function policyMatchesRail(policy, request) {
+    return policy.allowedRails.some((rail) => (rail.asset === request.asset
+        && rail.network === request.network
+        && rail.supportStates.includes(request.supportState)));
+}
+function policySpendCap(policy, request) {
+    return policy.spendCaps.find((cap) => (cap.asset === request.asset && cap.network === request.network && cap.window === 'per_request'));
+}
+export function validateBuyerAuthorityPolicy(policy) {
+    if (!isStructuredPolicy(policy)) {
+        return {
+            allowed: false,
+            reasonCodes: ['policy_malformed'],
+            auditNotes: ['Denied: buyer authority policy is malformed.'],
+        };
+    }
+    const reasonCodes = [];
+    const auditNotes = [];
+    if (sellerWrapperFixtureHasCredentialMaterial(policy)) {
+        reasonCodes.push('policy_contains_credentials');
+        auditNotes.push('Denied: buyer authority policy contains credential-like material.');
+    }
+    if (policy.supportStateConstraints.allowLivePayment) {
+        reasonCodes.push('live_payment_rejected');
+        auditNotes.push('Denied: #549 policies must not approve live payment.');
+    }
+    if (!policy.supportStateConstraints.forbidCustody) {
+        reasonCodes.push('custody_claim_rejected');
+        auditNotes.push('Denied: #549 policies must forbid custody.');
+    }
+    if (!policy.supportStateConstraints.forbidSettlementFinality) {
+        reasonCodes.push('settlement_finality_claim_rejected');
+        auditNotes.push('Denied: #549 policies must forbid settlement finality claims.');
+    }
+    if (policy.supportStateConstraints.allowedRuntimeStates.includes('live-gated')
+        || policy.allowedRails.some((rail) => rail.supportStates.includes('live-gated'))) {
+        reasonCodes.push('live_payment_rejected');
+        auditNotes.push('Denied: #549 policies must not include live-gated support states.');
+    }
+    if (textContains(policy, UNSAFE_LIVE_PATTERN)) {
+        reasonCodes.push('wallet_rpc_provider_call_rejected');
+        auditNotes.push('Denied: policy contains wallet/RPC/provider-call material.');
+    }
+    if (textContains(policy, TRANSFER_INSTRUCTION_PATTERN)) {
+        reasonCodes.push('transfer_instruction_rejected');
+        auditNotes.push('Denied: policy contains signing, broadcast, or transfer instructions.');
+    }
+    if (textContains(policy, CUSTODY_CLAIM_PATTERN)) {
+        reasonCodes.push('custody_claim_rejected');
+        auditNotes.push('Denied: policy must not claim custody.');
+    }
+    if (textContains(policy, SETTLEMENT_FINALITY_PATTERN)) {
+        reasonCodes.push('settlement_finality_claim_rejected');
+        auditNotes.push('Denied: policy must not claim settlement finality.');
+    }
+    if (reasonCodes.length > 0)
+        return { allowed: false, reasonCodes, auditNotes };
+    return {
+        allowed: true,
+        reasonCodes: ['buyer_authority_policy_valid'],
+        auditNotes: ['Allowed: buyer authority policy is static, non-secret, no-spend, and no-live.'],
+    };
+}
+export function evaluateBuyerAuthorityPolicy(policy, request) {
+    const structural = validateBuyerAuthorityPolicy(policy);
+    if (!structural.allowed || !isStructuredPolicy(policy))
+        return structural;
+    const reasonCodes = [];
+    const auditNotes = [];
+    if (policy.mode === 'deny') {
+        reasonCodes.push('policy_denied');
+        auditNotes.push('Denied: policy mode is deny.');
+    }
+    if (new Date(request.now).getTime() > new Date(policy.expiresAt).getTime()) {
+        reasonCodes.push('policy_expired');
+        auditNotes.push('Denied: buyer authority policy has expired.');
+    }
+    const railCurrencySupported = policy.allowedCurrencies.includes(request.asset)
+        && policyMatchesRail(policy, request);
+    if (!railCurrencySupported) {
+        reasonCodes.push('unsupported_rail_currency');
+        auditNotes.push('Denied: requested rail, currency, network, or support state is not allowed.');
+    }
+    if (!policy.sellerAllowlist.sellerIds.includes(request.sellerId)
+        || !policy.sellerAllowlist.endpointIds.includes(request.endpointId)) {
+        reasonCodes.push('seller_not_allowlisted');
+        auditNotes.push('Denied: requested seller or endpoint is not allowlisted.');
+    }
+    const cap = policySpendCap(policy, request);
+    if (railCurrencySupported && (!cap || amountGreaterThan(request.amountUnits, cap.maxAmountUnits))) {
+        reasonCodes.push('spend_cap_exceeded');
+        auditNotes.push('Denied: requested amount exceeds the per-request spend cap.');
+    }
+    if (policy.receiptEvidence.receiptRequired && !request.receiptPresented) {
+        reasonCodes.push('receipt_requirement_missing');
+        auditNotes.push('Denied: receipt requirement was not satisfied.');
+    }
+    if ((policy.receiptEvidence.evidenceRequired || policy.receiptEvidence.evidenceArchiveRequired) && !request.evidencePresented) {
+        reasonCodes.push('evidence_requirement_missing');
+        auditNotes.push('Denied: evidence requirement was not satisfied.');
+    }
+    const approvalState = request.operatorApprovalState ?? policy.operatorApproval.approvalState;
+    if (policy.mode === 'approval-required' || policy.operatorApproval.required) {
+        if (approvalState === 'denied') {
+            reasonCodes.push('operator_approval_denied');
+            auditNotes.push('Denied: operator approval was denied.');
+        }
+        else if (approvalState !== 'approved') {
+            reasonCodes.push('operator_approval_required');
+            auditNotes.push('Denied: operator approval is required before invocation.');
+        }
+    }
+    if (reasonCodes.length > 0)
+        return { allowed: false, reasonCodes, auditNotes };
+    return {
+        allowed: true,
+        reasonCodes: ['buyer_authority_policy_valid'],
+        auditNotes: ['Allowed: request satisfies buyer authority policy in no-live fixture mode.'],
+    };
+}
+const allowPolicy = basePolicy();
+const denyPolicy = basePolicy({ policyId: 'buyer-authority:deny-all', mode: 'deny' });
+const expiredPolicy = basePolicy({ policyId: 'buyer-authority:expired', expiresAt: '2026-06-01T00:00:00.000Z' });
+const approvalRequiredPolicy = basePolicy({
+    policyId: 'buyer-authority:approval-required',
+    mode: 'approval-required',
+    operatorApproval: {
+        required: true,
+        approvalState: 'requires_operator_approval',
+        thresholdAmountUnits: '1000000',
+    },
+});
+const unsupportedRailPolicy = basePolicy({ policyId: 'buyer-authority:unsupported-rail' });
+const sellerNotAllowlistedPolicy = basePolicy({ policyId: 'buyer-authority:seller-not-allowlisted' });
+const missingEvidencePolicy = basePolicy({ policyId: 'buyer-authority:missing-evidence' });
+export const buyerAuthorityPolicyExamples = {
+    allow: {
+        key: 'allow',
+        description: 'Allows AUDD proof/preflight metadata when seller, rail, approval, receipt, and evidence requirements are satisfied.',
+        policy: allowPolicy,
+        request: DEFAULT_REQUEST,
+        expectedAllowed: true,
+        expectedReasonCodes: ['buyer_authority_policy_valid'],
+    },
+    deny: {
+        key: 'deny',
+        description: 'Denies all invocation attempts while keeping policy shape valid and non-secret.',
+        policy: denyPolicy,
+        request: DEFAULT_REQUEST,
+        expectedAllowed: false,
+        expectedReasonCodes: ['policy_denied'],
+    },
+    expired: {
+        key: 'expired',
+        description: 'Denies when the buyer authority policy is past its expiry.',
+        policy: expiredPolicy,
+        request: DEFAULT_REQUEST,
+        expectedAllowed: false,
+        expectedReasonCodes: ['policy_expired'],
+    },
+    approvalRequired: {
+        key: 'approvalRequired',
+        description: 'Denies until operator approval is supplied for spend above the approval threshold.',
+        policy: approvalRequiredPolicy,
+        request: {
+            ...DEFAULT_REQUEST,
+            operatorApprovalState: 'requires_operator_approval',
+        },
+        expectedAllowed: false,
+        expectedReasonCodes: ['operator_approval_required'],
+    },
+    unsupportedRailCurrency: {
+        key: 'unsupportedRailCurrency',
+        description: 'Denies unsupported asset/network/support-state combinations.',
+        policy: unsupportedRailPolicy,
+        request: {
+            ...DEFAULT_REQUEST,
+            asset: 'EURC',
+            supportState: 'unsupported',
+        },
+        expectedAllowed: false,
+        expectedReasonCodes: ['unsupported_rail_currency'],
+    },
+    sellerNotAllowlisted: {
+        key: 'sellerNotAllowlisted',
+        description: 'Denies when a seller or endpoint is outside the allowlist.',
+        policy: sellerNotAllowlistedPolicy,
+        request: {
+            ...DEFAULT_REQUEST,
+            sellerId: 'seller:unknown',
+            endpointId: 'seller-wrapper:unknown:http',
+        },
+        expectedAllowed: false,
+        expectedReasonCodes: ['seller_not_allowlisted'],
+    },
+    missingEvidenceRequirement: {
+        key: 'missingEvidenceRequirement',
+        description: 'Denies when evidence requirements are not satisfied.',
+        policy: missingEvidencePolicy,
+        request: {
+            ...DEFAULT_REQUEST,
+            evidencePresented: false,
+        },
+        expectedAllowed: false,
+        expectedReasonCodes: ['evidence_requirement_missing'],
+    },
+};
+export function listBuyerAuthorityPolicyExamples() {
+    return Object.values(buyerAuthorityPolicyExamples).map((example) => ({
+        ...example,
+        policy: clonePolicy(example.policy),
+        request: structuredClone(example.request),
+    }));
+}

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -9,6 +9,7 @@ export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
+export * from './buyer-authority-policy.js';
 export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -9,6 +9,7 @@ export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
+export * from './buyer-authority-policy.js';
 export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -54,6 +54,10 @@
       "types": "./dist/audd-payment-plan.d.ts",
       "import": "./dist/audd-payment-plan.js"
     },
+    "./buyer-authority-policy": {
+      "types": "./dist/buyer-authority-policy.d.ts",
+      "import": "./dist/buyer-authority-policy.js"
+    },
     "./agent-stack-fixtures": {
       "types": "./dist/agent-stack-fixtures.d.ts",
       "import": "./dist/agent-stack-fixtures.js"

--- a/packages/agent-protocol/src/buyer-authority-policy.ts
+++ b/packages/agent-protocol/src/buyer-authority-policy.ts
@@ -1,0 +1,529 @@
+import { sellerWrapperFixtureHasCredentialMaterial } from './seller-wrapper-rail-fixtures.js';
+
+export const BUYER_AUTHORITY_POLICY_SCHEMA_VERSION = 'reddi.buyer-authority-policy.v1' as const;
+
+export type BuyerAuthorityAsset = 'SOL' | 'USDC' | 'AUDD';
+export type BuyerAuthoritySupportState =
+  | 'fixture'
+  | 'dry-run'
+  | 'proof-metadata-only'
+  | 'devnet-gated'
+  | 'live-gated';
+
+export type BuyerAuthorityOperatorApprovalState =
+  | 'approved'
+  | 'denied'
+  | 'requires_operator_approval'
+  | 'not_required';
+
+export type BuyerAuthorityPolicyMode = 'allow' | 'deny' | 'approval-required';
+
+export type BuyerAuthoritySpendCap = {
+  asset: BuyerAuthorityAsset;
+  network: string;
+  maxAmountUnits: string;
+  window: 'per_request' | 'daily' | 'monthly';
+  approvalRequiredAboveUnits?: string;
+};
+
+export type BuyerAuthorityRailPermission = {
+  asset: BuyerAuthorityAsset;
+  network: string;
+  supportStates: BuyerAuthoritySupportState[];
+};
+
+export type BuyerAuthorityPolicy = {
+  schemaVersion: typeof BUYER_AUTHORITY_POLICY_SCHEMA_VERSION;
+  issue: 549;
+  policyId: string;
+  mode: BuyerAuthorityPolicyMode;
+  buyerAgentId: string;
+  expiresAt: string;
+  allowedRails: BuyerAuthorityRailPermission[];
+  allowedCurrencies: BuyerAuthorityAsset[];
+  spendCaps: BuyerAuthoritySpendCap[];
+  sellerAllowlist: {
+    sellerIds: string[];
+    endpointIds: string[];
+  };
+  receiptEvidence: {
+    receiptRequired: boolean;
+    evidenceRequired: boolean;
+    evidenceArchiveRequired: boolean;
+  };
+  refundFailurePolicy: {
+    failureMode: 'no_charge_on_failure' | 'manual_review_required';
+    refundMode: 'manual_review' | 'not_applicable';
+    operatorReviewRequired: boolean;
+  };
+  operatorApproval: {
+    required: boolean;
+    approvalState: BuyerAuthorityOperatorApprovalState;
+    thresholdAmountUnits?: string;
+  };
+  supportStateConstraints: {
+    allowLivePayment: false;
+    allowedRuntimeStates: BuyerAuthoritySupportState[];
+    forbidCustody: true;
+    forbidSettlementFinality: true;
+  };
+  notes: string[];
+};
+
+export type BuyerAuthorityPolicyEvaluationRequest = {
+  sellerId: string;
+  endpointId: string;
+  asset: string;
+  network: string;
+  amountUnits: string;
+  supportState: string;
+  receiptPresented: boolean;
+  evidencePresented: boolean;
+  now: string;
+  operatorApprovalState?: BuyerAuthorityOperatorApprovalState;
+};
+
+export type BuyerAuthorityPolicyReasonCode =
+  | 'buyer_authority_policy_valid'
+  | 'policy_malformed'
+  | 'policy_contains_credentials'
+  | 'policy_denied'
+  | 'policy_expired'
+  | 'unsupported_rail_currency'
+  | 'seller_not_allowlisted'
+  | 'spend_cap_exceeded'
+  | 'receipt_requirement_missing'
+  | 'evidence_requirement_missing'
+  | 'operator_approval_required'
+  | 'operator_approval_denied'
+  | 'live_payment_rejected'
+  | 'wallet_rpc_provider_call_rejected'
+  | 'transfer_instruction_rejected'
+  | 'custody_claim_rejected'
+  | 'settlement_finality_claim_rejected';
+
+export type BuyerAuthorityPolicyEvaluation = {
+  allowed: boolean;
+  reasonCodes: BuyerAuthorityPolicyReasonCode[];
+  auditNotes: string[];
+};
+
+export type BuyerAuthorityPolicyExampleKey =
+  | 'allow'
+  | 'deny'
+  | 'expired'
+  | 'approvalRequired'
+  | 'unsupportedRailCurrency'
+  | 'sellerNotAllowlisted'
+  | 'missingEvidenceRequirement';
+
+export type BuyerAuthorityPolicyExampleCase = {
+  key: BuyerAuthorityPolicyExampleKey;
+  description: string;
+  policy: BuyerAuthorityPolicy;
+  request: BuyerAuthorityPolicyEvaluationRequest;
+  expectedAllowed: boolean;
+  expectedReasonCodes: BuyerAuthorityPolicyReasonCode[];
+};
+
+const BASE_EXPIRES_AT = '2026-07-01T00:00:00.000Z';
+const DEFAULT_REQUEST: BuyerAuthorityPolicyEvaluationRequest = {
+  sellerId: 'seller:listing-writer',
+  endpointId: 'seller-wrapper:listing-writer:http',
+  asset: 'AUDD',
+  network: 'solana-devnet',
+  amountUnits: '2500000',
+  supportState: 'proof-metadata-only',
+  receiptPresented: true,
+  evidencePresented: true,
+  now: '2026-06-27T00:00:00.000Z',
+  operatorApprovalState: 'approved',
+};
+
+const UNSAFE_LIVE_PATTERN = /\bhttps?:\/\/[^\s"]*(rpc|alchemy|helius|quicknode|api\.(mainnet-beta|devnet|testnet)\.solana\.com)[^\s"]*|\b(provider\s+credential|wallet\s+sign|signing\s+authority)\b/i;
+const TRANSFER_INSTRUCTION_PATTERN = /\b(submit|sign|transfer|broadcast)\b.*\b(transaction|payment|audd|usdc|sol)\b/i;
+const CUSTODY_CLAIM_PATTERN = /\b(audd|usdc|sol)\b.*\b(custody|custodied|escrowed|held)\b|\bheld\s+in\s+custody\b/i;
+const SETTLEMENT_FINALITY_PATTERN = /\bsettlement\s+finality\b|\bfinal\s+settlement\b/i;
+
+function basePolicy(overrides: Partial<BuyerAuthorityPolicy> = {}): BuyerAuthorityPolicy {
+  return {
+    schemaVersion: BUYER_AUTHORITY_POLICY_SCHEMA_VERSION,
+    issue: 549,
+    policyId: 'buyer-authority:listing-writer:audd',
+    mode: 'allow',
+    buyerAgentId: 'buyer-agent:planning-demo',
+    expiresAt: BASE_EXPIRES_AT,
+    allowedRails: [
+      {
+        asset: 'AUDD',
+        network: 'solana-devnet',
+        supportStates: ['proof-metadata-only', 'dry-run'],
+      },
+      {
+        asset: 'USDC',
+        network: 'solana-devnet',
+        supportStates: ['dry-run'],
+      },
+      {
+        asset: 'SOL',
+        network: 'solana-devnet',
+        supportStates: ['devnet-gated'],
+      },
+    ],
+    allowedCurrencies: ['AUDD', 'USDC', 'SOL'],
+    spendCaps: [
+      {
+        asset: 'AUDD',
+        network: 'solana-devnet',
+        maxAmountUnits: '2500000',
+        window: 'per_request',
+        approvalRequiredAboveUnits: '1000000',
+      },
+    ],
+    sellerAllowlist: {
+      sellerIds: ['seller:listing-writer'],
+      endpointIds: ['seller-wrapper:listing-writer:http'],
+    },
+    receiptEvidence: {
+      receiptRequired: true,
+      evidenceRequired: true,
+      evidenceArchiveRequired: true,
+    },
+    refundFailurePolicy: {
+      failureMode: 'no_charge_on_failure',
+      refundMode: 'manual_review',
+      operatorReviewRequired: true,
+    },
+    operatorApproval: {
+      required: true,
+      approvalState: 'approved',
+      thresholdAmountUnits: '1000000',
+    },
+    supportStateConstraints: {
+      allowLivePayment: false,
+      allowedRuntimeStates: ['proof-metadata-only', 'dry-run', 'devnet-gated'],
+      forbidCustody: true,
+      forbidSettlementFinality: true,
+    },
+    notes: [
+      'AUDD, SOL, and USDC are proof/preflight metadata in this policy.',
+      'Live settlement requires a separate approved and audited workstream.',
+    ],
+    ...overrides,
+  };
+}
+
+function clonePolicy(policy: BuyerAuthorityPolicy): BuyerAuthorityPolicy {
+  return structuredClone(policy) as BuyerAuthorityPolicy;
+}
+
+function textContains(value: unknown, pattern: RegExp): boolean {
+  if (typeof value === 'string') return pattern.test(value);
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some((item) => textContains(item, pattern));
+  return Object.values(value).some((item) => textContains(item, pattern));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isStructuredPolicy(value: unknown): value is BuyerAuthorityPolicy {
+  if (!isRecord(value)) return false;
+  const candidate = value as Partial<BuyerAuthorityPolicy>;
+  const sellerAllowlist = candidate.sellerAllowlist;
+  const receiptEvidence = candidate.receiptEvidence;
+  const refundFailurePolicy = candidate.refundFailurePolicy;
+  const operatorApproval = candidate.operatorApproval;
+  const supportStateConstraints = candidate.supportStateConstraints;
+
+  return candidate.schemaVersion === BUYER_AUTHORITY_POLICY_SCHEMA_VERSION
+    && candidate.issue === 549
+    && typeof candidate.policyId === 'string'
+    && typeof candidate.buyerAgentId === 'string'
+    && typeof candidate.expiresAt === 'string'
+    && candidate.mode !== undefined
+    && ['allow', 'deny', 'approval-required'].includes(candidate.mode)
+    && Array.isArray(candidate.allowedRails)
+    && candidate.allowedRails.every((rail) => isRecord(rail)
+      && ['SOL', 'USDC', 'AUDD'].includes(String(rail.asset))
+      && typeof rail.network === 'string'
+      && isStringArray(rail.supportStates))
+    && Array.isArray(candidate.allowedCurrencies)
+    && candidate.allowedCurrencies.every((asset) => ['SOL', 'USDC', 'AUDD'].includes(asset))
+    && Array.isArray(candidate.spendCaps)
+    && candidate.spendCaps.every((cap) => isRecord(cap)
+      && ['SOL', 'USDC', 'AUDD'].includes(String(cap.asset))
+      && typeof cap.network === 'string'
+      && typeof cap.maxAmountUnits === 'string'
+      && ['per_request', 'daily', 'monthly'].includes(String(cap.window)))
+    && isRecord(sellerAllowlist)
+    && isStringArray(sellerAllowlist.sellerIds)
+    && isStringArray(sellerAllowlist.endpointIds)
+    && isRecord(receiptEvidence)
+    && typeof receiptEvidence.receiptRequired === 'boolean'
+    && typeof receiptEvidence.evidenceRequired === 'boolean'
+    && typeof receiptEvidence.evidenceArchiveRequired === 'boolean'
+    && isRecord(refundFailurePolicy)
+    && ['no_charge_on_failure', 'manual_review_required'].includes(String(refundFailurePolicy.failureMode))
+    && ['manual_review', 'not_applicable'].includes(String(refundFailurePolicy.refundMode))
+    && typeof refundFailurePolicy.operatorReviewRequired === 'boolean'
+    && isRecord(operatorApproval)
+    && typeof operatorApproval.required === 'boolean'
+    && ['approved', 'denied', 'requires_operator_approval', 'not_required'].includes(String(operatorApproval.approvalState))
+    && isRecord(supportStateConstraints)
+    && typeof supportStateConstraints.allowLivePayment === 'boolean'
+    && isStringArray(supportStateConstraints.allowedRuntimeStates)
+    && typeof supportStateConstraints.forbidCustody === 'boolean'
+    && typeof supportStateConstraints.forbidSettlementFinality === 'boolean'
+    && isStringArray(candidate.notes);
+}
+
+function amountGreaterThan(amount: string, maxAmount: string): boolean {
+  try {
+    return BigInt(amount) > BigInt(maxAmount);
+  } catch {
+    return true;
+  }
+}
+
+function policyMatchesRail(policy: BuyerAuthorityPolicy, request: BuyerAuthorityPolicyEvaluationRequest): boolean {
+  return policy.allowedRails.some((rail) => (
+    rail.asset === request.asset
+    && rail.network === request.network
+    && rail.supportStates.includes(request.supportState as BuyerAuthoritySupportState)
+  ));
+}
+
+function policySpendCap(policy: BuyerAuthorityPolicy, request: BuyerAuthorityPolicyEvaluationRequest): BuyerAuthoritySpendCap | undefined {
+  return policy.spendCaps.find((cap) => (
+    cap.asset === request.asset && cap.network === request.network && cap.window === 'per_request'
+  ));
+}
+
+export function validateBuyerAuthorityPolicy(policy: unknown): BuyerAuthorityPolicyEvaluation {
+  if (!isStructuredPolicy(policy)) {
+    return {
+      allowed: false,
+      reasonCodes: ['policy_malformed'],
+      auditNotes: ['Denied: buyer authority policy is malformed.'],
+    };
+  }
+
+  const reasonCodes: BuyerAuthorityPolicyReasonCode[] = [];
+  const auditNotes: string[] = [];
+
+  if (sellerWrapperFixtureHasCredentialMaterial(policy)) {
+    reasonCodes.push('policy_contains_credentials');
+    auditNotes.push('Denied: buyer authority policy contains credential-like material.');
+  }
+  if (policy.supportStateConstraints.allowLivePayment) {
+    reasonCodes.push('live_payment_rejected');
+    auditNotes.push('Denied: #549 policies must not approve live payment.');
+  }
+  if (!policy.supportStateConstraints.forbidCustody) {
+    reasonCodes.push('custody_claim_rejected');
+    auditNotes.push('Denied: #549 policies must forbid custody.');
+  }
+  if (!policy.supportStateConstraints.forbidSettlementFinality) {
+    reasonCodes.push('settlement_finality_claim_rejected');
+    auditNotes.push('Denied: #549 policies must forbid settlement finality claims.');
+  }
+  if (
+    policy.supportStateConstraints.allowedRuntimeStates.includes('live-gated')
+    || policy.allowedRails.some((rail) => rail.supportStates.includes('live-gated'))
+  ) {
+    reasonCodes.push('live_payment_rejected');
+    auditNotes.push('Denied: #549 policies must not include live-gated support states.');
+  }
+  if (textContains(policy, UNSAFE_LIVE_PATTERN)) {
+    reasonCodes.push('wallet_rpc_provider_call_rejected');
+    auditNotes.push('Denied: policy contains wallet/RPC/provider-call material.');
+  }
+  if (textContains(policy, TRANSFER_INSTRUCTION_PATTERN)) {
+    reasonCodes.push('transfer_instruction_rejected');
+    auditNotes.push('Denied: policy contains signing, broadcast, or transfer instructions.');
+  }
+  if (textContains(policy, CUSTODY_CLAIM_PATTERN)) {
+    reasonCodes.push('custody_claim_rejected');
+    auditNotes.push('Denied: policy must not claim custody.');
+  }
+  if (textContains(policy, SETTLEMENT_FINALITY_PATTERN)) {
+    reasonCodes.push('settlement_finality_claim_rejected');
+    auditNotes.push('Denied: policy must not claim settlement finality.');
+  }
+
+  if (reasonCodes.length > 0) return { allowed: false, reasonCodes, auditNotes };
+  return {
+    allowed: true,
+    reasonCodes: ['buyer_authority_policy_valid'],
+    auditNotes: ['Allowed: buyer authority policy is static, non-secret, no-spend, and no-live.'],
+  };
+}
+
+export function evaluateBuyerAuthorityPolicy(
+  policy: unknown,
+  request: BuyerAuthorityPolicyEvaluationRequest,
+): BuyerAuthorityPolicyEvaluation {
+  const structural = validateBuyerAuthorityPolicy(policy);
+  if (!structural.allowed || !isStructuredPolicy(policy)) return structural;
+
+  const reasonCodes: BuyerAuthorityPolicyReasonCode[] = [];
+  const auditNotes: string[] = [];
+
+  if (policy.mode === 'deny') {
+    reasonCodes.push('policy_denied');
+    auditNotes.push('Denied: policy mode is deny.');
+  }
+  if (new Date(request.now).getTime() > new Date(policy.expiresAt).getTime()) {
+    reasonCodes.push('policy_expired');
+    auditNotes.push('Denied: buyer authority policy has expired.');
+  }
+  const railCurrencySupported = policy.allowedCurrencies.includes(request.asset as BuyerAuthorityAsset)
+    && policyMatchesRail(policy, request);
+  if (!railCurrencySupported) {
+    reasonCodes.push('unsupported_rail_currency');
+    auditNotes.push('Denied: requested rail, currency, network, or support state is not allowed.');
+  }
+  if (
+    !policy.sellerAllowlist.sellerIds.includes(request.sellerId)
+    || !policy.sellerAllowlist.endpointIds.includes(request.endpointId)
+  ) {
+    reasonCodes.push('seller_not_allowlisted');
+    auditNotes.push('Denied: requested seller or endpoint is not allowlisted.');
+  }
+
+  const cap = policySpendCap(policy, request);
+  if (railCurrencySupported && (!cap || amountGreaterThan(request.amountUnits, cap.maxAmountUnits))) {
+    reasonCodes.push('spend_cap_exceeded');
+    auditNotes.push('Denied: requested amount exceeds the per-request spend cap.');
+  }
+
+  if (policy.receiptEvidence.receiptRequired && !request.receiptPresented) {
+    reasonCodes.push('receipt_requirement_missing');
+    auditNotes.push('Denied: receipt requirement was not satisfied.');
+  }
+  if ((policy.receiptEvidence.evidenceRequired || policy.receiptEvidence.evidenceArchiveRequired) && !request.evidencePresented) {
+    reasonCodes.push('evidence_requirement_missing');
+    auditNotes.push('Denied: evidence requirement was not satisfied.');
+  }
+
+  const approvalState = request.operatorApprovalState ?? policy.operatorApproval.approvalState;
+  if (policy.mode === 'approval-required' || policy.operatorApproval.required) {
+    if (approvalState === 'denied') {
+      reasonCodes.push('operator_approval_denied');
+      auditNotes.push('Denied: operator approval was denied.');
+    } else if (approvalState !== 'approved') {
+      reasonCodes.push('operator_approval_required');
+      auditNotes.push('Denied: operator approval is required before invocation.');
+    }
+  }
+
+  if (reasonCodes.length > 0) return { allowed: false, reasonCodes, auditNotes };
+  return {
+    allowed: true,
+    reasonCodes: ['buyer_authority_policy_valid'],
+    auditNotes: ['Allowed: request satisfies buyer authority policy in no-live fixture mode.'],
+  };
+}
+
+const allowPolicy = basePolicy();
+const denyPolicy = basePolicy({ policyId: 'buyer-authority:deny-all', mode: 'deny' });
+const expiredPolicy = basePolicy({ policyId: 'buyer-authority:expired', expiresAt: '2026-06-01T00:00:00.000Z' });
+const approvalRequiredPolicy = basePolicy({
+  policyId: 'buyer-authority:approval-required',
+  mode: 'approval-required',
+  operatorApproval: {
+    required: true,
+    approvalState: 'requires_operator_approval',
+    thresholdAmountUnits: '1000000',
+  },
+});
+const unsupportedRailPolicy = basePolicy({ policyId: 'buyer-authority:unsupported-rail' });
+const sellerNotAllowlistedPolicy = basePolicy({ policyId: 'buyer-authority:seller-not-allowlisted' });
+const missingEvidencePolicy = basePolicy({ policyId: 'buyer-authority:missing-evidence' });
+
+export const buyerAuthorityPolicyExamples: Record<BuyerAuthorityPolicyExampleKey, BuyerAuthorityPolicyExampleCase> = {
+  allow: {
+    key: 'allow',
+    description: 'Allows AUDD proof/preflight metadata when seller, rail, approval, receipt, and evidence requirements are satisfied.',
+    policy: allowPolicy,
+    request: DEFAULT_REQUEST,
+    expectedAllowed: true,
+    expectedReasonCodes: ['buyer_authority_policy_valid'],
+  },
+  deny: {
+    key: 'deny',
+    description: 'Denies all invocation attempts while keeping policy shape valid and non-secret.',
+    policy: denyPolicy,
+    request: DEFAULT_REQUEST,
+    expectedAllowed: false,
+    expectedReasonCodes: ['policy_denied'],
+  },
+  expired: {
+    key: 'expired',
+    description: 'Denies when the buyer authority policy is past its expiry.',
+    policy: expiredPolicy,
+    request: DEFAULT_REQUEST,
+    expectedAllowed: false,
+    expectedReasonCodes: ['policy_expired'],
+  },
+  approvalRequired: {
+    key: 'approvalRequired',
+    description: 'Denies until operator approval is supplied for spend above the approval threshold.',
+    policy: approvalRequiredPolicy,
+    request: {
+      ...DEFAULT_REQUEST,
+      operatorApprovalState: 'requires_operator_approval',
+    },
+    expectedAllowed: false,
+    expectedReasonCodes: ['operator_approval_required'],
+  },
+  unsupportedRailCurrency: {
+    key: 'unsupportedRailCurrency',
+    description: 'Denies unsupported asset/network/support-state combinations.',
+    policy: unsupportedRailPolicy,
+    request: {
+      ...DEFAULT_REQUEST,
+      asset: 'EURC',
+      supportState: 'unsupported',
+    },
+    expectedAllowed: false,
+    expectedReasonCodes: ['unsupported_rail_currency'],
+  },
+  sellerNotAllowlisted: {
+    key: 'sellerNotAllowlisted',
+    description: 'Denies when a seller or endpoint is outside the allowlist.',
+    policy: sellerNotAllowlistedPolicy,
+    request: {
+      ...DEFAULT_REQUEST,
+      sellerId: 'seller:unknown',
+      endpointId: 'seller-wrapper:unknown:http',
+    },
+    expectedAllowed: false,
+    expectedReasonCodes: ['seller_not_allowlisted'],
+  },
+  missingEvidenceRequirement: {
+    key: 'missingEvidenceRequirement',
+    description: 'Denies when evidence requirements are not satisfied.',
+    policy: missingEvidencePolicy,
+    request: {
+      ...DEFAULT_REQUEST,
+      evidencePresented: false,
+    },
+    expectedAllowed: false,
+    expectedReasonCodes: ['evidence_requirement_missing'],
+  },
+};
+
+export function listBuyerAuthorityPolicyExamples(): BuyerAuthorityPolicyExampleCase[] {
+  return Object.values(buyerAuthorityPolicyExamples).map((example) => ({
+    ...example,
+    policy: clonePolicy(example.policy),
+    request: structuredClone(example.request) as BuyerAuthorityPolicyEvaluationRequest,
+  }));
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -9,6 +9,7 @@ export * from './source-diagnostics.js';
 export * from './attestation-reputation.js';
 export * from './buyer-seller.js';
 export * from './audd-payment-plan.js';
+export * from './buyer-authority-policy.js';
 export * from './agent-stack-fixtures.js';
 export * from './receipt-evidence-binding.js';
 export * from './offchain-reputation-preview.js';

--- a/packages/agent-protocol/tests/buyer-authority-policy.test.ts
+++ b/packages/agent-protocol/tests/buyer-authority-policy.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  BUYER_AUTHORITY_POLICY_SCHEMA_VERSION,
+  buyerAuthorityPolicyExamples,
+  evaluateBuyerAuthorityPolicy,
+  listBuyerAuthorityPolicyExamples,
+  validateBuyerAuthorityPolicy,
+  type BuyerAuthorityPolicy,
+} from '../dist/index.js';
+
+describe('buyer authority policy examples', () => {
+  it('exports static no-live buyer authority policy examples', () => {
+    const examples = listBuyerAuthorityPolicyExamples();
+
+    assert.equal(examples.length, 7);
+    assert.deepEqual(examples.map((example) => example.key).sort(), [
+      'allow',
+      'approvalRequired',
+      'deny',
+      'expired',
+      'missingEvidenceRequirement',
+      'sellerNotAllowlisted',
+      'unsupportedRailCurrency',
+    ]);
+
+    for (const example of examples) {
+      assert.equal(example.policy.schemaVersion, BUYER_AUTHORITY_POLICY_SCHEMA_VERSION);
+      assert.equal(example.policy.issue, 549);
+      assert.equal(example.policy.supportStateConstraints.allowLivePayment, false);
+      assert.equal(example.policy.supportStateConstraints.forbidCustody, true);
+      assert.equal(example.policy.supportStateConstraints.forbidSettlementFinality, true);
+      assert.equal(validateBuyerAuthorityPolicy(example.policy).allowed, true);
+    }
+  });
+
+  it('evaluates allow and fail-closed static policy cases', () => {
+    for (const example of Object.values(buyerAuthorityPolicyExamples)) {
+      const result = evaluateBuyerAuthorityPolicy(example.policy, example.request);
+
+      assert.equal(result.allowed, example.expectedAllowed, example.key);
+      assert.deepEqual(result.reasonCodes, example.expectedReasonCodes, example.key);
+    }
+  });
+
+  it('fails closed for credentials, live calls, custody, transfer, and settlement-finality claims', () => {
+    const credentialPolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy) as BuyerAuthorityPolicy & {
+      providerSecret?: string;
+    };
+    credentialPolicy.providerSecret = 'sk-test-secret';
+    assert.deepEqual(validateBuyerAuthorityPolicy(credentialPolicy).reasonCodes, ['policy_contains_credentials']);
+
+    const livePaymentPolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy) as unknown as {
+      supportStateConstraints: { allowLivePayment: boolean };
+    };
+    livePaymentPolicy.supportStateConstraints.allowLivePayment = true;
+    assert.deepEqual(validateBuyerAuthorityPolicy(livePaymentPolicy).reasonCodes, ['live_payment_rejected']);
+
+    const liveGatedPolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy);
+    liveGatedPolicy.allowedRails[0]?.supportStates.push('live-gated');
+    assert.deepEqual(validateBuyerAuthorityPolicy(liveGatedPolicy).reasonCodes, ['live_payment_rejected']);
+
+    const rpcPolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy);
+    rpcPolicy.notes.push('Use https://api.mainnet-beta.solana.com for the provider call.');
+    assert.deepEqual(validateBuyerAuthorityPolicy(rpcPolicy).reasonCodes, ['wallet_rpc_provider_call_rejected']);
+
+    const transferPolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy);
+    transferPolicy.notes.push('Sign and transfer AUDD after approval.');
+    assert.deepEqual(validateBuyerAuthorityPolicy(transferPolicy).reasonCodes, ['transfer_instruction_rejected']);
+
+    const custodyPolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy);
+    custodyPolicy.notes.push('AUDD is held in custody by the buyer agent.');
+    assert.deepEqual(validateBuyerAuthorityPolicy(custodyPolicy).reasonCodes, ['custody_claim_rejected']);
+
+    const finalityPolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy);
+    finalityPolicy.notes.push('This policy proves settlement finality.');
+    assert.deepEqual(validateBuyerAuthorityPolicy(finalityPolicy).reasonCodes, ['settlement_finality_claim_rejected']);
+  });
+});


### PR DESCRIPTION
Closes #549.

## Summary
- adds a static buyer authority policy module for spend caps, allowed rails/currencies, seller allowlists, expiry, receipt/evidence requirements, refund/failure policy, operator approval, and support-state constraints
- exports local allow/deny/expired/approval-required/unsupported-rail/seller-not-allowlisted/missing-evidence examples plus validation/evaluation helpers
- documents the package subpath export and regenerates package dist output

## Validation
- `npm --prefix packages/agent-protocol install --ignore-scripts`
- `npm --prefix packages/agent-protocol test -- --runInBand` - 173/173 passing
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `git diff --check`

## Boundary
- no UI changes, so no screenshots/video required
- no package publication
- no Airwallex/API/cloud/provider calls
- no live/devnet payment execution
- no wallet/RPC/provider call
- no custody, SPL transfer, or settlement-finality claim
