### PR TITLE
feat(agent-protocol): portable signed reputation credential export (reddi.reputation-credential.v1) — #565

### DIFF
--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -24,3 +24,4 @@ export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
 export * from './langgraph-rap-template.js';
+export * from './reputation-credential-export.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -24,3 +24,4 @@ export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
 export * from './langgraph-rap-template.js';
+export * from './reputation-credential-export.js';

--- a/packages/agent-protocol/dist/reputation-credential-export.d.ts
+++ b/packages/agent-protocol/dist/reputation-credential-export.d.ts
@@ -1,0 +1,146 @@
+import { type KeyObject } from 'node:crypto';
+import type { AttestationRecord } from './attestation-reputation.js';
+import type { OffchainReputationPreview } from './offchain-reputation-preview.js';
+export declare const REPUTATION_CREDENTIAL_SCHEMA_VERSION: "reddi.reputation-credential.v1";
+/**
+ * Canonicalisation + proof identifiers. These are baked into the signed payload
+ * so a third party can reproduce the exact bytes that were signed without any
+ * hosted RAP service, chain, or RPC — the credential is fully self-contained.
+ */
+export declare const REPUTATION_CREDENTIAL_CANONICALIZATION: "reddi-jcs-sort-keys.v1";
+export declare const REPUTATION_CREDENTIAL_PROOF_TYPE: "ed25519";
+export declare const REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING: "spki-der-base64";
+export type ReputationCredentialSubjectType = 'specialist' | 'provider' | 'listing';
+/**
+ * A hash-only reference to a single piece of attested evidence. Raw evidence
+ * payloads (prompts, completions, transcripts) are NEVER carried here — only the
+ * sha256 evidence hash plus non-sensitive attestation metadata.
+ */
+export type ReputationCredentialEvidenceRef = {
+    attestationId: string;
+    receiptId: string;
+    evidenceId: string;
+    evidenceHash: string;
+    verdict: AttestationRecord['verdict'];
+    trustBoundary: AttestationRecord['trustBoundary'];
+    confidence: number;
+};
+export type ReputationCredentialBody = {
+    schemaVersion: typeof REPUTATION_CREDENTIAL_SCHEMA_VERSION;
+    id: string;
+    subject: {
+        id: string;
+        type: ReputationCredentialSubjectType;
+    };
+    issuedAt: string;
+    reputation: {
+        status: OffchainReputationPreview['status'];
+        routingImpact: string;
+        score: number;
+        attestationKind: OffchainReputationPreview['backing']['attestationKind'];
+        buyerFacingClaimAllowed: false;
+    };
+    evidence: ReputationCredentialEvidenceRef[];
+    provenance: {
+        previewId: string;
+        previewSchemaVersion: OffchainReputationPreview['schemaVersion'];
+        bindingId: string;
+        receiptId: string;
+        sourceKind: string;
+        sourceId: string;
+    };
+    guardrails: {
+        chainAgnostic: true;
+        onchainSettlement: false;
+        walletSigning: false;
+        rpcCall: false;
+        hostedRegistryWrite: false;
+        livePaymentExecuted: false;
+        reputationMutated: false;
+        rawEvidencePayloadEmbedded: false;
+    };
+};
+export type ReputationCredentialProof = {
+    type: typeof REPUTATION_CREDENTIAL_PROOF_TYPE;
+    canonicalization: typeof REPUTATION_CREDENTIAL_CANONICALIZATION;
+    publicKeyEncoding: typeof REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING;
+    publicKey: string;
+    signature: string;
+};
+export type ReputationCredential = {
+    schemaVersion: typeof REPUTATION_CREDENTIAL_SCHEMA_VERSION;
+    credential: ReputationCredentialBody;
+    proof: ReputationCredentialProof;
+};
+export type ReputationCredentialInput = {
+    id: string;
+    preview: OffchainReputationPreview;
+    attestations: AttestationRecord[];
+    issuedAt: string;
+    subject?: {
+        id: string;
+        type: ReputationCredentialSubjectType;
+    };
+};
+export type ReputationCredentialSigner = {
+    privateKey: KeyObject;
+    publicKey: KeyObject;
+};
+export type ReputationCredentialErrorCode = 'malformed_credential' | 'unknown_version' | 'preview_not_ready' | 'missing_attestation' | 'missing_evidence_hash' | 'evidence_hash_mismatch' | 'subject_mismatch' | 'raw_payload_leakage_rejected' | 'credential_leakage_rejected' | 'missing_proof' | 'unsupported_proof_type' | 'signature_invalid';
+export type ReputationCredentialError = {
+    code: ReputationCredentialErrorCode;
+    path: string;
+    message: string;
+};
+export type ReputationCredentialBuildResult = {
+    ok: true;
+    body: ReputationCredentialBody;
+} | {
+    ok: false;
+    errors: ReputationCredentialError[];
+};
+export type ReputationCredentialExportResult = {
+    ok: true;
+    credential: ReputationCredential;
+} | {
+    ok: false;
+    errors: ReputationCredentialError[];
+};
+export type ReputationCredentialVerifyResult = {
+    ok: true;
+    credential: ReputationCredential;
+} | {
+    ok: false;
+    errors: ReputationCredentialError[];
+};
+export declare function canonicalizeReputationCredentialBody(body: ReputationCredentialBody): string;
+/**
+ * Build the unsigned, evidence-hash-bound credential body from an existing
+ * off-chain reputation preview plus its backing attestation records. Fails
+ * closed: a not-ready preview, a missing evidence hash, or any raw-payload /
+ * credential leakage aborts the build.
+ */
+export declare function buildReputationCredentialBody(input: ReputationCredentialInput): ReputationCredentialBuildResult;
+export declare function generateEphemeralEd25519Signer(): ReputationCredentialSigner;
+export declare function encodeEd25519PublicKey(publicKey: KeyObject): string;
+/**
+ * Sign a built credential body with an ed25519 keypair. When no signer is
+ * supplied an ephemeral keypair is generated in-process — the private key is
+ * discarded on return and never enters the credential. The public key and
+ * signature are embedded so verification is fully offline.
+ */
+export declare function signReputationCredentialBody(body: ReputationCredentialBody, signer?: ReputationCredentialSigner): ReputationCredential;
+/**
+ * Build + sign in one step. Generates an ephemeral ed25519 keypair unless one
+ * is provided. Chain-agnostic and no-settlement by construction.
+ */
+export declare function exportReputationCredential(input: ReputationCredentialInput, signer?: ReputationCredentialSigner): ReputationCredentialExportResult;
+/**
+ * Verify a portable reputation credential entirely offline:
+ *   1. recompute the canonical serialisation of the credential body,
+ *   2. verify the ed25519 signature with the embedded public key,
+ *   3. fail closed on any tampering, missing field, unknown version,
+ *      raw-payload / credential leakage, or unsupported proof.
+ * No chain, RPC, RAP hosting, or settlement is consulted.
+ */
+export declare function verifyReputationCredential(credential: unknown): ReputationCredentialVerifyResult;

