### PR TITLE
test: expand buyer authority fixture matrix

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -65,6 +65,7 @@ The helper is no-spend and non-secret. It rejects credential-shaped metadata, li
 import {
   buyerAuthorityPolicyExamples,
   evaluateBuyerAuthorityPolicy,
+  listBuyerAuthorityPolicyFixtureMatrix,
 } from '@reddi/agent-protocol/buyer-authority-policy';
 
 const example = buyerAuthorityPolicyExamples.allow;
@@ -76,11 +77,14 @@ const denied = evaluateBuyerAuthorityPolicy(
   buyerAuthorityPolicyExamples.missingEvidenceRequirement.request,
 );
 console.log(denied.reasonCodes); // evidence_requirement_missing
+
+const matrix = listBuyerAuthorityPolicyFixtureMatrix();
+console.log(matrix.map((case_) => case_.key));
 ```
 
 Buyer authority policy examples make an agent's spending authority explicit before it discovers, quotes, preflights, invokes, or simulates payment for another agent. The static contract covers spend caps, allowed rails and currencies, seller allowlists, expiry, receipt/evidence requirements, refund/failure policy, operator approval thresholds, and support-state constraints.
 
-The built-in examples cover allow, deny, expired, approval-required, unsupported rail/currency, seller-not-allowlisted, and missing-evidence states. AUDD/SOL/USDC remain proof, preflight, and support metadata only unless a separate audited custody or settlement workstream is approved.
+The built-in fixture matrix covers allow, deny, expired, approval-required, unsupported rail, unsupported currency, seller-not-allowlisted, missing-receipt, missing-evidence, refund/failure-policy mismatch, and spend-cap-exceeded states. Downstream #543 framework-template conformance and #375 seller-wrapper flows should consume these reason-coded cases instead of inventing parallel buyer-authority semantics. AUDD/SOL/USDC remain proof, preflight, and support metadata only unless a separate audited custody or settlement workstream is approved.
 
 The helper is no-spend and non-secret. It rejects credential-shaped metadata, live-payment approval, wallet/RPC/provider-call material, signing/transfer instructions, custody claims, and settlement-finality claims. It does not contact Airwallex, invoke providers, call wallets/RPC endpoints, transfer SPL tokens, activate Pay.sh, or settle funds.
 

--- a/packages/agent-protocol/dist/buyer-authority-policy.d.ts
+++ b/packages/agent-protocol/dist/buyer-authority-policy.d.ts
@@ -62,15 +62,17 @@ export type BuyerAuthorityPolicyEvaluationRequest = {
     receiptPresented: boolean;
     evidencePresented: boolean;
     now: string;
+    failureMode?: BuyerAuthorityPolicy['refundFailurePolicy']['failureMode'];
+    refundMode?: BuyerAuthorityPolicy['refundFailurePolicy']['refundMode'];
     operatorApprovalState?: BuyerAuthorityOperatorApprovalState;
 };
-export type BuyerAuthorityPolicyReasonCode = 'buyer_authority_policy_valid' | 'policy_malformed' | 'policy_contains_credentials' | 'policy_denied' | 'policy_expired' | 'unsupported_rail_currency' | 'seller_not_allowlisted' | 'spend_cap_exceeded' | 'receipt_requirement_missing' | 'evidence_requirement_missing' | 'operator_approval_required' | 'operator_approval_denied' | 'live_payment_rejected' | 'wallet_rpc_provider_call_rejected' | 'transfer_instruction_rejected' | 'custody_claim_rejected' | 'settlement_finality_claim_rejected';
+export type BuyerAuthorityPolicyReasonCode = 'buyer_authority_policy_valid' | 'policy_malformed' | 'policy_contains_credentials' | 'policy_denied' | 'policy_expired' | 'unsupported_rail_currency' | 'seller_not_allowlisted' | 'spend_cap_exceeded' | 'receipt_requirement_missing' | 'evidence_requirement_missing' | 'refund_failure_policy_mismatch' | 'operator_approval_required' | 'operator_approval_denied' | 'live_payment_rejected' | 'wallet_rpc_provider_call_rejected' | 'transfer_instruction_rejected' | 'custody_claim_rejected' | 'settlement_finality_claim_rejected';
 export type BuyerAuthorityPolicyEvaluation = {
     allowed: boolean;
     reasonCodes: BuyerAuthorityPolicyReasonCode[];
     auditNotes: string[];
 };
-export type BuyerAuthorityPolicyExampleKey = 'allow' | 'deny' | 'expired' | 'approvalRequired' | 'unsupportedRailCurrency' | 'sellerNotAllowlisted' | 'missingEvidenceRequirement';
+export type BuyerAuthorityPolicyExampleKey = 'allow' | 'deny' | 'expired' | 'approvalRequired' | 'unsupportedRail' | 'unsupportedCurrency' | 'sellerNotAllowlisted' | 'missingReceiptRequirement' | 'missingEvidenceRequirement' | 'refundFailurePolicyMismatch' | 'spendCapExceeded';
 export type BuyerAuthorityPolicyExampleCase = {
     key: BuyerAuthorityPolicyExampleKey;
     description: string;
@@ -83,3 +85,4 @@ export declare function validateBuyerAuthorityPolicy(policy: unknown): BuyerAuth
 export declare function evaluateBuyerAuthorityPolicy(policy: unknown, request: BuyerAuthorityPolicyEvaluationRequest): BuyerAuthorityPolicyEvaluation;
 export declare const buyerAuthorityPolicyExamples: Record<BuyerAuthorityPolicyExampleKey, BuyerAuthorityPolicyExampleCase>;
 export declare function listBuyerAuthorityPolicyExamples(): BuyerAuthorityPolicyExampleCase[];
+export declare function listBuyerAuthorityPolicyFixtureMatrix(): BuyerAuthorityPolicyExampleCase[];

--- a/packages/agent-protocol/dist/buyer-authority-policy.js
+++ b/packages/agent-protocol/dist/buyer-authority-policy.js
@@ -17,6 +17,13 @@ const UNSAFE_LIVE_PATTERN = /\bhttps?:\/\/[^\s"]*(rpc|alchemy|helius|quicknode|a
 const TRANSFER_INSTRUCTION_PATTERN = /\b(submit|sign|transfer|broadcast)\b.*\b(transaction|payment|audd|usdc|sol)\b/i;
 const CUSTODY_CLAIM_PATTERN = /\b(audd|usdc|sol)\b.*\b(custody|custodied|escrowed|held)\b|\bheld\s+in\s+custody\b/i;
 const SETTLEMENT_FINALITY_PATTERN = /\bsettlement\s+finality\b|\bfinal\s+settlement\b/i;
+const KNOWN_SUPPORT_STATES = [
+    'fixture',
+    'dry-run',
+    'proof-metadata-only',
+    'devnet-gated',
+    'live-gated',
+];
 function basePolicy(overrides = {}) {
     return {
         schemaVersion: BUYER_AUTHORITY_POLICY_SCHEMA_VERSION,
@@ -102,6 +109,9 @@ function isRecord(value) {
 function isStringArray(value) {
     return Array.isArray(value) && value.every((item) => typeof item === 'string');
 }
+function hasOnlyKnownSupportStates(value) {
+    return isStringArray(value) && value.every((state) => (KNOWN_SUPPORT_STATES.includes(state)));
+}
 function isStructuredPolicy(value) {
     if (!isRecord(value))
         return false;
@@ -122,7 +132,7 @@ function isStructuredPolicy(value) {
         && candidate.allowedRails.every((rail) => isRecord(rail)
             && ['SOL', 'USDC', 'AUDD'].includes(String(rail.asset))
             && typeof rail.network === 'string'
-            && isStringArray(rail.supportStates))
+            && hasOnlyKnownSupportStates(rail.supportStates))
         && Array.isArray(candidate.allowedCurrencies)
         && candidate.allowedCurrencies.every((asset) => ['SOL', 'USDC', 'AUDD'].includes(asset))
         && Array.isArray(candidate.spendCaps)
@@ -147,7 +157,7 @@ function isStructuredPolicy(value) {
         && ['approved', 'denied', 'requires_operator_approval', 'not_required'].includes(String(operatorApproval.approvalState))
         && isRecord(supportStateConstraints)
         && typeof supportStateConstraints.allowLivePayment === 'boolean'
-        && isStringArray(supportStateConstraints.allowedRuntimeStates)
+        && hasOnlyKnownSupportStates(supportStateConstraints.allowedRuntimeStates)
         && typeof supportStateConstraints.forbidCustody === 'boolean'
         && typeof supportStateConstraints.forbidSettlementFinality === 'boolean'
         && isStringArray(candidate.notes);
@@ -261,6 +271,11 @@ export function evaluateBuyerAuthorityPolicy(policy, request) {
         reasonCodes.push('evidence_requirement_missing');
         auditNotes.push('Denied: evidence requirement was not satisfied.');
     }
+    if ((request.failureMode !== undefined && request.failureMode !== policy.refundFailurePolicy.failureMode)
+        || (request.refundMode !== undefined && request.refundMode !== policy.refundFailurePolicy.refundMode)) {
+        reasonCodes.push('refund_failure_policy_mismatch');
+        auditNotes.push('Denied: requested refund/failure handling does not match the buyer authority policy.');
+    }
     const approvalState = request.operatorApprovalState ?? policy.operatorApproval.approvalState;
     if (policy.mode === 'approval-required' || policy.operatorApproval.required) {
         if (approvalState === 'denied') {
@@ -293,8 +308,12 @@ const approvalRequiredPolicy = basePolicy({
     },
 });
 const unsupportedRailPolicy = basePolicy({ policyId: 'buyer-authority:unsupported-rail' });
+const unsupportedCurrencyPolicy = basePolicy({ policyId: 'buyer-authority:unsupported-currency' });
 const sellerNotAllowlistedPolicy = basePolicy({ policyId: 'buyer-authority:seller-not-allowlisted' });
+const missingReceiptPolicy = basePolicy({ policyId: 'buyer-authority:missing-receipt' });
 const missingEvidencePolicy = basePolicy({ policyId: 'buyer-authority:missing-evidence' });
+const refundFailureMismatchPolicy = basePolicy({ policyId: 'buyer-authority:refund-failure-mismatch' });
+const spendCapExceededPolicy = basePolicy({ policyId: 'buyer-authority:spend-cap-exceeded' });
 export const buyerAuthorityPolicyExamples = {
     allow: {
         key: 'allow',
@@ -331,14 +350,24 @@ export const buyerAuthorityPolicyExamples = {
         expectedAllowed: false,
         expectedReasonCodes: ['operator_approval_required'],
     },
-    unsupportedRailCurrency: {
-        key: 'unsupportedRailCurrency',
-        description: 'Denies unsupported asset/network/support-state combinations.',
+    unsupportedRail: {
+        key: 'unsupportedRail',
+        description: 'Denies unsupported network or support-state combinations for an otherwise allowed currency.',
         policy: unsupportedRailPolicy,
         request: {
             ...DEFAULT_REQUEST,
+            network: 'solana-mainnet',
+        },
+        expectedAllowed: false,
+        expectedReasonCodes: ['unsupported_rail_currency'],
+    },
+    unsupportedCurrency: {
+        key: 'unsupportedCurrency',
+        description: 'Denies unsupported currencies even when the request otherwise resembles an allowed rail.',
+        policy: unsupportedCurrencyPolicy,
+        request: {
+            ...DEFAULT_REQUEST,
             asset: 'EURC',
-            supportState: 'unsupported',
         },
         expectedAllowed: false,
         expectedReasonCodes: ['unsupported_rail_currency'],
@@ -355,6 +384,17 @@ export const buyerAuthorityPolicyExamples = {
         expectedAllowed: false,
         expectedReasonCodes: ['seller_not_allowlisted'],
     },
+    missingReceiptRequirement: {
+        key: 'missingReceiptRequirement',
+        description: 'Denies when receipt requirements are not satisfied.',
+        policy: missingReceiptPolicy,
+        request: {
+            ...DEFAULT_REQUEST,
+            receiptPresented: false,
+        },
+        expectedAllowed: false,
+        expectedReasonCodes: ['receipt_requirement_missing'],
+    },
     missingEvidenceRequirement: {
         key: 'missingEvidenceRequirement',
         description: 'Denies when evidence requirements are not satisfied.',
@@ -366,6 +406,29 @@ export const buyerAuthorityPolicyExamples = {
         expectedAllowed: false,
         expectedReasonCodes: ['evidence_requirement_missing'],
     },
+    refundFailurePolicyMismatch: {
+        key: 'refundFailurePolicyMismatch',
+        description: 'Denies when requested failure/refund semantics do not match the policy.',
+        policy: refundFailureMismatchPolicy,
+        request: {
+            ...DEFAULT_REQUEST,
+            failureMode: 'manual_review_required',
+            refundMode: 'not_applicable',
+        },
+        expectedAllowed: false,
+        expectedReasonCodes: ['refund_failure_policy_mismatch'],
+    },
+    spendCapExceeded: {
+        key: 'spendCapExceeded',
+        description: 'Denies when requested spend exceeds the per-request cap.',
+        policy: spendCapExceededPolicy,
+        request: {
+            ...DEFAULT_REQUEST,
+            amountUnits: '2500001',
+        },
+        expectedAllowed: false,
+        expectedReasonCodes: ['spend_cap_exceeded'],
+    },
 };
 export function listBuyerAuthorityPolicyExamples() {
     return Object.values(buyerAuthorityPolicyExamples).map((example) => ({
@@ -373,4 +436,7 @@ export function listBuyerAuthorityPolicyExamples() {
         policy: clonePolicy(example.policy),
         request: structuredClone(example.request),
     }));
+}
+export function listBuyerAuthorityPolicyFixtureMatrix() {
+    return listBuyerAuthorityPolicyExamples();
 }

--- a/packages/agent-protocol/src/buyer-authority-policy.ts
+++ b/packages/agent-protocol/src/buyer-authority-policy.ts
@@ -80,6 +80,8 @@ export type BuyerAuthorityPolicyEvaluationRequest = {
   receiptPresented: boolean;
   evidencePresented: boolean;
   now: string;
+  failureMode?: BuyerAuthorityPolicy['refundFailurePolicy']['failureMode'];
+  refundMode?: BuyerAuthorityPolicy['refundFailurePolicy']['refundMode'];
   operatorApprovalState?: BuyerAuthorityOperatorApprovalState;
 };
 
@@ -94,6 +96,7 @@ export type BuyerAuthorityPolicyReasonCode =
   | 'spend_cap_exceeded'
   | 'receipt_requirement_missing'
   | 'evidence_requirement_missing'
+  | 'refund_failure_policy_mismatch'
   | 'operator_approval_required'
   | 'operator_approval_denied'
   | 'live_payment_rejected'
@@ -113,9 +116,13 @@ export type BuyerAuthorityPolicyExampleKey =
   | 'deny'
   | 'expired'
   | 'approvalRequired'
-  | 'unsupportedRailCurrency'
+  | 'unsupportedRail'
+  | 'unsupportedCurrency'
   | 'sellerNotAllowlisted'
-  | 'missingEvidenceRequirement';
+  | 'missingReceiptRequirement'
+  | 'missingEvidenceRequirement'
+  | 'refundFailurePolicyMismatch'
+  | 'spendCapExceeded';
 
 export type BuyerAuthorityPolicyExampleCase = {
   key: BuyerAuthorityPolicyExampleKey;
@@ -144,6 +151,13 @@ const UNSAFE_LIVE_PATTERN = /\bhttps?:\/\/[^\s"]*(rpc|alchemy|helius|quicknode|a
 const TRANSFER_INSTRUCTION_PATTERN = /\b(submit|sign|transfer|broadcast)\b.*\b(transaction|payment|audd|usdc|sol)\b/i;
 const CUSTODY_CLAIM_PATTERN = /\b(audd|usdc|sol)\b.*\b(custody|custodied|escrowed|held)\b|\bheld\s+in\s+custody\b/i;
 const SETTLEMENT_FINALITY_PATTERN = /\bsettlement\s+finality\b|\bfinal\s+settlement\b/i;
+const KNOWN_SUPPORT_STATES: BuyerAuthoritySupportState[] = [
+  'fixture',
+  'dry-run',
+  'proof-metadata-only',
+  'devnet-gated',
+  'live-gated',
+];
 
 function basePolicy(overrides: Partial<BuyerAuthorityPolicy> = {}): BuyerAuthorityPolicy {
   return {
@@ -232,6 +246,12 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string');
 }
 
+function hasOnlyKnownSupportStates(value: unknown): value is BuyerAuthoritySupportState[] {
+  return isStringArray(value) && value.every((state) => (
+    KNOWN_SUPPORT_STATES.includes(state as BuyerAuthoritySupportState)
+  ));
+}
+
 function isStructuredPolicy(value: unknown): value is BuyerAuthorityPolicy {
   if (!isRecord(value)) return false;
   const candidate = value as Partial<BuyerAuthorityPolicy>;
@@ -252,7 +272,7 @@ function isStructuredPolicy(value: unknown): value is BuyerAuthorityPolicy {
     && candidate.allowedRails.every((rail) => isRecord(rail)
       && ['SOL', 'USDC', 'AUDD'].includes(String(rail.asset))
       && typeof rail.network === 'string'
-      && isStringArray(rail.supportStates))
+      && hasOnlyKnownSupportStates(rail.supportStates))
     && Array.isArray(candidate.allowedCurrencies)
     && candidate.allowedCurrencies.every((asset) => ['SOL', 'USDC', 'AUDD'].includes(asset))
     && Array.isArray(candidate.spendCaps)
@@ -277,7 +297,7 @@ function isStructuredPolicy(value: unknown): value is BuyerAuthorityPolicy {
     && ['approved', 'denied', 'requires_operator_approval', 'not_required'].includes(String(operatorApproval.approvalState))
     && isRecord(supportStateConstraints)
     && typeof supportStateConstraints.allowLivePayment === 'boolean'
-    && isStringArray(supportStateConstraints.allowedRuntimeStates)
+    && hasOnlyKnownSupportStates(supportStateConstraints.allowedRuntimeStates)
     && typeof supportStateConstraints.forbidCustody === 'boolean'
     && typeof supportStateConstraints.forbidSettlementFinality === 'boolean'
     && isStringArray(candidate.notes);
@@ -411,6 +431,13 @@ export function evaluateBuyerAuthorityPolicy(
     reasonCodes.push('evidence_requirement_missing');
     auditNotes.push('Denied: evidence requirement was not satisfied.');
   }
+  if (
+    (request.failureMode !== undefined && request.failureMode !== policy.refundFailurePolicy.failureMode)
+    || (request.refundMode !== undefined && request.refundMode !== policy.refundFailurePolicy.refundMode)
+  ) {
+    reasonCodes.push('refund_failure_policy_mismatch');
+    auditNotes.push('Denied: requested refund/failure handling does not match the buyer authority policy.');
+  }
 
   const approvalState = request.operatorApprovalState ?? policy.operatorApproval.approvalState;
   if (policy.mode === 'approval-required' || policy.operatorApproval.required) {
@@ -444,8 +471,12 @@ const approvalRequiredPolicy = basePolicy({
   },
 });
 const unsupportedRailPolicy = basePolicy({ policyId: 'buyer-authority:unsupported-rail' });
+const unsupportedCurrencyPolicy = basePolicy({ policyId: 'buyer-authority:unsupported-currency' });
 const sellerNotAllowlistedPolicy = basePolicy({ policyId: 'buyer-authority:seller-not-allowlisted' });
+const missingReceiptPolicy = basePolicy({ policyId: 'buyer-authority:missing-receipt' });
 const missingEvidencePolicy = basePolicy({ policyId: 'buyer-authority:missing-evidence' });
+const refundFailureMismatchPolicy = basePolicy({ policyId: 'buyer-authority:refund-failure-mismatch' });
+const spendCapExceededPolicy = basePolicy({ policyId: 'buyer-authority:spend-cap-exceeded' });
 
 export const buyerAuthorityPolicyExamples: Record<BuyerAuthorityPolicyExampleKey, BuyerAuthorityPolicyExampleCase> = {
   allow: {
@@ -483,14 +514,24 @@ export const buyerAuthorityPolicyExamples: Record<BuyerAuthorityPolicyExampleKey
     expectedAllowed: false,
     expectedReasonCodes: ['operator_approval_required'],
   },
-  unsupportedRailCurrency: {
-    key: 'unsupportedRailCurrency',
-    description: 'Denies unsupported asset/network/support-state combinations.',
+  unsupportedRail: {
+    key: 'unsupportedRail',
+    description: 'Denies unsupported network or support-state combinations for an otherwise allowed currency.',
     policy: unsupportedRailPolicy,
     request: {
       ...DEFAULT_REQUEST,
+      network: 'solana-mainnet',
+    },
+    expectedAllowed: false,
+    expectedReasonCodes: ['unsupported_rail_currency'],
+  },
+  unsupportedCurrency: {
+    key: 'unsupportedCurrency',
+    description: 'Denies unsupported currencies even when the request otherwise resembles an allowed rail.',
+    policy: unsupportedCurrencyPolicy,
+    request: {
+      ...DEFAULT_REQUEST,
       asset: 'EURC',
-      supportState: 'unsupported',
     },
     expectedAllowed: false,
     expectedReasonCodes: ['unsupported_rail_currency'],
@@ -507,6 +548,17 @@ export const buyerAuthorityPolicyExamples: Record<BuyerAuthorityPolicyExampleKey
     expectedAllowed: false,
     expectedReasonCodes: ['seller_not_allowlisted'],
   },
+  missingReceiptRequirement: {
+    key: 'missingReceiptRequirement',
+    description: 'Denies when receipt requirements are not satisfied.',
+    policy: missingReceiptPolicy,
+    request: {
+      ...DEFAULT_REQUEST,
+      receiptPresented: false,
+    },
+    expectedAllowed: false,
+    expectedReasonCodes: ['receipt_requirement_missing'],
+  },
   missingEvidenceRequirement: {
     key: 'missingEvidenceRequirement',
     description: 'Denies when evidence requirements are not satisfied.',
@@ -518,6 +570,29 @@ export const buyerAuthorityPolicyExamples: Record<BuyerAuthorityPolicyExampleKey
     expectedAllowed: false,
     expectedReasonCodes: ['evidence_requirement_missing'],
   },
+  refundFailurePolicyMismatch: {
+    key: 'refundFailurePolicyMismatch',
+    description: 'Denies when requested failure/refund semantics do not match the policy.',
+    policy: refundFailureMismatchPolicy,
+    request: {
+      ...DEFAULT_REQUEST,
+      failureMode: 'manual_review_required',
+      refundMode: 'not_applicable',
+    },
+    expectedAllowed: false,
+    expectedReasonCodes: ['refund_failure_policy_mismatch'],
+  },
+  spendCapExceeded: {
+    key: 'spendCapExceeded',
+    description: 'Denies when requested spend exceeds the per-request cap.',
+    policy: spendCapExceededPolicy,
+    request: {
+      ...DEFAULT_REQUEST,
+      amountUnits: '2500001',
+    },
+    expectedAllowed: false,
+    expectedReasonCodes: ['spend_cap_exceeded'],
+  },
 };
 
 export function listBuyerAuthorityPolicyExamples(): BuyerAuthorityPolicyExampleCase[] {
@@ -526,4 +601,8 @@ export function listBuyerAuthorityPolicyExamples(): BuyerAuthorityPolicyExampleC
     policy: clonePolicy(example.policy),
     request: structuredClone(example.request) as BuyerAuthorityPolicyEvaluationRequest,
   }));
+}
+
+export function listBuyerAuthorityPolicyFixtureMatrix(): BuyerAuthorityPolicyExampleCase[] {
+  return listBuyerAuthorityPolicyExamples();
 }

--- a/packages/agent-protocol/tests/buyer-authority-policy.test.ts
+++ b/packages/agent-protocol/tests/buyer-authority-policy.test.ts
@@ -4,6 +4,7 @@ import {
   BUYER_AUTHORITY_POLICY_SCHEMA_VERSION,
   buyerAuthorityPolicyExamples,
   evaluateBuyerAuthorityPolicy,
+  listBuyerAuthorityPolicyFixtureMatrix,
   listBuyerAuthorityPolicyExamples,
   validateBuyerAuthorityPolicy,
   type BuyerAuthorityPolicy,
@@ -13,15 +14,19 @@ describe('buyer authority policy examples', () => {
   it('exports static no-live buyer authority policy examples', () => {
     const examples = listBuyerAuthorityPolicyExamples();
 
-    assert.equal(examples.length, 7);
+    assert.equal(examples.length, 11);
     assert.deepEqual(examples.map((example) => example.key).sort(), [
       'allow',
       'approvalRequired',
       'deny',
       'expired',
       'missingEvidenceRequirement',
+      'missingReceiptRequirement',
+      'refundFailurePolicyMismatch',
       'sellerNotAllowlisted',
-      'unsupportedRailCurrency',
+      'spendCapExceeded',
+      'unsupportedCurrency',
+      'unsupportedRail',
     ]);
 
     for (const example of examples) {
@@ -32,6 +37,13 @@ describe('buyer authority policy examples', () => {
       assert.equal(example.policy.supportStateConstraints.forbidSettlementFinality, true);
       assert.equal(validateBuyerAuthorityPolicy(example.policy).allowed, true);
     }
+  });
+
+  it('exports the same cases through the fixture matrix helper for downstream conformance checks', () => {
+    assert.deepEqual(
+      listBuyerAuthorityPolicyFixtureMatrix().map((example) => example.key),
+      listBuyerAuthorityPolicyExamples().map((example) => example.key),
+    );
   });
 
   it('evaluates allow and fail-closed static policy cases', () => {
@@ -60,6 +72,18 @@ describe('buyer authority policy examples', () => {
     liveGatedPolicy.allowedRails[0]?.supportStates.push('live-gated');
     assert.deepEqual(validateBuyerAuthorityPolicy(liveGatedPolicy).reasonCodes, ['live_payment_rejected']);
 
+    const unsupportedSupportStatePolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy) as unknown as {
+      allowedRails: { supportStates: string[] }[];
+    };
+    unsupportedSupportStatePolicy.allowedRails[0]?.supportStates.push('live-payment-approved');
+    assert.deepEqual(validateBuyerAuthorityPolicy(unsupportedSupportStatePolicy).reasonCodes, ['policy_malformed']);
+
+    const unsupportedRuntimeStatePolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy) as unknown as {
+      supportStateConstraints: { allowedRuntimeStates: string[] };
+    };
+    unsupportedRuntimeStatePolicy.supportStateConstraints.allowedRuntimeStates.push('custody-supported');
+    assert.deepEqual(validateBuyerAuthorityPolicy(unsupportedRuntimeStatePolicy).reasonCodes, ['policy_malformed']);
+
     const rpcPolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy);
     rpcPolicy.notes.push('Use https://api.mainnet-beta.solana.com for the provider call.');
     assert.deepEqual(validateBuyerAuthorityPolicy(rpcPolicy).reasonCodes, ['wallet_rpc_provider_call_rejected']);
@@ -75,5 +99,43 @@ describe('buyer authority policy examples', () => {
     const finalityPolicy = structuredClone(buyerAuthorityPolicyExamples.allow.policy);
     finalityPolicy.notes.push('This policy proves settlement finality.');
     assert.deepEqual(validateBuyerAuthorityPolicy(finalityPolicy).reasonCodes, ['settlement_finality_claim_rejected']);
+  });
+
+  it('keeps matrix denial reasons machine-readable and single-purpose where possible', () => {
+    assert.deepEqual(
+      evaluateBuyerAuthorityPolicy(
+        buyerAuthorityPolicyExamples.unsupportedRail.policy,
+        buyerAuthorityPolicyExamples.unsupportedRail.request,
+      ).reasonCodes,
+      ['unsupported_rail_currency'],
+    );
+    assert.deepEqual(
+      evaluateBuyerAuthorityPolicy(
+        buyerAuthorityPolicyExamples.unsupportedCurrency.policy,
+        buyerAuthorityPolicyExamples.unsupportedCurrency.request,
+      ).reasonCodes,
+      ['unsupported_rail_currency'],
+    );
+    assert.deepEqual(
+      evaluateBuyerAuthorityPolicy(
+        buyerAuthorityPolicyExamples.missingReceiptRequirement.policy,
+        buyerAuthorityPolicyExamples.missingReceiptRequirement.request,
+      ).reasonCodes,
+      ['receipt_requirement_missing'],
+    );
+    assert.deepEqual(
+      evaluateBuyerAuthorityPolicy(
+        buyerAuthorityPolicyExamples.refundFailurePolicyMismatch.policy,
+        buyerAuthorityPolicyExamples.refundFailurePolicyMismatch.request,
+      ).reasonCodes,
+      ['refund_failure_policy_mismatch'],
+    );
+    assert.deepEqual(
+      evaluateBuyerAuthorityPolicy(
+        buyerAuthorityPolicyExamples.spendCapExceeded.policy,
+        buyerAuthorityPolicyExamples.spendCapExceeded.request,
+      ).reasonCodes,
+      ['spend_cap_exceeded'],
+    );
   });
 });


### PR DESCRIPTION
Closes #550.

## Summary
- expands the buyer-authority fixture matrix from the #549 base examples to explicit allow, deny, expired, approval-required, unsupported rail, unsupported currency, seller-not-allowlisted, missing-receipt, missing-evidence, refund/failure-policy mismatch, and spend-cap-exceeded cases
- adds `listBuyerAuthorityPolicyFixtureMatrix()` for downstream #543 conformance and #375 seller-wrapper consumption
- adds machine-readable reason-code coverage for refund/failure-policy mismatches and focused matrix-denial assertions
- documents downstream consumption expectations in the package README

## Validation
- `npm --prefix packages/agent-protocol install --ignore-scripts`
- `npm --prefix packages/agent-protocol test -- --runInBand` - 175/175 passing
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `git diff --check`

## Boundary
- no UI changes, so no screenshots/video required
- no package publication
- no Airwallex/API/cloud/provider calls
- no live/devnet payment execution
- no wallet/RPC/provider call
- no custody, SPL transfer, external spend, or settlement-finality claim
