### PR TITLE
feat: wire buyer authority into seller wrapper config

### DIFF
--- a/lib/__tests__/onboarding-routes-wrappers.test.ts
+++ b/lib/__tests__/onboarding-routes-wrappers.test.ts
@@ -66,6 +66,25 @@ describe("onboarding wrapper routes", () => {
     expect(body.result.schemaVersion).toBe("reddi.onboarding-seller-wrapper-config.v1");
     expect(body.result.mode).toBe("no-spend-config-preview");
     expect(body.result.validation.valid).toBe(true);
+    expect(body.result.buyerAuthorityPolicy.policySchemaVersion).toBe("reddi.buyer-authority-policy.v1");
+    expect(body.result.buyerAuthorityPolicy.fixtureMatrixIssue).toBe(550);
+    expect(body.result.buyerAuthorityPolicy.fixtureStates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "approvalRequired",
+          expectedReasonCodes: expect.arrayContaining(["operator_approval_required"]),
+        }),
+        expect.objectContaining({
+          key: "missingReceiptRequirement",
+          expectedReasonCodes: expect.arrayContaining(["receipt_requirement_missing"]),
+        }),
+        expect.objectContaining({
+          key: "refundFailurePolicyMismatch",
+          expectedReasonCodes: expect.arrayContaining(["refund_failure_policy_mismatch"]),
+        }),
+      ])
+    );
+    expect(body.result.buyerAuthorityPolicy.onboardingCopy.boundary).toContain("does not carry private keys");
     expect(body.result.boundaries).toMatchObject({
       networkCalls: false,
       livePayment: false,

--- a/lib/onboarding/seller-wrapper-config.ts
+++ b/lib/onboarding/seller-wrapper-config.ts
@@ -20,6 +20,17 @@ export function getOnboardingSellerWrapperConfig() {
     schemaVersion: ONBOARDING_SELLER_WRAPPER_CONFIG_SCHEMA_VERSION,
     mode: "no-spend-config-preview",
     config,
+    buyerAuthorityPolicy: {
+      ...config.buyerAuthorityPolicy,
+      onboardingCopy: {
+        preflight:
+          "Buyer authority is checked before seller-wrapper invocation using spend caps, allowed rails/currencies, seller allowlists, expiry, receipt/evidence requirements, refund/failure policy, and operator approval.",
+        denial:
+          "Denied, expired, unsupported, over-cap, missing-receipt/evidence, refund/failure mismatch, and approval-required states remain local fixture states until separate live-payment approval exists.",
+        boundary:
+          "Seller-wrapper config does not carry private keys, provider credentials, signing instructions, wallet/RPC/provider calls, custody claims, or settlement-finality claims.",
+      },
+    },
     validation,
     boundaries: {
       networkCalls: false,

--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -49,6 +49,7 @@ import {
 const config = generateSellerWrapperConfigExamples();
 console.log(config.endpoints[0].wrapper.quoteRoute); // /seller-wrapper/listing-writer-http/quote
 console.log(config.endpoints[0].rails.map((rail) => rail.asset)); // SOL, USDC, AUDD
+console.log(config.buyerAuthorityPolicy.fixtureStates.map((case_) => case_.key));
 
 const check = await runSellerWrapperConfigNoSpendCheck();
 console.log(check.validation.valid); // true
@@ -56,6 +57,8 @@ console.log(check.auddFlow.preflight.allowed); // true for the local no-spend AU
 ```
 
 Seller-wrapper config examples turn the local rail-state fixture into MCP and HTTP/OpenAPI wrapper metadata: quote route, policy preflight route, mocked invocation route, receipt hook, evidence hook, and SOL/USDC/AUDD rail states. AUDD is represented as first-class payment-plan/proof metadata with mint, payee, settlement account, expiry, failure policy, refund policy, and evidence requirements.
+
+Seller-wrapper config also carries buyer-authority policy contract metadata for onboarding and downstream templates. It references the buyer policy schema, #550 fixture matrix states, spend caps, allowed rails/currencies, seller allowlist, expiry, receipt/evidence requirements, refund/failure policy, operator approval, support-state constraints, and the discovery -> quote -> buyer-policy-preflight -> operator-approval -> invocation -> receipt/evidence lifecycle. The config points #543 framework-template conformance and #375 seller-wrapper flows at the same reason-coded matrix instead of creating parallel policy semantics.
 
 The helper is no-spend and non-secret. It rejects credential-shaped metadata, live-payment approval, wallet/RPC/signing/transfer instructions, custody claims, and settlement-finality claims. It does not publish packages, invoke providers, call wallets/RPC endpoints, submit Pay.sh payments, or activate live rails.
 

--- a/packages/agent-protocol/dist/seller-wrapper-config.d.ts
+++ b/packages/agent-protocol/dist/seller-wrapper-config.d.ts
@@ -1,4 +1,5 @@
 import type { AuddSolanaPaymentPlan } from './audd-payment-plan.js';
+import { BUYER_AUTHORITY_POLICY_SCHEMA_VERSION, type BuyerAuthorityPolicyExampleKey, type BuyerAuthorityPolicyReasonCode } from './buyer-authority-policy.js';
 import { SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION, type SellerWrapperEndpointFixture, type SellerWrapperRailConfig, type SellerWrapperRailFixture, type SellerWrapperRailState } from './seller-wrapper-rail-fixtures.js';
 export declare const SELLER_WRAPPER_CONFIG_SCHEMA_VERSION: "reddi.seller-wrapper-config.v1";
 export type SellerWrapperRuntimeState = 'local-dry-run' | 'devnet-gated' | 'proof-metadata-only' | 'live-gated' | 'custody-supported' | 'unsupported' | 'live-payment-approved';
@@ -41,6 +42,38 @@ export type SellerWrapperEndpointConfigExample = {
     };
     rails: SellerWrapperRailConfigExample[];
 };
+export type SellerWrapperBuyerAuthorityPolicyCase = {
+    key: BuyerAuthorityPolicyExampleKey;
+    expectedAllowed: boolean;
+    expectedReasonCodes: BuyerAuthorityPolicyReasonCode[];
+};
+export type SellerWrapperBuyerAuthorityPolicyContract = {
+    policySchemaVersion: typeof BUYER_AUTHORITY_POLICY_SCHEMA_VERSION;
+    policyIssue: 549;
+    fixtureMatrixIssue: 550;
+    downstreamIssues: {
+        sellerWrapperFeature: 375;
+        frameworkTemplateContract: 543;
+        frameworkTemplatesFeature: 542;
+    };
+    fields: readonly string[];
+    lifecycle: readonly string[];
+    fixtureStates: SellerWrapperBuyerAuthorityPolicyCase[];
+    onboardingSurface: {
+        displayStateLater: true;
+        currentMode: 'api-contract-only';
+        uiEvidenceRequiredWhenVisualized: true;
+    };
+    boundaries: {
+        noPrivateKeys: true;
+        noProviderCredentials: true;
+        noSigningInstructions: true;
+        noWalletRpcProviderCalls: true;
+        noLivePaymentExecution: true;
+        noCustodyClaims: true;
+        noSettlementFinalityClaims: true;
+    };
+};
 export type SellerWrapperConfigExamples = {
     schemaVersion: typeof SELLER_WRAPPER_CONFIG_SCHEMA_VERSION;
     issue: 535;
@@ -50,6 +83,7 @@ export type SellerWrapperConfigExamples = {
         railFixtureSchemaVersion: typeof SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION;
     };
     generatedMode: 'no-spend-config-examples';
+    buyerAuthorityPolicy: SellerWrapperBuyerAuthorityPolicyContract;
     endpoints: SellerWrapperEndpointConfigExample[];
     guardrails: SellerWrapperRailFixture['guardrails'] & {
         noSecrets: true;
@@ -57,7 +91,7 @@ export type SellerWrapperConfigExamples = {
         noLivePaymentInstructions: true;
     };
 };
-export type SellerWrapperConfigValidationReasonCode = 'seller_wrapper_config_valid' | 'config_malformed' | 'fixture_contains_credentials' | 'config_contains_credentials' | 'missing_audd_rail' | 'missing_audd_payment_plan' | 'missing_wrapper_hooks' | 'live_payment_not_approved' | 'live_payment_instruction_rejected' | 'custody_claim_rejected' | 'settlement_finality_claim_rejected';
+export type SellerWrapperConfigValidationReasonCode = 'seller_wrapper_config_valid' | 'config_malformed' | 'fixture_contains_credentials' | 'config_contains_credentials' | 'missing_audd_rail' | 'missing_audd_payment_plan' | 'missing_buyer_authority_policy' | 'missing_wrapper_hooks' | 'live_payment_not_approved' | 'live_payment_instruction_rejected' | 'custody_claim_rejected' | 'settlement_finality_claim_rejected';
 export type SellerWrapperConfigValidationResult = {
     valid: boolean;
     reasonCodes: SellerWrapperConfigValidationReasonCode[];

--- a/packages/agent-protocol/dist/seller-wrapper-config.js
+++ b/packages/agent-protocol/dist/seller-wrapper-config.js
@@ -1,3 +1,4 @@
+import { BUYER_AUTHORITY_POLICY_SCHEMA_VERSION, listBuyerAuthorityPolicyFixtureMatrix, } from './buyer-authority-policy.js';
 import { SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION, getSellerWrapperRail, runAuddSellerWrapperNoSpendFlow, sellerWrapperFixtureHasCredentialMaterial, sellerWrapperRailFixture, } from './seller-wrapper-rail-fixtures.js';
 export const SELLER_WRAPPER_CONFIG_SCHEMA_VERSION = 'reddi.seller-wrapper-config.v1';
 const REQUIRED_WRAPPER_HOOKS = [
@@ -81,6 +82,74 @@ function endpointConfigExample(endpoint) {
         rails: endpoint.rails.map(railConfigExample),
     };
 }
+function buyerAuthorityPolicyCase(example) {
+    return {
+        key: example.key,
+        expectedAllowed: example.expectedAllowed,
+        expectedReasonCodes: [...example.expectedReasonCodes],
+    };
+}
+function buyerAuthorityPolicyContract() {
+    return {
+        policySchemaVersion: BUYER_AUTHORITY_POLICY_SCHEMA_VERSION,
+        policyIssue: 549,
+        fixtureMatrixIssue: 550,
+        downstreamIssues: {
+            sellerWrapperFeature: 375,
+            frameworkTemplateContract: 543,
+            frameworkTemplatesFeature: 542,
+        },
+        fields: [
+            'spendCaps',
+            'allowedRails',
+            'allowedCurrencies',
+            'sellerAllowlist',
+            'expiresAt',
+            'receiptEvidence',
+            'refundFailurePolicy',
+            'operatorApproval',
+            'supportStateConstraints',
+        ],
+        lifecycle: [
+            'discovery',
+            'quote',
+            'buyer-policy-preflight',
+            'operator-approval',
+            'seller-wrapper-invocation',
+            'receipt-evidence',
+            'failure-refund',
+        ],
+        fixtureStates: listBuyerAuthorityPolicyFixtureMatrix().map(buyerAuthorityPolicyCase),
+        onboardingSurface: {
+            displayStateLater: true,
+            currentMode: 'api-contract-only',
+            uiEvidenceRequiredWhenVisualized: true,
+        },
+        boundaries: {
+            noPrivateKeys: true,
+            noProviderCredentials: true,
+            noSigningInstructions: true,
+            noWalletRpcProviderCalls: true,
+            noLivePaymentExecution: true,
+            noCustodyClaims: true,
+            noSettlementFinalityClaims: true,
+        },
+    };
+}
+function buyerAuthorityFixtureMatrixMatches(contract) {
+    if (!contract)
+        return false;
+    const expectedCases = listBuyerAuthorityPolicyFixtureMatrix().map(buyerAuthorityPolicyCase);
+    if (contract.fixtureStates.length !== expectedCases.length)
+        return false;
+    return expectedCases.every((expected) => {
+        const actual = contract.fixtureStates.find((item) => item.key === expected.key);
+        return !!actual
+            && actual.expectedAllowed === expected.expectedAllowed
+            && actual.expectedReasonCodes.length === expected.expectedReasonCodes.length
+            && expected.expectedReasonCodes.every((reason) => actual.expectedReasonCodes.includes(reason));
+    });
+}
 function generatedEndpoints(fixture) {
     if (fixture.endpoints.some((endpoint) => endpoint.kind === 'mcp'))
         return fixture.endpoints;
@@ -141,6 +210,7 @@ export function generateSellerWrapperConfigExamples(input = {}) {
             railFixtureSchemaVersion: SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION,
         },
         generatedMode: 'no-spend-config-examples',
+        buyerAuthorityPolicy: buyerAuthorityPolicyContract(),
         endpoints: generatedEndpoints(fixture).map(endpointConfigExample),
         guardrails: {
             ...fixture.guardrails,
@@ -177,6 +247,12 @@ export function validateSellerWrapperConfigExamples(config) {
         reasonCodes.push('missing_audd_payment_plan');
         auditNotes.push('Denied: AUDD payment-plan metadata is missing from generated config.');
     }
+    if (config.buyerAuthorityPolicy?.policySchemaVersion !== BUYER_AUTHORITY_POLICY_SCHEMA_VERSION
+        || config.buyerAuthorityPolicy.fixtureMatrixIssue !== 550
+        || !buyerAuthorityFixtureMatrixMatches(config.buyerAuthorityPolicy)) {
+        reasonCodes.push('missing_buyer_authority_policy');
+        auditNotes.push('Denied: buyer authority policy contract metadata is missing from generated config.');
+    }
     const missingHooks = config.endpoints.some((endpoint) => REQUIRED_WRAPPER_HOOKS.some((hook) => (typeof endpoint.wrapper[hook] !== 'string' || endpoint.wrapper[hook].trim().length === 0)));
     if (missingHooks) {
         reasonCodes.push('missing_wrapper_hooks');
@@ -185,6 +261,14 @@ export function validateSellerWrapperConfigExamples(config) {
     if (config.endpoints.some((endpoint) => endpoint.rails.some((rail) => rail.livePaymentApproved))) {
         reasonCodes.push('live_payment_not_approved');
         auditNotes.push('Denied: generated examples must not approve live payment.');
+    }
+    if (config.endpoints.some((endpoint) => endpoint.rails.some((rail) => rail.runtimeState === 'live-payment-approved'))) {
+        reasonCodes.push('live_payment_not_approved');
+        auditNotes.push('Denied: generated examples must not mark runtime state as live-payment-approved.');
+    }
+    if (config.endpoints.some((endpoint) => endpoint.rails.some((rail) => rail.runtimeState === 'custody-supported'))) {
+        reasonCodes.push('custody_claim_rejected');
+        auditNotes.push('Denied: generated examples must not mark runtime state as custody-supported.');
     }
     if (textContains(config, LIVE_PAYMENT_INSTRUCTION_PATTERN)) {
         reasonCodes.push('live_payment_instruction_rejected');

--- a/packages/agent-protocol/src/seller-wrapper-config.ts
+++ b/packages/agent-protocol/src/seller-wrapper-config.ts
@@ -1,5 +1,12 @@
 import type { AuddSolanaPaymentPlan } from './audd-payment-plan.js';
 import {
+  BUYER_AUTHORITY_POLICY_SCHEMA_VERSION,
+  listBuyerAuthorityPolicyFixtureMatrix,
+  type BuyerAuthorityPolicyExampleCase,
+  type BuyerAuthorityPolicyExampleKey,
+  type BuyerAuthorityPolicyReasonCode,
+} from './buyer-authority-policy.js';
+import {
   SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION,
   getSellerWrapperRail,
   runAuddSellerWrapperNoSpendFlow,
@@ -63,6 +70,40 @@ export type SellerWrapperEndpointConfigExample = {
   rails: SellerWrapperRailConfigExample[];
 };
 
+export type SellerWrapperBuyerAuthorityPolicyCase = {
+  key: BuyerAuthorityPolicyExampleKey;
+  expectedAllowed: boolean;
+  expectedReasonCodes: BuyerAuthorityPolicyReasonCode[];
+};
+
+export type SellerWrapperBuyerAuthorityPolicyContract = {
+  policySchemaVersion: typeof BUYER_AUTHORITY_POLICY_SCHEMA_VERSION;
+  policyIssue: 549;
+  fixtureMatrixIssue: 550;
+  downstreamIssues: {
+    sellerWrapperFeature: 375;
+    frameworkTemplateContract: 543;
+    frameworkTemplatesFeature: 542;
+  };
+  fields: readonly string[];
+  lifecycle: readonly string[];
+  fixtureStates: SellerWrapperBuyerAuthorityPolicyCase[];
+  onboardingSurface: {
+    displayStateLater: true;
+    currentMode: 'api-contract-only';
+    uiEvidenceRequiredWhenVisualized: true;
+  };
+  boundaries: {
+    noPrivateKeys: true;
+    noProviderCredentials: true;
+    noSigningInstructions: true;
+    noWalletRpcProviderCalls: true;
+    noLivePaymentExecution: true;
+    noCustodyClaims: true;
+    noSettlementFinalityClaims: true;
+  };
+};
+
 export type SellerWrapperConfigExamples = {
   schemaVersion: typeof SELLER_WRAPPER_CONFIG_SCHEMA_VERSION;
   issue: 535;
@@ -72,6 +113,7 @@ export type SellerWrapperConfigExamples = {
     railFixtureSchemaVersion: typeof SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION;
   };
   generatedMode: 'no-spend-config-examples';
+  buyerAuthorityPolicy: SellerWrapperBuyerAuthorityPolicyContract;
   endpoints: SellerWrapperEndpointConfigExample[];
   guardrails: SellerWrapperRailFixture['guardrails'] & {
     noSecrets: true;
@@ -87,6 +129,7 @@ export type SellerWrapperConfigValidationReasonCode =
   | 'config_contains_credentials'
   | 'missing_audd_rail'
   | 'missing_audd_payment_plan'
+  | 'missing_buyer_authority_policy'
   | 'missing_wrapper_hooks'
   | 'live_payment_not_approved'
   | 'live_payment_instruction_rejected'
@@ -179,6 +222,76 @@ function endpointConfigExample(endpoint: SellerWrapperEndpointFixture): SellerWr
   };
 }
 
+function buyerAuthorityPolicyCase(example: BuyerAuthorityPolicyExampleCase): SellerWrapperBuyerAuthorityPolicyCase {
+  return {
+    key: example.key,
+    expectedAllowed: example.expectedAllowed,
+    expectedReasonCodes: [...example.expectedReasonCodes],
+  };
+}
+
+function buyerAuthorityPolicyContract(): SellerWrapperBuyerAuthorityPolicyContract {
+  return {
+    policySchemaVersion: BUYER_AUTHORITY_POLICY_SCHEMA_VERSION,
+    policyIssue: 549,
+    fixtureMatrixIssue: 550,
+    downstreamIssues: {
+      sellerWrapperFeature: 375,
+      frameworkTemplateContract: 543,
+      frameworkTemplatesFeature: 542,
+    },
+    fields: [
+      'spendCaps',
+      'allowedRails',
+      'allowedCurrencies',
+      'sellerAllowlist',
+      'expiresAt',
+      'receiptEvidence',
+      'refundFailurePolicy',
+      'operatorApproval',
+      'supportStateConstraints',
+    ],
+    lifecycle: [
+      'discovery',
+      'quote',
+      'buyer-policy-preflight',
+      'operator-approval',
+      'seller-wrapper-invocation',
+      'receipt-evidence',
+      'failure-refund',
+    ],
+    fixtureStates: listBuyerAuthorityPolicyFixtureMatrix().map(buyerAuthorityPolicyCase),
+    onboardingSurface: {
+      displayStateLater: true,
+      currentMode: 'api-contract-only',
+      uiEvidenceRequiredWhenVisualized: true,
+    },
+    boundaries: {
+      noPrivateKeys: true,
+      noProviderCredentials: true,
+      noSigningInstructions: true,
+      noWalletRpcProviderCalls: true,
+      noLivePaymentExecution: true,
+      noCustodyClaims: true,
+      noSettlementFinalityClaims: true,
+    },
+  };
+}
+
+function buyerAuthorityFixtureMatrixMatches(contract: SellerWrapperBuyerAuthorityPolicyContract | undefined): boolean {
+  if (!contract) return false;
+  const expectedCases = listBuyerAuthorityPolicyFixtureMatrix().map(buyerAuthorityPolicyCase);
+  if (contract.fixtureStates.length !== expectedCases.length) return false;
+
+  return expectedCases.every((expected) => {
+    const actual = contract.fixtureStates.find((item) => item.key === expected.key);
+    return !!actual
+      && actual.expectedAllowed === expected.expectedAllowed
+      && actual.expectedReasonCodes.length === expected.expectedReasonCodes.length
+      && expected.expectedReasonCodes.every((reason) => actual.expectedReasonCodes.includes(reason));
+  });
+}
+
 function generatedEndpoints(fixture: SellerWrapperRailFixture): SellerWrapperEndpointFixture[] {
   if (fixture.endpoints.some((endpoint) => endpoint.kind === 'mcp')) return fixture.endpoints;
   const first = fixture.endpoints[0];
@@ -238,6 +351,7 @@ export function generateSellerWrapperConfigExamples(input: {
       railFixtureSchemaVersion: SELLER_WRAPPER_RAIL_FIXTURE_SCHEMA_VERSION,
     },
     generatedMode: 'no-spend-config-examples',
+    buyerAuthorityPolicy: buyerAuthorityPolicyContract(),
     endpoints: generatedEndpoints(fixture).map(endpointConfigExample),
     guardrails: {
       ...fixture.guardrails,
@@ -281,6 +395,15 @@ export function validateSellerWrapperConfigExamples(config: unknown): SellerWrap
     auditNotes.push('Denied: AUDD payment-plan metadata is missing from generated config.');
   }
 
+  if (
+    config.buyerAuthorityPolicy?.policySchemaVersion !== BUYER_AUTHORITY_POLICY_SCHEMA_VERSION
+    || config.buyerAuthorityPolicy.fixtureMatrixIssue !== 550
+    || !buyerAuthorityFixtureMatrixMatches(config.buyerAuthorityPolicy)
+  ) {
+    reasonCodes.push('missing_buyer_authority_policy');
+    auditNotes.push('Denied: buyer authority policy contract metadata is missing from generated config.');
+  }
+
   const missingHooks = config.endpoints.some((endpoint) => REQUIRED_WRAPPER_HOOKS.some((hook) => (
     typeof endpoint.wrapper[hook] !== 'string' || endpoint.wrapper[hook].trim().length === 0
   )));
@@ -292,6 +415,14 @@ export function validateSellerWrapperConfigExamples(config: unknown): SellerWrap
   if (config.endpoints.some((endpoint) => endpoint.rails.some((rail) => rail.livePaymentApproved))) {
     reasonCodes.push('live_payment_not_approved');
     auditNotes.push('Denied: generated examples must not approve live payment.');
+  }
+  if (config.endpoints.some((endpoint) => endpoint.rails.some((rail) => rail.runtimeState === 'live-payment-approved'))) {
+    reasonCodes.push('live_payment_not_approved');
+    auditNotes.push('Denied: generated examples must not mark runtime state as live-payment-approved.');
+  }
+  if (config.endpoints.some((endpoint) => endpoint.rails.some((rail) => rail.runtimeState === 'custody-supported'))) {
+    reasonCodes.push('custody_claim_rejected');
+    auditNotes.push('Denied: generated examples must not mark runtime state as custody-supported.');
   }
   if (textContains(config, LIVE_PAYMENT_INSTRUCTION_PATTERN)) {
     reasonCodes.push('live_payment_instruction_rejected');

--- a/packages/agent-protocol/tests/seller-wrapper-config.test.ts
+++ b/packages/agent-protocol/tests/seller-wrapper-config.test.ts
@@ -24,6 +24,30 @@ describe('seller-wrapper config examples', () => {
     assert.equal(config.guardrails.noLivePayment, true);
     assert.equal(config.guardrails.noWalletSigning, true);
     assert.equal(config.guardrails.noRpcCall, true);
+    assert.equal(config.buyerAuthorityPolicy.policySchemaVersion, 'reddi.buyer-authority-policy.v1');
+    assert.equal(config.buyerAuthorityPolicy.policyIssue, 549);
+    assert.equal(config.buyerAuthorityPolicy.fixtureMatrixIssue, 550);
+    assert.equal(config.buyerAuthorityPolicy.downstreamIssues.frameworkTemplateContract, 543);
+    assert.equal(config.buyerAuthorityPolicy.boundaries.noPrivateKeys, true);
+    assert.equal(config.buyerAuthorityPolicy.boundaries.noWalletRpcProviderCalls, true);
+    assert.equal(config.buyerAuthorityPolicy.boundaries.noCustodyClaims, true);
+    assert.deepEqual(config.buyerAuthorityPolicy.fields, [
+      'spendCaps',
+      'allowedRails',
+      'allowedCurrencies',
+      'sellerAllowlist',
+      'expiresAt',
+      'receiptEvidence',
+      'refundFailurePolicy',
+      'operatorApproval',
+      'supportStateConstraints',
+    ]);
+    assert.ok(config.buyerAuthorityPolicy.fixtureStates.some((state) => (
+      state.key === 'approvalRequired' && state.expectedReasonCodes.includes('operator_approval_required')
+    )));
+    assert.ok(config.buyerAuthorityPolicy.fixtureStates.some((state) => (
+      state.key === 'refundFailurePolicyMismatch' && state.expectedReasonCodes.includes('refund_failure_policy_mismatch')
+    )));
 
     assert.deepEqual(config.endpoints.map((endpoint) => endpoint.kind).sort(), ['http-openapi', 'mcp']);
 
@@ -92,6 +116,14 @@ describe('seller-wrapper config examples', () => {
     configWithLivePayment.endpoints[0].rails[0].livePaymentApproved = true;
     assert.deepEqual(validateSellerWrapperConfigExamples(configWithLivePayment).reasonCodes, ['live_payment_not_approved']);
 
+    const configWithLiveRuntimeState = structuredClone(generateSellerWrapperConfigExamples());
+    configWithLiveRuntimeState.endpoints[0].rails[0].runtimeState = 'live-payment-approved';
+    assert.deepEqual(validateSellerWrapperConfigExamples(configWithLiveRuntimeState).reasonCodes, ['live_payment_not_approved']);
+
+    const configWithCustodyRuntimeState = structuredClone(generateSellerWrapperConfigExamples());
+    configWithCustodyRuntimeState.endpoints[0].rails[0].runtimeState = 'custody-supported';
+    assert.deepEqual(validateSellerWrapperConfigExamples(configWithCustodyRuntimeState).reasonCodes, ['custody_claim_rejected']);
+
     const configWithRpcInstruction = structuredClone(generateSellerWrapperConfigExamples());
     configWithRpcInstruction.endpoints[0].rails[0].notes.push('Submit the transaction through RPC after wallet sign.');
     assert.deepEqual(validateSellerWrapperConfigExamples(configWithRpcInstruction).reasonCodes, ['live_payment_instruction_rejected']);
@@ -103,5 +135,15 @@ describe('seller-wrapper config examples', () => {
     const configWithoutHook = structuredClone(generateSellerWrapperConfigExamples());
     configWithoutHook.endpoints[0].wrapper.receiptHook = '';
     assert.deepEqual(validateSellerWrapperConfigExamples(configWithoutHook).reasonCodes, ['missing_wrapper_hooks']);
+
+    const configWithoutBuyerAuthority = structuredClone(generateSellerWrapperConfigExamples()) as Partial<SellerWrapperConfigExamples>;
+    delete configWithoutBuyerAuthority.buyerAuthorityPolicy;
+    assert.deepEqual(validateSellerWrapperConfigExamples(configWithoutBuyerAuthority).reasonCodes, ['missing_buyer_authority_policy']);
+
+    const configWithTruncatedMatrix = structuredClone(generateSellerWrapperConfigExamples());
+    const firstFixtureState = configWithTruncatedMatrix.buyerAuthorityPolicy.fixtureStates[0];
+    assert.ok(firstFixtureState);
+    configWithTruncatedMatrix.buyerAuthorityPolicy.fixtureStates = [firstFixtureState];
+    assert.deepEqual(validateSellerWrapperConfigExamples(configWithTruncatedMatrix).reasonCodes, ['missing_buyer_authority_policy']);
   });
 });


### PR DESCRIPTION
Closes #551.

## Summary
- adds buyer-authority policy contract metadata to seller-wrapper config examples, pointing #375/#543/#542 consumers at the #549/#550 policy schema and fixture matrix
- exposes buyer-authority policy state and onboarding copy through `GET /api/onboarding/seller-wrapper-config` without changing the visual onboarding UI
- documents seller-wrapper buyer-authority lifecycle and no-live boundaries in the package README
- adds package and onboarding route coverage for the buyer-authority contract surface

## Validation
- `npm install --ignore-scripts` (fresh worktree deps; existing audit baseline reported 95 vulnerabilities)
- `npm --prefix packages/agent-protocol install --ignore-scripts`
- `npm --prefix packages/agent-protocol test -- --runInBand` - 175/175 passing
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `npx jest lib/__tests__/onboarding-routes-wrappers.test.ts --runInBand` - 6/6 passing
- `git diff --check`

## UI evidence
- no visual UI route/component changes, so screenshots/video are not required

## Boundary
- no package publication
- no Airwallex/API/cloud/provider calls
- no live/devnet payment execution
- no wallet/RPC/provider call
- no custody, SPL transfer, external spend, or settlement-finality claim