--- a/packages/agent-protocol/dist/reputation-credential-export.js
+++ b/packages/agent-protocol/dist/reputation-credential-export.js
@@ -1,0 +1,360 @@
+import { createPublicKey, generateKeyPairSync, sign as edSign, verify as edVerify, } from 'node:crypto';
+export const REPUTATION_CREDENTIAL_SCHEMA_VERSION = 'reddi.reputation-credential.v1';
+/**
+ * Canonicalisation + proof identifiers. These are baked into the signed payload
+ * so a third party can reproduce the exact bytes that were signed without any
+ * hosted RAP service, chain, or RPC — the credential is fully self-contained.
+ */
+export const REPUTATION_CREDENTIAL_CANONICALIZATION = 'reddi-jcs-sort-keys.v1';
+export const REPUTATION_CREDENTIAL_PROOF_TYPE = 'ed25519';
+export const REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING = 'spki-der-base64';
+const HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+const RAW_PAYLOAD_KEY_PATTERN = /(^|[_-])(raw[_-]?prompt|prompt|completion|raw[_-]?output|output|transcript|result[_-]?summary|resultsummary)($|[_-])|resultSummary/i;
+function error(code, path, message) {
+    return { code, path, message };
+}
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function isHashRef(value) {
+    return isNonEmptyString(value) && HASH_PATTERN.test(value);
+}
+/**
+ * Deterministic, recursively key-sorted JSON serialisation. This is the exact
+ * byte string that is signed and re-verified — no `Date.now()`, randomness, or
+ * environment state enters it, so any third party can reproduce it offline.
+ */
+function sortValue(value) {
+    if (Array.isArray(value))
+        return value.map(sortValue);
+    if (value && typeof value === 'object') {
+        const out = {};
+        for (const key of Object.keys(value).sort()) {
+            out[key] = sortValue(value[key]);
+        }
+        return out;
+    }
+    return value;
+}
+export function canonicalizeReputationCredentialBody(body) {
+    return JSON.stringify(sortValue(body));
+}
+function findRawPayload(value, path = '$') {
+    if (!value || typeof value !== 'object')
+        return undefined;
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index += 1) {
+            const found = findRawPayload(value[index], `${path}[${index}]`);
+            if (found)
+                return found;
+        }
+        return undefined;
+    }
+    for (const [key, nested] of Object.entries(value)) {
+        const nextPath = `${path}.${key}`;
+        if (RAW_PAYLOAD_KEY_PATTERN.test(key))
+            return nextPath;
+        const found = findRawPayload(nested, nextPath);
+        if (found)
+            return found;
+    }
+    return undefined;
+}
+function findCredentialMaterial(value, path = '$') {
+    if (typeof value === 'string')
+        return SENSITIVE_VALUE_PATTERN.test(value) ? path : undefined;
+    if (!value || typeof value !== 'object')
+        return undefined;
+    if (Array.isArray(value)) {
+        for (let index = 0; index < value.length; index += 1) {
+            const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+            if (found)
+                return found;
+        }
+        return undefined;
+    }
+    for (const [key, nested] of Object.entries(value)) {
+        const nextPath = `${path}.${key}`;
+        if (SENSITIVE_KEY_PATTERN.test(key))
+            return nextPath;
+        const found = findCredentialMaterial(nested, nextPath);
+        if (found)
+            return found;
+    }
+    return undefined;
+}
+function buildEvidenceRefs(preview, attestations, errors) {
+    if (!Array.isArray(attestations) || attestations.length === 0) {
+        errors.push(error('missing_attestation', '$.attestations', 'at least one attestation record is required'));
+        return [];
+    }
+    const refs = [];
+    attestations.forEach((attestation, index) => {
+        const path = `$.attestations[${index}]`;
+        if (!isPlainObject(attestation)) {
+            errors.push(error('malformed_credential', path, 'attestation must be an object'));
+            return;
+        }
+        if (!isHashRef(attestation.evidenceHash)) {
+            errors.push(error('missing_evidence_hash', `${path}.evidenceHash`, 'each attestation must reference a sha256 evidence hash'));
+            return;
+        }
+        if (!isNonEmptyString(attestation.id) || !isNonEmptyString(attestation.receiptId) || !isNonEmptyString(attestation.evidenceId)) {
+            errors.push(error('malformed_credential', path, 'attestation must include id, receiptId, and evidenceId'));
+            return;
+        }
+        refs.push({
+            attestationId: attestation.id,
+            receiptId: attestation.receiptId,
+            evidenceId: attestation.evidenceId,
+            evidenceHash: attestation.evidenceHash,
+            verdict: attestation.verdict,
+            trustBoundary: attestation.trustBoundary,
+            confidence: attestation.confidence,
+        });
+    });
+    return refs;
+}
+/**
+ * Build the unsigned, evidence-hash-bound credential body from an existing
+ * off-chain reputation preview plus its backing attestation records. Fails
+ * closed: a not-ready preview, a missing evidence hash, or any raw-payload /
+ * credential leakage aborts the build.
+ */
+export function buildReputationCredentialBody(input) {
+    const errors = [];
+    if (!isNonEmptyString(input?.id)) {
+        errors.push(error('malformed_credential', '$.id', 'credential id is required'));
+    }
+    if (!isNonEmptyString(input?.issuedAt) || Number.isNaN(Date.parse(input.issuedAt))) {
+        errors.push(error('malformed_credential', '$.issuedAt', 'issuedAt must be an ISO timestamp'));
+    }
+    const preview = input?.preview;
+    if (!isPlainObject(preview) || preview.schemaVersion !== 'reddi.offchain-reputation-preview.v1') {
+        errors.push(error('malformed_credential', '$.preview', 'a reddi.offchain-reputation-preview.v1 preview is required'));
+        return { ok: false, errors };
+    }
+    if (preview.status !== 'preview_ready') {
+        errors.push(error('preview_not_ready', '$.preview.status', 'only a preview_ready preview can be exported as a credential'));
+    }
+    const previewEvent = preview.previewEvent;
+    if (!isPlainObject(previewEvent)) {
+        errors.push(error('preview_not_ready', '$.preview.previewEvent', 'preview must carry a reputation event to export a score'));
+    }
+    if (!isHashRef(preview.evidenceSummary?.evidenceHash)) {
+        errors.push(error('missing_evidence_hash', '$.preview.evidenceSummary.evidenceHash', 'preview evidence summary must carry a sha256 evidence hash'));
+    }
+    const refs = buildEvidenceRefs(preview, input.attestations, errors);
+    if (isHashRef(preview.evidenceSummary?.evidenceHash) && refs.length > 0) {
+        const summaryHash = preview.evidenceSummary.evidenceHash;
+        if (!refs.some((ref) => ref.evidenceHash === summaryHash)) {
+            errors.push(error('evidence_hash_mismatch', '$.preview.evidenceSummary.evidenceHash', 'preview evidence hash must match one of the attestation evidence hashes'));
+        }
+    }
+    const subject = input.subject ?? preview.subject;
+    if (!isPlainObject(subject) || !isNonEmptyString(subject.id)) {
+        errors.push(error('malformed_credential', '$.subject', 'subject id is required'));
+    }
+    else if (input.subject && preview.subject && input.subject.id !== preview.subject.id) {
+        errors.push(error('subject_mismatch', '$.subject.id', 'explicit subject must match the preview subject'));
+    }
+    if (errors.length > 0)
+        return { ok: false, errors };
+    const body = {
+        schemaVersion: REPUTATION_CREDENTIAL_SCHEMA_VERSION,
+        id: input.id,
+        subject: { id: subject.id, type: subject.type },
+        issuedAt: input.issuedAt,
+        reputation: {
+            status: preview.status,
+            routingImpact: String(previewEvent.routingImpact),
+            score: Number(previewEvent.nextScore),
+            attestationKind: preview.backing.attestationKind,
+            buyerFacingClaimAllowed: false,
+        },
+        evidence: refs,
+        provenance: {
+            previewId: preview.id,
+            previewSchemaVersion: preview.schemaVersion,
+            bindingId: preview.evidenceSummary.bindingId,
+            receiptId: preview.evidenceSummary.receiptId,
+            sourceKind: String(preview.source?.kind ?? 'unknown'),
+            sourceId: String(preview.source?.sourceId ?? 'unknown'),
+        },
+        guardrails: {
+            chainAgnostic: true,
+            onchainSettlement: false,
+            walletSigning: false,
+            rpcCall: false,
+            hostedRegistryWrite: false,
+            livePaymentExecuted: false,
+            reputationMutated: false,
+            rawEvidencePayloadEmbedded: false,
+        },
+    };
+    // Defensive: the body must never carry raw evidence payloads or credential material.
+    const rawPath = findRawPayload(body);
+    if (rawPath) {
+        errors.push(error('raw_payload_leakage_rejected', rawPath, 'credential body must reference evidence hashes only, never raw payloads'));
+    }
+    const credentialPath = findCredentialMaterial(body);
+    if (credentialPath) {
+        errors.push(error('credential_leakage_rejected', credentialPath, 'credential body must not contain credential-shaped material'));
+    }
+    if (errors.length > 0)
+        return { ok: false, errors };
+    return { ok: true, body };
+}
+export function generateEphemeralEd25519Signer() {
+    const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+    return { privateKey, publicKey };
+}
+export function encodeEd25519PublicKey(publicKey) {
+    return publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+}
+/**
+ * Sign a built credential body with an ed25519 keypair. When no signer is
+ * supplied an ephemeral keypair is generated in-process — the private key is
+ * discarded on return and never enters the credential. The public key and
+ * signature are embedded so verification is fully offline.
+ */
+export function signReputationCredentialBody(body, signer = generateEphemeralEd25519Signer()) {
+    const canonical = canonicalizeReputationCredentialBody(body);
+    const signature = edSign(null, Buffer.from(canonical, 'utf8'), signer.privateKey);
+    return {
+        schemaVersion: REPUTATION_CREDENTIAL_SCHEMA_VERSION,
+        credential: body,
+        proof: {
+            type: REPUTATION_CREDENTIAL_PROOF_TYPE,
+            canonicalization: REPUTATION_CREDENTIAL_CANONICALIZATION,
+            publicKeyEncoding: REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING,
+            publicKey: encodeEd25519PublicKey(signer.publicKey),
+            signature: signature.toString('base64'),
+        },
+    };
+}
+/**
+ * Build + sign in one step. Generates an ephemeral ed25519 keypair unless one
+ * is provided. Chain-agnostic and no-settlement by construction.
+ */
+export function exportReputationCredential(input, signer = generateEphemeralEd25519Signer()) {
+    const built = buildReputationCredentialBody(input);
+    if (!built.ok)
+        return built;
+    return { ok: true, credential: signReputationCredentialBody(built.body, signer) };
+}
+function validateCredentialBodyShape(body, errors) {
+    if (!isPlainObject(body)) {
+        errors.push(error('malformed_credential', '$.credential', 'credential body must be a plain object'));
+        return false;
+    }
+    if (body.schemaVersion !== REPUTATION_CREDENTIAL_SCHEMA_VERSION) {
+        errors.push(error('unknown_version', '$.credential.schemaVersion', `expected ${REPUTATION_CREDENTIAL_SCHEMA_VERSION}`));
+    }
+    if (!isNonEmptyString(body.id))
+        errors.push(error('malformed_credential', '$.credential.id', 'credential id is required'));
+    if (!isNonEmptyString(body.issuedAt) || Number.isNaN(Date.parse(String(body.issuedAt)))) {
+        errors.push(error('malformed_credential', '$.credential.issuedAt', 'issuedAt must be an ISO timestamp'));
+    }
+    const subject = body.subject;
+    if (!isPlainObject(subject) || !isNonEmptyString(subject.id)) {
+        errors.push(error('malformed_credential', '$.credential.subject', 'subject id is required'));
+    }
+    const evidence = body.evidence;
+    if (!Array.isArray(evidence) || evidence.length === 0) {
+        errors.push(error('missing_evidence_hash', '$.credential.evidence', 'credential must reference at least one evidence hash'));
+    }
+    else {
+        evidence.forEach((ref, index) => {
+            const refObj = ref;
+            if (!isPlainObject(refObj) || !isHashRef(refObj.evidenceHash)) {
+                errors.push(error('missing_evidence_hash', `$.credential.evidence[${index}].evidenceHash`, 'each evidence ref must carry a sha256 evidence hash'));
+            }
+        });
+    }
+    const reputation = body.reputation;
+    if (!isPlainObject(reputation) || reputation.buyerFacingClaimAllowed !== false) {
+        errors.push(error('malformed_credential', '$.credential.reputation', 'reputation block must be present with buyerFacingClaimAllowed=false'));
+    }
+    return errors.length === 0;
+}
+/**
+ * Verify a portable reputation credential entirely offline:
+ *   1. recompute the canonical serialisation of the credential body,
+ *   2. verify the ed25519 signature with the embedded public key,
+ *   3. fail closed on any tampering, missing field, unknown version,
+ *      raw-payload / credential leakage, or unsupported proof.
+ * No chain, RPC, RAP hosting, or settlement is consulted.
+ */
+export function verifyReputationCredential(credential) {
+    const errors = [];
+    if (!isPlainObject(credential)) {
+        return { ok: false, errors: [error('malformed_credential', '$', 'credential must be a plain object')] };
+    }
+    if (credential.schemaVersion !== REPUTATION_CREDENTIAL_SCHEMA_VERSION) {
+        errors.push(error('unknown_version', '$.schemaVersion', `expected ${REPUTATION_CREDENTIAL_SCHEMA_VERSION}`));
+    }
+    const body = credential.credential;
+    const bodyOk = validateCredentialBodyShape(body, errors);
+    const proof = credential.proof;
+    if (!isPlainObject(proof)) {
+        errors.push(error('missing_proof', '$.proof', 'signature proof is required'));
+    }
+    else {
+        if (proof.type !== REPUTATION_CREDENTIAL_PROOF_TYPE) {
+            errors.push(error('unsupported_proof_type', '$.proof.type', `expected ${REPUTATION_CREDENTIAL_PROOF_TYPE}`));
+        }
+        if (proof.canonicalization !== REPUTATION_CREDENTIAL_CANONICALIZATION) {
+            errors.push(error('unsupported_proof_type', '$.proof.canonicalization', `expected ${REPUTATION_CREDENTIAL_CANONICALIZATION}`));
+        }
+        if (proof.publicKeyEncoding !== REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING) {
+            errors.push(error('unsupported_proof_type', '$.proof.publicKeyEncoding', `expected ${REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING}`));
+        }
+        if (!isNonEmptyString(proof.publicKey)) {
+            errors.push(error('missing_proof', '$.proof.publicKey', 'public key is required'));
+        }
+        if (!isNonEmptyString(proof.signature)) {
+            errors.push(error('missing_proof', '$.proof.signature', 'signature is required'));
+        }
+    }
+    // Leakage guard runs over the whole credential regardless of proof outcome.
+    const rawPath = findRawPayload(credential);
+    if (rawPath) {
+        errors.push(error('raw_payload_leakage_rejected', rawPath, 'credential must reference evidence hashes only, never raw payloads'));
+    }
+    const credentialPath = findCredentialMaterial(body);
+    if (credentialPath) {
+        errors.push(error('credential_leakage_rejected', credentialPath, 'credential must not contain credential-shaped material'));
+    }
+    if (errors.length > 0)
+        return { ok: false, errors };
+    // At this point the body shape is valid and proof fields are present.
+    const validBody = body;
+    const proofObj = proof;
+    let signatureValid = false;
+    try {
+        const canonical = canonicalizeReputationCredentialBody(validBody);
+        const publicKey = createPublicKey({
+            key: Buffer.from(proofObj.publicKey, 'base64'),
+            type: 'spki',
+            format: 'der',
+        });
+        signatureValid = edVerify(null, Buffer.from(canonical, 'utf8'), publicKey, Buffer.from(proofObj.signature, 'base64'));
+    }
+    catch {
+        signatureValid = false;
+    }
+    if (!signatureValid) {
+        return { ok: false, errors: [error('signature_invalid', '$.proof.signature', 'ed25519 signature does not verify against the canonical credential body')] };
+    }
+    void bodyOk;
+    return { ok: true, credential: { schemaVersion: REPUTATION_CREDENTIAL_SCHEMA_VERSION, credential: validBody, proof: proofObj } };
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -114,6 +114,10 @@
       "types": "./dist/langgraph-rap-template.d.ts",
       "import": "./dist/langgraph-rap-template.js"
     },
