### PR TITLE
feat: add framework template contract fixtures

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -91,6 +91,28 @@ The built-in fixture matrix covers allow, deny, expired, approval-required, unsu
 
 The helper is no-spend and non-secret. It rejects credential-shaped metadata, live-payment approval, wallet/RPC/provider-call material, signing/transfer instructions, custody claims, and settlement-finality claims. It does not contact Airwallex, invoke providers, call wallets/RPC endpoints, transfer SPL tokens, activate Pay.sh, or settle funds.
 
+## Framework Template Contract
+
+```typescript
+import {
+  frameworkTemplateFixtures,
+  listFrameworkTemplateFixtures,
+  validateFrameworkTemplateContract,
+} from '@reddi/agent-protocol/framework-template-contract';
+
+const fixtures = listFrameworkTemplateFixtures();
+console.log(fixtures.map((fixture) => fixture.kind)); // discovery, quote, preflight, ...
+
+const result = validateFrameworkTemplateContract(frameworkTemplateFixtures.preflight.contract);
+console.log(result.valid); // true in local static fixture mode
+```
+
+Framework-template contract fixtures define the shared surface that LangGraph, Strands, and ADK templates should consume before they add framework-specific scaffolding. The contract covers buyer-enabled, seller-enabled, and dual-mode profiles; agent identity; framework id; capability tags; invocation modes; seller profile; buyer authority policy matrix; execution result; receipt/evidence references; failure/refund state; and support-state metadata.
+
+The built-in fixtures cover discovery, quote, buyer-policy preflight, operator approval, invocation, receipt/evidence binding, denial, and failure outcomes. They consume the #549 buyer-authority schema, #550 fixture matrix, and #551 seller-wrapper buyer-authority contract. Template implementations for #544/#545/#546 should import this contract instead of inventing framework-specific payment, policy, receipt, failure/refund, or support-state semantics.
+
+The helper is static and no-live. It rejects credential-shaped metadata, truncated buyer-authority matrices, unsafe support states, live-payment approval, wallet/RPC/provider-call material, signing/transfer instructions, custody claims, missing receipt/evidence refs for allowed invocations, and settlement-finality claims.
+
 ## AI Catalog Ingestion
 
 ```typescript

--- a/packages/agent-protocol/dist/framework-template-contract.d.ts
+++ b/packages/agent-protocol/dist/framework-template-contract.d.ts
@@ -1,0 +1,101 @@
+import { type BuyerAuthorityPolicyExampleKey, type BuyerAuthorityPolicyReasonCode } from './buyer-authority-policy.js';
+import { type SellerWrapperBuyerAuthorityPolicyContract, type SellerWrapperConfigExamples } from './seller-wrapper-config.js';
+export declare const FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION: "reddi.framework-template-contract.v1";
+export type FrameworkTemplateId = 'generic' | 'langgraph' | 'strands' | 'adk';
+export type FrameworkTemplateMode = 'buyer-enabled' | 'seller-enabled' | 'dual-mode';
+export type FrameworkTemplateInvocationMode = 'http-openapi' | 'mcp' | 'a2a-agent-card' | 'local-fixture';
+export type FrameworkTemplateScenarioKind = 'discovery' | 'quote' | 'preflight' | 'operator-approval' | 'invocation' | 'receipt-evidence' | 'denial' | 'failure';
+export type FrameworkTemplateSupportState = 'fixture' | 'dry-run' | 'proof-metadata-only' | 'devnet-gated';
+export type FrameworkTemplateAgentIdentity = {
+    agentId: string;
+    displayName: string;
+    framework: FrameworkTemplateId;
+    templateMode: FrameworkTemplateMode;
+    capabilityTags: string[];
+};
+export type FrameworkTemplateSellerProfile = {
+    sellerId: string;
+    endpointId: string;
+    endpointKind: 'http-openapi' | 'mcp' | 'a2a-agent-card';
+    quoteRoute: string;
+    policyPreflightRoute: string;
+    invocationRoute: string;
+    receiptHook: string;
+    evidenceHook: string;
+};
+export type FrameworkTemplateExecutionResult = {
+    status: 'not-run' | 'allowed' | 'denied' | 'failed';
+    invocationId: string;
+    outputRef?: string;
+};
+export type FrameworkTemplateReceiptEvidenceRefs = {
+    receiptRequired: boolean;
+    evidenceRequired: boolean;
+    receiptRef?: string;
+    evidenceRef?: string;
+};
+export type FrameworkTemplateFailureRefundState = {
+    failureMode: 'no_charge_on_failure' | 'manual_review_required';
+    refundMode: 'manual_review' | 'not_applicable';
+    state: 'not-applicable' | 'blocked' | 'manual-review';
+};
+export type FrameworkTemplateSupportStateMetadata = {
+    runtimeState: FrameworkTemplateSupportState;
+    livePaymentApproved: false;
+    walletRpcProviderCalls: false;
+    custodySupported: false;
+    settlementFinalityClaimed: false;
+};
+export type FrameworkTemplateBuyerAuthorityCase = {
+    key: BuyerAuthorityPolicyExampleKey;
+    expectedAllowed: boolean;
+    expectedReasonCodes: BuyerAuthorityPolicyReasonCode[];
+};
+export type FrameworkTemplateContract = {
+    schemaVersion: typeof FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION;
+    issue: 552;
+    parentIssues: {
+        frameworkTemplateContract: 543;
+        frameworkTemplatesFeature: 542;
+        buyerAuthority: 548;
+        productCore: 334;
+        railNeutralPayments: 338;
+    };
+    agentIdentity: FrameworkTemplateAgentIdentity;
+    invocationModes: FrameworkTemplateInvocationMode[];
+    sellerProfile?: FrameworkTemplateSellerProfile;
+    buyerAuthorityPolicy?: SellerWrapperBuyerAuthorityPolicyContract;
+    buyerAuthorityCases: FrameworkTemplateBuyerAuthorityCase[];
+    executionResult: FrameworkTemplateExecutionResult;
+    receiptEvidenceRefs: FrameworkTemplateReceiptEvidenceRefs;
+    failureRefundState: FrameworkTemplateFailureRefundState;
+    supportStateMetadata: FrameworkTemplateSupportStateMetadata;
+    sourceContracts: {
+        sellerWrapperConfigSchemaVersion: SellerWrapperConfigExamples['schemaVersion'];
+        buyerAuthorityPolicySchemaVersion: SellerWrapperBuyerAuthorityPolicyContract['policySchemaVersion'];
+        buyerAuthorityFixtureMatrixIssue: 550;
+    };
+    downstreamConsumption: {
+        langGraphIssue: 544;
+        strandsIssue: 545;
+        adkIssue: 546;
+        comparisonDocsIssue: 547;
+    };
+    notes: string[];
+};
+export type FrameworkTemplateFixture = {
+    kind: FrameworkTemplateScenarioKind;
+    description: string;
+    contract: FrameworkTemplateContract;
+    expectedValid: boolean;
+    expectedReasonCodes: FrameworkTemplateValidationReasonCode[];
+};
+export type FrameworkTemplateValidationReasonCode = 'framework_template_contract_valid' | 'framework_template_contract_malformed' | 'framework_template_contains_credentials' | 'buyer_authority_matrix_mismatch' | 'seller_wrapper_contract_invalid' | 'unsupported_framework_mode' | 'unsafe_support_state' | 'live_payment_rejected' | 'wallet_rpc_provider_call_rejected' | 'custody_claim_rejected' | 'settlement_finality_claim_rejected' | 'missing_receipt_evidence_refs' | 'missing_failure_refund_state';
+export type FrameworkTemplateValidationResult = {
+    valid: boolean;
+    reasonCodes: FrameworkTemplateValidationReasonCode[];
+    auditNotes: string[];
+};
+export declare const frameworkTemplateFixtures: Record<FrameworkTemplateScenarioKind, FrameworkTemplateFixture>;
+export declare function listFrameworkTemplateFixtures(): FrameworkTemplateFixture[];
+export declare function validateFrameworkTemplateContract(contract: unknown): FrameworkTemplateValidationResult;

--- a/packages/agent-protocol/dist/framework-template-contract.js
+++ b/packages/agent-protocol/dist/framework-template-contract.js
@@ -1,0 +1,344 @@
+import { listBuyerAuthorityPolicyFixtureMatrix, } from './buyer-authority-policy.js';
+import { generateSellerWrapperConfigExamples, validateSellerWrapperConfigExamples, } from './seller-wrapper-config.js';
+import { sellerWrapperFixtureHasCredentialMaterial } from './seller-wrapper-rail-fixtures.js';
+export const FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION = 'reddi.framework-template-contract.v1';
+const UNSAFE_LIVE_PATTERN = /\bhttps?:\/\/[^\s"]*(rpc|alchemy|helius|quicknode|api\.(mainnet-beta|devnet|testnet)\.solana\.com)[^\s"]*|\b(provider\s+credential|wallet\s+sign|signing\s+authority)\b/i;
+const TRANSFER_INSTRUCTION_PATTERN = /\b(submit|sign|transfer|broadcast)\b.*\b(transaction|payment|audd|usdc|sol)\b/i;
+const CUSTODY_CLAIM_PATTERN = /\b(audd|usdc|sol)\b.*\b(custody|custodied|escrowed|held)\b|\bheld\s+in\s+custody\b/i;
+const SETTLEMENT_FINALITY_PATTERN = /\bsettlement\s+finality\b|\bfinal\s+settlement\b/i;
+const SAFE_SUPPORT_STATES = ['fixture', 'dry-run', 'proof-metadata-only', 'devnet-gated'];
+function textContains(value, pattern) {
+    if (typeof value === 'string')
+        return pattern.test(value);
+    if (!value || typeof value !== 'object')
+        return false;
+    if (Array.isArray(value))
+        return value.some((item) => textContains(item, pattern));
+    return Object.values(value).some((item) => textContains(item, pattern));
+}
+function cloneContract(contract) {
+    return structuredClone(contract);
+}
+function buyerAuthorityCases() {
+    return listBuyerAuthorityPolicyFixtureMatrix().map((example) => ({
+        key: example.key,
+        expectedAllowed: example.expectedAllowed,
+        expectedReasonCodes: [...example.expectedReasonCodes],
+    }));
+}
+function buyerAuthorityCasesMatch(cases) {
+    const expectedCases = buyerAuthorityCases();
+    if (cases.length !== expectedCases.length)
+        return false;
+    return expectedCases.every((expected) => {
+        const actual = cases.find((item) => item.key === expected.key);
+        return !!actual
+            && actual.expectedAllowed === expected.expectedAllowed
+            && actual.expectedReasonCodes.length === expected.expectedReasonCodes.length
+            && expected.expectedReasonCodes.every((reason) => actual.expectedReasonCodes.includes(reason));
+    });
+}
+function buyerAuthorityPolicyMatches(contract) {
+    if (!contract)
+        return false;
+    const expectedCases = buyerAuthorityCases();
+    if (contract.policyIssue !== 549
+        || contract.fixtureMatrixIssue !== 550
+        || contract.fixtureStates.length !== expectedCases.length) {
+        return false;
+    }
+    return expectedCases.every((expected) => {
+        const actual = contract.fixtureStates.find((item) => item.key === expected.key);
+        return !!actual
+            && actual.expectedAllowed === expected.expectedAllowed
+            && actual.expectedReasonCodes.length === expected.expectedReasonCodes.length
+            && expected.expectedReasonCodes.every((reason) => actual.expectedReasonCodes.includes(reason));
+    });
+}
+function supportStateBoundariesExplicitlyFalse(metadata) {
+    return metadata.livePaymentApproved === false
+        && metadata.walletRpcProviderCalls === false
+        && metadata.custodySupported === false
+        && metadata.settlementFinalityClaimed === false;
+}
+function isStructuredContract(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const candidate = value;
+    return candidate.schemaVersion === FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION
+        && candidate.issue === 552
+        && !!candidate.agentIdentity
+        && typeof candidate.agentIdentity === 'object'
+        && typeof candidate.agentIdentity.agentId === 'string'
+        && typeof candidate.agentIdentity.displayName === 'string'
+        && ['generic', 'langgraph', 'strands', 'adk'].includes(String(candidate.agentIdentity.framework))
+        && ['buyer-enabled', 'seller-enabled', 'dual-mode'].includes(String(candidate.agentIdentity.templateMode))
+        && Array.isArray(candidate.agentIdentity.capabilityTags)
+        && Array.isArray(candidate.invocationModes)
+        && Array.isArray(candidate.buyerAuthorityCases)
+        && !!candidate.executionResult
+        && !!candidate.receiptEvidenceRefs
+        && !!candidate.failureRefundState
+        && !!candidate.supportStateMetadata
+        && !!candidate.sourceContracts
+        && !!candidate.downstreamConsumption
+        && Array.isArray(candidate.notes);
+}
+function sellerProfileFromConfig(config) {
+    const endpoint = config.endpoints.find((item) => item.kind === 'http-openapi') ?? config.endpoints[0];
+    if (!endpoint)
+        throw new Error('framework_template_missing_seller_endpoint');
+    return {
+        sellerId: 'seller:listing-writer',
+        endpointId: endpoint.endpointId,
+        endpointKind: endpoint.kind,
+        quoteRoute: endpoint.wrapper.quoteRoute,
+        policyPreflightRoute: endpoint.wrapper.policyPreflightRoute,
+        invocationRoute: endpoint.wrapper.invocationRoute,
+        receiptHook: endpoint.wrapper.receiptHook,
+        evidenceHook: endpoint.wrapper.evidenceHook,
+    };
+}
+function baseContract(overrides = {}) {
+    const sellerWrapperConfig = generateSellerWrapperConfigExamples();
+    return {
+        schemaVersion: FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION,
+        issue: 552,
+        parentIssues: {
+            frameworkTemplateContract: 543,
+            frameworkTemplatesFeature: 542,
+            buyerAuthority: 548,
+            productCore: 334,
+            railNeutralPayments: 338,
+        },
+        agentIdentity: {
+            agentId: 'framework-template:generic:listing-writer',
+            displayName: 'Generic listing writer RAP template',
+            framework: 'generic',
+            templateMode: 'dual-mode',
+            capabilityTags: ['listing-writing', 'seller-wrapper', 'buyer-authority'],
+        },
+        invocationModes: ['http-openapi', 'mcp', 'local-fixture'],
+        sellerProfile: sellerProfileFromConfig(sellerWrapperConfig),
+        buyerAuthorityPolicy: sellerWrapperConfig.buyerAuthorityPolicy,
+        buyerAuthorityCases: buyerAuthorityCases(),
+        executionResult: {
+            status: 'allowed',
+            invocationId: 'local-fixture:framework-template:allowed',
+            outputRef: 'local-fixture:framework-template:output',
+        },
+        receiptEvidenceRefs: {
+            receiptRequired: true,
+            evidenceRequired: true,
+            receiptRef: 'local-fixture:receipt:listing-writer',
+            evidenceRef: 'local-fixture:evidence:listing-writer',
+        },
+        failureRefundState: {
+            failureMode: 'no_charge_on_failure',
+            refundMode: 'manual_review',
+            state: 'not-applicable',
+        },
+        supportStateMetadata: {
+            runtimeState: 'proof-metadata-only',
+            livePaymentApproved: false,
+            walletRpcProviderCalls: false,
+            custodySupported: false,
+            settlementFinalityClaimed: false,
+        },
+        sourceContracts: {
+            sellerWrapperConfigSchemaVersion: sellerWrapperConfig.schemaVersion,
+            buyerAuthorityPolicySchemaVersion: sellerWrapperConfig.buyerAuthorityPolicy.policySchemaVersion,
+            buyerAuthorityFixtureMatrixIssue: 550,
+        },
+        downstreamConsumption: {
+            langGraphIssue: 544,
+            strandsIssue: 545,
+            adkIssue: 546,
+            comparisonDocsIssue: 547,
+        },
+        notes: [
+            'Framework templates consume this contract without inventing framework-specific payment semantics.',
+            'No framework template may activate live payment, custody, wallet/RPC/provider calls, or finality claims.',
+        ],
+        ...overrides,
+    };
+}
+const discoveryContract = baseContract({
+    executionResult: { status: 'not-run', invocationId: 'local-fixture:framework-template:discovery' },
+});
+const quoteContract = baseContract({
+    executionResult: { status: 'not-run', invocationId: 'local-fixture:framework-template:quote' },
+});
+const preflightContract = baseContract({
+    executionResult: { status: 'allowed', invocationId: 'local-fixture:framework-template:preflight' },
+});
+const operatorApprovalContract = baseContract({
+    executionResult: { status: 'denied', invocationId: 'local-fixture:framework-template:operator-approval' },
+    notes: [
+        'Operator approval is required before invocation for over-threshold buyer authority cases.',
+        'This fixture remains local and does not execute a payment.',
+    ],
+});
+const invocationContract = baseContract();
+const receiptEvidenceContract = baseContract({
+    executionResult: { status: 'allowed', invocationId: 'local-fixture:framework-template:receipt-evidence', outputRef: 'local-fixture:output:receipt-evidence' },
+});
+const denialContract = baseContract({
+    executionResult: { status: 'denied', invocationId: 'local-fixture:framework-template:denial' },
+    receiptEvidenceRefs: { receiptRequired: true, evidenceRequired: true },
+});
+const failureContract = baseContract({
+    executionResult: { status: 'failed', invocationId: 'local-fixture:framework-template:failure' },
+    failureRefundState: {
+        failureMode: 'no_charge_on_failure',
+        refundMode: 'manual_review',
+        state: 'manual-review',
+    },
+});
+export const frameworkTemplateFixtures = {
+    discovery: {
+        kind: 'discovery',
+        description: 'Framework-neutral discovery fixture with seller profile and buyer authority matrix references.',
+        contract: discoveryContract,
+        expectedValid: true,
+        expectedReasonCodes: ['framework_template_contract_valid'],
+    },
+    quote: {
+        kind: 'quote',
+        description: 'Framework-neutral quote fixture before buyer authority preflight.',
+        contract: quoteContract,
+        expectedValid: true,
+        expectedReasonCodes: ['framework_template_contract_valid'],
+    },
+    preflight: {
+        kind: 'preflight',
+        description: 'Buyer authority preflight fixture using the shared #550 matrix.',
+        contract: preflightContract,
+        expectedValid: true,
+        expectedReasonCodes: ['framework_template_contract_valid'],
+    },
+    'operator-approval': {
+        kind: 'operator-approval',
+        description: 'Operator approval required fixture with no payment execution.',
+        contract: operatorApprovalContract,
+        expectedValid: true,
+        expectedReasonCodes: ['framework_template_contract_valid'],
+    },
+    invocation: {
+        kind: 'invocation',
+        description: 'Mock seller-wrapper invocation fixture after buyer policy passes.',
+        contract: invocationContract,
+        expectedValid: true,
+        expectedReasonCodes: ['framework_template_contract_valid'],
+    },
+    'receipt-evidence': {
+        kind: 'receipt-evidence',
+        description: 'Receipt/evidence binding fixture with local references only.',
+        contract: receiptEvidenceContract,
+        expectedValid: true,
+        expectedReasonCodes: ['framework_template_contract_valid'],
+    },
+    denial: {
+        kind: 'denial',
+        description: 'Denial fixture preserving machine-readable buyer authority reason codes.',
+        contract: denialContract,
+        expectedValid: true,
+        expectedReasonCodes: ['framework_template_contract_valid'],
+    },
+    failure: {
+        kind: 'failure',
+        description: 'Failure/refund fixture using no-charge-on-failure and manual review semantics.',
+        contract: failureContract,
+        expectedValid: true,
+        expectedReasonCodes: ['framework_template_contract_valid'],
+    },
+};
+export function listFrameworkTemplateFixtures() {
+    return Object.values(frameworkTemplateFixtures).map((fixture) => ({
+        ...fixture,
+        contract: cloneContract(fixture.contract),
+    }));
+}
+export function validateFrameworkTemplateContract(contract) {
+    if (!isStructuredContract(contract)) {
+        return {
+            valid: false,
+            reasonCodes: ['framework_template_contract_malformed'],
+            auditNotes: ['Denied: framework-template contract is malformed.'],
+        };
+    }
+    const reasonCodes = [];
+    const auditNotes = [];
+    if (sellerWrapperFixtureHasCredentialMaterial(contract)) {
+        reasonCodes.push('framework_template_contains_credentials');
+        auditNotes.push('Denied: framework-template contract contains credential-like material.');
+    }
+    const sellerWrapperConfig = generateSellerWrapperConfigExamples();
+    const sellerValidation = validateSellerWrapperConfigExamples(sellerWrapperConfig);
+    if (!sellerValidation.valid) {
+        reasonCodes.push('seller_wrapper_contract_invalid');
+        auditNotes.push('Denied: source seller-wrapper contract is invalid.');
+    }
+    if (!buyerAuthorityCasesMatch(contract.buyerAuthorityCases)) {
+        reasonCodes.push('buyer_authority_matrix_mismatch');
+        auditNotes.push('Denied: buyer authority fixture matrix does not match #550.');
+    }
+    if (contract.agentIdentity.templateMode !== 'seller-enabled'
+        && !buyerAuthorityPolicyMatches(contract.buyerAuthorityPolicy)) {
+        reasonCodes.push('seller_wrapper_contract_invalid');
+        auditNotes.push('Denied: buyer authority policy contract does not match #551 seller-wrapper contract metadata.');
+    }
+    if (contract.agentIdentity.templateMode === 'seller-enabled'
+        && contract.buyerAuthorityPolicy
+        && !buyerAuthorityPolicyMatches(contract.buyerAuthorityPolicy)) {
+        reasonCodes.push('seller_wrapper_contract_invalid');
+        auditNotes.push('Denied: seller-only buyer authority policy contract is present but does not match #551 metadata.');
+    }
+    if (!SAFE_SUPPORT_STATES.includes(contract.supportStateMetadata.runtimeState)) {
+        reasonCodes.push('unsafe_support_state');
+        auditNotes.push('Denied: framework-template support state is not a safe local/static state.');
+    }
+    if (!supportStateBoundariesExplicitlyFalse(contract.supportStateMetadata)) {
+        reasonCodes.push('framework_template_contract_malformed');
+        auditNotes.push('Denied: framework-template runtime boundary booleans must be explicitly false.');
+    }
+    if (contract.supportStateMetadata.livePaymentApproved) {
+        reasonCodes.push('live_payment_rejected');
+        auditNotes.push('Denied: framework templates must not approve live payment.');
+    }
+    if (contract.supportStateMetadata.walletRpcProviderCalls || textContains(contract, UNSAFE_LIVE_PATTERN)) {
+        reasonCodes.push('wallet_rpc_provider_call_rejected');
+        auditNotes.push('Denied: framework-template contract contains wallet/RPC/provider-call material.');
+    }
+    if (textContains(contract, TRANSFER_INSTRUCTION_PATTERN)) {
+        reasonCodes.push('live_payment_rejected');
+        auditNotes.push('Denied: framework-template contract contains signing, transfer, broadcast, or payment execution instructions.');
+    }
+    if (contract.supportStateMetadata.custodySupported || textContains(contract, CUSTODY_CLAIM_PATTERN)) {
+        reasonCodes.push('custody_claim_rejected');
+        auditNotes.push('Denied: framework-template contract must not claim custody.');
+    }
+    if (contract.supportStateMetadata.settlementFinalityClaimed || textContains(contract, SETTLEMENT_FINALITY_PATTERN)) {
+        reasonCodes.push('settlement_finality_claim_rejected');
+        auditNotes.push('Denied: framework-template contract must not claim settlement finality.');
+    }
+    if (contract.receiptEvidenceRefs.receiptRequired && !contract.receiptEvidenceRefs.receiptRef && contract.executionResult.status === 'allowed') {
+        reasonCodes.push('missing_receipt_evidence_refs');
+        auditNotes.push('Denied: allowed invocations require receipt refs.');
+    }
+    if (contract.receiptEvidenceRefs.evidenceRequired && !contract.receiptEvidenceRefs.evidenceRef && contract.executionResult.status === 'allowed') {
+        reasonCodes.push('missing_receipt_evidence_refs');
+        auditNotes.push('Denied: allowed invocations require evidence refs.');
+    }
+    if (!contract.failureRefundState.failureMode || !contract.failureRefundState.refundMode) {
+        reasonCodes.push('missing_failure_refund_state');
+        auditNotes.push('Denied: failure/refund state is required.');
+    }
+    if (reasonCodes.length > 0)
+        return { valid: false, reasonCodes, auditNotes };
+    return {
+        valid: true,
+        reasonCodes: ['framework_template_contract_valid'],
+        auditNotes: ['Allowed: framework-template contract is static, non-secret, no-spend, and no-live.'],
+    };
+}

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -21,3 +21,4 @@ export * from './rail-neutral-payment-receipts.js';
 export * from './rail-neutral-proof-chain-fixture.js';
 export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
+export * from './framework-template-contract.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -21,3 +21,4 @@ export * from './rail-neutral-payment-receipts.js';
 export * from './rail-neutral-proof-chain-fixture.js';
 export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
+export * from './framework-template-contract.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -102,6 +102,10 @@
       "types": "./dist/seller-wrapper-config.d.ts",
       "import": "./dist/seller-wrapper-config.js"
     },
+    "./framework-template-contract": {
+      "types": "./dist/framework-template-contract.d.ts",
+      "import": "./dist/framework-template-contract.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/framework-template-contract.ts
+++ b/packages/agent-protocol/src/framework-template-contract.ts
@@ -1,0 +1,505 @@
+import {
+  listBuyerAuthorityPolicyFixtureMatrix,
+  type BuyerAuthorityPolicyExampleKey,
+  type BuyerAuthorityPolicyReasonCode,
+} from './buyer-authority-policy.js';
+import {
+  generateSellerWrapperConfigExamples,
+  validateSellerWrapperConfigExamples,
+  type SellerWrapperBuyerAuthorityPolicyContract,
+  type SellerWrapperConfigExamples,
+} from './seller-wrapper-config.js';
+import { sellerWrapperFixtureHasCredentialMaterial } from './seller-wrapper-rail-fixtures.js';
+
+export const FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION = 'reddi.framework-template-contract.v1' as const;
+
+export type FrameworkTemplateId = 'generic' | 'langgraph' | 'strands' | 'adk';
+export type FrameworkTemplateMode = 'buyer-enabled' | 'seller-enabled' | 'dual-mode';
+export type FrameworkTemplateInvocationMode = 'http-openapi' | 'mcp' | 'a2a-agent-card' | 'local-fixture';
+export type FrameworkTemplateScenarioKind =
+  | 'discovery'
+  | 'quote'
+  | 'preflight'
+  | 'operator-approval'
+  | 'invocation'
+  | 'receipt-evidence'
+  | 'denial'
+  | 'failure';
+export type FrameworkTemplateSupportState =
+  | 'fixture'
+  | 'dry-run'
+  | 'proof-metadata-only'
+  | 'devnet-gated';
+
+export type FrameworkTemplateAgentIdentity = {
+  agentId: string;
+  displayName: string;
+  framework: FrameworkTemplateId;
+  templateMode: FrameworkTemplateMode;
+  capabilityTags: string[];
+};
+
+export type FrameworkTemplateSellerProfile = {
+  sellerId: string;
+  endpointId: string;
+  endpointKind: 'http-openapi' | 'mcp' | 'a2a-agent-card';
+  quoteRoute: string;
+  policyPreflightRoute: string;
+  invocationRoute: string;
+  receiptHook: string;
+  evidenceHook: string;
+};
+
+export type FrameworkTemplateExecutionResult = {
+  status: 'not-run' | 'allowed' | 'denied' | 'failed';
+  invocationId: string;
+  outputRef?: string;
+};
+
+export type FrameworkTemplateReceiptEvidenceRefs = {
+  receiptRequired: boolean;
+  evidenceRequired: boolean;
+  receiptRef?: string;
+  evidenceRef?: string;
+};
+
+export type FrameworkTemplateFailureRefundState = {
+  failureMode: 'no_charge_on_failure' | 'manual_review_required';
+  refundMode: 'manual_review' | 'not_applicable';
+  state: 'not-applicable' | 'blocked' | 'manual-review';
+};
+
+export type FrameworkTemplateSupportStateMetadata = {
+  runtimeState: FrameworkTemplateSupportState;
+  livePaymentApproved: false;
+  walletRpcProviderCalls: false;
+  custodySupported: false;
+  settlementFinalityClaimed: false;
+};
+
+export type FrameworkTemplateBuyerAuthorityCase = {
+  key: BuyerAuthorityPolicyExampleKey;
+  expectedAllowed: boolean;
+  expectedReasonCodes: BuyerAuthorityPolicyReasonCode[];
+};
+
+export type FrameworkTemplateContract = {
+  schemaVersion: typeof FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION;
+  issue: 552;
+  parentIssues: {
+    frameworkTemplateContract: 543;
+    frameworkTemplatesFeature: 542;
+    buyerAuthority: 548;
+    productCore: 334;
+    railNeutralPayments: 338;
+  };
+  agentIdentity: FrameworkTemplateAgentIdentity;
+  invocationModes: FrameworkTemplateInvocationMode[];
+  sellerProfile?: FrameworkTemplateSellerProfile;
+  buyerAuthorityPolicy?: SellerWrapperBuyerAuthorityPolicyContract;
+  buyerAuthorityCases: FrameworkTemplateBuyerAuthorityCase[];
+  executionResult: FrameworkTemplateExecutionResult;
+  receiptEvidenceRefs: FrameworkTemplateReceiptEvidenceRefs;
+  failureRefundState: FrameworkTemplateFailureRefundState;
+  supportStateMetadata: FrameworkTemplateSupportStateMetadata;
+  sourceContracts: {
+    sellerWrapperConfigSchemaVersion: SellerWrapperConfigExamples['schemaVersion'];
+    buyerAuthorityPolicySchemaVersion: SellerWrapperBuyerAuthorityPolicyContract['policySchemaVersion'];
+    buyerAuthorityFixtureMatrixIssue: 550;
+  };
+  downstreamConsumption: {
+    langGraphIssue: 544;
+    strandsIssue: 545;
+    adkIssue: 546;
+    comparisonDocsIssue: 547;
+  };
+  notes: string[];
+};
+
+export type FrameworkTemplateFixture = {
+  kind: FrameworkTemplateScenarioKind;
+  description: string;
+  contract: FrameworkTemplateContract;
+  expectedValid: boolean;
+  expectedReasonCodes: FrameworkTemplateValidationReasonCode[];
+};
+
+export type FrameworkTemplateValidationReasonCode =
+  | 'framework_template_contract_valid'
+  | 'framework_template_contract_malformed'
+  | 'framework_template_contains_credentials'
+  | 'buyer_authority_matrix_mismatch'
+  | 'seller_wrapper_contract_invalid'
+  | 'unsupported_framework_mode'
+  | 'unsafe_support_state'
+  | 'live_payment_rejected'
+  | 'wallet_rpc_provider_call_rejected'
+  | 'custody_claim_rejected'
+  | 'settlement_finality_claim_rejected'
+  | 'missing_receipt_evidence_refs'
+  | 'missing_failure_refund_state';
+
+export type FrameworkTemplateValidationResult = {
+  valid: boolean;
+  reasonCodes: FrameworkTemplateValidationReasonCode[];
+  auditNotes: string[];
+};
+
+const UNSAFE_LIVE_PATTERN = /\bhttps?:\/\/[^\s"]*(rpc|alchemy|helius|quicknode|api\.(mainnet-beta|devnet|testnet)\.solana\.com)[^\s"]*|\b(provider\s+credential|wallet\s+sign|signing\s+authority)\b/i;
+const TRANSFER_INSTRUCTION_PATTERN = /\b(submit|sign|transfer|broadcast)\b.*\b(transaction|payment|audd|usdc|sol)\b/i;
+const CUSTODY_CLAIM_PATTERN = /\b(audd|usdc|sol)\b.*\b(custody|custodied|escrowed|held)\b|\bheld\s+in\s+custody\b/i;
+const SETTLEMENT_FINALITY_PATTERN = /\bsettlement\s+finality\b|\bfinal\s+settlement\b/i;
+const SAFE_SUPPORT_STATES: FrameworkTemplateSupportState[] = ['fixture', 'dry-run', 'proof-metadata-only', 'devnet-gated'];
+
+function textContains(value: unknown, pattern: RegExp): boolean {
+  if (typeof value === 'string') return pattern.test(value);
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some((item) => textContains(item, pattern));
+  return Object.values(value).some((item) => textContains(item, pattern));
+}
+
+function cloneContract(contract: FrameworkTemplateContract): FrameworkTemplateContract {
+  return structuredClone(contract) as FrameworkTemplateContract;
+}
+
+function buyerAuthorityCases(): FrameworkTemplateBuyerAuthorityCase[] {
+  return listBuyerAuthorityPolicyFixtureMatrix().map((example) => ({
+    key: example.key,
+    expectedAllowed: example.expectedAllowed,
+    expectedReasonCodes: [...example.expectedReasonCodes],
+  }));
+}
+
+function buyerAuthorityCasesMatch(cases: FrameworkTemplateBuyerAuthorityCase[]): boolean {
+  const expectedCases = buyerAuthorityCases();
+  if (cases.length !== expectedCases.length) return false;
+  return expectedCases.every((expected) => {
+    const actual = cases.find((item) => item.key === expected.key);
+    return !!actual
+      && actual.expectedAllowed === expected.expectedAllowed
+      && actual.expectedReasonCodes.length === expected.expectedReasonCodes.length
+      && expected.expectedReasonCodes.every((reason) => actual.expectedReasonCodes.includes(reason));
+  });
+}
+
+function buyerAuthorityPolicyMatches(contract: SellerWrapperBuyerAuthorityPolicyContract | undefined): boolean {
+  if (!contract) return false;
+  const expectedCases = buyerAuthorityCases();
+  if (
+    contract.policyIssue !== 549
+    || contract.fixtureMatrixIssue !== 550
+    || contract.fixtureStates.length !== expectedCases.length
+  ) {
+    return false;
+  }
+  return expectedCases.every((expected) => {
+    const actual = contract.fixtureStates.find((item) => item.key === expected.key);
+    return !!actual
+      && actual.expectedAllowed === expected.expectedAllowed
+      && actual.expectedReasonCodes.length === expected.expectedReasonCodes.length
+      && expected.expectedReasonCodes.every((reason) => actual.expectedReasonCodes.includes(reason));
+  });
+}
+
+function supportStateBoundariesExplicitlyFalse(metadata: FrameworkTemplateSupportStateMetadata): boolean {
+  return metadata.livePaymentApproved === false
+    && metadata.walletRpcProviderCalls === false
+    && metadata.custodySupported === false
+    && metadata.settlementFinalityClaimed === false;
+}
+
+function isStructuredContract(value: unknown): value is FrameworkTemplateContract {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as Partial<FrameworkTemplateContract>;
+  return candidate.schemaVersion === FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION
+    && candidate.issue === 552
+    && !!candidate.agentIdentity
+    && typeof candidate.agentIdentity === 'object'
+    && typeof candidate.agentIdentity.agentId === 'string'
+    && typeof candidate.agentIdentity.displayName === 'string'
+    && ['generic', 'langgraph', 'strands', 'adk'].includes(String(candidate.agentIdentity.framework))
+    && ['buyer-enabled', 'seller-enabled', 'dual-mode'].includes(String(candidate.agentIdentity.templateMode))
+    && Array.isArray(candidate.agentIdentity.capabilityTags)
+    && Array.isArray(candidate.invocationModes)
+    && Array.isArray(candidate.buyerAuthorityCases)
+    && !!candidate.executionResult
+    && !!candidate.receiptEvidenceRefs
+    && !!candidate.failureRefundState
+    && !!candidate.supportStateMetadata
+    && !!candidate.sourceContracts
+    && !!candidate.downstreamConsumption
+    && Array.isArray(candidate.notes);
+}
+
+function sellerProfileFromConfig(config: SellerWrapperConfigExamples): FrameworkTemplateSellerProfile {
+  const endpoint = config.endpoints.find((item) => item.kind === 'http-openapi') ?? config.endpoints[0];
+  if (!endpoint) throw new Error('framework_template_missing_seller_endpoint');
+  return {
+    sellerId: 'seller:listing-writer',
+    endpointId: endpoint.endpointId,
+    endpointKind: endpoint.kind,
+    quoteRoute: endpoint.wrapper.quoteRoute,
+    policyPreflightRoute: endpoint.wrapper.policyPreflightRoute,
+    invocationRoute: endpoint.wrapper.invocationRoute,
+    receiptHook: endpoint.wrapper.receiptHook,
+    evidenceHook: endpoint.wrapper.evidenceHook,
+  };
+}
+
+function baseContract(overrides: Partial<FrameworkTemplateContract> = {}): FrameworkTemplateContract {
+  const sellerWrapperConfig = generateSellerWrapperConfigExamples();
+  return {
+    schemaVersion: FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION,
+    issue: 552,
+    parentIssues: {
+      frameworkTemplateContract: 543,
+      frameworkTemplatesFeature: 542,
+      buyerAuthority: 548,
+      productCore: 334,
+      railNeutralPayments: 338,
+    },
+    agentIdentity: {
+      agentId: 'framework-template:generic:listing-writer',
+      displayName: 'Generic listing writer RAP template',
+      framework: 'generic',
+      templateMode: 'dual-mode',
+      capabilityTags: ['listing-writing', 'seller-wrapper', 'buyer-authority'],
+    },
+    invocationModes: ['http-openapi', 'mcp', 'local-fixture'],
+    sellerProfile: sellerProfileFromConfig(sellerWrapperConfig),
+    buyerAuthorityPolicy: sellerWrapperConfig.buyerAuthorityPolicy,
+    buyerAuthorityCases: buyerAuthorityCases(),
+    executionResult: {
+      status: 'allowed',
+      invocationId: 'local-fixture:framework-template:allowed',
+      outputRef: 'local-fixture:framework-template:output',
+    },
+    receiptEvidenceRefs: {
+      receiptRequired: true,
+      evidenceRequired: true,
+      receiptRef: 'local-fixture:receipt:listing-writer',
+      evidenceRef: 'local-fixture:evidence:listing-writer',
+    },
+    failureRefundState: {
+      failureMode: 'no_charge_on_failure',
+      refundMode: 'manual_review',
+      state: 'not-applicable',
+    },
+    supportStateMetadata: {
+      runtimeState: 'proof-metadata-only',
+      livePaymentApproved: false,
+      walletRpcProviderCalls: false,
+      custodySupported: false,
+      settlementFinalityClaimed: false,
+    },
+    sourceContracts: {
+      sellerWrapperConfigSchemaVersion: sellerWrapperConfig.schemaVersion,
+      buyerAuthorityPolicySchemaVersion: sellerWrapperConfig.buyerAuthorityPolicy.policySchemaVersion,
+      buyerAuthorityFixtureMatrixIssue: 550,
+    },
+    downstreamConsumption: {
+      langGraphIssue: 544,
+      strandsIssue: 545,
+      adkIssue: 546,
+      comparisonDocsIssue: 547,
+    },
+    notes: [
+      'Framework templates consume this contract without inventing framework-specific payment semantics.',
+      'No framework template may activate live payment, custody, wallet/RPC/provider calls, or finality claims.',
+    ],
+    ...overrides,
+  };
+}
+
+const discoveryContract = baseContract({
+  executionResult: { status: 'not-run', invocationId: 'local-fixture:framework-template:discovery' },
+});
+const quoteContract = baseContract({
+  executionResult: { status: 'not-run', invocationId: 'local-fixture:framework-template:quote' },
+});
+const preflightContract = baseContract({
+  executionResult: { status: 'allowed', invocationId: 'local-fixture:framework-template:preflight' },
+});
+const operatorApprovalContract = baseContract({
+  executionResult: { status: 'denied', invocationId: 'local-fixture:framework-template:operator-approval' },
+  notes: [
+    'Operator approval is required before invocation for over-threshold buyer authority cases.',
+    'This fixture remains local and does not execute a payment.',
+  ],
+});
+const invocationContract = baseContract();
+const receiptEvidenceContract = baseContract({
+  executionResult: { status: 'allowed', invocationId: 'local-fixture:framework-template:receipt-evidence', outputRef: 'local-fixture:output:receipt-evidence' },
+});
+const denialContract = baseContract({
+  executionResult: { status: 'denied', invocationId: 'local-fixture:framework-template:denial' },
+  receiptEvidenceRefs: { receiptRequired: true, evidenceRequired: true },
+});
+const failureContract = baseContract({
+  executionResult: { status: 'failed', invocationId: 'local-fixture:framework-template:failure' },
+  failureRefundState: {
+    failureMode: 'no_charge_on_failure',
+    refundMode: 'manual_review',
+    state: 'manual-review',
+  },
+});
+
+export const frameworkTemplateFixtures: Record<FrameworkTemplateScenarioKind, FrameworkTemplateFixture> = {
+  discovery: {
+    kind: 'discovery',
+    description: 'Framework-neutral discovery fixture with seller profile and buyer authority matrix references.',
+    contract: discoveryContract,
+    expectedValid: true,
+    expectedReasonCodes: ['framework_template_contract_valid'],
+  },
+  quote: {
+    kind: 'quote',
+    description: 'Framework-neutral quote fixture before buyer authority preflight.',
+    contract: quoteContract,
+    expectedValid: true,
+    expectedReasonCodes: ['framework_template_contract_valid'],
+  },
+  preflight: {
+    kind: 'preflight',
+    description: 'Buyer authority preflight fixture using the shared #550 matrix.',
+    contract: preflightContract,
+    expectedValid: true,
+    expectedReasonCodes: ['framework_template_contract_valid'],
+  },
+  'operator-approval': {
+    kind: 'operator-approval',
+    description: 'Operator approval required fixture with no payment execution.',
+    contract: operatorApprovalContract,
+    expectedValid: true,
+    expectedReasonCodes: ['framework_template_contract_valid'],
+  },
+  invocation: {
+    kind: 'invocation',
+    description: 'Mock seller-wrapper invocation fixture after buyer policy passes.',
+    contract: invocationContract,
+    expectedValid: true,
+    expectedReasonCodes: ['framework_template_contract_valid'],
+  },
+  'receipt-evidence': {
+    kind: 'receipt-evidence',
+    description: 'Receipt/evidence binding fixture with local references only.',
+    contract: receiptEvidenceContract,
+    expectedValid: true,
+    expectedReasonCodes: ['framework_template_contract_valid'],
+  },
+  denial: {
+    kind: 'denial',
+    description: 'Denial fixture preserving machine-readable buyer authority reason codes.',
+    contract: denialContract,
+    expectedValid: true,
+    expectedReasonCodes: ['framework_template_contract_valid'],
+  },
+  failure: {
+    kind: 'failure',
+    description: 'Failure/refund fixture using no-charge-on-failure and manual review semantics.',
+    contract: failureContract,
+    expectedValid: true,
+    expectedReasonCodes: ['framework_template_contract_valid'],
+  },
+};
+
+export function listFrameworkTemplateFixtures(): FrameworkTemplateFixture[] {
+  return Object.values(frameworkTemplateFixtures).map((fixture) => ({
+    ...fixture,
+    contract: cloneContract(fixture.contract),
+  }));
+}
+
+export function validateFrameworkTemplateContract(contract: unknown): FrameworkTemplateValidationResult {
+  if (!isStructuredContract(contract)) {
+    return {
+      valid: false,
+      reasonCodes: ['framework_template_contract_malformed'],
+      auditNotes: ['Denied: framework-template contract is malformed.'],
+    };
+  }
+
+  const reasonCodes: FrameworkTemplateValidationReasonCode[] = [];
+  const auditNotes: string[] = [];
+
+  if (sellerWrapperFixtureHasCredentialMaterial(contract)) {
+    reasonCodes.push('framework_template_contains_credentials');
+    auditNotes.push('Denied: framework-template contract contains credential-like material.');
+  }
+
+  const sellerWrapperConfig = generateSellerWrapperConfigExamples();
+  const sellerValidation = validateSellerWrapperConfigExamples(sellerWrapperConfig);
+  if (!sellerValidation.valid) {
+    reasonCodes.push('seller_wrapper_contract_invalid');
+    auditNotes.push('Denied: source seller-wrapper contract is invalid.');
+  }
+
+  if (!buyerAuthorityCasesMatch(contract.buyerAuthorityCases)) {
+    reasonCodes.push('buyer_authority_matrix_mismatch');
+    auditNotes.push('Denied: buyer authority fixture matrix does not match #550.');
+  }
+
+  if (
+    contract.agentIdentity.templateMode !== 'seller-enabled'
+    && !buyerAuthorityPolicyMatches(contract.buyerAuthorityPolicy)
+  ) {
+    reasonCodes.push('seller_wrapper_contract_invalid');
+    auditNotes.push('Denied: buyer authority policy contract does not match #551 seller-wrapper contract metadata.');
+  }
+  if (
+    contract.agentIdentity.templateMode === 'seller-enabled'
+    && contract.buyerAuthorityPolicy
+    && !buyerAuthorityPolicyMatches(contract.buyerAuthorityPolicy)
+  ) {
+    reasonCodes.push('seller_wrapper_contract_invalid');
+    auditNotes.push('Denied: seller-only buyer authority policy contract is present but does not match #551 metadata.');
+  }
+
+  if (!SAFE_SUPPORT_STATES.includes(contract.supportStateMetadata.runtimeState)) {
+    reasonCodes.push('unsafe_support_state');
+    auditNotes.push('Denied: framework-template support state is not a safe local/static state.');
+  }
+  if (!supportStateBoundariesExplicitlyFalse(contract.supportStateMetadata)) {
+    reasonCodes.push('framework_template_contract_malformed');
+    auditNotes.push('Denied: framework-template runtime boundary booleans must be explicitly false.');
+  }
+  if (contract.supportStateMetadata.livePaymentApproved) {
+    reasonCodes.push('live_payment_rejected');
+    auditNotes.push('Denied: framework templates must not approve live payment.');
+  }
+  if (contract.supportStateMetadata.walletRpcProviderCalls || textContains(contract, UNSAFE_LIVE_PATTERN)) {
+    reasonCodes.push('wallet_rpc_provider_call_rejected');
+    auditNotes.push('Denied: framework-template contract contains wallet/RPC/provider-call material.');
+  }
+  if (textContains(contract, TRANSFER_INSTRUCTION_PATTERN)) {
+    reasonCodes.push('live_payment_rejected');
+    auditNotes.push('Denied: framework-template contract contains signing, transfer, broadcast, or payment execution instructions.');
+  }
+  if (contract.supportStateMetadata.custodySupported || textContains(contract, CUSTODY_CLAIM_PATTERN)) {
+    reasonCodes.push('custody_claim_rejected');
+    auditNotes.push('Denied: framework-template contract must not claim custody.');
+  }
+  if (contract.supportStateMetadata.settlementFinalityClaimed || textContains(contract, SETTLEMENT_FINALITY_PATTERN)) {
+    reasonCodes.push('settlement_finality_claim_rejected');
+    auditNotes.push('Denied: framework-template contract must not claim settlement finality.');
+  }
+  if (contract.receiptEvidenceRefs.receiptRequired && !contract.receiptEvidenceRefs.receiptRef && contract.executionResult.status === 'allowed') {
+    reasonCodes.push('missing_receipt_evidence_refs');
+    auditNotes.push('Denied: allowed invocations require receipt refs.');
+  }
+  if (contract.receiptEvidenceRefs.evidenceRequired && !contract.receiptEvidenceRefs.evidenceRef && contract.executionResult.status === 'allowed') {
+    reasonCodes.push('missing_receipt_evidence_refs');
+    auditNotes.push('Denied: allowed invocations require evidence refs.');
+  }
+  if (!contract.failureRefundState.failureMode || !contract.failureRefundState.refundMode) {
+    reasonCodes.push('missing_failure_refund_state');
+    auditNotes.push('Denied: failure/refund state is required.');
+  }
+
+  if (reasonCodes.length > 0) return { valid: false, reasonCodes, auditNotes };
+  return {
+    valid: true,
+    reasonCodes: ['framework_template_contract_valid'],
+    auditNotes: ['Allowed: framework-template contract is static, non-secret, no-spend, and no-live.'],
+  };
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -21,3 +21,4 @@ export * from './rail-neutral-payment-receipts.js';
 export * from './rail-neutral-proof-chain-fixture.js';
 export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
+export * from './framework-template-contract.js';

--- a/packages/agent-protocol/tests/framework-template-contract.test.ts
+++ b/packages/agent-protocol/tests/framework-template-contract.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION,
+  frameworkTemplateFixtures,
+  listBuyerAuthorityPolicyFixtureMatrix,
+  listFrameworkTemplateFixtures,
+  validateFrameworkTemplateContract,
+  type FrameworkTemplateContract,
+} from '../dist/index.js';
+
+describe('framework-template contract fixtures', () => {
+  it('exports framework-neutral lifecycle fixtures for template authors', () => {
+    const fixtures = listFrameworkTemplateFixtures();
+
+    assert.equal(fixtures.length, 8);
+    assert.deepEqual(fixtures.map((fixture) => fixture.kind).sort(), [
+      'denial',
+      'discovery',
+      'failure',
+      'invocation',
+      'operator-approval',
+      'preflight',
+      'quote',
+      'receipt-evidence',
+    ]);
+
+    for (const fixture of fixtures) {
+      assert.equal(fixture.contract.schemaVersion, FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION);
+      assert.equal(fixture.contract.issue, 552);
+      assert.equal(fixture.contract.parentIssues.frameworkTemplateContract, 543);
+      assert.equal(fixture.contract.parentIssues.frameworkTemplatesFeature, 542);
+      assert.equal(fixture.contract.parentIssues.buyerAuthority, 548);
+      assert.equal(fixture.contract.downstreamConsumption.langGraphIssue, 544);
+      assert.equal(fixture.contract.downstreamConsumption.strandsIssue, 545);
+      assert.equal(fixture.contract.downstreamConsumption.adkIssue, 546);
+      assert.equal(validateFrameworkTemplateContract(fixture.contract).valid, fixture.expectedValid);
+      assert.deepEqual(validateFrameworkTemplateContract(fixture.contract).reasonCodes, fixture.expectedReasonCodes);
+    }
+  });
+
+  it('keeps buyer, seller, and dual-mode template profiles representable', () => {
+    const base = frameworkTemplateFixtures.invocation.contract;
+    const buyerOnly: FrameworkTemplateContract = structuredClone(base);
+    buyerOnly.agentIdentity.templateMode = 'buyer-enabled';
+    buyerOnly.sellerProfile = undefined;
+
+    const sellerOnly: FrameworkTemplateContract = structuredClone(base);
+    sellerOnly.agentIdentity.templateMode = 'seller-enabled';
+    sellerOnly.buyerAuthorityPolicy = undefined;
+
+    const dualMode: FrameworkTemplateContract = structuredClone(base);
+    dualMode.agentIdentity.templateMode = 'dual-mode';
+
+    assert.equal(validateFrameworkTemplateContract(buyerOnly).valid, true);
+    assert.equal(validateFrameworkTemplateContract(sellerOnly).valid, true);
+    assert.equal(validateFrameworkTemplateContract(dualMode).valid, true);
+  });
+
+  it('binds the full buyer authority fixture matrix into shared templates', () => {
+    const expected = listBuyerAuthorityPolicyFixtureMatrix().map((example) => ({
+      key: example.key,
+      expectedAllowed: example.expectedAllowed,
+      expectedReasonCodes: example.expectedReasonCodes,
+    }));
+    const actual = frameworkTemplateFixtures.preflight.contract.buyerAuthorityCases;
+
+    assert.deepEqual(actual, expected);
+  });
+
+  it('requires buyer-enabled and dual-mode contracts to carry the #551 buyer authority payload', () => {
+    const missingPolicy = structuredClone(frameworkTemplateFixtures.preflight.contract);
+    missingPolicy.buyerAuthorityPolicy = undefined;
+    assert.deepEqual(validateFrameworkTemplateContract(missingPolicy).reasonCodes, ['seller_wrapper_contract_invalid']);
+
+    const truncatedPolicy = structuredClone(frameworkTemplateFixtures.preflight.contract);
+    const firstState = truncatedPolicy.buyerAuthorityPolicy?.fixtureStates[0];
+    assert.ok(truncatedPolicy.buyerAuthorityPolicy);
+    assert.ok(firstState);
+    truncatedPolicy.buyerAuthorityPolicy.fixtureStates = [firstState];
+    assert.deepEqual(validateFrameworkTemplateContract(truncatedPolicy).reasonCodes, ['seller_wrapper_contract_invalid']);
+  });
+
+  it('fails closed for truncated matrices, unsafe states, credentials, live calls, custody, and finality claims', () => {
+    const truncated = structuredClone(frameworkTemplateFixtures.preflight.contract);
+    const firstCase = truncated.buyerAuthorityCases[0];
+    assert.ok(firstCase);
+    truncated.buyerAuthorityCases = [firstCase];
+    assert.deepEqual(validateFrameworkTemplateContract(truncated).reasonCodes, ['buyer_authority_matrix_mismatch']);
+
+    const unsafeState = structuredClone(frameworkTemplateFixtures.preflight.contract) as unknown as {
+      supportStateMetadata: { runtimeState: string };
+    };
+    unsafeState.supportStateMetadata.runtimeState = 'live-payment-approved';
+    assert.deepEqual(validateFrameworkTemplateContract(unsafeState).reasonCodes, ['unsafe_support_state']);
+
+    const livePayment = structuredClone(frameworkTemplateFixtures.preflight.contract) as unknown as {
+      supportStateMetadata: { livePaymentApproved: boolean };
+    };
+    livePayment.supportStateMetadata.livePaymentApproved = true;
+    assert.deepEqual(validateFrameworkTemplateContract(livePayment).reasonCodes, [
+      'framework_template_contract_malformed',
+      'live_payment_rejected',
+    ]);
+
+    const missingBoundary = structuredClone(frameworkTemplateFixtures.preflight.contract);
+    const missingBoundaryMetadata = missingBoundary.supportStateMetadata as Partial<FrameworkTemplateContract['supportStateMetadata']>;
+    delete missingBoundaryMetadata.walletRpcProviderCalls;
+    assert.deepEqual(validateFrameworkTemplateContract(missingBoundary).reasonCodes, ['framework_template_contract_malformed']);
+
+    const credentialContract = structuredClone(frameworkTemplateFixtures.preflight.contract) as FrameworkTemplateContract & {
+      providerSecret?: string;
+    };
+    credentialContract.providerSecret = 'sk-test-secret';
+    assert.deepEqual(validateFrameworkTemplateContract(credentialContract).reasonCodes, ['framework_template_contains_credentials']);
+
+    const rpcContract = structuredClone(frameworkTemplateFixtures.preflight.contract);
+    rpcContract.notes.push('Use https://api.mainnet-beta.solana.com as the provider call.');
+    assert.deepEqual(validateFrameworkTemplateContract(rpcContract).reasonCodes, ['wallet_rpc_provider_call_rejected']);
+
+    const custodyContract = structuredClone(frameworkTemplateFixtures.preflight.contract);
+    custodyContract.notes.push('AUDD is held in custody by the template.');
+    assert.deepEqual(validateFrameworkTemplateContract(custodyContract).reasonCodes, ['custody_claim_rejected']);
+
+    const finalityContract = structuredClone(frameworkTemplateFixtures.preflight.contract);
+    finalityContract.notes.push('Template confirms settlement finality.');
+    assert.deepEqual(validateFrameworkTemplateContract(finalityContract).reasonCodes, ['settlement_finality_claim_rejected']);
+  });
+
+  it('requires receipt and evidence refs for allowed invocation contracts', () => {
+    const missingReceipt = structuredClone(frameworkTemplateFixtures.invocation.contract);
+    missingReceipt.receiptEvidenceRefs.receiptRef = undefined;
+    assert.deepEqual(validateFrameworkTemplateContract(missingReceipt).reasonCodes, ['missing_receipt_evidence_refs']);
+
+    const missingEvidence = structuredClone(frameworkTemplateFixtures.invocation.contract);
+    missingEvidence.receiptEvidenceRefs.evidenceRef = undefined;
+    assert.deepEqual(validateFrameworkTemplateContract(missingEvidence).reasonCodes, ['missing_receipt_evidence_refs']);
+  });
+});


### PR DESCRIPTION
Closes #552.

## Summary
- add `@reddi/agent-protocol/framework-template-contract` with shared buyer/seller/dual-mode template contract types
- add static lifecycle fixtures for discovery, quote, preflight, operator approval, invocation, receipt/evidence binding, denial, and failure
- bind templates to the #549 buyer-authority policy, #550 fixture matrix, and #551 seller-wrapper buyer-authority contract
- document how #544/#545/#546 should consume the shared contract instead of inventing framework-specific payment semantics

## Validation
- `npm --prefix packages/agent-protocol test -- --runInBand`
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `git diff --check`

## UI evidence
- Not required: package/API/docs text only; no UI route, docs-rendered product screen, onboarding visual surface, or demo page changed.

## Boundary
- No LangGraph/Strands/ADK package install or scaffold.
- No external/cloud/API call, package publication, hosted registry write, wallet/RPC/provider call, live/devnet payment, custody, SPL transfer, or settlement-finality claim.