### PR TITLE
feat: add LangGraph RAP template fixture

### DIFF
--- a/packages/agent-protocol/README.md
+++ b/packages/agent-protocol/README.md
@@ -130,6 +130,25 @@ The checker validates required lifecycle fixtures, profile modes, agent identity
 
 This checker is local/static only. It does not install LangGraph, Strands, or ADK packages, scaffold projects, publish packages, call cloud or provider APIs, register hosted agents, access wallets/RPC endpoints, execute live or devnet payments, custody assets, transfer SPL tokens, or claim settlement finality.
 
+## LangGraph RAP Template
+
+```typescript
+import {
+  createLangGraphRapTemplateFixture,
+  validateLangGraphRapTemplate,
+} from '@reddi/agent-protocol/langgraph-rap-template';
+
+const template = createLangGraphRapTemplateFixture();
+const result = validateLangGraphRapTemplate(template);
+console.log(result.valid); // true for the allowed local no-live fixture
+```
+
+The LangGraph template fixture maps RAP lifecycle state onto graph-shaped nodes without installing LangGraph or calling LangSmith, providers, wallets, RPC endpoints, or payment rails. It includes discovery, quote, buyer-policy preflight, operator approval, paid-agent invocation, receipt/evidence binding, and seller-wrapper endpoint helper nodes.
+
+The fixture consumes the shared #552 framework-template contract and #553 no-live conformance checker. It stores framework-neutral RAP refs in graph state instead of inventing LangGraph-specific payment, policy, receipt, failure/refund, support-state, custody, or settlement semantics.
+
+Built-in cases cover allowed no-live invocation, policy denial, missing approval, malformed quote/payment plan, credential-shaped output, and unsafe live/custody/provider claims. The validator fails closed for missing graph nodes, missing middleware, missing seller-wrapper helper routes, missing receipt/evidence refs, malformed shared contracts, credentials, wallet/RPC/provider material, custody claims, transfer instructions, and settlement-finality claims.
+
 ## AI Catalog Ingestion
 
 ```typescript

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -23,3 +23,4 @@ export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
+export * from './langgraph-rap-template.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -23,3 +23,4 @@ export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
+export * from './langgraph-rap-template.js';

--- a/packages/agent-protocol/dist/langgraph-rap-template.d.ts
+++ b/packages/agent-protocol/dist/langgraph-rap-template.d.ts
@@ -1,0 +1,47 @@
+import { type FrameworkTemplateContract, type FrameworkTemplateScenarioKind } from './framework-template-contract.js';
+export declare const LANGGRAPH_RAP_TEMPLATE_SCHEMA_VERSION: "reddi.langgraph-rap-template.v1";
+export type LangGraphRapTemplateScenario = 'allowed-no-live-invocation' | 'policy-denial' | 'missing-approval' | 'malformed-quote-payment-plan' | 'credential-shaped-output' | 'unsafe-live-custody-provider-claim';
+export type LangGraphRapGraphNode = 'discover' | 'quote' | 'buyerPolicyPreflight' | 'operatorApproval' | 'invokePaidAgent' | 'bindReceiptEvidence' | 'sellerWrapperEndpoint';
+export type LangGraphRapTemplateState = {
+    graphId: string;
+    scenario: LangGraphRapTemplateScenario;
+    nodes: LangGraphRapGraphNode[];
+    middleware: {
+        buyerPolicy: boolean;
+        receiptEvidence: boolean;
+        sellerWrapper: boolean;
+    };
+    contracts: Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract>;
+    selectedContract: FrameworkTemplateContract;
+    sellerWrapperEndpointHelper: {
+        endpointId: string;
+        quoteRoute: string;
+        policyPreflightRoute: string;
+        invocationRoute: string;
+        receiptHook: string;
+        evidenceHook: string;
+    };
+    graphState: {
+        discoveryRef: string;
+        quoteRef: string;
+        buyerPolicyRef: string;
+        operatorApprovalRef?: string;
+        invocationRef?: string;
+        receiptRef?: string;
+        evidenceRef?: string;
+        denialReasonCodes: string[];
+        failureMode?: string;
+    };
+    expectedAllowed: boolean;
+    notes: string[];
+};
+export type LangGraphRapTemplateValidationReasonCode = 'langgraph_rap_template_valid' | 'langgraph_template_malformed' | 'framework_contract_invalid' | 'framework_conformance_invalid' | 'missing_required_graph_node' | 'missing_required_middleware' | 'missing_seller_wrapper_endpoint_helper' | 'missing_receipt_evidence_refs' | 'missing_operator_approval' | 'malformed_quote_payment_plan' | 'template_contains_credentials' | 'unsafe_live_custody_provider_claim';
+export type LangGraphRapTemplateValidationResult = {
+    valid: boolean;
+    reasonCodes: LangGraphRapTemplateValidationReasonCode[];
+    auditNotes: string[];
+};
+export declare function createLangGraphRapTemplateFixture(input?: {
+    scenario?: LangGraphRapTemplateScenario;
+}): LangGraphRapTemplateState;
+export declare function validateLangGraphRapTemplate(template: unknown): LangGraphRapTemplateValidationResult;

--- a/packages/agent-protocol/dist/langgraph-rap-template.js
+++ b/packages/agent-protocol/dist/langgraph-rap-template.js
@@ -1,0 +1,219 @@
+import { frameworkTemplateFixtures, validateFrameworkTemplateContract, } from './framework-template-contract.js';
+import { runFrameworkTemplateNoLiveConformanceCheck } from './framework-template-conformance.js';
+import { sellerWrapperFixtureHasCredentialMaterial } from './seller-wrapper-rail-fixtures.js';
+export const LANGGRAPH_RAP_TEMPLATE_SCHEMA_VERSION = 'reddi.langgraph-rap-template.v1';
+const REQUIRED_NODES = [
+    'discover',
+    'quote',
+    'buyerPolicyPreflight',
+    'operatorApproval',
+    'invokePaidAgent',
+    'bindReceiptEvidence',
+    'sellerWrapperEndpoint',
+];
+const REQUIRED_CONTRACTS = [
+    'discovery',
+    'quote',
+    'preflight',
+    'operator-approval',
+    'invocation',
+    'receipt-evidence',
+    'denial',
+    'failure',
+];
+const UNSAFE_LIVE_PATTERN = /\bhttps?:\/\/[^\s"]*(rpc|alchemy|helius|quicknode|api\.(mainnet-beta|devnet|testnet)\.solana\.com)[^\s"]*|\b(wallet|provider|sign|transfer|broadcast)\b.*\b(payment|transaction|audd|usdc|sol)\b/i;
+const CUSTODY_FINALITY_PATTERN = /\b(custody|custodied|escrowed|settlement finality|final settlement)\b/i;
+function cloneContract(contract) {
+    return structuredClone(contract);
+}
+function textContains(value, pattern) {
+    if (typeof value === 'string')
+        return pattern.test(value);
+    if (!value || typeof value !== 'object')
+        return false;
+    if (Array.isArray(value))
+        return value.some((item) => textContains(item, pattern));
+    return Object.values(value).some((item) => textContains(item, pattern));
+}
+function contractMap() {
+    return {
+        discovery: cloneContract(frameworkTemplateFixtures.discovery.contract),
+        quote: cloneContract(frameworkTemplateFixtures.quote.contract),
+        preflight: cloneContract(frameworkTemplateFixtures.preflight.contract),
+        'operator-approval': cloneContract(frameworkTemplateFixtures['operator-approval'].contract),
+        invocation: cloneContract(frameworkTemplateFixtures.invocation.contract),
+        'receipt-evidence': cloneContract(frameworkTemplateFixtures['receipt-evidence'].contract),
+        denial: cloneContract(frameworkTemplateFixtures.denial.contract),
+        failure: cloneContract(frameworkTemplateFixtures.failure.contract),
+    };
+}
+export function createLangGraphRapTemplateFixture(input = {}) {
+    const scenario = input.scenario ?? 'allowed-no-live-invocation';
+    const contracts = contractMap();
+    const selectedContract = scenario === 'policy-denial'
+        ? contracts.denial
+        : scenario === 'missing-approval'
+            ? contracts['operator-approval']
+            : scenario === 'malformed-quote-payment-plan'
+                ? contracts.quote
+                : scenario === 'unsafe-live-custody-provider-claim'
+                    ? contracts.preflight
+                    : contracts.invocation;
+    if (!selectedContract.sellerProfile)
+        throw new Error('langgraph_template_missing_seller_profile');
+    const fixture = {
+        graphId: 'langgraph:rap-template:listing-writer',
+        scenario,
+        nodes: [...REQUIRED_NODES],
+        middleware: {
+            buyerPolicy: true,
+            receiptEvidence: true,
+            sellerWrapper: true,
+        },
+        contracts,
+        selectedContract: cloneContract(selectedContract),
+        sellerWrapperEndpointHelper: {
+            endpointId: selectedContract.sellerProfile.endpointId,
+            quoteRoute: selectedContract.sellerProfile.quoteRoute,
+            policyPreflightRoute: selectedContract.sellerProfile.policyPreflightRoute,
+            invocationRoute: selectedContract.sellerProfile.invocationRoute,
+            receiptHook: selectedContract.sellerProfile.receiptHook,
+            evidenceHook: selectedContract.sellerProfile.evidenceHook,
+        },
+        graphState: {
+            discoveryRef: 'local-fixture:langgraph:discovery',
+            quoteRef: 'local-fixture:langgraph:quote',
+            buyerPolicyRef: 'local-fixture:langgraph:buyer-policy',
+            operatorApprovalRef: 'local-fixture:langgraph:operator-approval',
+            invocationRef: 'local-fixture:langgraph:invocation',
+            receiptRef: 'local-fixture:receipt:listing-writer',
+            evidenceRef: 'local-fixture:evidence:listing-writer',
+            denialReasonCodes: scenario === 'policy-denial' ? ['policy_denied'] : [],
+            failureMode: scenario === 'malformed-quote-payment-plan' ? 'malformed_quote_payment_plan' : undefined,
+        },
+        expectedAllowed: scenario === 'allowed-no-live-invocation',
+        notes: [
+            'This is a local/static LangGraph template fixture, not a LangGraph package scaffold.',
+            'Graph state stores framework-neutral RAP refs only; external services and live rails stay disabled.',
+        ],
+    };
+    if (scenario === 'policy-denial') {
+        fixture.expectedAllowed = false;
+        fixture.graphState.denialReasonCodes = ['policy_denied'];
+    }
+    if (scenario === 'missing-approval') {
+        fixture.expectedAllowed = false;
+        fixture.graphState.operatorApprovalRef = undefined;
+    }
+    if (scenario === 'malformed-quote-payment-plan') {
+        fixture.expectedAllowed = false;
+        fixture.graphState.quoteRef = '';
+    }
+    if (scenario === 'credential-shaped-output') {
+        fixture.expectedAllowed = false;
+        fixture.notes.push('Rejected fixture output contains providerSecret=sk-test-secret.');
+    }
+    if (scenario === 'unsafe-live-custody-provider-claim') {
+        fixture.expectedAllowed = false;
+        fixture.notes.push('Rejected fixture attempts https://api.mainnet-beta.solana.com and claims AUDD custody.');
+    }
+    return fixture;
+}
+function isStructuredTemplate(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const candidate = value;
+    return typeof candidate.graphId === 'string'
+        && typeof candidate.scenario === 'string'
+        && Array.isArray(candidate.nodes)
+        && !!candidate.middleware
+        && !!candidate.contracts
+        && !!candidate.selectedContract
+        && !!candidate.sellerWrapperEndpointHelper
+        && !!candidate.graphState
+        && Array.isArray(candidate.notes);
+}
+export function validateLangGraphRapTemplate(template) {
+    if (!isStructuredTemplate(template)) {
+        return {
+            valid: false,
+            reasonCodes: ['langgraph_template_malformed'],
+            auditNotes: ['Denied: LangGraph RAP template fixture is malformed.'],
+        };
+    }
+    const reasonCodes = [];
+    const auditNotes = [];
+    for (const node of REQUIRED_NODES) {
+        if (!template.nodes.includes(node)) {
+            reasonCodes.push('missing_required_graph_node');
+            auditNotes.push(`Denied: missing LangGraph node ${node}.`);
+            break;
+        }
+    }
+    if (!template.middleware.buyerPolicy || !template.middleware.receiptEvidence || !template.middleware.sellerWrapper) {
+        reasonCodes.push('missing_required_middleware');
+        auditNotes.push('Denied: buyer policy, receipt/evidence, and seller-wrapper middleware are required.');
+    }
+    for (const key of REQUIRED_CONTRACTS) {
+        const contract = template.contracts[key];
+        if (!contract || !validateFrameworkTemplateContract(contract).valid) {
+            reasonCodes.push('framework_contract_invalid');
+            auditNotes.push(`Denied: ${key} framework contract is invalid.`);
+            break;
+        }
+    }
+    if (!validateFrameworkTemplateContract(template.selectedContract).valid) {
+        reasonCodes.push('framework_contract_invalid');
+        auditNotes.push('Denied: selected framework contract is invalid.');
+    }
+    const conformance = runFrameworkTemplateNoLiveConformanceCheck();
+    if (!conformance.valid) {
+        reasonCodes.push('framework_conformance_invalid');
+        auditNotes.push(`Denied: shared framework conformance failed: ${conformance.reasonCodes.join(',')}.`);
+    }
+    if (!template.sellerWrapperEndpointHelper.endpointId
+        || !template.sellerWrapperEndpointHelper.quoteRoute
+        || !template.sellerWrapperEndpointHelper.policyPreflightRoute
+        || !template.sellerWrapperEndpointHelper.invocationRoute
+        || !template.sellerWrapperEndpointHelper.receiptHook
+        || !template.sellerWrapperEndpointHelper.evidenceHook) {
+        reasonCodes.push('missing_seller_wrapper_endpoint_helper');
+        auditNotes.push('Denied: seller-wrapper endpoint helper routes are required.');
+    }
+    if (template.scenario === 'allowed-no-live-invocation' && (!template.graphState.receiptRef || !template.graphState.evidenceRef)) {
+        reasonCodes.push('missing_receipt_evidence_refs');
+        auditNotes.push('Denied: allowed no-live invocation requires receipt and evidence refs.');
+    }
+    if (template.scenario === 'missing-approval' && !template.graphState.operatorApprovalRef) {
+        reasonCodes.push('missing_operator_approval');
+        auditNotes.push('Denied: operator approval ref is required before paid-agent invocation.');
+    }
+    if (template.scenario === 'malformed-quote-payment-plan' && !template.graphState.quoteRef) {
+        reasonCodes.push('malformed_quote_payment_plan');
+        auditNotes.push('Denied: quote/payment-plan ref is malformed or missing.');
+    }
+    if (sellerWrapperFixtureHasCredentialMaterial(template)) {
+        reasonCodes.push('template_contains_credentials');
+        auditNotes.push('Denied: LangGraph RAP template contains credential-shaped material.');
+    }
+    const templateBoundaryText = {
+        graphId: template.graphId,
+        scenario: template.scenario,
+        nodes: template.nodes,
+        middleware: template.middleware,
+        sellerWrapperEndpointHelper: template.sellerWrapperEndpointHelper,
+        graphState: template.graphState,
+        notes: template.notes,
+    };
+    if (textContains(templateBoundaryText, UNSAFE_LIVE_PATTERN) || textContains(templateBoundaryText, CUSTODY_FINALITY_PATTERN)) {
+        reasonCodes.push('unsafe_live_custody_provider_claim');
+        auditNotes.push('Denied: LangGraph RAP template contains unsafe live, provider, custody, transfer, or finality material.');
+    }
+    if (reasonCodes.length > 0)
+        return { valid: false, reasonCodes: [...new Set(reasonCodes)], auditNotes };
+    return {
+        valid: true,
+        reasonCodes: ['langgraph_rap_template_valid'],
+        auditNotes: ['Allowed: LangGraph RAP template fixture is local, no-live, and consumes shared RAP framework contracts.'],
+    };
+}

--- a/packages/agent-protocol/dist/langgraph-rap-template.js
+++ b/packages/agent-protocol/dist/langgraph-rap-template.js
@@ -100,6 +100,10 @@ export function createLangGraphRapTemplateFixture(input = {}) {
     if (scenario === 'policy-denial') {
         fixture.expectedAllowed = false;
         fixture.graphState.denialReasonCodes = ['policy_denied'];
+        fixture.graphState.operatorApprovalRef = undefined;
+        fixture.graphState.invocationRef = undefined;
+        fixture.graphState.receiptRef = undefined;
+        fixture.graphState.evidenceRef = undefined;
     }
     if (scenario === 'missing-approval') {
         fixture.expectedAllowed = false;
@@ -183,6 +187,14 @@ export function validateLangGraphRapTemplate(template) {
     if (template.scenario === 'allowed-no-live-invocation' && (!template.graphState.receiptRef || !template.graphState.evidenceRef)) {
         reasonCodes.push('missing_receipt_evidence_refs');
         auditNotes.push('Denied: allowed no-live invocation requires receipt and evidence refs.');
+    }
+    if (template.scenario === 'policy-denial'
+        && (template.graphState.operatorApprovalRef
+            || template.graphState.invocationRef
+            || template.graphState.receiptRef
+            || template.graphState.evidenceRef)) {
+        reasonCodes.push('missing_operator_approval');
+        auditNotes.push('Denied: policy-denial case must stop before approval, invocation, receipt, and evidence refs.');
     }
     if (template.scenario === 'missing-approval' && !template.graphState.operatorApprovalRef) {
         reasonCodes.push('missing_operator_approval');

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -110,6 +110,10 @@
       "types": "./dist/framework-template-conformance.d.ts",
       "import": "./dist/framework-template-conformance.js"
     },
+    "./langgraph-rap-template": {
+      "types": "./dist/langgraph-rap-template.d.ts",
+      "import": "./dist/langgraph-rap-template.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -23,3 +23,4 @@ export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
+export * from './langgraph-rap-template.js';

--- a/packages/agent-protocol/src/langgraph-rap-template.ts
+++ b/packages/agent-protocol/src/langgraph-rap-template.ts
@@ -181,6 +181,10 @@ export function createLangGraphRapTemplateFixture(input: {
   if (scenario === 'policy-denial') {
     fixture.expectedAllowed = false;
     fixture.graphState.denialReasonCodes = ['policy_denied'];
+    fixture.graphState.operatorApprovalRef = undefined;
+    fixture.graphState.invocationRef = undefined;
+    fixture.graphState.receiptRef = undefined;
+    fixture.graphState.evidenceRef = undefined;
   }
   if (scenario === 'missing-approval') {
     fixture.expectedAllowed = false;
@@ -268,6 +272,18 @@ export function validateLangGraphRapTemplate(template: unknown): LangGraphRapTem
   if (template.scenario === 'allowed-no-live-invocation' && (!template.graphState.receiptRef || !template.graphState.evidenceRef)) {
     reasonCodes.push('missing_receipt_evidence_refs');
     auditNotes.push('Denied: allowed no-live invocation requires receipt and evidence refs.');
+  }
+  if (
+    template.scenario === 'policy-denial'
+    && (
+      template.graphState.operatorApprovalRef
+      || template.graphState.invocationRef
+      || template.graphState.receiptRef
+      || template.graphState.evidenceRef
+    )
+  ) {
+    reasonCodes.push('missing_operator_approval');
+    auditNotes.push('Denied: policy-denial case must stop before approval, invocation, receipt, and evidence refs.');
   }
   if (template.scenario === 'missing-approval' && !template.graphState.operatorApprovalRef) {
     reasonCodes.push('missing_operator_approval');

--- a/packages/agent-protocol/src/langgraph-rap-template.ts
+++ b/packages/agent-protocol/src/langgraph-rap-template.ts
@@ -1,0 +1,304 @@
+import {
+  frameworkTemplateFixtures,
+  validateFrameworkTemplateContract,
+  type FrameworkTemplateContract,
+  type FrameworkTemplateScenarioKind,
+} from './framework-template-contract.js';
+import { runFrameworkTemplateNoLiveConformanceCheck } from './framework-template-conformance.js';
+import { sellerWrapperFixtureHasCredentialMaterial } from './seller-wrapper-rail-fixtures.js';
+
+export const LANGGRAPH_RAP_TEMPLATE_SCHEMA_VERSION = 'reddi.langgraph-rap-template.v1' as const;
+
+export type LangGraphRapTemplateScenario =
+  | 'allowed-no-live-invocation'
+  | 'policy-denial'
+  | 'missing-approval'
+  | 'malformed-quote-payment-plan'
+  | 'credential-shaped-output'
+  | 'unsafe-live-custody-provider-claim';
+
+export type LangGraphRapGraphNode =
+  | 'discover'
+  | 'quote'
+  | 'buyerPolicyPreflight'
+  | 'operatorApproval'
+  | 'invokePaidAgent'
+  | 'bindReceiptEvidence'
+  | 'sellerWrapperEndpoint';
+
+export type LangGraphRapTemplateState = {
+  graphId: string;
+  scenario: LangGraphRapTemplateScenario;
+  nodes: LangGraphRapGraphNode[];
+  middleware: {
+    buyerPolicy: boolean;
+    receiptEvidence: boolean;
+    sellerWrapper: boolean;
+  };
+  contracts: Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract>;
+  selectedContract: FrameworkTemplateContract;
+  sellerWrapperEndpointHelper: {
+    endpointId: string;
+    quoteRoute: string;
+    policyPreflightRoute: string;
+    invocationRoute: string;
+    receiptHook: string;
+    evidenceHook: string;
+  };
+  graphState: {
+    discoveryRef: string;
+    quoteRef: string;
+    buyerPolicyRef: string;
+    operatorApprovalRef?: string;
+    invocationRef?: string;
+    receiptRef?: string;
+    evidenceRef?: string;
+    denialReasonCodes: string[];
+    failureMode?: string;
+  };
+  expectedAllowed: boolean;
+  notes: string[];
+};
+
+export type LangGraphRapTemplateValidationReasonCode =
+  | 'langgraph_rap_template_valid'
+  | 'langgraph_template_malformed'
+  | 'framework_contract_invalid'
+  | 'framework_conformance_invalid'
+  | 'missing_required_graph_node'
+  | 'missing_required_middleware'
+  | 'missing_seller_wrapper_endpoint_helper'
+  | 'missing_receipt_evidence_refs'
+  | 'missing_operator_approval'
+  | 'malformed_quote_payment_plan'
+  | 'template_contains_credentials'
+  | 'unsafe_live_custody_provider_claim';
+
+export type LangGraphRapTemplateValidationResult = {
+  valid: boolean;
+  reasonCodes: LangGraphRapTemplateValidationReasonCode[];
+  auditNotes: string[];
+};
+
+const REQUIRED_NODES: LangGraphRapGraphNode[] = [
+  'discover',
+  'quote',
+  'buyerPolicyPreflight',
+  'operatorApproval',
+  'invokePaidAgent',
+  'bindReceiptEvidence',
+  'sellerWrapperEndpoint',
+];
+const REQUIRED_CONTRACTS: FrameworkTemplateScenarioKind[] = [
+  'discovery',
+  'quote',
+  'preflight',
+  'operator-approval',
+  'invocation',
+  'receipt-evidence',
+  'denial',
+  'failure',
+];
+const UNSAFE_LIVE_PATTERN = /\bhttps?:\/\/[^\s"]*(rpc|alchemy|helius|quicknode|api\.(mainnet-beta|devnet|testnet)\.solana\.com)[^\s"]*|\b(wallet|provider|sign|transfer|broadcast)\b.*\b(payment|transaction|audd|usdc|sol)\b/i;
+const CUSTODY_FINALITY_PATTERN = /\b(custody|custodied|escrowed|settlement finality|final settlement)\b/i;
+
+function cloneContract(contract: FrameworkTemplateContract): FrameworkTemplateContract {
+  return structuredClone(contract) as FrameworkTemplateContract;
+}
+
+function textContains(value: unknown, pattern: RegExp): boolean {
+  if (typeof value === 'string') return pattern.test(value);
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some((item) => textContains(item, pattern));
+  return Object.values(value).some((item) => textContains(item, pattern));
+}
+
+function contractMap(): Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract> {
+  return {
+    discovery: cloneContract(frameworkTemplateFixtures.discovery.contract),
+    quote: cloneContract(frameworkTemplateFixtures.quote.contract),
+    preflight: cloneContract(frameworkTemplateFixtures.preflight.contract),
+    'operator-approval': cloneContract(frameworkTemplateFixtures['operator-approval'].contract),
+    invocation: cloneContract(frameworkTemplateFixtures.invocation.contract),
+    'receipt-evidence': cloneContract(frameworkTemplateFixtures['receipt-evidence'].contract),
+    denial: cloneContract(frameworkTemplateFixtures.denial.contract),
+    failure: cloneContract(frameworkTemplateFixtures.failure.contract),
+  };
+}
+
+export function createLangGraphRapTemplateFixture(input: {
+  scenario?: LangGraphRapTemplateScenario;
+} = {}): LangGraphRapTemplateState {
+  const scenario = input.scenario ?? 'allowed-no-live-invocation';
+  const contracts = contractMap();
+  const selectedContract = scenario === 'policy-denial'
+    ? contracts.denial
+    : scenario === 'missing-approval'
+      ? contracts['operator-approval']
+      : scenario === 'malformed-quote-payment-plan'
+        ? contracts.quote
+        : scenario === 'unsafe-live-custody-provider-claim'
+          ? contracts.preflight
+          : contracts.invocation;
+  if (!selectedContract.sellerProfile) throw new Error('langgraph_template_missing_seller_profile');
+  const fixture: LangGraphRapTemplateState = {
+    graphId: 'langgraph:rap-template:listing-writer',
+    scenario,
+    nodes: [...REQUIRED_NODES],
+    middleware: {
+      buyerPolicy: true,
+      receiptEvidence: true,
+      sellerWrapper: true,
+    },
+    contracts,
+    selectedContract: cloneContract(selectedContract),
+    sellerWrapperEndpointHelper: {
+      endpointId: selectedContract.sellerProfile.endpointId,
+      quoteRoute: selectedContract.sellerProfile.quoteRoute,
+      policyPreflightRoute: selectedContract.sellerProfile.policyPreflightRoute,
+      invocationRoute: selectedContract.sellerProfile.invocationRoute,
+      receiptHook: selectedContract.sellerProfile.receiptHook,
+      evidenceHook: selectedContract.sellerProfile.evidenceHook,
+    },
+    graphState: {
+      discoveryRef: 'local-fixture:langgraph:discovery',
+      quoteRef: 'local-fixture:langgraph:quote',
+      buyerPolicyRef: 'local-fixture:langgraph:buyer-policy',
+      operatorApprovalRef: 'local-fixture:langgraph:operator-approval',
+      invocationRef: 'local-fixture:langgraph:invocation',
+      receiptRef: 'local-fixture:receipt:listing-writer',
+      evidenceRef: 'local-fixture:evidence:listing-writer',
+      denialReasonCodes: scenario === 'policy-denial' ? ['policy_denied'] : [],
+      failureMode: scenario === 'malformed-quote-payment-plan' ? 'malformed_quote_payment_plan' : undefined,
+    },
+    expectedAllowed: scenario === 'allowed-no-live-invocation',
+    notes: [
+      'This is a local/static LangGraph template fixture, not a LangGraph package scaffold.',
+      'Graph state stores framework-neutral RAP refs only; external services and live rails stay disabled.',
+    ],
+  };
+
+  if (scenario === 'policy-denial') {
+    fixture.expectedAllowed = false;
+    fixture.graphState.denialReasonCodes = ['policy_denied'];
+  }
+  if (scenario === 'missing-approval') {
+    fixture.expectedAllowed = false;
+    fixture.graphState.operatorApprovalRef = undefined;
+  }
+  if (scenario === 'malformed-quote-payment-plan') {
+    fixture.expectedAllowed = false;
+    fixture.graphState.quoteRef = '';
+  }
+  if (scenario === 'credential-shaped-output') {
+    fixture.expectedAllowed = false;
+    fixture.notes.push('Rejected fixture output contains providerSecret=sk-test-secret.');
+  }
+  if (scenario === 'unsafe-live-custody-provider-claim') {
+    fixture.expectedAllowed = false;
+    fixture.notes.push('Rejected fixture attempts https://api.mainnet-beta.solana.com and claims AUDD custody.');
+  }
+  return fixture;
+}
+
+function isStructuredTemplate(value: unknown): value is LangGraphRapTemplateState {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as Partial<LangGraphRapTemplateState>;
+  return typeof candidate.graphId === 'string'
+    && typeof candidate.scenario === 'string'
+    && Array.isArray(candidate.nodes)
+    && !!candidate.middleware
+    && !!candidate.contracts
+    && !!candidate.selectedContract
+    && !!candidate.sellerWrapperEndpointHelper
+    && !!candidate.graphState
+    && Array.isArray(candidate.notes);
+}
+
+export function validateLangGraphRapTemplate(template: unknown): LangGraphRapTemplateValidationResult {
+  if (!isStructuredTemplate(template)) {
+    return {
+      valid: false,
+      reasonCodes: ['langgraph_template_malformed'],
+      auditNotes: ['Denied: LangGraph RAP template fixture is malformed.'],
+    };
+  }
+
+  const reasonCodes: LangGraphRapTemplateValidationReasonCode[] = [];
+  const auditNotes: string[] = [];
+  for (const node of REQUIRED_NODES) {
+    if (!template.nodes.includes(node)) {
+      reasonCodes.push('missing_required_graph_node');
+      auditNotes.push(`Denied: missing LangGraph node ${node}.`);
+      break;
+    }
+  }
+  if (!template.middleware.buyerPolicy || !template.middleware.receiptEvidence || !template.middleware.sellerWrapper) {
+    reasonCodes.push('missing_required_middleware');
+    auditNotes.push('Denied: buyer policy, receipt/evidence, and seller-wrapper middleware are required.');
+  }
+  for (const key of REQUIRED_CONTRACTS) {
+    const contract = template.contracts[key];
+    if (!contract || !validateFrameworkTemplateContract(contract).valid) {
+      reasonCodes.push('framework_contract_invalid');
+      auditNotes.push(`Denied: ${key} framework contract is invalid.`);
+      break;
+    }
+  }
+  if (!validateFrameworkTemplateContract(template.selectedContract).valid) {
+    reasonCodes.push('framework_contract_invalid');
+    auditNotes.push('Denied: selected framework contract is invalid.');
+  }
+  const conformance = runFrameworkTemplateNoLiveConformanceCheck();
+  if (!conformance.valid) {
+    reasonCodes.push('framework_conformance_invalid');
+    auditNotes.push(`Denied: shared framework conformance failed: ${conformance.reasonCodes.join(',')}.`);
+  }
+  if (
+    !template.sellerWrapperEndpointHelper.endpointId
+    || !template.sellerWrapperEndpointHelper.quoteRoute
+    || !template.sellerWrapperEndpointHelper.policyPreflightRoute
+    || !template.sellerWrapperEndpointHelper.invocationRoute
+    || !template.sellerWrapperEndpointHelper.receiptHook
+    || !template.sellerWrapperEndpointHelper.evidenceHook
+  ) {
+    reasonCodes.push('missing_seller_wrapper_endpoint_helper');
+    auditNotes.push('Denied: seller-wrapper endpoint helper routes are required.');
+  }
+  if (template.scenario === 'allowed-no-live-invocation' && (!template.graphState.receiptRef || !template.graphState.evidenceRef)) {
+    reasonCodes.push('missing_receipt_evidence_refs');
+    auditNotes.push('Denied: allowed no-live invocation requires receipt and evidence refs.');
+  }
+  if (template.scenario === 'missing-approval' && !template.graphState.operatorApprovalRef) {
+    reasonCodes.push('missing_operator_approval');
+    auditNotes.push('Denied: operator approval ref is required before paid-agent invocation.');
+  }
+  if (template.scenario === 'malformed-quote-payment-plan' && !template.graphState.quoteRef) {
+    reasonCodes.push('malformed_quote_payment_plan');
+    auditNotes.push('Denied: quote/payment-plan ref is malformed or missing.');
+  }
+  if (sellerWrapperFixtureHasCredentialMaterial(template)) {
+    reasonCodes.push('template_contains_credentials');
+    auditNotes.push('Denied: LangGraph RAP template contains credential-shaped material.');
+  }
+  const templateBoundaryText = {
+    graphId: template.graphId,
+    scenario: template.scenario,
+    nodes: template.nodes,
+    middleware: template.middleware,
+    sellerWrapperEndpointHelper: template.sellerWrapperEndpointHelper,
+    graphState: template.graphState,
+    notes: template.notes,
+  };
+  if (textContains(templateBoundaryText, UNSAFE_LIVE_PATTERN) || textContains(templateBoundaryText, CUSTODY_FINALITY_PATTERN)) {
+    reasonCodes.push('unsafe_live_custody_provider_claim');
+    auditNotes.push('Denied: LangGraph RAP template contains unsafe live, provider, custody, transfer, or finality material.');
+  }
+
+  if (reasonCodes.length > 0) return { valid: false, reasonCodes: [...new Set(reasonCodes)], auditNotes };
+  return {
+    valid: true,
+    reasonCodes: ['langgraph_rap_template_valid'],
+    auditNotes: ['Allowed: LangGraph RAP template fixture is local, no-live, and consumes shared RAP framework contracts.'],
+  };
+}

--- a/packages/agent-protocol/tests/langgraph-rap-template.test.ts
+++ b/packages/agent-protocol/tests/langgraph-rap-template.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createLangGraphRapTemplateFixture,
+  runFrameworkTemplateNoLiveConformanceCheck,
+  validateLangGraphRapTemplate,
+  type LangGraphRapTemplateState,
+} from '../dist/index.js';
+
+describe('LangGraph RAP template fixture', () => {
+  it('exports an allowed local no-live buyer/seller graph template', () => {
+    const template = createLangGraphRapTemplateFixture();
+    const result = validateLangGraphRapTemplate(template);
+
+    assert.equal(template.graphId, 'langgraph:rap-template:listing-writer');
+    assert.equal(template.expectedAllowed, true);
+    assert.deepEqual(result.reasonCodes, ['langgraph_rap_template_valid']);
+    assert.equal(runFrameworkTemplateNoLiveConformanceCheck().valid, true);
+    assert.deepEqual(template.nodes, [
+      'discover',
+      'quote',
+      'buyerPolicyPreflight',
+      'operatorApproval',
+      'invokePaidAgent',
+      'bindReceiptEvidence',
+      'sellerWrapperEndpoint',
+    ]);
+    assert.equal(template.middleware.buyerPolicy, true);
+    assert.equal(template.middleware.receiptEvidence, true);
+    assert.equal(template.middleware.sellerWrapper, true);
+    assert.equal(template.selectedContract.agentIdentity.templateMode, 'dual-mode');
+  });
+
+  it('keeps policy denial local and reason-coded without making the template malformed', () => {
+    const template = createLangGraphRapTemplateFixture({ scenario: 'policy-denial' });
+    const result = validateLangGraphRapTemplate(template);
+
+    assert.equal(template.expectedAllowed, false);
+    assert.deepEqual(template.graphState.denialReasonCodes, ['policy_denied']);
+    assert.deepEqual(result.reasonCodes, ['langgraph_rap_template_valid']);
+  });
+
+  it('fails closed for missing approval and malformed quote/payment-plan fixtures', () => {
+    const missingApproval = createLangGraphRapTemplateFixture({ scenario: 'missing-approval' });
+    assert.deepEqual(validateLangGraphRapTemplate(missingApproval).reasonCodes, ['missing_operator_approval']);
+
+    const malformedQuote = createLangGraphRapTemplateFixture({ scenario: 'malformed-quote-payment-plan' });
+    assert.deepEqual(validateLangGraphRapTemplate(malformedQuote).reasonCodes, ['malformed_quote_payment_plan']);
+  });
+
+  it('fails closed for missing graph nodes, middleware, endpoint helper, and receipt/evidence refs', () => {
+    const missingNode = createLangGraphRapTemplateFixture();
+    missingNode.nodes = missingNode.nodes.filter((node) => node !== 'quote');
+    assert.ok(validateLangGraphRapTemplate(missingNode).reasonCodes.includes('missing_required_graph_node'));
+
+    const missingMiddleware = createLangGraphRapTemplateFixture();
+    missingMiddleware.middleware.buyerPolicy = false;
+    assert.ok(validateLangGraphRapTemplate(missingMiddleware).reasonCodes.includes('missing_required_middleware'));
+
+    const missingEndpoint = createLangGraphRapTemplateFixture();
+    missingEndpoint.sellerWrapperEndpointHelper.quoteRoute = '';
+    assert.ok(validateLangGraphRapTemplate(missingEndpoint).reasonCodes.includes('missing_seller_wrapper_endpoint_helper'));
+
+    const missingEvidence = createLangGraphRapTemplateFixture();
+    missingEvidence.graphState.evidenceRef = undefined;
+    assert.ok(validateLangGraphRapTemplate(missingEvidence).reasonCodes.includes('missing_receipt_evidence_refs'));
+  });
+
+  it('rejects credential-shaped output and unsafe live/custody/provider claims', () => {
+    const credential = createLangGraphRapTemplateFixture({ scenario: 'credential-shaped-output' });
+    assert.ok(validateLangGraphRapTemplate(credential).reasonCodes.includes('template_contains_credentials'));
+
+    const unsafe = createLangGraphRapTemplateFixture({ scenario: 'unsafe-live-custody-provider-claim' });
+    assert.ok(validateLangGraphRapTemplate(unsafe).reasonCodes.includes('unsafe_live_custody_provider_claim'));
+
+    const finality = createLangGraphRapTemplateFixture();
+    finality.notes.push('Template confirms settlement finality.');
+    assert.ok(validateLangGraphRapTemplate(finality).reasonCodes.includes('unsafe_live_custody_provider_claim'));
+  });
+
+  it('rejects malformed or diverged framework contracts instead of redefining shared RAP semantics', () => {
+    const template = createLangGraphRapTemplateFixture() as LangGraphRapTemplateState & {
+      contracts: LangGraphRapTemplateState['contracts'];
+    };
+    template.contracts.preflight.buyerAuthorityCases = [];
+    assert.ok(validateLangGraphRapTemplate(template).reasonCodes.includes('framework_contract_invalid'));
+  });
+});

--- a/packages/agent-protocol/tests/langgraph-rap-template.test.ts
+++ b/packages/agent-protocol/tests/langgraph-rap-template.test.ts
@@ -37,7 +37,15 @@ describe('LangGraph RAP template fixture', () => {
 
     assert.equal(template.expectedAllowed, false);
     assert.deepEqual(template.graphState.denialReasonCodes, ['policy_denied']);
+    assert.equal(template.graphState.operatorApprovalRef, undefined);
+    assert.equal(template.graphState.invocationRef, undefined);
+    assert.equal(template.graphState.receiptRef, undefined);
+    assert.equal(template.graphState.evidenceRef, undefined);
     assert.deepEqual(result.reasonCodes, ['langgraph_rap_template_valid']);
+
+    const unsafeDenied = createLangGraphRapTemplateFixture({ scenario: 'policy-denial' });
+    unsafeDenied.graphState.invocationRef = 'local-fixture:langgraph:invocation';
+    assert.ok(validateLangGraphRapTemplate(unsafeDenied).reasonCodes.includes('missing_operator_approval'));
   });
 
   it('fails closed for missing approval and malformed quote/payment-plan fixtures', () => {


### PR DESCRIPTION
Closes #544.

## Summary
- add `@reddi/agent-protocol/langgraph-rap-template` as a static/local LangGraph-shaped RAP template fixture
- map discovery, quote, buyer-policy preflight, operator approval, paid-agent invocation, receipt/evidence binding, and seller-wrapper helper into graph nodes and framework-neutral state refs
- consume #552 framework-template contract fixtures and #553 no-live conformance checker instead of redefining payment/policy/receipt/failure semantics
- cover allowed no-live invocation, policy denial, missing approval, malformed quote/payment-plan, credential-shaped output, and unsafe live/custody/provider claims

## Validation
- `npm --prefix packages/agent-protocol install --ignore-scripts`
- `npm --prefix packages/agent-protocol test -- --runInBand` => 193/193
- `npm run check:rap:naming`
- `npm run test:bdd:index`
- `git diff --check`

## UI evidence
- Not required: package/API/docs text only; no UI route, docs-rendered product screen, onboarding visual surface, or demo page changed.

## Boundary
- Static/local fixture only.
- No LangGraph package install or scaffold.
- No LangSmith/cloud/API/provider call, package publication, hosted registry write, wallet/RPC/provider call, live/devnet payment, custody, SPL transfer, or settlement-finality claim.