+    "./reputation-credential-export": {
+      "types": "./dist/reputation-credential-export.d.ts",
+      "import": "./dist/reputation-credential-export.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -24,3 +24,4 @@ export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
 export * from './langgraph-rap-template.js';
+export * from './reputation-credential-export.js';

--- a/packages/agent-protocol/src/reputation-credential-export.ts
+++ b/packages/agent-protocol/src/reputation-credential-export.ts
@@ -1,0 +1,510 @@
+import {
+  createPublicKey,
+  generateKeyPairSync,
+  sign as edSign,
+  verify as edVerify,
+  type KeyObject,
+} from 'node:crypto';
+import type { AttestationRecord } from './attestation-reputation.js';
+import type { OffchainReputationPreview } from './offchain-reputation-preview.js';
+
+export const REPUTATION_CREDENTIAL_SCHEMA_VERSION = 'reddi.reputation-credential.v1' as const;
+
+/**
+ * Canonicalisation + proof identifiers. These are baked into the signed payload
+ * so a third party can reproduce the exact bytes that were signed without any
+ * hosted RAP service, chain, or RPC — the credential is fully self-contained.
+ */
+export const REPUTATION_CREDENTIAL_CANONICALIZATION = 'reddi-jcs-sort-keys.v1' as const;
+export const REPUTATION_CREDENTIAL_PROOF_TYPE = 'ed25519' as const;
+export const REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING = 'spki-der-base64' as const;
+
+export type ReputationCredentialSubjectType = 'specialist' | 'provider' | 'listing';
+
+/**
+ * A hash-only reference to a single piece of attested evidence. Raw evidence
+ * payloads (prompts, completions, transcripts) are NEVER carried here — only the
+ * sha256 evidence hash plus non-sensitive attestation metadata.
+ */
+export type ReputationCredentialEvidenceRef = {
+  attestationId: string;
+  receiptId: string;
+  evidenceId: string;
+  evidenceHash: string;
+  verdict: AttestationRecord['verdict'];
+  trustBoundary: AttestationRecord['trustBoundary'];
+  confidence: number;
+};
+
+export type ReputationCredentialBody = {
+  schemaVersion: typeof REPUTATION_CREDENTIAL_SCHEMA_VERSION;
+  id: string;
+  subject: { id: string; type: ReputationCredentialSubjectType };
+  issuedAt: string;
+  reputation: {
+    status: OffchainReputationPreview['status'];
+    routingImpact: string;
+    score: number;
+    attestationKind: OffchainReputationPreview['backing']['attestationKind'];
+    buyerFacingClaimAllowed: false;
+  };
+  evidence: ReputationCredentialEvidenceRef[];
+  provenance: {
+    previewId: string;
+    previewSchemaVersion: OffchainReputationPreview['schemaVersion'];
+    bindingId: string;
+    receiptId: string;
+    sourceKind: string;
+    sourceId: string;
+  };
+  guardrails: {
+    chainAgnostic: true;
+    onchainSettlement: false;
+    walletSigning: false;
+    rpcCall: false;
+    hostedRegistryWrite: false;
+    livePaymentExecuted: false;
+    reputationMutated: false;
+    rawEvidencePayloadEmbedded: false;
+  };
+};
+
+export type ReputationCredentialProof = {
+  type: typeof REPUTATION_CREDENTIAL_PROOF_TYPE;
+  canonicalization: typeof REPUTATION_CREDENTIAL_CANONICALIZATION;
+  publicKeyEncoding: typeof REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING;
+  publicKey: string;
+  signature: string;
+};
+
+export type ReputationCredential = {
+  schemaVersion: typeof REPUTATION_CREDENTIAL_SCHEMA_VERSION;
+  credential: ReputationCredentialBody;
+  proof: ReputationCredentialProof;
+};
+
+export type ReputationCredentialInput = {
+  id: string;
+  preview: OffchainReputationPreview;
+  attestations: AttestationRecord[];
+  issuedAt: string;
+  subject?: { id: string; type: ReputationCredentialSubjectType };
+};
+
+export type ReputationCredentialSigner = {
+  privateKey: KeyObject;
+  publicKey: KeyObject;
+};
+
+export type ReputationCredentialErrorCode =
+  | 'malformed_credential'
+  | 'unknown_version'
+  | 'preview_not_ready'
+  | 'missing_attestation'
+  | 'missing_evidence_hash'
+  | 'evidence_hash_mismatch'
+  | 'subject_mismatch'
+  | 'raw_payload_leakage_rejected'
+  | 'credential_leakage_rejected'
+  | 'missing_proof'
+  | 'unsupported_proof_type'
+  | 'signature_invalid';
+
+export type ReputationCredentialError = {
+  code: ReputationCredentialErrorCode;
+  path: string;
+  message: string;
+};
+
+export type ReputationCredentialBuildResult =
+  | { ok: true; body: ReputationCredentialBody }
+  | { ok: false; errors: ReputationCredentialError[] };
+
+export type ReputationCredentialExportResult =
+  | { ok: true; credential: ReputationCredential }
+  | { ok: false; errors: ReputationCredentialError[] };
+
+export type ReputationCredentialVerifyResult =
+  | { ok: true; credential: ReputationCredential }
+  | { ok: false; errors: ReputationCredentialError[] };
+
+const HASH_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)($|[_-])|apiKey|accessToken|refreshToken|sessionToken|privateKey|X-Goog-Signature|X-Amz-Signature/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+const RAW_PAYLOAD_KEY_PATTERN = /(^|[_-])(raw[_-]?prompt|prompt|completion|raw[_-]?output|output|transcript|result[_-]?summary|resultsummary)($|[_-])|resultSummary/i;
+
+function error(code: ReputationCredentialErrorCode, path: string, message: string): ReputationCredentialError {
+  return { code, path, message };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isHashRef(value: unknown): value is string {
+  return isNonEmptyString(value) && HASH_PATTERN.test(value);
+}
+
+/**
+ * Deterministic, recursively key-sorted JSON serialisation. This is the exact
+ * byte string that is signed and re-verified — no `Date.now()`, randomness, or
+ * environment state enters it, so any third party can reproduce it offline.
+ */
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = sortValue((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+export function canonicalizeReputationCredentialBody(body: ReputationCredentialBody): string {
+  return JSON.stringify(sortValue(body));
+}
+
+function findRawPayload(value: unknown, path = '$'): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const found = findRawPayload(value[index], `${path}[${index}]`);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  for (const [key, nested] of Object.entries(value)) {
+    const nextPath = `${path}.${key}`;
+    if (RAW_PAYLOAD_KEY_PATTERN.test(key)) return nextPath;
+    const found = findRawPayload(nested, nextPath);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function findCredentialMaterial(value: unknown, path = '$'): string | undefined {
+  if (typeof value === 'string') return SENSITIVE_VALUE_PATTERN.test(value) ? path : undefined;
+  if (!value || typeof value !== 'object') return undefined;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const found = findCredentialMaterial(value[index], `${path}[${index}]`);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  for (const [key, nested] of Object.entries(value)) {
+    const nextPath = `${path}.${key}`;
+    if (SENSITIVE_KEY_PATTERN.test(key)) return nextPath;
+    const found = findCredentialMaterial(nested, nextPath);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function buildEvidenceRefs(
+  preview: OffchainReputationPreview,
+  attestations: AttestationRecord[],
+  errors: ReputationCredentialError[],
+): ReputationCredentialEvidenceRef[] {
+  if (!Array.isArray(attestations) || attestations.length === 0) {
+    errors.push(error('missing_attestation', '$.attestations', 'at least one attestation record is required'));
+    return [];
+  }
+
+  const refs: ReputationCredentialEvidenceRef[] = [];
+  attestations.forEach((attestation, index) => {
+    const path = `$.attestations[${index}]`;
+    if (!isPlainObject(attestation)) {
+      errors.push(error('malformed_credential', path, 'attestation must be an object'));
+      return;
+    }
+    if (!isHashRef(attestation.evidenceHash)) {
+      errors.push(error('missing_evidence_hash', `${path}.evidenceHash`, 'each attestation must reference a sha256 evidence hash'));
+      return;
+    }
+    if (!isNonEmptyString(attestation.id) || !isNonEmptyString(attestation.receiptId) || !isNonEmptyString(attestation.evidenceId)) {
+      errors.push(error('malformed_credential', path, 'attestation must include id, receiptId, and evidenceId'));
+      return;
+    }
+    refs.push({
+      attestationId: attestation.id,
+      receiptId: attestation.receiptId,
+      evidenceId: attestation.evidenceId,
+      evidenceHash: attestation.evidenceHash,
+      verdict: attestation.verdict,
+      trustBoundary: attestation.trustBoundary,
+      confidence: attestation.confidence,
+    });
+  });
+
+  return refs;
+}
+
+/**
+ * Build the unsigned, evidence-hash-bound credential body from an existing
+ * off-chain reputation preview plus its backing attestation records. Fails
+ * closed: a not-ready preview, a missing evidence hash, or any raw-payload /
+ * credential leakage aborts the build.
+ */
+export function buildReputationCredentialBody(input: ReputationCredentialInput): ReputationCredentialBuildResult {
+  const errors: ReputationCredentialError[] = [];
+
+  if (!isNonEmptyString(input?.id)) {
+    errors.push(error('malformed_credential', '$.id', 'credential id is required'));
+  }
+  if (!isNonEmptyString(input?.issuedAt) || Number.isNaN(Date.parse(input.issuedAt))) {
+    errors.push(error('malformed_credential', '$.issuedAt', 'issuedAt must be an ISO timestamp'));
+  }
+
+  const preview = input?.preview;
+  if (!isPlainObject(preview) || preview.schemaVersion !== 'reddi.offchain-reputation-preview.v1') {
+    errors.push(error('malformed_credential', '$.preview', 'a reddi.offchain-reputation-preview.v1 preview is required'));
+    return { ok: false, errors };
+  }
+  if (preview.status !== 'preview_ready') {
+    errors.push(error('preview_not_ready', '$.preview.status', 'only a preview_ready preview can be exported as a credential'));
+  }
+  const previewEvent = preview.previewEvent;
+  if (!isPlainObject(previewEvent)) {
+    errors.push(error('preview_not_ready', '$.preview.previewEvent', 'preview must carry a reputation event to export a score'));
+  }
+  if (!isHashRef(preview.evidenceSummary?.evidenceHash)) {
+    errors.push(error('missing_evidence_hash', '$.preview.evidenceSummary.evidenceHash', 'preview evidence summary must carry a sha256 evidence hash'));
+  }
+
+  const refs = buildEvidenceRefs(preview, input.attestations, errors);
+
+  if (isHashRef(preview.evidenceSummary?.evidenceHash) && refs.length > 0) {
+    const summaryHash = preview.evidenceSummary.evidenceHash;
+    if (!refs.some((ref) => ref.evidenceHash === summaryHash)) {
+      errors.push(error('evidence_hash_mismatch', '$.preview.evidenceSummary.evidenceHash', 'preview evidence hash must match one of the attestation evidence hashes'));
+    }
+  }
+
+  const subject = input.subject ?? preview.subject;
+  if (!isPlainObject(subject) || !isNonEmptyString(subject.id)) {
+    errors.push(error('malformed_credential', '$.subject', 'subject id is required'));
+  } else if (input.subject && preview.subject && input.subject.id !== preview.subject.id) {
+    errors.push(error('subject_mismatch', '$.subject.id', 'explicit subject must match the preview subject'));
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  const body: ReputationCredentialBody = {
+    schemaVersion: REPUTATION_CREDENTIAL_SCHEMA_VERSION,
+    id: input.id,
+    subject: { id: subject.id, type: subject.type },
+    issuedAt: input.issuedAt,
+    reputation: {
+      status: preview.status,
+      routingImpact: String(previewEvent!.routingImpact),
+      score: Number(previewEvent!.nextScore),
+      attestationKind: preview.backing.attestationKind,
+      buyerFacingClaimAllowed: false,
+    },
+    evidence: refs,
+    provenance: {
+      previewId: preview.id,
+      previewSchemaVersion: preview.schemaVersion,
+      bindingId: preview.evidenceSummary.bindingId,
+      receiptId: preview.evidenceSummary.receiptId,
+      sourceKind: String(preview.source?.kind ?? 'unknown'),
+      sourceId: String(preview.source?.sourceId ?? 'unknown'),
+    },
+    guardrails: {
+      chainAgnostic: true,
+      onchainSettlement: false,
+      walletSigning: false,
+      rpcCall: false,
+      hostedRegistryWrite: false,
+      livePaymentExecuted: false,
+      reputationMutated: false,
+      rawEvidencePayloadEmbedded: false,
+    },
+  };
+
+  // Defensive: the body must never carry raw evidence payloads or credential material.
+  const rawPath = findRawPayload(body);
+  if (rawPath) {
+    errors.push(error('raw_payload_leakage_rejected', rawPath, 'credential body must reference evidence hashes only, never raw payloads'));
+  }
+  const credentialPath = findCredentialMaterial(body);
+  if (credentialPath) {
+    errors.push(error('credential_leakage_rejected', credentialPath, 'credential body must not contain credential-shaped material'));
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, body };
+}
+
+export function generateEphemeralEd25519Signer(): ReputationCredentialSigner {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  return { privateKey, publicKey };
+}
+
+export function encodeEd25519PublicKey(publicKey: KeyObject): string {
+  return publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+}
+
+/**
+ * Sign a built credential body with an ed25519 keypair. When no signer is
+ * supplied an ephemeral keypair is generated in-process — the private key is
+ * discarded on return and never enters the credential. The public key and
+ * signature are embedded so verification is fully offline.
+ */
+export function signReputationCredentialBody(
+  body: ReputationCredentialBody,
+  signer: ReputationCredentialSigner = generateEphemeralEd25519Signer(),
+): ReputationCredential {
+  const canonical = canonicalizeReputationCredentialBody(body);
+  const signature = edSign(null, Buffer.from(canonical, 'utf8'), signer.privateKey);
+  return {
+    schemaVersion: REPUTATION_CREDENTIAL_SCHEMA_VERSION,
+    credential: body,
+    proof: {
+      type: REPUTATION_CREDENTIAL_PROOF_TYPE,
+      canonicalization: REPUTATION_CREDENTIAL_CANONICALIZATION,
+      publicKeyEncoding: REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING,
+      publicKey: encodeEd25519PublicKey(signer.publicKey),
+      signature: signature.toString('base64'),
+    },
+  };
+}
+
+/**
+ * Build + sign in one step. Generates an ephemeral ed25519 keypair unless one
+ * is provided. Chain-agnostic and no-settlement by construction.
+ */
+export function exportReputationCredential(
+  input: ReputationCredentialInput,
+  signer: ReputationCredentialSigner = generateEphemeralEd25519Signer(),
+): ReputationCredentialExportResult {
+  const built = buildReputationCredentialBody(input);
+  if (!built.ok) return built;
+  return { ok: true, credential: signReputationCredentialBody(built.body, signer) };
+}
+
+function validateCredentialBodyShape(body: unknown, errors: ReputationCredentialError[]): body is ReputationCredentialBody {
+  if (!isPlainObject(body)) {
+    errors.push(error('malformed_credential', '$.credential', 'credential body must be a plain object'));
+    return false;
+  }
+  if (body.schemaVersion !== REPUTATION_CREDENTIAL_SCHEMA_VERSION) {
+    errors.push(error('unknown_version', '$.credential.schemaVersion', `expected ${REPUTATION_CREDENTIAL_SCHEMA_VERSION}`));
+  }
+  if (!isNonEmptyString(body.id)) errors.push(error('malformed_credential', '$.credential.id', 'credential id is required'));
+  if (!isNonEmptyString((body.issuedAt as string)) || Number.isNaN(Date.parse(String(body.issuedAt)))) {
+    errors.push(error('malformed_credential', '$.credential.issuedAt', 'issuedAt must be an ISO timestamp'));
+  }
+  const subject = body.subject as Record<string, unknown> | undefined;
+  if (!isPlainObject(subject) || !isNonEmptyString(subject.id)) {
+    errors.push(error('malformed_credential', '$.credential.subject', 'subject id is required'));
+  }
+  const evidence = body.evidence;
+  if (!Array.isArray(evidence) || evidence.length === 0) {
+    errors.push(error('missing_evidence_hash', '$.credential.evidence', 'credential must reference at least one evidence hash'));
+  } else {
+    evidence.forEach((ref, index) => {
+      const refObj = ref as Record<string, unknown> | undefined;
+      if (!isPlainObject(refObj) || !isHashRef(refObj.evidenceHash)) {
+        errors.push(error('missing_evidence_hash', `$.credential.evidence[${index}].evidenceHash`, 'each evidence ref must carry a sha256 evidence hash'));
+      }
+    });
+  }
+  const reputation = body.reputation as Record<string, unknown> | undefined;
+  if (!isPlainObject(reputation) || reputation.buyerFacingClaimAllowed !== false) {
+    errors.push(error('malformed_credential', '$.credential.reputation', 'reputation block must be present with buyerFacingClaimAllowed=false'));
+  }
+  return errors.length === 0;
+}
+
+/**
+ * Verify a portable reputation credential entirely offline:
+ *   1. recompute the canonical serialisation of the credential body,
+ *   2. verify the ed25519 signature with the embedded public key,
+ *   3. fail closed on any tampering, missing field, unknown version,
+ *      raw-payload / credential leakage, or unsupported proof.
+ * No chain, RPC, RAP hosting, or settlement is consulted.
+ */
+export function verifyReputationCredential(credential: unknown): ReputationCredentialVerifyResult {
+  const errors: ReputationCredentialError[] = [];
+
+  if (!isPlainObject(credential)) {
+    return { ok: false, errors: [error('malformed_credential', '$', 'credential must be a plain object')] };
+  }
+  if (credential.schemaVersion !== REPUTATION_CREDENTIAL_SCHEMA_VERSION) {
+    errors.push(error('unknown_version', '$.schemaVersion', `expected ${REPUTATION_CREDENTIAL_SCHEMA_VERSION}`));
+  }
+
+  const body = credential.credential;
+  const bodyOk = validateCredentialBodyShape(body, errors);
+
+  const proof = credential.proof as Record<string, unknown> | undefined;
+  if (!isPlainObject(proof)) {
+    errors.push(error('missing_proof', '$.proof', 'signature proof is required'));
+  } else {
+    if (proof.type !== REPUTATION_CREDENTIAL_PROOF_TYPE) {
+      errors.push(error('unsupported_proof_type', '$.proof.type', `expected ${REPUTATION_CREDENTIAL_PROOF_TYPE}`));
+    }
+    if (proof.canonicalization !== REPUTATION_CREDENTIAL_CANONICALIZATION) {
+      errors.push(error('unsupported_proof_type', '$.proof.canonicalization', `expected ${REPUTATION_CREDENTIAL_CANONICALIZATION}`));
+    }
+    if (proof.publicKeyEncoding !== REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING) {
+      errors.push(error('unsupported_proof_type', '$.proof.publicKeyEncoding', `expected ${REPUTATION_CREDENTIAL_PUBLIC_KEY_ENCODING}`));
+    }
+    if (!isNonEmptyString(proof.publicKey)) {
+      errors.push(error('missing_proof', '$.proof.publicKey', 'public key is required'));
+    }
+    if (!isNonEmptyString(proof.signature)) {
+      errors.push(error('missing_proof', '$.proof.signature', 'signature is required'));
+    }
+  }
+
+  // Leakage guard runs over the whole credential regardless of proof outcome.
+  const rawPath = findRawPayload(credential);
+  if (rawPath) {
+    errors.push(error('raw_payload_leakage_rejected', rawPath, 'credential must reference evidence hashes only, never raw payloads'));
+  }
+  const credentialPath = findCredentialMaterial(body);
+  if (credentialPath) {
+    errors.push(error('credential_leakage_rejected', credentialPath, 'credential must not contain credential-shaped material'));
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  // At this point the body shape is valid and proof fields are present.
+  const validBody = body as ReputationCredentialBody;
+  const proofObj = proof as unknown as ReputationCredentialProof;
+  let signatureValid = false;
+  try {
+    const canonical = canonicalizeReputationCredentialBody(validBody);
+    const publicKey = createPublicKey({
+      key: Buffer.from(proofObj.publicKey, 'base64'),
+      type: 'spki',
+      format: 'der',
+    });
+    signatureValid = edVerify(
+      null,
+      Buffer.from(canonical, 'utf8'),
+      publicKey,
+      Buffer.from(proofObj.signature, 'base64'),
+    );
+  } catch {
+    signatureValid = false;
+  }
+
+  if (!signatureValid) {
+    return { ok: false, errors: [error('signature_invalid', '$.proof.signature', 'ed25519 signature does not verify against the canonical credential body')] };
+  }
+
+  void bodyOk;
+  return { ok: true, credential: { schemaVersion: REPUTATION_CREDENTIAL_SCHEMA_VERSION, credential: validBody, proof: proofObj } };
+}

--- a/packages/agent-protocol/tests/reputation-credential-export.test.ts
+++ b/packages/agent-protocol/tests/reputation-credential-export.test.ts
@@ -1,0 +1,325 @@
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import { describe, it } from 'node:test';
+import {
+  applyAttestationToReputation,
+  buildReputationCredentialBody,
+  canonicalizeReputationCredentialBody,
+  createAttestationRecord,
+  createEvidenceArchiveRecord,
+  createReceiptEvidenceBinding,
+  createReddiReceipt,
+  deriveOffchainReputationPreview,
+  encodeEd25519PublicKey,
+  exportReputationCredential,
+  policyDecisionFromBudgetPolicyDecision,
+  signReputationCredentialBody,
+  verifyReputationCredential,
+  type AttestationRecord,
+  type AuddPaymentPlanPreflightDecision,
+  type OffchainReputationPreview,
+  type ReceiptEvidenceBindingInput,
+  type ReputationCredentialInput,
+} from '../dist/index.js';
+
+const createdAt = '2026-06-20T02:10:00.000Z';
+const issuedAt = '2026-06-20T02:30:00.000Z';
+const requestHash = 'sha256:4f2d0ef8455d0f0f41a37ea5e6a47f52c0d73d97f426097f159a98f8c8fb6b15';
+const responseHash = 'sha256:5c9d1f1e3d0f02b5afcbb31dfbb3ab3de70ce1b84ff3ca856d272b2f4f7f4501';
+const sourceId = 'source:hosted-rap:credential-export';
+const jobId = 'job:ard-onboarded:credential-export';
+const evidenceId = 'evidence:ard-onboarded:credential-export';
+const paymentProofRef = 'dry-run:audd-proof:credential-export';
+const RAW_RESULT_SUMMARY = 'SECRET RAW PROMPT AND COMPLETION TRANSCRIPT that must never leak into a credential.';
+
+function validBindingInput(): ReceiptEvidenceBindingInput {
+  const policyDecision = policyDecisionFromBudgetPolicyDecision({
+    allowed: true,
+    reasonCodes: ['allowed'],
+    quotedAmount: {
+      amount: '2500000',
+      asset: 'AUDD',
+      network: 'solana-devnet',
+      source: sourceId,
+      specialist: 'listing:credential-export',
+    },
+    remainingBudget: { perRequest: '3000000' },
+    auditNotes: ['Allowed by local AUDD dry-run policy.'],
+  });
+
+  const receipt = createReddiReceipt({
+    schemaVersion: 'reddi.receipt.v1',
+    job: { id: jobId, type: 'ard-onboarded-agent-dry-run' },
+    source: {
+      id: sourceId,
+      type: 'hosted-rap-registry',
+      uri: 'urn:reddi:marketplace-listing:credentialExport',
+    },
+    payer: { id: 'buyer:fixture' },
+    specialist: { id: 'listing:credential-export' },
+    protocol: { name: 'Reddi Agent Protocol', version: '0.1.0' },
+    payment: {
+      network: 'solana-devnet',
+      asset: 'AUDD',
+      amount: '2500000',
+      paymentProofRef,
+    },
+    requestHash,
+    responseHash,
+    evidenceRef: 'file://fixtures/evidence/ard-onboarded-credential-export.json',
+    policyDecision,
+    attestationStatus: 'attested',
+    createdAt,
+  });
+
+  const evidencePayload = {
+    request: { hash: requestHash },
+    response: { hash: responseHash },
+    resultSummary: RAW_RESULT_SUMMARY,
+  };
+
+  const evidence = createEvidenceArchiveRecord({
+    id: evidenceId,
+    receiptId: jobId,
+    sourceId,
+    requestHash,
+    responseHash,
+    evidenceRef: receipt.evidenceRef,
+    createdAt,
+    evidencePayload,
+  });
+
+  const attestation = createAttestationRecord({
+    schemaVersion: 'reddi.attestation.v1',
+    id: 'attestation:ard-onboarded:credential-export',
+    receiptId: jobId,
+    evidenceId,
+    evidenceRef: evidence.evidenceRef,
+    evidenceHash: evidence.evidenceHash,
+    attestor: { id: 'attestor:local-fixture', type: 'local-fixture' },
+    trustBoundary: 'self_attested',
+    verdict: 'passed',
+    workStatus: 'completed',
+    confidence: 92,
+    rubric: {
+      dimensions: [
+        { id: 'evidence_integrity', score: 95, weight: 1, summary: 'Evidence hashes match.', reasonCodes: ['hashes_match'] },
+        { id: 'policy_compliance', score: 90, weight: 1, summary: 'Policy decision and payment proof are present.', reasonCodes: ['policy_bound'] },
+        { id: 'delivery_quality', score: 90, weight: 1, summary: 'Dry-run output met fixture expectations.', reasonCodes: ['fixture_passed'] },
+      ],
+    },
+    createdAt,
+  });
+
+  const reputation = applyAttestationToReputation(attestation, undefined, {
+    subject: { id: 'listing:credential-export', type: 'listing' },
+    now: createdAt,
+  });
+  if (!reputation.ok) throw new Error('unexpected reputation fixture failure');
+
+  const paymentPreflight: AuddPaymentPlanPreflightDecision = {
+    allowed: true,
+    reasonCodes: ['audd_payment_plan_allowed'],
+    paymentProofRef,
+    policyDecision,
+    paymentPlan: {
+      schemaVersion: 'reddi.audd-payment-plan.v1',
+      asset: 'AUDD',
+      network: 'solana-devnet',
+      mint: 'AUDDdev111111111111111111111111111111111111',
+      payee: 'solana:payeeFixture111111111111111111111111111111',
+      settlementAccount: 'solana:settlementFixture1111111111111111111111',
+      amount: '2500000',
+      quoteExpiresAt: '2026-06-20T03:00:00.000Z',
+      failurePolicy: { mode: 'no_charge_on_failure', description: 'Dry-run failure does not charge.' },
+      refundPolicy: { mode: 'manual_review', description: 'Refunds require manual review.' },
+      evidenceRequired: true,
+      paymentMode: 'dry-run',
+    },
+    auditNotes: ['Allowed by local AUDD dry-run policy.'],
+  };
+
+  return {
+    id: 'binding:ard-onboarded:credential-export',
+    source: {
+      kind: 'hosted-rap-registry',
+      sourceId,
+      catalogRef: '/.well-known/ai-catalog.json',
+      listingId: 'credentialExport',
+      rawSnapshotRef: 'sha256:hosted-rap-ai-catalog-credential-fixture',
+    },
+    receipt,
+    evidence,
+    evidencePayload,
+    paymentPreflight,
+    attestation,
+    reputationEventDraft: reputation.event,
+    createdAt,
+  };
+}
+
+function readyPreview(): OffchainReputationPreview {
+  const binding = createReceiptEvidenceBinding(validBindingInput());
+  const result = deriveOffchainReputationPreview({
+    id: 'preview:listing:credential-export',
+    binding,
+    createdAt,
+  });
+  if (!result.ok || result.preview.status !== 'preview_ready') {
+    throw new Error('expected a preview_ready fixture');
+  }
+  return result.preview;
+}
+
+function fixtureAttestation(): AttestationRecord {
+  const input = validBindingInput();
+  return input.attestation as AttestationRecord;
+}
+
+function credentialInput(overrides: Partial<ReputationCredentialInput> = {}): ReputationCredentialInput {
+  return {
+    id: 'credential:listing:credential-export',
+    preview: readyPreview(),
+    attestations: [fixtureAttestation()],
+    issuedAt,
+    ...overrides,
+  };
+}
+
+describe('reputation credential export', () => {
+  it('builds, signs, and verifies a credential round-trip', () => {
+    const exported = exportReputationCredential(credentialInput());
+    assert.equal(exported.ok, true);
+    if (!exported.ok) return;
+
+    const credential = exported.credential;
+    assert.equal(credential.schemaVersion, 'reddi.reputation-credential.v1');
+    assert.equal(credential.credential.subject.id, 'listing:credential-export');
+    assert.equal(credential.credential.reputation.buyerFacingClaimAllowed, false);
+    assert.equal(credential.credential.guardrails.chainAgnostic, true);
+    assert.equal(credential.credential.guardrails.onchainSettlement, false);
+    assert.ok(credential.credential.evidence.length >= 1);
+    assert.match(credential.credential.evidence[0].evidenceHash, /^sha256:[a-f0-9]{64}$/);
+    assert.equal(credential.proof.type, 'ed25519');
+    assert.ok(credential.proof.publicKey.length > 0);
+    assert.ok(credential.proof.signature.length > 0);
+
+    const verified = verifyReputationCredential(credential);
+    assert.equal(verified.ok, true);
+  });
+
+  it('does not leak any raw evidence payload into the serialized credential', () => {
+    const exported = exportReputationCredential(credentialInput());
+    assert.equal(exported.ok, true);
+    if (!exported.ok) return;
+
+    const serialized = JSON.stringify(exported.credential);
+    assert.ok(!serialized.includes(RAW_RESULT_SUMMARY), 'raw result summary must not appear');
+    assert.ok(!/resultSummary/i.test(serialized), 'no resultSummary key may appear');
+    assert.ok(!/transcript/i.test(serialized), 'no transcript may appear');
+    // The evidence hash (the only permitted binding) IS present.
+    assert.ok(serialized.includes(exported.credential.credential.evidence[0].evidenceHash));
+
+    // The canonical body that gets signed is likewise payload-free.
+    const canonical = canonicalizeReputationCredentialBody(exported.credential.credential);
+    assert.ok(!canonical.includes(RAW_RESULT_SUMMARY));
+  });
+
+  it('fails verification when a signed field is tampered with', () => {
+    const exported = exportReputationCredential(credentialInput());
+    assert.equal(exported.ok, true);
+    if (!exported.ok) return;
+
+    const tampered = {
+      ...exported.credential,
+      credential: {
+        ...exported.credential.credential,
+        reputation: { ...exported.credential.credential.reputation, score: 999 },
+      },
+    };
+
+    const verified = verifyReputationCredential(tampered);
+    assert.equal(verified.ok, false);
+    if (verified.ok) return;
+    assert.ok(verified.errors.some((e) => e.code === 'signature_invalid'));
+  });
+
+  it('fails build and verify when an evidence-hash binding is missing', () => {
+    const attestation = fixtureAttestation();
+    const build = buildReputationCredentialBody(
+      credentialInput({ attestations: [{ ...attestation, evidenceHash: '' }] as AttestationRecord[] }),
+    );
+    assert.equal(build.ok, false);
+    if (build.ok) return;
+    assert.ok(build.errors.some((e) => e.code === 'missing_evidence_hash'));
+
+    // A hand-assembled credential body with an empty evidence array must fail verify too.
+    const exported = exportReputationCredential(credentialInput());
+    assert.equal(exported.ok, true);
+    if (!exported.ok) return;
+    const stripped = {
+      ...exported.credential,
+      credential: { ...exported.credential.credential, evidence: [] },
+    };
+    const verified = verifyReputationCredential(stripped);
+    assert.equal(verified.ok, false);
+    if (verified.ok) return;
+    assert.ok(verified.errors.some((e) => e.code === 'missing_evidence_hash'));
+  });
+
+  it('fails verification when signed by the wrong key', () => {
+    const built = buildReputationCredentialBody(credentialInput());
+    assert.equal(built.ok, true);
+    if (!built.ok) return;
+
+    const signerA = generateKeyPairSync('ed25519');
+    const credential = signReputationCredentialBody(built.body, {
+      privateKey: signerA.privateKey,
+      publicKey: signerA.publicKey,
+    });
+
+    // Swap in a different public key: signature was made by A, but the credential now claims B.
+    const signerB = generateKeyPairSync('ed25519');
+    const wrongKeyed = {
+      ...credential,
+      proof: { ...credential.proof, publicKey: encodeEd25519PublicKey(signerB.publicKey) },
+    };
+
+    const verified = verifyReputationCredential(wrongKeyed);
+    assert.equal(verified.ok, false);
+    if (verified.ok) return;
+    assert.ok(verified.errors.some((e) => e.code === 'signature_invalid'));
+  });
+
+  it('fails closed on an unknown schema version', () => {
+    const exported = exportReputationCredential(credentialInput());
+    assert.equal(exported.ok, true);
+    if (!exported.ok) return;
+
+    const unknownVersion = { ...exported.credential, schemaVersion: 'reddi.reputation-credential.v2' };
+    const verified = verifyReputationCredential(unknownVersion);
+    assert.equal(verified.ok, false);
+    if (verified.ok) return;
+    assert.ok(verified.errors.some((e) => e.code === 'unknown_version'));
+  });
+
+  it('refuses to export a preview that is not preview_ready', () => {
+    const preview = readyPreview();
+    const notReady = { ...preview, status: 'insufficient_evidence', previewEvent: undefined } as OffchainReputationPreview;
+    const build = buildReputationCredentialBody(credentialInput({ preview: notReady }));
+    assert.equal(build.ok, false);
+    if (build.ok) return;
+    assert.ok(build.errors.some((e) => e.code === 'preview_not_ready'));
+  });
+
+  it('rejects a missing proof block', () => {
+    const exported = exportReputationCredential(credentialInput());
+    assert.equal(exported.ok, true);
+    if (!exported.ok) return;
+    const noProof = { schemaVersion: exported.credential.schemaVersion, credential: exported.credential.credential };
+    const verified = verifyReputationCredential(noProof);
+    assert.equal(verified.ok, false);
+    if (verified.ok) return;
+    assert.ok(verified.errors.some((e) => e.code === 'missing_proof'));
+  });
+});


### PR DESCRIPTION
## What this adds

A new SDK module `packages/agent-protocol/src/reputation-credential-export.ts` exporting schema **`reddi.reputation-credential.v1`** — a portable, signed, **chain-agnostic** reputation credential.

- **`buildReputationCredentialBody(input)`** — builds a self-contained credential body from an existing off-chain reputation preview (`reddi.offchain-reputation-preview.v1`) plus its backing attestation records. It references **evidence hashes only** — never raw prompt/completion/transcript payloads. Fails closed on: not-ready preview, missing sha256 evidence hash, preview↔attestation hash mismatch, subject mismatch, or any raw-payload / credential-shaped leakage detected in the body.
- **`signReputationCredentialBody` / `exportReputationCredential`** — sign the canonical (recursively key-sorted) body with an **ephemeral ed25519 keypair** generated via `node:crypto` `generateKeyPairSync('ed25519')`. The credential embeds the public key (SPKI/DER base64) + signature so any third party can **verify OFFLINE** with no RAP hosting, chain, or RPC. The private key is never serialized.
- **`verifyReputationCredential(credential)`** — (a) recomputes the canonical serialization, (b) verifies the ed25519 signature against the embedded public key, (c) fails closed on tampering, missing fields, unknown schema version, unsupported proof, or leakage.

Wired into the `src/index.ts` barrel and the `package.json` `./reputation-credential-export` export subpath, mirroring the existing sibling-module pattern. **No new runtime dependencies** — Node built-ins only (`node:crypto`).

## Tests

`tests/reputation-credential-export.test.ts` (node:test + node:assert): create→sign→verify round-trip PASS; tampered field → FAIL; missing evidence-hash binding → build+verify FAIL; wrong-key signature → FAIL; unknown version fail-closed; not-ready preview refused; missing proof rejected; and an assertion that **no raw evidence payload appears** in the serialized credential (only the evidence hash does).

Full SDK suite is green:

```
ℹ tests 201
ℹ pass 201
ℹ fail 0
```

## Safety

No-live-settlement / proof-only: no chain, RPC, wallet signing, custody, escrow, or settlement anywhere. Guardrail flags in the credential body assert `chainAgnostic: true`, `onchainSettlement: false`. Signing uses an ephemeral in-process keypair — no real secret from env or 1Password.

Advances #565.

overnight autonomous, test-gated, review before merge — do NOT auto-merge.