### PR TITLE
feat: add framework template no-live conformance checker

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -113,6 +113,23 @@ The built-in fixtures cover discovery, quote, buyer-policy preflight, operator a
 
 The helper is static and no-live. It rejects credential-shaped metadata, truncated buyer-authority matrices, unsafe support states, live-payment approval, wallet/RPC/provider-call material, signing/transfer instructions, custody claims, missing receipt/evidence refs for allowed invocations, and settlement-finality claims.
 
+## Framework Template Conformance
+
+```typescript
+import {
+  runFrameworkTemplateNoLiveConformanceCheck,
+} from '@reddi/agent-protocol/framework-template-conformance';
+
+const check = runFrameworkTemplateNoLiveConformanceCheck();
+console.log(check.valid); // true for the built-in local/static cases
+```
+
+The conformance checker is the #553 no-live gate for framework templates. It runs the shared #552 lifecycle fixtures plus explicit buyer-enabled, seller-enabled, and dual-mode profile cases before #544 LangGraph, #545 Strands, #546 ADK, or #547 comparison docs claim compatibility.
+
+The checker validates required lifecycle fixtures, profile modes, agent identity, invocation modes, buyer-authority policy metadata, seller profile metadata, receipt/evidence refs for allowed invocations, failure/refund state, support-state metadata, and the same no-secret/no-wallet/no-RPC/no-provider/no-custody/no-transfer/no-settlement-finality boundary enforced by the contract validator.
+
+This checker is local/static only. It does not install LangGraph, Strands, or ADK packages, scaffold projects, publish packages, call cloud or provider APIs, register hosted agents, access wallets/RPC endpoints, execute live or devnet payments, custody assets, transfer SPL tokens, or claim settlement finality.
+
 ## AI Catalog Ingestion
 
 ```typescript

--- a/packages/agent-protocol/dist/framework-template-conformance.d.ts
+++ b/packages/agent-protocol/dist/framework-template-conformance.d.ts
@@ -1,0 +1,39 @@
+import { type FrameworkTemplateContract, type FrameworkTemplateFixture, type FrameworkTemplateMode, type FrameworkTemplateScenarioKind } from './framework-template-contract.js';
+export declare const FRAMEWORK_TEMPLATE_CONFORMANCE_CHECK_VERSION: "reddi.framework-template-conformance.v1";
+export type FrameworkTemplateConformanceCaseKind = `lifecycle:${FrameworkTemplateScenarioKind}` | `mode:${FrameworkTemplateMode}`;
+export type FrameworkTemplateConformanceCase = {
+    kind: FrameworkTemplateConformanceCaseKind;
+    description: string;
+    contract: FrameworkTemplateContract;
+};
+export type FrameworkTemplateConformanceReasonCode = 'framework_template_conformance_valid' | 'framework_template_contract_invalid' | 'framework_template_contains_credentials' | 'missing_required_lifecycle_fixture' | 'missing_required_profile_mode' | 'missing_agent_identity_fields' | 'missing_invocation_modes' | 'missing_mode_required_buyer_authority_policy' | 'missing_mode_required_seller_profile' | 'missing_receipt_evidence_refs' | 'missing_failure_refund_state' | 'unsafe_support_state_metadata' | 'live_boundary_rejected' | 'conformance_case_kind_mismatch';
+export type FrameworkTemplateConformanceCaseResult = {
+    kind: FrameworkTemplateConformanceCaseKind;
+    valid: boolean;
+    reasonCodes: FrameworkTemplateConformanceReasonCode[];
+    contractReasonCodes: string[];
+    auditNotes: string[];
+};
+export type FrameworkTemplateConformanceResult = {
+    version: typeof FRAMEWORK_TEMPLATE_CONFORMANCE_CHECK_VERSION;
+    issue: 553;
+    valid: boolean;
+    reasonCodes: FrameworkTemplateConformanceReasonCode[];
+    checkedCases: FrameworkTemplateConformanceCaseResult[];
+    requiredLifecycle: FrameworkTemplateScenarioKind[];
+    requiredProfileModes: FrameworkTemplateMode[];
+    downstreamIssues: {
+        sharedContract: 552;
+        langGraphTemplate: 544;
+        strandsTemplate: 545;
+        adkTemplate: 546;
+        comparisonDocs: 547;
+    };
+    auditNotes: string[];
+};
+export declare function listFrameworkTemplateConformanceCases(input?: {
+    lifecycleFixtures?: FrameworkTemplateFixture[];
+}): FrameworkTemplateConformanceCase[];
+export declare function runFrameworkTemplateNoLiveConformanceCheck(input?: {
+    cases?: FrameworkTemplateConformanceCase[];
+}): FrameworkTemplateConformanceResult;

--- a/packages/agent-protocol/dist/framework-template-conformance.js
+++ b/packages/agent-protocol/dist/framework-template-conformance.js
@@ -1,0 +1,197 @@
+import { frameworkTemplateFixtures, listFrameworkTemplateFixtures, validateFrameworkTemplateContract, } from './framework-template-contract.js';
+import { sellerWrapperFixtureHasCredentialMaterial } from './seller-wrapper-rail-fixtures.js';
+export const FRAMEWORK_TEMPLATE_CONFORMANCE_CHECK_VERSION = 'reddi.framework-template-conformance.v1';
+const REQUIRED_LIFECYCLE = [
+    'discovery',
+    'quote',
+    'preflight',
+    'operator-approval',
+    'invocation',
+    'receipt-evidence',
+    'denial',
+    'failure',
+];
+const REQUIRED_PROFILE_MODES = ['buyer-enabled', 'seller-enabled', 'dual-mode'];
+const SAFE_SUPPORT_STATES = ['fixture', 'dry-run', 'proof-metadata-only', 'devnet-gated'];
+function cloneContract(contract) {
+    return structuredClone(contract);
+}
+function modeCase(mode) {
+    const contract = cloneContract(frameworkTemplateFixtures.invocation.contract);
+    contract.agentIdentity.templateMode = mode;
+    if (mode === 'buyer-enabled')
+        contract.sellerProfile = undefined;
+    if (mode === 'seller-enabled')
+        contract.buyerAuthorityPolicy = undefined;
+    return {
+        kind: `mode:${mode}`,
+        description: `${mode} profile contract conformance case.`,
+        contract,
+    };
+}
+export function listFrameworkTemplateConformanceCases(input = {}) {
+    const lifecycleFixtures = input.lifecycleFixtures ?? listFrameworkTemplateFixtures();
+    return [
+        ...lifecycleFixtures.map((fixture) => ({
+            kind: `lifecycle:${fixture.kind}`,
+            description: fixture.description,
+            contract: cloneContract(fixture.contract),
+        })),
+        ...REQUIRED_PROFILE_MODES.map(modeCase),
+    ];
+}
+function addUnique(items, item) {
+    if (!items.includes(item))
+        items.push(item);
+}
+function hasNonEmptyStrings(values) {
+    return Array.isArray(values) && values.length > 0 && values.every((item) => typeof item === 'string' && item.trim().length > 0);
+}
+function requiredFieldsForMode(contract, reasonCodes, auditNotes) {
+    const mode = contract.agentIdentity.templateMode;
+    if ((mode === 'buyer-enabled' || mode === 'dual-mode') && !contract.buyerAuthorityPolicy) {
+        addUnique(reasonCodes, 'missing_mode_required_buyer_authority_policy');
+        auditNotes.push(`Denied: ${mode} profile requires buyer authority policy metadata.`);
+    }
+    if ((mode === 'seller-enabled' || mode === 'dual-mode') && !contract.sellerProfile) {
+        addUnique(reasonCodes, 'missing_mode_required_seller_profile');
+        auditNotes.push(`Denied: ${mode} profile requires seller profile metadata.`);
+    }
+}
+function boundaryFieldsAreExplicitFalse(contract) {
+    return contract.supportStateMetadata.livePaymentApproved === false
+        && contract.supportStateMetadata.walletRpcProviderCalls === false
+        && contract.supportStateMetadata.custodySupported === false
+        && contract.supportStateMetadata.settlementFinalityClaimed === false;
+}
+function canonicalLifecycleContract(kind) {
+    if (!kind.startsWith('lifecycle:'))
+        return undefined;
+    const lifecycleKind = kind.slice('lifecycle:'.length);
+    return frameworkTemplateFixtures[lifecycleKind]?.contract;
+}
+function contractsMatchCanonicalLifecycle(kind, contract) {
+    const canonical = canonicalLifecycleContract(kind);
+    if (!canonical)
+        return true;
+    return JSON.stringify(contract) === JSON.stringify(canonical);
+}
+function modeMatchesKind(kind, contract) {
+    if (!kind.startsWith('mode:'))
+        return true;
+    return contract.agentIdentity.templateMode === kind.slice('mode:'.length);
+}
+function evaluateCase(item) {
+    const reasonCodes = [];
+    const auditNotes = [];
+    const validation = validateFrameworkTemplateContract(item.contract);
+    if (!validation.valid) {
+        addUnique(reasonCodes, 'framework_template_contract_invalid');
+        auditNotes.push(...validation.auditNotes);
+    }
+    if (sellerWrapperFixtureHasCredentialMaterial(item.contract)) {
+        addUnique(reasonCodes, 'framework_template_contains_credentials');
+        auditNotes.push('Denied: conformance case contains credential-shaped material.');
+    }
+    if (!contractsMatchCanonicalLifecycle(item.kind, item.contract)) {
+        addUnique(reasonCodes, 'conformance_case_kind_mismatch');
+        auditNotes.push(`Denied: ${item.kind} must match the canonical #552 lifecycle fixture.`);
+    }
+    if (!modeMatchesKind(item.kind, item.contract)) {
+        addUnique(reasonCodes, 'conformance_case_kind_mismatch');
+        auditNotes.push(`Denied: ${item.kind} must match contract agentIdentity.templateMode.`);
+    }
+    if (!item.contract.agentIdentity.agentId.trim()
+        || !item.contract.agentIdentity.displayName.trim()
+        || !hasNonEmptyStrings(item.contract.agentIdentity.capabilityTags)) {
+        addUnique(reasonCodes, 'missing_agent_identity_fields');
+        auditNotes.push('Denied: agent identity requires id, display name, and capability tags.');
+    }
+    if (!hasNonEmptyStrings(item.contract.invocationModes)) {
+        addUnique(reasonCodes, 'missing_invocation_modes');
+        auditNotes.push('Denied: at least one invocation mode is required.');
+    }
+    requiredFieldsForMode(item.contract, reasonCodes, auditNotes);
+    if (item.contract.executionResult.status === 'allowed') {
+        if (item.contract.receiptEvidenceRefs.receiptRequired && !item.contract.receiptEvidenceRefs.receiptRef) {
+            addUnique(reasonCodes, 'missing_receipt_evidence_refs');
+            auditNotes.push('Denied: allowed conformance case requires receipt ref.');
+        }
+        if (item.contract.receiptEvidenceRefs.evidenceRequired && !item.contract.receiptEvidenceRefs.evidenceRef) {
+            addUnique(reasonCodes, 'missing_receipt_evidence_refs');
+            auditNotes.push('Denied: allowed conformance case requires evidence ref.');
+        }
+    }
+    if (!item.contract.failureRefundState.failureMode || !item.contract.failureRefundState.refundMode || !item.contract.failureRefundState.state) {
+        addUnique(reasonCodes, 'missing_failure_refund_state');
+        auditNotes.push('Denied: failure/refund state requires mode and state fields.');
+    }
+    if (!SAFE_SUPPORT_STATES.includes(item.contract.supportStateMetadata.runtimeState) || !boundaryFieldsAreExplicitFalse(item.contract)) {
+        addUnique(reasonCodes, 'unsafe_support_state_metadata');
+        auditNotes.push('Denied: support-state metadata must be safe and all live boundary fields must be explicitly false.');
+    }
+    if (item.contract.supportStateMetadata.livePaymentApproved
+        || item.contract.supportStateMetadata.walletRpcProviderCalls
+        || item.contract.supportStateMetadata.custodySupported
+        || item.contract.supportStateMetadata.settlementFinalityClaimed) {
+        addUnique(reasonCodes, 'live_boundary_rejected');
+        auditNotes.push('Denied: live payment, wallet/RPC/provider, custody, and settlement-finality boundaries must stay false.');
+    }
+    if (reasonCodes.length === 0) {
+        return {
+            kind: item.kind,
+            valid: true,
+            reasonCodes: ['framework_template_conformance_valid'],
+            contractReasonCodes: validation.reasonCodes,
+            auditNotes: ['Allowed: framework-template conformance case is local, static, no-secret, and no-live.'],
+        };
+    }
+    return {
+        kind: item.kind,
+        valid: false,
+        reasonCodes,
+        contractReasonCodes: validation.reasonCodes,
+        auditNotes,
+    };
+}
+export function runFrameworkTemplateNoLiveConformanceCheck(input = {}) {
+    const cases = input.cases ?? listFrameworkTemplateConformanceCases();
+    const checkedCases = cases.map(evaluateCase);
+    const reasonCodes = [];
+    const lifecycleKinds = new Set(cases.map((item) => item.kind));
+    const profileKinds = new Set(cases.map((item) => item.kind));
+    for (const lifecycle of REQUIRED_LIFECYCLE) {
+        if (!lifecycleKinds.has(`lifecycle:${lifecycle}`))
+            addUnique(reasonCodes, 'missing_required_lifecycle_fixture');
+    }
+    for (const mode of REQUIRED_PROFILE_MODES) {
+        if (!profileKinds.has(`mode:${mode}`))
+            addUnique(reasonCodes, 'missing_required_profile_mode');
+    }
+    for (const caseResult of checkedCases) {
+        for (const reason of caseResult.reasonCodes) {
+            if (reason !== 'framework_template_conformance_valid')
+                addUnique(reasonCodes, reason);
+        }
+    }
+    const valid = reasonCodes.length === 0;
+    return {
+        version: FRAMEWORK_TEMPLATE_CONFORMANCE_CHECK_VERSION,
+        issue: 553,
+        valid,
+        reasonCodes: valid ? ['framework_template_conformance_valid'] : reasonCodes,
+        checkedCases,
+        requiredLifecycle: [...REQUIRED_LIFECYCLE],
+        requiredProfileModes: [...REQUIRED_PROFILE_MODES],
+        downstreamIssues: {
+            sharedContract: 552,
+            langGraphTemplate: 544,
+            strandsTemplate: 545,
+            adkTemplate: 546,
+            comparisonDocs: 547,
+        },
+        auditNotes: valid
+            ? ['Allowed: all framework-template conformance cases passed local no-live checks.']
+            : ['Denied: one or more framework-template conformance cases failed local no-live checks.'],
+    };
+}

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -22,3 +22,4 @@ export * from './rail-neutral-proof-chain-fixture.js';
 export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
+export * from './framework-template-conformance.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -22,3 +22,4 @@ export * from './rail-neutral-proof-chain-fixture.js';
 export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
+export * from './framework-template-conformance.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -106,6 +106,10 @@
       "types": "./dist/framework-template-contract.d.ts",
       "import": "./dist/framework-template-contract.js"
     },
+    "./framework-template-conformance": {
+      "types": "./dist/framework-template-conformance.d.ts",
+      "import": "./dist/framework-template-conformance.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/framework-template-conformance.ts
+++ b/packages/agent-protocol/src/framework-template-conformance.ts
@@ -1,0 +1,276 @@
+import {
+  frameworkTemplateFixtures,
+  listFrameworkTemplateFixtures,
+  validateFrameworkTemplateContract,
+  type FrameworkTemplateContract,
+  type FrameworkTemplateFixture,
+  type FrameworkTemplateMode,
+  type FrameworkTemplateScenarioKind,
+} from './framework-template-contract.js';
+import { sellerWrapperFixtureHasCredentialMaterial } from './seller-wrapper-rail-fixtures.js';
+
+export const FRAMEWORK_TEMPLATE_CONFORMANCE_CHECK_VERSION = 'reddi.framework-template-conformance.v1' as const;
+
+export type FrameworkTemplateConformanceCaseKind =
+  | `lifecycle:${FrameworkTemplateScenarioKind}`
+  | `mode:${FrameworkTemplateMode}`;
+
+export type FrameworkTemplateConformanceCase = {
+  kind: FrameworkTemplateConformanceCaseKind;
+  description: string;
+  contract: FrameworkTemplateContract;
+};
+
+export type FrameworkTemplateConformanceReasonCode =
+  | 'framework_template_conformance_valid'
+  | 'framework_template_contract_invalid'
+  | 'framework_template_contains_credentials'
+  | 'missing_required_lifecycle_fixture'
+  | 'missing_required_profile_mode'
+  | 'missing_agent_identity_fields'
+  | 'missing_invocation_modes'
+  | 'missing_mode_required_buyer_authority_policy'
+  | 'missing_mode_required_seller_profile'
+  | 'missing_receipt_evidence_refs'
+  | 'missing_failure_refund_state'
+  | 'unsafe_support_state_metadata'
+  | 'live_boundary_rejected'
+  | 'conformance_case_kind_mismatch';
+
+export type FrameworkTemplateConformanceCaseResult = {
+  kind: FrameworkTemplateConformanceCaseKind;
+  valid: boolean;
+  reasonCodes: FrameworkTemplateConformanceReasonCode[];
+  contractReasonCodes: string[];
+  auditNotes: string[];
+};
+
+export type FrameworkTemplateConformanceResult = {
+  version: typeof FRAMEWORK_TEMPLATE_CONFORMANCE_CHECK_VERSION;
+  issue: 553;
+  valid: boolean;
+  reasonCodes: FrameworkTemplateConformanceReasonCode[];
+  checkedCases: FrameworkTemplateConformanceCaseResult[];
+  requiredLifecycle: FrameworkTemplateScenarioKind[];
+  requiredProfileModes: FrameworkTemplateMode[];
+  downstreamIssues: {
+    sharedContract: 552;
+    langGraphTemplate: 544;
+    strandsTemplate: 545;
+    adkTemplate: 546;
+    comparisonDocs: 547;
+  };
+  auditNotes: string[];
+};
+
+const REQUIRED_LIFECYCLE: FrameworkTemplateScenarioKind[] = [
+  'discovery',
+  'quote',
+  'preflight',
+  'operator-approval',
+  'invocation',
+  'receipt-evidence',
+  'denial',
+  'failure',
+];
+const REQUIRED_PROFILE_MODES: FrameworkTemplateMode[] = ['buyer-enabled', 'seller-enabled', 'dual-mode'];
+const SAFE_SUPPORT_STATES = ['fixture', 'dry-run', 'proof-metadata-only', 'devnet-gated'];
+
+function cloneContract(contract: FrameworkTemplateContract): FrameworkTemplateContract {
+  return structuredClone(contract) as FrameworkTemplateContract;
+}
+
+function modeCase(mode: FrameworkTemplateMode): FrameworkTemplateConformanceCase {
+  const contract = cloneContract(frameworkTemplateFixtures.invocation.contract);
+  contract.agentIdentity.templateMode = mode;
+  if (mode === 'buyer-enabled') contract.sellerProfile = undefined;
+  if (mode === 'seller-enabled') contract.buyerAuthorityPolicy = undefined;
+  return {
+    kind: `mode:${mode}`,
+    description: `${mode} profile contract conformance case.`,
+    contract,
+  };
+}
+
+export function listFrameworkTemplateConformanceCases(input: {
+  lifecycleFixtures?: FrameworkTemplateFixture[];
+} = {}): FrameworkTemplateConformanceCase[] {
+  const lifecycleFixtures = input.lifecycleFixtures ?? listFrameworkTemplateFixtures();
+  return [
+    ...lifecycleFixtures.map((fixture) => ({
+      kind: `lifecycle:${fixture.kind}` as const,
+      description: fixture.description,
+      contract: cloneContract(fixture.contract),
+    })),
+    ...REQUIRED_PROFILE_MODES.map(modeCase),
+  ];
+}
+
+function addUnique<T>(items: T[], item: T): void {
+  if (!items.includes(item)) items.push(item);
+}
+
+function hasNonEmptyStrings(values: unknown): values is string[] {
+  return Array.isArray(values) && values.length > 0 && values.every((item) => typeof item === 'string' && item.trim().length > 0);
+}
+
+function requiredFieldsForMode(contract: FrameworkTemplateContract, reasonCodes: FrameworkTemplateConformanceReasonCode[], auditNotes: string[]): void {
+  const mode = contract.agentIdentity.templateMode;
+  if ((mode === 'buyer-enabled' || mode === 'dual-mode') && !contract.buyerAuthorityPolicy) {
+    addUnique(reasonCodes, 'missing_mode_required_buyer_authority_policy');
+    auditNotes.push(`Denied: ${mode} profile requires buyer authority policy metadata.`);
+  }
+  if ((mode === 'seller-enabled' || mode === 'dual-mode') && !contract.sellerProfile) {
+    addUnique(reasonCodes, 'missing_mode_required_seller_profile');
+    auditNotes.push(`Denied: ${mode} profile requires seller profile metadata.`);
+  }
+}
+
+function boundaryFieldsAreExplicitFalse(contract: FrameworkTemplateContract): boolean {
+  return contract.supportStateMetadata.livePaymentApproved === false
+    && contract.supportStateMetadata.walletRpcProviderCalls === false
+    && contract.supportStateMetadata.custodySupported === false
+    && contract.supportStateMetadata.settlementFinalityClaimed === false;
+}
+
+function canonicalLifecycleContract(kind: FrameworkTemplateConformanceCaseKind): FrameworkTemplateContract | undefined {
+  if (!kind.startsWith('lifecycle:')) return undefined;
+  const lifecycleKind = kind.slice('lifecycle:'.length) as FrameworkTemplateScenarioKind;
+  return frameworkTemplateFixtures[lifecycleKind]?.contract;
+}
+
+function contractsMatchCanonicalLifecycle(kind: FrameworkTemplateConformanceCaseKind, contract: FrameworkTemplateContract): boolean {
+  const canonical = canonicalLifecycleContract(kind);
+  if (!canonical) return true;
+  return JSON.stringify(contract) === JSON.stringify(canonical);
+}
+
+function modeMatchesKind(kind: FrameworkTemplateConformanceCaseKind, contract: FrameworkTemplateContract): boolean {
+  if (!kind.startsWith('mode:')) return true;
+  return contract.agentIdentity.templateMode === kind.slice('mode:'.length);
+}
+
+function evaluateCase(item: FrameworkTemplateConformanceCase): FrameworkTemplateConformanceCaseResult {
+  const reasonCodes: FrameworkTemplateConformanceReasonCode[] = [];
+  const auditNotes: string[] = [];
+  const validation = validateFrameworkTemplateContract(item.contract);
+
+  if (!validation.valid) {
+    addUnique(reasonCodes, 'framework_template_contract_invalid');
+    auditNotes.push(...validation.auditNotes);
+  }
+  if (sellerWrapperFixtureHasCredentialMaterial(item.contract)) {
+    addUnique(reasonCodes, 'framework_template_contains_credentials');
+    auditNotes.push('Denied: conformance case contains credential-shaped material.');
+  }
+  if (!contractsMatchCanonicalLifecycle(item.kind, item.contract)) {
+    addUnique(reasonCodes, 'conformance_case_kind_mismatch');
+    auditNotes.push(`Denied: ${item.kind} must match the canonical #552 lifecycle fixture.`);
+  }
+  if (!modeMatchesKind(item.kind, item.contract)) {
+    addUnique(reasonCodes, 'conformance_case_kind_mismatch');
+    auditNotes.push(`Denied: ${item.kind} must match contract agentIdentity.templateMode.`);
+  }
+  if (
+    !item.contract.agentIdentity.agentId.trim()
+    || !item.contract.agentIdentity.displayName.trim()
+    || !hasNonEmptyStrings(item.contract.agentIdentity.capabilityTags)
+  ) {
+    addUnique(reasonCodes, 'missing_agent_identity_fields');
+    auditNotes.push('Denied: agent identity requires id, display name, and capability tags.');
+  }
+  if (!hasNonEmptyStrings(item.contract.invocationModes)) {
+    addUnique(reasonCodes, 'missing_invocation_modes');
+    auditNotes.push('Denied: at least one invocation mode is required.');
+  }
+
+  requiredFieldsForMode(item.contract, reasonCodes, auditNotes);
+
+  if (item.contract.executionResult.status === 'allowed') {
+    if (item.contract.receiptEvidenceRefs.receiptRequired && !item.contract.receiptEvidenceRefs.receiptRef) {
+      addUnique(reasonCodes, 'missing_receipt_evidence_refs');
+      auditNotes.push('Denied: allowed conformance case requires receipt ref.');
+    }
+    if (item.contract.receiptEvidenceRefs.evidenceRequired && !item.contract.receiptEvidenceRefs.evidenceRef) {
+      addUnique(reasonCodes, 'missing_receipt_evidence_refs');
+      auditNotes.push('Denied: allowed conformance case requires evidence ref.');
+    }
+  }
+  if (!item.contract.failureRefundState.failureMode || !item.contract.failureRefundState.refundMode || !item.contract.failureRefundState.state) {
+    addUnique(reasonCodes, 'missing_failure_refund_state');
+    auditNotes.push('Denied: failure/refund state requires mode and state fields.');
+  }
+  if (!SAFE_SUPPORT_STATES.includes(item.contract.supportStateMetadata.runtimeState) || !boundaryFieldsAreExplicitFalse(item.contract)) {
+    addUnique(reasonCodes, 'unsafe_support_state_metadata');
+    auditNotes.push('Denied: support-state metadata must be safe and all live boundary fields must be explicitly false.');
+  }
+  if (
+    item.contract.supportStateMetadata.livePaymentApproved
+    || item.contract.supportStateMetadata.walletRpcProviderCalls
+    || item.contract.supportStateMetadata.custodySupported
+    || item.contract.supportStateMetadata.settlementFinalityClaimed
+  ) {
+    addUnique(reasonCodes, 'live_boundary_rejected');
+    auditNotes.push('Denied: live payment, wallet/RPC/provider, custody, and settlement-finality boundaries must stay false.');
+  }
+
+  if (reasonCodes.length === 0) {
+    return {
+      kind: item.kind,
+      valid: true,
+      reasonCodes: ['framework_template_conformance_valid'],
+      contractReasonCodes: validation.reasonCodes,
+      auditNotes: ['Allowed: framework-template conformance case is local, static, no-secret, and no-live.'],
+    };
+  }
+  return {
+    kind: item.kind,
+    valid: false,
+    reasonCodes,
+    contractReasonCodes: validation.reasonCodes,
+    auditNotes,
+  };
+}
+
+export function runFrameworkTemplateNoLiveConformanceCheck(input: {
+  cases?: FrameworkTemplateConformanceCase[];
+} = {}): FrameworkTemplateConformanceResult {
+  const cases = input.cases ?? listFrameworkTemplateConformanceCases();
+  const checkedCases = cases.map(evaluateCase);
+  const reasonCodes: FrameworkTemplateConformanceReasonCode[] = [];
+  const lifecycleKinds = new Set(cases.map((item) => item.kind));
+  const profileKinds = new Set(cases.map((item) => item.kind));
+
+  for (const lifecycle of REQUIRED_LIFECYCLE) {
+    if (!lifecycleKinds.has(`lifecycle:${lifecycle}`)) addUnique(reasonCodes, 'missing_required_lifecycle_fixture');
+  }
+  for (const mode of REQUIRED_PROFILE_MODES) {
+    if (!profileKinds.has(`mode:${mode}`)) addUnique(reasonCodes, 'missing_required_profile_mode');
+  }
+  for (const caseResult of checkedCases) {
+    for (const reason of caseResult.reasonCodes) {
+      if (reason !== 'framework_template_conformance_valid') addUnique(reasonCodes, reason);
+    }
+  }
+
+  const valid = reasonCodes.length === 0;
+  return {
+    version: FRAMEWORK_TEMPLATE_CONFORMANCE_CHECK_VERSION,
+    issue: 553,
+    valid,
+    reasonCodes: valid ? ['framework_template_conformance_valid'] : reasonCodes,
+    checkedCases,
+    requiredLifecycle: [...REQUIRED_LIFECYCLE],
+    requiredProfileModes: [...REQUIRED_PROFILE_MODES],
+    downstreamIssues: {
+      sharedContract: 552,
+      langGraphTemplate: 544,
+      strandsTemplate: 545,
+      adkTemplate: 546,
+      comparisonDocs: 547,
+    },
+    auditNotes: valid
+      ? ['Allowed: all framework-template conformance cases passed local no-live checks.']
+      : ['Denied: one or more framework-template conformance cases failed local no-live checks.'],
+  };
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -22,3 +22,4 @@ export * from './rail-neutral-proof-chain-fixture.js';
 export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
+export * from './framework-template-conformance.js';

--- a/packages/agent-protocol/tests/framework-template-conformance.test.ts
+++ b/packages/agent-protocol/tests/framework-template-conformance.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  FRAMEWORK_TEMPLATE_CONFORMANCE_CHECK_VERSION,
+  frameworkTemplateFixtures,
+  listFrameworkTemplateConformanceCases,
+  runFrameworkTemplateNoLiveConformanceCheck,
+  type FrameworkTemplateConformanceCase,
+  type FrameworkTemplateContract,
+} from '../dist/index.js';
+
+describe('framework-template no-live conformance checker', () => {
+  it('passes the built-in lifecycle and profile-mode conformance cases', () => {
+    const cases = listFrameworkTemplateConformanceCases();
+    const result = runFrameworkTemplateNoLiveConformanceCheck({ cases });
+
+    assert.equal(result.version, FRAMEWORK_TEMPLATE_CONFORMANCE_CHECK_VERSION);
+    assert.equal(result.issue, 553);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.reasonCodes, ['framework_template_conformance_valid']);
+    assert.equal(result.checkedCases.length, 11);
+    assert.deepEqual(result.requiredLifecycle.sort(), [
+      'denial',
+      'discovery',
+      'failure',
+      'invocation',
+      'operator-approval',
+      'preflight',
+      'quote',
+      'receipt-evidence',
+    ]);
+    assert.deepEqual(result.requiredProfileModes.sort(), ['buyer-enabled', 'dual-mode', 'seller-enabled']);
+    assert.equal(result.downstreamIssues.sharedContract, 552);
+    assert.equal(result.downstreamIssues.langGraphTemplate, 544);
+    assert.equal(result.downstreamIssues.strandsTemplate, 545);
+    assert.equal(result.downstreamIssues.adkTemplate, 546);
+    assert.equal(result.downstreamIssues.comparisonDocs, 547);
+  });
+
+  it('fails closed when required lifecycle or profile cases are missing', () => {
+    const onlyLifecycle = listFrameworkTemplateConformanceCases().filter((item) => item.kind.startsWith('lifecycle:'));
+    assert.deepEqual(runFrameworkTemplateNoLiveConformanceCheck({ cases: onlyLifecycle }).reasonCodes, [
+      'missing_required_profile_mode',
+    ]);
+
+    const onlyModes = listFrameworkTemplateConformanceCases().filter((item) => item.kind.startsWith('mode:'));
+    assert.deepEqual(runFrameworkTemplateNoLiveConformanceCheck({ cases: onlyModes }).reasonCodes, [
+      'missing_required_lifecycle_fixture',
+    ]);
+  });
+
+  it('fails closed when case labels spoof lifecycle or profile coverage', () => {
+    const spoofedLifecycle = conformanceCase('lifecycle:failure', () => {});
+    assert.deepEqual(runFrameworkTemplateNoLiveConformanceCheck({ cases: [spoofedLifecycle] }).checkedCases[0]?.reasonCodes, [
+      'conformance_case_kind_mismatch',
+    ]);
+
+    const spoofedMode = conformanceCase('mode:buyer-enabled', (contract) => {
+      contract.agentIdentity.templateMode = 'dual-mode';
+    });
+    assert.deepEqual(runFrameworkTemplateNoLiveConformanceCheck({ cases: [spoofedMode] }).checkedCases[0]?.reasonCodes, [
+      'conformance_case_kind_mismatch',
+    ]);
+  });
+
+  it('validates buyer, seller, and dual-mode required fields', () => {
+    const buyerMissingPolicy = conformanceCase('mode:buyer-enabled', (contract) => {
+      contract.agentIdentity.templateMode = 'buyer-enabled';
+      contract.sellerProfile = undefined;
+      contract.buyerAuthorityPolicy = undefined;
+    });
+    assert.deepEqual(runFrameworkTemplateNoLiveConformanceCheck({ cases: [buyerMissingPolicy] }).checkedCases[0]?.reasonCodes, [
+      'framework_template_contract_invalid',
+      'missing_mode_required_buyer_authority_policy',
+    ]);
+
+    const sellerMissingProfile = conformanceCase('mode:seller-enabled', (contract) => {
+      contract.agentIdentity.templateMode = 'seller-enabled';
+      contract.buyerAuthorityPolicy = undefined;
+      contract.sellerProfile = undefined;
+    });
+    assert.deepEqual(runFrameworkTemplateNoLiveConformanceCheck({ cases: [sellerMissingProfile] }).checkedCases[0]?.reasonCodes, [
+      'missing_mode_required_seller_profile',
+    ]);
+
+    const dualMissingSeller = conformanceCase('mode:dual-mode', (contract) => {
+      contract.agentIdentity.templateMode = 'dual-mode';
+      contract.sellerProfile = undefined;
+    });
+    assert.deepEqual(runFrameworkTemplateNoLiveConformanceCheck({ cases: [dualMissingSeller] }).checkedCases[0]?.reasonCodes, [
+      'missing_mode_required_seller_profile',
+    ]);
+  });
+
+  it('fails closed for missing identity, invocation modes, receipt/evidence refs, and failure state', () => {
+    const missingIdentity = conformanceCase('lifecycle:preflight', (contract) => {
+      contract.agentIdentity.agentId = '';
+      contract.agentIdentity.capabilityTags = [];
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [missingIdentity] }).reasonCodes.includes('missing_agent_identity_fields'));
+
+    const missingInvocationModes = conformanceCase('lifecycle:preflight', (contract) => {
+      contract.invocationModes = [];
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [missingInvocationModes] }).reasonCodes.includes('missing_invocation_modes'));
+
+    const missingReceipt = conformanceCase('lifecycle:invocation', (contract) => {
+      contract.receiptEvidenceRefs.receiptRef = undefined;
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [missingReceipt] }).reasonCodes.includes('missing_receipt_evidence_refs'));
+
+    const missingFailureState = conformanceCase('lifecycle:failure', (contract) => {
+      contract.failureRefundState.state = '' as FrameworkTemplateContract['failureRefundState']['state'];
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [missingFailureState] }).reasonCodes.includes('missing_failure_refund_state'));
+  });
+
+  it('rejects secret, live, wallet/RPC/provider, custody, transfer, and finality regressions', () => {
+    const credential = conformanceCase('lifecycle:preflight', (contract) => {
+      (contract as FrameworkTemplateContract & { providerSecret?: string }).providerSecret = 'sk-test-secret';
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [credential] }).reasonCodes.includes('framework_template_contains_credentials'));
+
+    const missingBoundary = conformanceCase('lifecycle:preflight', (contract) => {
+      const metadata = contract.supportStateMetadata as Partial<FrameworkTemplateContract['supportStateMetadata']>;
+      delete metadata.walletRpcProviderCalls;
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [missingBoundary] }).reasonCodes.includes('unsafe_support_state_metadata'));
+
+    const liveBoundary = conformanceCase('lifecycle:preflight', (contract) => {
+      (contract.supportStateMetadata as unknown as { livePaymentApproved: boolean }).livePaymentApproved = true;
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [liveBoundary] }).reasonCodes.includes('live_boundary_rejected'));
+
+    const unsafeState = conformanceCase('lifecycle:preflight', (contract) => {
+      contract.supportStateMetadata.runtimeState = 'live-payment-approved' as FrameworkTemplateContract['supportStateMetadata']['runtimeState'];
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [unsafeState] }).reasonCodes.includes('unsafe_support_state_metadata'));
+
+    const rpc = conformanceCase('lifecycle:preflight', (contract) => {
+      contract.notes.push('Use https://api.mainnet-beta.solana.com as the provider endpoint.');
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [rpc] }).reasonCodes.includes('framework_template_contract_invalid'));
+
+    const custody = conformanceCase('lifecycle:preflight', (contract) => {
+      contract.notes.push('AUDD is held in custody by this template.');
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [custody] }).reasonCodes.includes('framework_template_contract_invalid'));
+
+    const transfer = conformanceCase('lifecycle:preflight', (contract) => {
+      contract.notes.push('Submit the AUDD payment transaction.');
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [transfer] }).reasonCodes.includes('framework_template_contract_invalid'));
+
+    const finality = conformanceCase('lifecycle:preflight', (contract) => {
+      contract.notes.push('Template confirms settlement finality.');
+    });
+    assert.ok(runFrameworkTemplateNoLiveConformanceCheck({ cases: [finality] }).reasonCodes.includes('framework_template_contract_invalid'));
+  });
+});
+
+function conformanceCase(
+  kind: FrameworkTemplateConformanceCase['kind'],
+  mutate: (contract: FrameworkTemplateContract) => void,
+): FrameworkTemplateConformanceCase {
+  const contract = structuredClone(frameworkTemplateFixtures.preflight.contract) as FrameworkTemplateContract;
+  mutate(contract);
+  return {
+    kind,
+    description: `${kind} mutated test case`,
+    contract,
+  };
+}


### PR DESCRIPTION
Closes #553.

## Summary
- add `@reddi/agent-protocol/framework-template-conformance` as the shared no-live checker for #544/#545/#546/#547 consumers
- run #552 lifecycle fixtures plus explicit buyer-enabled, seller-enabled, and dual-mode profile conformance cases
- validate required lifecycle/profile coverage, agent identity, invocation modes, buyer-authority/seller profile fields, receipt/evidence refs, failure/refund state, support-state metadata, and no-live boundary fields
- document the checker and downstream usage in the package README

## Validation
- `npm --prefix packages/agent-protocol install --ignore-scripts`
- `npm --prefix packages/agent-protocol test -- --runInBand` => 186/186
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `git diff --check`

## UI evidence
- Not required: package/API/docs text only; no UI route, docs-rendered product screen, onboarding visual surface, or demo page changed.

## Boundary
- Static/local conformance only.
- No LangGraph/Strands/ADK package install or scaffold.
- No external/cloud/API call, package publication, hosted registry write, wallet/RPC/provider call, live/devnet payment, custody, SPL transfer, or settlement-finality claim.