### PR TITLE
DRAFT v1: AP2 mandate ingestion adapter + #338 AP2 support-state row (#563)

### DIFF
--- a/packages/agent-protocol/dist/ap2-mandate-ingestion.d.ts
+++ b/packages/agent-protocol/dist/ap2-mandate-ingestion.d.ts
@@ -1,0 +1,195 @@
+import type { BuyerAuthorityAsset, BuyerAuthoritySpendCap } from './buyer-authority-policy.js';
+import type { ReddiReceipt } from './receipts.js';
+/**
+ * DRAFT v1 adapter — Google AP2 (Agent Payments Protocol) mandate ingestion.
+ *
+ * AP2 is a trust/authorization layer, NOT a settlement rail. This module maps a
+ * STATIC signed-mandate fixture onto Reddi buyer-authority-policy constraints and
+ * emits a receipt-bindable `mandateRef`, with ZERO settlement-finality claim.
+ *
+ * DRAFT DISCIPLINE: every AP2 / FIDO / Visa / Mastercard structural detail below
+ * (mandate vocabulary, VDC envelope, field names) is UNVERIFIED against the live
+ * standard and is derived from low/medium-confidence research. Each external-standard
+ * field is tagged inline. Fixtures are ILLUSTRATIVE, not authoritative. The VDC
+ * signature is treated as an OPAQUE, fixture-asserted blob and is NEVER verified
+ * against a live key.
+ */
+export declare const AP2_MANDATE_INGESTION_SCHEMA_VERSION: "reddi.ap2-mandate-ingestion.v1";
+/** Top-level draft flag: this schema signals draft/unverified external-standard shapes. */
+export declare const AP2_MANDATE_INGESTION_DRAFT: true;
+/**
+ * AP2 mandate vocabulary.
+ * (DRAFT/unverified — AP2, confirm mandate-type names/shape.)
+ * - `intent | cart | payment` are the Sept-2025 launch vocabulary.
+ * - `checkout_open | checkout_closed | payment_open | payment_closed` are the v0.2
+ *   Open/Closed staging read from ap2-protocol.org (medium confidence on the rename).
+ */
+export type Ap2MandateType = 'intent' | 'cart' | 'payment' | 'checkout_open' | 'checkout_closed' | 'payment_open' | 'payment_closed';
+/**
+ * AP2 Verifiable Digital Credential (VDC) envelope.
+ * (DRAFT/unverified — AP2 VDC, confirm envelope: JWT vs SD-JWT vs LD-Proof is NOT
+ * confirmed against the live spec.) The signature is OPAQUE and fixture-asserted:
+ * this adapter never verifies it against a live key.
+ */
+export type Ap2VerifiableDigitalCredential = {
+    /** (DRAFT/unverified — AP2 VDC) illustrative algorithm label; never used to verify. */
+    alg?: string;
+    /** (DRAFT/unverified — AP2 VDC) base64 signature blob; OPAQUE, fixture-asserted, NOT verified live. */
+    signatureB64: string;
+    /** Fixed marker: the VDC signature is fixture-asserted and is not verified against any live key. */
+    verification: 'fixture-asserted';
+};
+/**
+ * A static, signed AP2 mandate fixture.
+ * (DRAFT/unverified — AP2, confirm every field name/shape.) Illustrative only.
+ */
+export type Ap2MandateFixture = {
+    /** (DRAFT/unverified — AP2) mandate stage discriminator. */
+    mandateType: Ap2MandateType;
+    /** (DRAFT/unverified — AP2) human-present vs delegated/not-present authorization semantics. */
+    humanPresent?: boolean;
+    /** (DRAFT/unverified — AP2) merchant/seller reference; maps to a seller allowlist addition. */
+    merchant?: {
+        id: string;
+        name?: string;
+    };
+    /** (DRAFT/unverified — AP2) finalized cart (present only for cart/closed mandates). */
+    cart?: {
+        items: Array<{
+            sku?: string;
+            name?: string;
+            amount: string;
+        }>;
+        total: {
+            amount: string;
+            currency: string;
+        };
+        /** (DRAFT/unverified — AP2) opaque cart-binding hash carried through only as a reference. */
+        cartHash?: string;
+    };
+    /** (DRAFT/unverified — AP2) payment constraints; instruments are categories, NEVER a PAN. */
+    payment?: {
+        amount: string;
+        currency: string;
+        /** (DRAFT/unverified — AP2) e.g. ["stablecoin","card"] — category labels only, never card numbers. */
+        allowedInstruments?: string[];
+        budgetCap?: string;
+    };
+    /** (DRAFT/unverified — AP2) mandate expiry. */
+    expiresAt?: string;
+    /** (DRAFT/unverified — AP2) VDC envelope; opaque + fixture-asserted. */
+    vdc: Ap2VerifiableDigitalCredential;
+};
+/**
+ * AP2 support-state additions to the #338 rail-neutral support-state vocabulary.
+ * (DRAFT/unverified — AP2 support states are Reddi-internal names for illustrative AP2 handling.)
+ */
+export type Ap2SupportState = 'ap2_mandate_fixture' | 'ap2_mandate_probe_only' | 'unsupported_live_ap2_settlement';
+/**
+ * Receipt-bindable AP2 mandate reference. Carries hash + type + support-state only —
+ * never the VDC signature, cart contents, or any credential material.
+ */
+export type Ap2MandateRef = {
+    schemaVersion: typeof AP2_MANDATE_INGESTION_SCHEMA_VERSION;
+    draft: true;
+    mandateType: Ap2MandateType;
+    /** sha256 over the canonicalized mandate with the VDC signature removed. */
+    mandateHash: string;
+    supportState: Ap2SupportState;
+    humanPresent?: boolean;
+    /** The VDC signature was treated as opaque and was NOT verified against a live key. */
+    vdcVerification: 'fixture-asserted';
+    /** This adapter never asserts settlement finality. */
+    settlementFinalityClaimed: false;
+};
+/**
+ * Buyer-authority-policy constraints derived from a mandate.
+ * Does NOT itself authorize spend — it only tightens the existing buyer gate.
+ */
+export type Ap2DerivedPolicyConstraints = {
+    allowedCurrencies: BuyerAuthorityAsset[];
+    spendCaps: BuyerAuthoritySpendCap[];
+    sellerAllowlistAdditions: {
+        sellerIds: string[];
+        endpointIds: string[];
+    };
+    expiresAt?: string;
+    operatorApprovalRequired: boolean;
+};
+export type Ap2IngestReasonCode = 'ap2_mandate_ingested' | 'mandate_malformed' | 'mandate_contains_credentials' | 'settlement_finality_claim_rejected' | 'custody_claim_rejected' | 'unsupported_currency_rail' | 'probe_only_no_cart_binding' | 'mandate_expired' | 'mandate_over_cap';
+export type Ap2MandateIngestionGuardrails = {
+    fixtureOnly: true;
+    vdcSignatureVerifiedLive: false;
+    livePaymentExecuted: false;
+    walletSigning: false;
+    rpcCall: false;
+    custodyClaim: false;
+    settlementFinalityClaim: false;
+};
+export type Ap2MandateIngestionResult = {
+    schemaVersion: typeof AP2_MANDATE_INGESTION_SCHEMA_VERSION;
+    draft: true;
+    supportState: Ap2SupportState;
+    mandateRef: Ap2MandateRef;
+    derived: Ap2DerivedPolicyConstraints | null;
+    reasonCodes: Ap2IngestReasonCode[];
+    auditNotes: string[];
+    guardrails: Ap2MandateIngestionGuardrails;
+};
+/**
+ * AP2 metadata written onto a receipt by `bindMandateToReceipt`. Authorization-provenance
+ * only — hash + type + support-state, with an explicit no-settlement flag.
+ */
+export type Ap2ReceiptMandateBinding = {
+    draft: true;
+    mandateType: Ap2MandateType;
+    mandateHash: string;
+    supportState: Ap2SupportState;
+    humanPresent?: boolean;
+    vdcVerification: 'fixture-asserted';
+    settlementFinalityClaimed: false;
+};
+export declare const AP2_MANDATE_INGESTION_GUARDRAILS: Ap2MandateIngestionGuardrails;
+/** Illustrative default `now` for fixtures (fixture-only, no wall-clock dependency). */
+export declare const AP2_MANDATE_INGESTION_FIXTURE_NOW: "2026-07-05T00:00:00.000Z";
+/**
+ * Ingest a static AP2 mandate fixture into buyer-authority constraints.
+ *
+ * Pure function: no network, no wallet, no RPC, no live VDC verification. The VDC
+ * signature is treated as opaque. Fails closed on credentials/PAN, settlement/custody
+ * claims, expiry, over-cap, and unsupported rails.
+ */
+export declare function ingestAp2Mandate(mandate: Ap2MandateFixture, now: string): Ap2MandateIngestionResult;
+/**
+ * Bind a mandate reference onto a receipt WITHOUT any settlement claim.
+ * Sets `receipt.metadata.ap2MandateRef` to hash + type + support-state only.
+ */
+export declare function bindMandateToReceipt(receipt: ReddiReceipt, ref: Ap2MandateRef): ReddiReceipt;
+export type Ap2RailSupportStateRow = {
+    rail: 'google-ap2';
+    standard: 'Google AP2 (Agent Payments Protocol)';
+    supportState: Ap2SupportState;
+    mandateTypes: Ap2MandateType[];
+    description: string;
+    /** Every AP2/FIDO/Visa/Mastercard field in this row is DRAFT/unverified (low confidence). */
+    draft: true;
+    confidence: 'low';
+    /** Governance lineage note — DRAFT/unverified (FIDO/Visa/Mastercard). */
+    governanceNote: string;
+    claimBoundary: string[];
+};
+export declare const AP2_RAIL_SUPPORT_STATE_MATRIX: Ap2RailSupportStateRow[];
+export declare const ap2MandateFixtures: {
+    readonly checkoutClosedPaymentClosedValid: Ap2MandateFixture;
+    readonly paymentOpenProbeOnly: Ap2MandateFixture;
+    readonly expiredMandate: Ap2MandateFixture;
+    readonly humanNotPresent: Ap2MandateFixture;
+    readonly overBudgetMandate: Ap2MandateFixture;
+    readonly railMismatchMandate: Ap2MandateFixture;
+    readonly panLeakMandate: Ap2MandateFixture;
+    readonly settlementClaimMandate: Ap2MandateFixture;
+};
+export declare function listAp2MandateFixtures(): Array<{
+    key: string;
+    mandate: Ap2MandateFixture;
+}>;

--- a/packages/agent-protocol/dist/ap2-mandate-ingestion.js
+++ b/packages/agent-protocol/dist/ap2-mandate-ingestion.js
@@ -1,0 +1,462 @@
+import { createHash } from 'node:crypto';
+/**
+ * DRAFT v1 adapter — Google AP2 (Agent Payments Protocol) mandate ingestion.
+ *
+ * AP2 is a trust/authorization layer, NOT a settlement rail. This module maps a
+ * STATIC signed-mandate fixture onto Reddi buyer-authority-policy constraints and
+ * emits a receipt-bindable `mandateRef`, with ZERO settlement-finality claim.
+ *
+ * DRAFT DISCIPLINE: every AP2 / FIDO / Visa / Mastercard structural detail below
+ * (mandate vocabulary, VDC envelope, field names) is UNVERIFIED against the live
+ * standard and is derived from low/medium-confidence research. Each external-standard
+ * field is tagged inline. Fixtures are ILLUSTRATIVE, not authoritative. The VDC
+ * signature is treated as an OPAQUE, fixture-asserted blob and is NEVER verified
+ * against a live key.
+ */
+export const AP2_MANDATE_INGESTION_SCHEMA_VERSION = 'reddi.ap2-mandate-ingestion.v1';
+/** Top-level draft flag: this schema signals draft/unverified external-standard shapes. */
+export const AP2_MANDATE_INGESTION_DRAFT = true;
+export const AP2_MANDATE_INGESTION_GUARDRAILS = {
+    fixtureOnly: true,
+    vdcSignatureVerifiedLive: false,
+    livePaymentExecuted: false,
+    walletSigning: false,
+    rpcCall: false,
+    custodyClaim: false,
+    settlementFinalityClaim: false,
+};
+/** Illustrative default `now` for fixtures (fixture-only, no wall-clock dependency). */
+export const AP2_MANDATE_INGESTION_FIXTURE_NOW = '2026-07-05T00:00:00.000Z';
+// Reuse the receipts.ts sensitive-key/value patterns (which deliberately do NOT flag
+// an expected opaque `signature` field). The VDC signature is stripped before scanning.
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)([_-]|$)|apiKey|accessToken|refreshToken|sessionToken|privateKey/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+// PAN-shaped: a run of 13–19 digits (optionally space/dash separated). Rejects raw card numbers.
+const PAN_PATTERN = /\b(?:\d[ -]?){13,19}\b/;
+// Explicit settlement/custody claim markers. AP2 carries no settlement finality, so any
+// mandate asserting one is rejected into the `unsupported_live_ap2_settlement` state.
+const SETTLEMENT_CLAIM_MARKERS = [
+    '"settled":true',
+    '"final":true',
+    '"finalized":true',
+    'settlement finality',
+    'final settlement',
+    'onchain_transfer',
+    'onchain transfer completed',
+    'payment settled',
+    'settlement proven',
+];
+const CUSTODY_CLAIM_MARKERS = [
+    '"custody":true',
+    'takes custody',
+    'funds in custody',
+    'held in custody',
+    'custody accepted',
+    'escrowed',
+];
+/**
+ * AP2 currency -> RAP fixture rail mapping.
+ * (DRAFT/unverified — AP2, confirm currency codes.) Only AUDD/USDC/SOL fixture rails
+ * are mapped; anything else fails closed as an unsupported rail.
+ */
+const AP2_CURRENCY_TO_RAP_ASSET = {
+    USDC: 'USDC',
+    AUDD: 'AUDD',
+    SOL: 'SOL',
+};
+const FINALIZED_MANDATE_TYPES = ['cart', 'payment', 'checkout_closed', 'payment_closed'];
+/**
+ * Ingest a static AP2 mandate fixture into buyer-authority constraints.
+ *
+ * Pure function: no network, no wallet, no RPC, no live VDC verification. The VDC
+ * signature is treated as opaque. Fails closed on credentials/PAN, settlement/custody
+ * claims, expiry, over-cap, and unsupported rails.
+ */
+export function ingestAp2Mandate(mandate, now) {
+    if (!isStructuredMandate(mandate)) {
+        return failClosed(mandate, 'ap2_mandate_probe_only', ['mandate_malformed'], [
+            'Denied: AP2 mandate fixture is malformed.',
+        ]);
+    }
+    const stripped = stripSignature(mandate);
+    const reasonCodes = [];
+    const auditNotes = [];
+    if (mandateContainsCredentialMaterial(stripped)) {
+        reasonCodes.push('mandate_contains_credentials');
+        auditNotes.push('Denied: AP2 mandate contains credential-, key-, or PAN-shaped material.');
+    }
+    if (serializedContainsMarker(stripped, SETTLEMENT_CLAIM_MARKERS)) {
+        reasonCodes.push('settlement_finality_claim_rejected');
+        auditNotes.push('Denied: AP2 is a trust/authorization layer; settlement-finality claims are rejected.');
+    }
+    if (serializedContainsMarker(stripped, CUSTODY_CLAIM_MARKERS)) {
+        reasonCodes.push('custody_claim_rejected');
+        auditNotes.push('Denied: AP2 mandate must not claim custody of funds.');
+    }
+    if (reasonCodes.length > 0) {
+        return failClosed(mandate, 'unsupported_live_ap2_settlement', reasonCodes, auditNotes);
+    }
+    const finalized = FINALIZED_MANDATE_TYPES.includes(mandate.mandateType);
+    const hasCart = !!mandate.cart && Array.isArray(mandate.cart.items) && mandate.cart.items.length > 0;
+    // Open/intent (or cart-less) mandates are probe-only: usable for preflight/planning and
+    // parser tests, but they cannot authorize a specific spend.
+    if (!finalized || !hasCart) {
+        return {
+            schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+            draft: true,
+            supportState: 'ap2_mandate_probe_only',
+            mandateRef: buildMandateRef(mandate, 'ap2_mandate_probe_only'),
+            derived: null,
+            reasonCodes: ['probe_only_no_cart_binding'],
+            auditNotes: ['AP2 open/intent (or cart-less) mandate is probe-only; it cannot authorize a specific spend.'],
+            guardrails: AP2_MANDATE_INGESTION_GUARDRAILS,
+        };
+    }
+    // Finalized authorization path — fail-closed checks.
+    if (isExpired(mandate.expiresAt, now)) {
+        reasonCodes.push('mandate_expired');
+        auditNotes.push('Denied: AP2 mandate has expired.');
+    }
+    const currency = mapCurrency(mandate);
+    if (currency === null) {
+        reasonCodes.push('unsupported_currency_rail');
+        auditNotes.push('Denied: AP2 mandate currency does not map to a supported RAP fixture rail (AUDD/USDC/SOL).');
+    }
+    if (mandateOverCap(mandate)) {
+        reasonCodes.push('mandate_over_cap');
+        auditNotes.push('Denied: AP2 mandate payment amount exceeds its own declared budget cap.');
+    }
+    if (reasonCodes.length > 0 || currency === null) {
+        return failClosed(mandate, 'ap2_mandate_probe_only', reasonCodes, auditNotes);
+    }
+    return {
+        schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+        draft: true,
+        supportState: 'ap2_mandate_fixture',
+        mandateRef: buildMandateRef(mandate, 'ap2_mandate_fixture'),
+        derived: deriveConstraints(mandate, currency),
+        reasonCodes: ['ap2_mandate_ingested'],
+        auditNotes: [
+            'AP2 mandate ingested as fixture-asserted buyer-authority constraints.',
+            'VDC signature treated as opaque (not verified live); no settlement-finality claim.',
+        ],
+        guardrails: AP2_MANDATE_INGESTION_GUARDRAILS,
+    };
+}
+/**
+ * Bind a mandate reference onto a receipt WITHOUT any settlement claim.
+ * Sets `receipt.metadata.ap2MandateRef` to hash + type + support-state only.
+ */
+export function bindMandateToReceipt(receipt, ref) {
+    const binding = {
+        draft: true,
+        mandateType: ref.mandateType,
+        mandateHash: ref.mandateHash,
+        supportState: ref.supportState,
+        humanPresent: ref.humanPresent,
+        vdcVerification: 'fixture-asserted',
+        settlementFinalityClaimed: false,
+    };
+    return {
+        ...receipt,
+        metadata: {
+            ...(receipt.metadata ?? {}),
+            ap2MandateRef: binding,
+        },
+    };
+}
+function deriveConstraints(mandate, currency) {
+    const maxAmountUnits = mandate.payment?.budgetCap
+        ?? mandate.payment?.amount
+        ?? mandate.cart?.total.amount
+        ?? '0';
+    const sellerIds = mandate.merchant?.id ? [`ap2-merchant:${mandate.merchant.id}`] : [];
+    const endpointIds = mandate.merchant?.id ? [`ap2-merchant-endpoint:${mandate.merchant.id}`] : [];
+    return {
+        allowedCurrencies: [currency],
+        spendCaps: [
+            {
+                asset: currency,
+                // (DRAFT/unverified — AP2) illustrative rail label; AP2 is not a settlement network.
+                network: 'ap2-authorization-fixture',
+                maxAmountUnits,
+                window: 'per_request',
+            },
+        ],
+        sellerAllowlistAdditions: { sellerIds, endpointIds },
+        expiresAt: mandate.expiresAt,
+        operatorApprovalRequired: mandate.humanPresent === false,
+    };
+}
+function buildMandateRef(mandate, supportState) {
+    return {
+        schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+        draft: true,
+        mandateType: mandate.mandateType,
+        mandateHash: hashMandate(mandate),
+        supportState,
+        humanPresent: mandate.humanPresent,
+        vdcVerification: 'fixture-asserted',
+        settlementFinalityClaimed: false,
+    };
+}
+function failClosed(mandate, supportState, reasonCodes, auditNotes) {
+    const mandateType = isStructuredMandate(mandate) ? mandate.mandateType : 'intent';
+    return {
+        schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+        draft: true,
+        supportState,
+        mandateRef: {
+            schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+            draft: true,
+            mandateType,
+            mandateHash: hashMandate(mandate),
+            supportState,
+            humanPresent: isStructuredMandate(mandate) ? mandate.humanPresent : undefined,
+            vdcVerification: 'fixture-asserted',
+            settlementFinalityClaimed: false,
+        },
+        derived: null,
+        reasonCodes,
+        auditNotes,
+        guardrails: AP2_MANDATE_INGESTION_GUARDRAILS,
+    };
+}
+function isStructuredMandate(value) {
+    if (!isRecord(value))
+        return false;
+    const candidate = value;
+    const validType = typeof candidate.mandateType === 'string'
+        && [
+            'intent', 'cart', 'payment',
+            'checkout_open', 'checkout_closed', 'payment_open', 'payment_closed',
+        ].includes(candidate.mandateType);
+    const vdc = candidate.vdc;
+    const validVdc = isRecord(vdc)
+        && typeof vdc.signatureB64 === 'string'
+        && vdc.verification === 'fixture-asserted';
+    return validType && validVdc;
+}
+function stripSignature(mandate) {
+    const clone = structuredClone(mandate);
+    if (isRecord(clone.vdc)) {
+        const vdc = clone.vdc;
+        delete vdc.signatureB64;
+    }
+    return clone;
+}
+function hashMandate(mandate) {
+    const source = isStructuredMandate(mandate) ? stripSignature(mandate) : mandate;
+    return `sha256:${createHash('sha256').update(canonicalize(source)).digest('hex')}`;
+}
+function canonicalize(value) {
+    if (value === null || typeof value !== 'object')
+        return JSON.stringify(value) ?? 'null';
+    if (Array.isArray(value))
+        return `[${value.map(canonicalize).join(',')}]`;
+    const entries = Object.entries(value)
+        .filter(([, nested]) => nested !== undefined)
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return `{${entries.map(([key, nested]) => `${JSON.stringify(key)}:${canonicalize(nested)}`).join(',')}}`;
+}
+function mandateContainsCredentialMaterial(value) {
+    if (typeof value === 'string') {
+        return SENSITIVE_VALUE_PATTERN.test(value) || PAN_PATTERN.test(value);
+    }
+    if (!value || typeof value !== 'object')
+        return false;
+    if (Array.isArray(value))
+        return value.some(mandateContainsCredentialMaterial);
+    return Object.entries(value).some(([key, nested]) => (SENSITIVE_KEY_PATTERN.test(key) || mandateContainsCredentialMaterial(nested)));
+}
+function serializedContainsMarker(value, markers) {
+    const serialized = JSON.stringify(value).toLowerCase();
+    return markers.some((marker) => serialized.includes(marker));
+}
+function mapCurrency(mandate) {
+    const currency = mandate.payment?.currency ?? mandate.cart?.total.currency;
+    if (typeof currency !== 'string')
+        return null;
+    return AP2_CURRENCY_TO_RAP_ASSET[currency.trim().toUpperCase()] ?? null;
+}
+function mandateOverCap(mandate) {
+    const cap = mandate.payment?.budgetCap;
+    if (typeof cap !== 'string')
+        return false;
+    const amount = mandate.payment?.amount ?? mandate.cart?.total.amount;
+    if (typeof amount !== 'string')
+        return false;
+    const capValue = parseAmount(cap);
+    const amountValue = parseAmount(amount);
+    if (capValue === null || amountValue === null)
+        return true; // unparseable -> fail closed
+    return amountValue > capValue;
+}
+function isExpired(expiresAt, now) {
+    if (typeof expiresAt !== 'string')
+        return false;
+    const expiry = Date.parse(expiresAt);
+    const nowMs = Date.parse(now);
+    if (Number.isNaN(expiry) || Number.isNaN(nowMs))
+        return true;
+    return nowMs > expiry;
+}
+function parseAmount(value) {
+    if (!/^\d+(\.\d+)?$/.test(value.trim()))
+        return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+function isRecord(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+export const AP2_RAIL_SUPPORT_STATE_MATRIX = [
+    {
+        rail: 'google-ap2',
+        standard: 'Google AP2 (Agent Payments Protocol)',
+        supportState: 'ap2_mandate_fixture',
+        mandateTypes: ['cart', 'payment', 'checkout_closed', 'payment_closed'],
+        description: 'Finalized Checkout/Cart + Payment mandate present; VDC signature treated as fixture-asserted (opaque, not verified live); buyer-authority constraints derivable; no settlement claim.',
+        draft: true,
+        confidence: 'low',
+        governanceNote: '(DRAFT/unverified — FIDO/Visa/Mastercard) AP2 + Mastercard Verifiable Intent reportedly contributed to FIDO (~2026-05); Visa TAP and Mastercard Agent Pay are distinct downstream rails, NOT the mandate format. Confirm before relying.',
+        claimBoundary: [
+            'AP2 is a trust/authorization layer, not a settlement rail.',
+            'RAP claims no settlement finality, custody, or live payment from an AP2 mandate.',
+            'The VDC signature is opaque and is not verified against any live key.',
+        ],
+    },
+    {
+        rail: 'google-ap2',
+        standard: 'Google AP2 (Agent Payments Protocol)',
+        supportState: 'ap2_mandate_probe_only',
+        mandateTypes: ['intent', 'checkout_open', 'payment_open'],
+        description: 'Only an Open/Intent mandate (constraints, no finalized cart) — usable for preflight/planning and parser tests, not for authorizing a specific spend.',
+        draft: true,
+        confidence: 'low',
+        governanceNote: '(DRAFT/unverified — AP2) Open/Closed staging read from ap2-protocol.org (medium confidence on the v0.2 rename).',
+        claimBoundary: [
+            'Probe-only mandates derive no spend authorization.',
+            'No settlement, custody, or live payment is implied.',
+        ],
+    },
+    {
+        rail: 'google-ap2',
+        standard: 'Google AP2 (Agent Payments Protocol)',
+        supportState: 'unsupported_live_ap2_settlement',
+        mandateTypes: ['cart', 'payment', 'checkout_closed', 'payment_closed'],
+        description: 'Any mandate asserting completed settlement, custody, or finality is rejected. A future live lane must first define live VDC signature verification, wallet custody, spend limits, replay handling, operator approval, and rollback.',
+        draft: true,
+        confidence: 'low',
+        governanceNote: '(DRAFT/unverified — AP2/FIDO) live AP2 settlement is out of scope; no live VDC verification exists in this adapter.',
+        claimBoundary: [
+            'Live AP2 settlement is unsupported in this fixture corpus.',
+            'Settlement-finality and custody claims fail closed.',
+        ],
+    },
+];
+// ---------------------------------------------------------------------------
+// Illustrative fixtures (static, no I/O). DRAFT/unverified AP2 shapes.
+// ---------------------------------------------------------------------------
+const BASE_VDC = {
+    alg: 'ES256',
+    signatureB64: 'Zml4dHVyZS1hc3NlcnRlZC1vcGFxdWUtdmRjLXNpZ25hdHVyZS1ub3QtdmVyaWZpZWQ',
+    verification: 'fixture-asserted',
+};
+const checkoutClosedPaymentClosedValid = {
+    mandateType: 'payment_closed',
+    humanPresent: true,
+    merchant: { id: 'seller:listing-writer', name: 'Listing Writer' },
+    cart: {
+        items: [{ sku: 'listing-writeup', name: 'Property listing write-up', amount: '25.00' }],
+        total: { amount: '25.00', currency: 'USDC' },
+        cartHash: 'ap2-cart-hash:listing-writeup-fixture',
+    },
+    payment: {
+        amount: '25.00',
+        currency: 'USDC',
+        allowedInstruments: ['stablecoin'],
+        budgetCap: '50.00',
+    },
+    expiresAt: '2027-01-01T00:00:00.000Z',
+    vdc: BASE_VDC,
+};
+const paymentOpenProbeOnly = {
+    mandateType: 'payment_open',
+    humanPresent: true,
+    merchant: { id: 'seller:listing-writer' },
+    payment: {
+        amount: '25.00',
+        currency: 'USDC',
+        allowedInstruments: ['stablecoin', 'card'],
+        budgetCap: '50.00',
+    },
+    expiresAt: '2027-01-01T00:00:00.000Z',
+    vdc: BASE_VDC,
+};
+const expiredMandate = {
+    ...checkoutClosedPaymentClosedValid,
+    expiresAt: '2026-06-01T00:00:00.000Z',
+};
+const humanNotPresent = {
+    ...checkoutClosedPaymentClosedValid,
+    humanPresent: false,
+};
+const overBudgetMandate = {
+    ...checkoutClosedPaymentClosedValid,
+    cart: {
+        items: [{ sku: 'listing-writeup', name: 'Property listing write-up', amount: '75.00' }],
+        total: { amount: '75.00', currency: 'USDC' },
+        cartHash: 'ap2-cart-hash:over-budget-fixture',
+    },
+    payment: {
+        amount: '75.00',
+        currency: 'USDC',
+        allowedInstruments: ['stablecoin'],
+        budgetCap: '50.00',
+    },
+};
+const railMismatchMandate = {
+    ...checkoutClosedPaymentClosedValid,
+    cart: {
+        items: [{ sku: 'listing-writeup', name: 'Property listing write-up', amount: '25.00' }],
+        total: { amount: '25.00', currency: 'EUR' },
+        cartHash: 'ap2-cart-hash:rail-mismatch-fixture',
+    },
+    payment: {
+        amount: '25.00',
+        currency: 'EUR',
+        allowedInstruments: ['card'],
+        budgetCap: '50.00',
+    },
+};
+// PAN embedded in an otherwise ordinary cart item name -> must fail closed.
+const panLeakMandate = {
+    ...checkoutClosedPaymentClosedValid,
+    cart: {
+        items: [{ sku: 'listing-writeup', name: 'card on file 4111111111111111', amount: '25.00' }],
+        total: { amount: '25.00', currency: 'USDC' },
+        cartHash: 'ap2-cart-hash:pan-leak-fixture',
+    },
+};
+// Mandate asserting settlement finality via an out-of-schema `settled` flag -> rejected.
+const settlementClaimMandate = {
+    ...checkoutClosedPaymentClosedValid,
+    settled: true,
+};
+export const ap2MandateFixtures = {
+    checkoutClosedPaymentClosedValid,
+    paymentOpenProbeOnly,
+    expiredMandate,
+    humanNotPresent,
+    overBudgetMandate,
+    railMismatchMandate,
+    panLeakMandate,
+    settlementClaimMandate,
+};
+export function listAp2MandateFixtures() {
+    return Object.entries(ap2MandateFixtures).map(([key, mandate]) => ({
+        key,
+        mandate: structuredClone(mandate),
+    }));
+}

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -24,3 +24,4 @@ export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
 export * from './langgraph-rap-template.js';
+export * from './ap2-mandate-ingestion.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -24,3 +24,4 @@ export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
 export * from './langgraph-rap-template.js';
+export * from './ap2-mandate-ingestion.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -114,6 +114,10 @@
       "types": "./dist/langgraph-rap-template.d.ts",
       "import": "./dist/langgraph-rap-template.js"
     },
+    "./ap2-mandate-ingestion": {
+      "types": "./dist/ap2-mandate-ingestion.d.ts",
+      "import": "./dist/ap2-mandate-ingestion.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/ap2-mandate-ingestion.ts
+++ b/packages/agent-protocol/src/ap2-mandate-ingestion.ts
@@ -1,0 +1,686 @@
+import { createHash } from 'node:crypto';
+
+import type {
+  BuyerAuthorityAsset,
+  BuyerAuthoritySpendCap,
+} from './buyer-authority-policy.js';
+import type { ReddiReceipt } from './receipts.js';
+
+/**
+ * DRAFT v1 adapter — Google AP2 (Agent Payments Protocol) mandate ingestion.
+ *
+ * AP2 is a trust/authorization layer, NOT a settlement rail. This module maps a
+ * STATIC signed-mandate fixture onto Reddi buyer-authority-policy constraints and
+ * emits a receipt-bindable `mandateRef`, with ZERO settlement-finality claim.
+ *
+ * DRAFT DISCIPLINE: every AP2 / FIDO / Visa / Mastercard structural detail below
+ * (mandate vocabulary, VDC envelope, field names) is UNVERIFIED against the live
+ * standard and is derived from low/medium-confidence research. Each external-standard
+ * field is tagged inline. Fixtures are ILLUSTRATIVE, not authoritative. The VDC
+ * signature is treated as an OPAQUE, fixture-asserted blob and is NEVER verified
+ * against a live key.
+ */
+export const AP2_MANDATE_INGESTION_SCHEMA_VERSION = 'reddi.ap2-mandate-ingestion.v1' as const;
+
+/** Top-level draft flag: this schema signals draft/unverified external-standard shapes. */
+export const AP2_MANDATE_INGESTION_DRAFT = true as const;
+
+/**
+ * AP2 mandate vocabulary.
+ * (DRAFT/unverified — AP2, confirm mandate-type names/shape.)
+ * - `intent | cart | payment` are the Sept-2025 launch vocabulary.
+ * - `checkout_open | checkout_closed | payment_open | payment_closed` are the v0.2
+ *   Open/Closed staging read from ap2-protocol.org (medium confidence on the rename).
+ */
+export type Ap2MandateType =
+  | 'intent'
+  | 'cart'
+  | 'payment'
+  | 'checkout_open'
+  | 'checkout_closed'
+  | 'payment_open'
+  | 'payment_closed';
+
+/**
+ * AP2 Verifiable Digital Credential (VDC) envelope.
+ * (DRAFT/unverified — AP2 VDC, confirm envelope: JWT vs SD-JWT vs LD-Proof is NOT
+ * confirmed against the live spec.) The signature is OPAQUE and fixture-asserted:
+ * this adapter never verifies it against a live key.
+ */
+export type Ap2VerifiableDigitalCredential = {
+  /** (DRAFT/unverified — AP2 VDC) illustrative algorithm label; never used to verify. */
+  alg?: string;
+  /** (DRAFT/unverified — AP2 VDC) base64 signature blob; OPAQUE, fixture-asserted, NOT verified live. */
+  signatureB64: string;
+  /** Fixed marker: the VDC signature is fixture-asserted and is not verified against any live key. */
+  verification: 'fixture-asserted';
+};
+
+/**
+ * A static, signed AP2 mandate fixture.
+ * (DRAFT/unverified — AP2, confirm every field name/shape.) Illustrative only.
+ */
+export type Ap2MandateFixture = {
+  /** (DRAFT/unverified — AP2) mandate stage discriminator. */
+  mandateType: Ap2MandateType;
+  /** (DRAFT/unverified — AP2) human-present vs delegated/not-present authorization semantics. */
+  humanPresent?: boolean;
+  /** (DRAFT/unverified — AP2) merchant/seller reference; maps to a seller allowlist addition. */
+  merchant?: { id: string; name?: string };
+  /** (DRAFT/unverified — AP2) finalized cart (present only for cart/closed mandates). */
+  cart?: {
+    items: Array<{ sku?: string; name?: string; amount: string }>;
+    total: { amount: string; currency: string };
+    /** (DRAFT/unverified — AP2) opaque cart-binding hash carried through only as a reference. */
+    cartHash?: string;
+  };
+  /** (DRAFT/unverified — AP2) payment constraints; instruments are categories, NEVER a PAN. */
+  payment?: {
+    amount: string;
+    currency: string;
+    /** (DRAFT/unverified — AP2) e.g. ["stablecoin","card"] — category labels only, never card numbers. */
+    allowedInstruments?: string[];
+    budgetCap?: string;
+  };
+  /** (DRAFT/unverified — AP2) mandate expiry. */
+  expiresAt?: string;
+  /** (DRAFT/unverified — AP2) VDC envelope; opaque + fixture-asserted. */
+  vdc: Ap2VerifiableDigitalCredential;
+};
+
+/**
+ * AP2 support-state additions to the #338 rail-neutral support-state vocabulary.
+ * (DRAFT/unverified — AP2 support states are Reddi-internal names for illustrative AP2 handling.)
+ */
+export type Ap2SupportState =
+  | 'ap2_mandate_fixture'
+  | 'ap2_mandate_probe_only'
+  | 'unsupported_live_ap2_settlement';
+
+/**
+ * Receipt-bindable AP2 mandate reference. Carries hash + type + support-state only —
+ * never the VDC signature, cart contents, or any credential material.
+ */
+export type Ap2MandateRef = {
+  schemaVersion: typeof AP2_MANDATE_INGESTION_SCHEMA_VERSION;
+  draft: true;
+  mandateType: Ap2MandateType;
+  /** sha256 over the canonicalized mandate with the VDC signature removed. */
+  mandateHash: string;
+  supportState: Ap2SupportState;
+  humanPresent?: boolean;
+  /** The VDC signature was treated as opaque and was NOT verified against a live key. */
+  vdcVerification: 'fixture-asserted';
+  /** This adapter never asserts settlement finality. */
+  settlementFinalityClaimed: false;
+};
+
+/**
+ * Buyer-authority-policy constraints derived from a mandate.
+ * Does NOT itself authorize spend — it only tightens the existing buyer gate.
+ */
+export type Ap2DerivedPolicyConstraints = {
+  allowedCurrencies: BuyerAuthorityAsset[];
+  spendCaps: BuyerAuthoritySpendCap[];
+  sellerAllowlistAdditions: { sellerIds: string[]; endpointIds: string[] };
+  expiresAt?: string;
+  operatorApprovalRequired: boolean;
+};
+
+export type Ap2IngestReasonCode =
+  | 'ap2_mandate_ingested'
+  | 'mandate_malformed'
+  | 'mandate_contains_credentials'
+  | 'settlement_finality_claim_rejected'
+  | 'custody_claim_rejected'
+  | 'unsupported_currency_rail'
+  | 'probe_only_no_cart_binding'
+  | 'mandate_expired'
+  | 'mandate_over_cap';
+
+export type Ap2MandateIngestionGuardrails = {
+  fixtureOnly: true;
+  vdcSignatureVerifiedLive: false;
+  livePaymentExecuted: false;
+  walletSigning: false;
+  rpcCall: false;
+  custodyClaim: false;
+  settlementFinalityClaim: false;
+};
+
+export type Ap2MandateIngestionResult = {
+  schemaVersion: typeof AP2_MANDATE_INGESTION_SCHEMA_VERSION;
+  draft: true;
+  supportState: Ap2SupportState;
+  mandateRef: Ap2MandateRef;
+  derived: Ap2DerivedPolicyConstraints | null;
+  reasonCodes: Ap2IngestReasonCode[];
+  auditNotes: string[];
+  guardrails: Ap2MandateIngestionGuardrails;
+};
+
+/**
+ * AP2 metadata written onto a receipt by `bindMandateToReceipt`. Authorization-provenance
+ * only — hash + type + support-state, with an explicit no-settlement flag.
+ */
+export type Ap2ReceiptMandateBinding = {
+  draft: true;
+  mandateType: Ap2MandateType;
+  mandateHash: string;
+  supportState: Ap2SupportState;
+  humanPresent?: boolean;
+  vdcVerification: 'fixture-asserted';
+  settlementFinalityClaimed: false;
+};
+
+export const AP2_MANDATE_INGESTION_GUARDRAILS: Ap2MandateIngestionGuardrails = {
+  fixtureOnly: true,
+  vdcSignatureVerifiedLive: false,
+  livePaymentExecuted: false,
+  walletSigning: false,
+  rpcCall: false,
+  custodyClaim: false,
+  settlementFinalityClaim: false,
+};
+
+/** Illustrative default `now` for fixtures (fixture-only, no wall-clock dependency). */
+export const AP2_MANDATE_INGESTION_FIXTURE_NOW = '2026-07-05T00:00:00.000Z' as const;
+
+// Reuse the receipts.ts sensitive-key/value patterns (which deliberately do NOT flag
+// an expected opaque `signature` field). The VDC signature is stripped before scanning.
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(api[_-]?key|authorization|bearer|cookie|credential|mnemonic|password|private[_-]?key|refresh[_-]?token|secret|seed|session[_-]?token|token)([_-]|$)|apiKey|accessToken|refreshToken|sessionToken|privateKey/i;
+const SENSITIVE_VALUE_PATTERN = /(-----BEGIN [A-Z ]*PRIVATE KEY-----|authorization:\s*bearer\s+|bearer\s+[a-z0-9._-]{8,}|sk-[a-z0-9_-]{8,})/i;
+// PAN-shaped: a run of 13–19 digits (optionally space/dash separated). Rejects raw card numbers.
+const PAN_PATTERN = /\b(?:\d[ -]?){13,19}\b/;
+
+// Explicit settlement/custody claim markers. AP2 carries no settlement finality, so any
+// mandate asserting one is rejected into the `unsupported_live_ap2_settlement` state.
+const SETTLEMENT_CLAIM_MARKERS = [
+  '"settled":true',
+  '"final":true',
+  '"finalized":true',
+  'settlement finality',
+  'final settlement',
+  'onchain_transfer',
+  'onchain transfer completed',
+  'payment settled',
+  'settlement proven',
+];
+const CUSTODY_CLAIM_MARKERS = [
+  '"custody":true',
+  'takes custody',
+  'funds in custody',
+  'held in custody',
+  'custody accepted',
+  'escrowed',
+];
+
+/**
+ * AP2 currency -> RAP fixture rail mapping.
+ * (DRAFT/unverified — AP2, confirm currency codes.) Only AUDD/USDC/SOL fixture rails
+ * are mapped; anything else fails closed as an unsupported rail.
+ */
+const AP2_CURRENCY_TO_RAP_ASSET: Record<string, BuyerAuthorityAsset> = {
+  USDC: 'USDC',
+  AUDD: 'AUDD',
+  SOL: 'SOL',
+};
+
+const FINALIZED_MANDATE_TYPES: Ap2MandateType[] = ['cart', 'payment', 'checkout_closed', 'payment_closed'];
+
+/**
+ * Ingest a static AP2 mandate fixture into buyer-authority constraints.
+ *
+ * Pure function: no network, no wallet, no RPC, no live VDC verification. The VDC
+ * signature is treated as opaque. Fails closed on credentials/PAN, settlement/custody
+ * claims, expiry, over-cap, and unsupported rails.
+ */
+export function ingestAp2Mandate(mandate: Ap2MandateFixture, now: string): Ap2MandateIngestionResult {
+  if (!isStructuredMandate(mandate)) {
+    return failClosed(mandate, 'ap2_mandate_probe_only', ['mandate_malformed'], [
+      'Denied: AP2 mandate fixture is malformed.',
+    ]);
+  }
+
+  const stripped = stripSignature(mandate);
+
+  const reasonCodes: Ap2IngestReasonCode[] = [];
+  const auditNotes: string[] = [];
+
+  if (mandateContainsCredentialMaterial(stripped)) {
+    reasonCodes.push('mandate_contains_credentials');
+    auditNotes.push('Denied: AP2 mandate contains credential-, key-, or PAN-shaped material.');
+  }
+  if (serializedContainsMarker(stripped, SETTLEMENT_CLAIM_MARKERS)) {
+    reasonCodes.push('settlement_finality_claim_rejected');
+    auditNotes.push('Denied: AP2 is a trust/authorization layer; settlement-finality claims are rejected.');
+  }
+  if (serializedContainsMarker(stripped, CUSTODY_CLAIM_MARKERS)) {
+    reasonCodes.push('custody_claim_rejected');
+    auditNotes.push('Denied: AP2 mandate must not claim custody of funds.');
+  }
+  if (reasonCodes.length > 0) {
+    return failClosed(mandate, 'unsupported_live_ap2_settlement', reasonCodes, auditNotes);
+  }
+
+  const finalized = FINALIZED_MANDATE_TYPES.includes(mandate.mandateType);
+  const hasCart = !!mandate.cart && Array.isArray(mandate.cart.items) && mandate.cart.items.length > 0;
+
+  // Open/intent (or cart-less) mandates are probe-only: usable for preflight/planning and
+  // parser tests, but they cannot authorize a specific spend.
+  if (!finalized || !hasCart) {
+    return {
+      schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+      draft: true,
+      supportState: 'ap2_mandate_probe_only',
+      mandateRef: buildMandateRef(mandate, 'ap2_mandate_probe_only'),
+      derived: null,
+      reasonCodes: ['probe_only_no_cart_binding'],
+      auditNotes: ['AP2 open/intent (or cart-less) mandate is probe-only; it cannot authorize a specific spend.'],
+      guardrails: AP2_MANDATE_INGESTION_GUARDRAILS,
+    };
+  }
+
+  // Finalized authorization path — fail-closed checks.
+  if (isExpired(mandate.expiresAt, now)) {
+    reasonCodes.push('mandate_expired');
+    auditNotes.push('Denied: AP2 mandate has expired.');
+  }
+  const currency = mapCurrency(mandate);
+  if (currency === null) {
+    reasonCodes.push('unsupported_currency_rail');
+    auditNotes.push('Denied: AP2 mandate currency does not map to a supported RAP fixture rail (AUDD/USDC/SOL).');
+  }
+  if (mandateOverCap(mandate)) {
+    reasonCodes.push('mandate_over_cap');
+    auditNotes.push('Denied: AP2 mandate payment amount exceeds its own declared budget cap.');
+  }
+
+  if (reasonCodes.length > 0 || currency === null) {
+    return failClosed(mandate, 'ap2_mandate_probe_only', reasonCodes, auditNotes);
+  }
+
+  return {
+    schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+    draft: true,
+    supportState: 'ap2_mandate_fixture',
+    mandateRef: buildMandateRef(mandate, 'ap2_mandate_fixture'),
+    derived: deriveConstraints(mandate, currency),
+    reasonCodes: ['ap2_mandate_ingested'],
+    auditNotes: [
+      'AP2 mandate ingested as fixture-asserted buyer-authority constraints.',
+      'VDC signature treated as opaque (not verified live); no settlement-finality claim.',
+    ],
+    guardrails: AP2_MANDATE_INGESTION_GUARDRAILS,
+  };
+}
+
+/**
+ * Bind a mandate reference onto a receipt WITHOUT any settlement claim.
+ * Sets `receipt.metadata.ap2MandateRef` to hash + type + support-state only.
+ */
+export function bindMandateToReceipt(receipt: ReddiReceipt, ref: Ap2MandateRef): ReddiReceipt {
+  const binding: Ap2ReceiptMandateBinding = {
+    draft: true,
+    mandateType: ref.mandateType,
+    mandateHash: ref.mandateHash,
+    supportState: ref.supportState,
+    humanPresent: ref.humanPresent,
+    vdcVerification: 'fixture-asserted',
+    settlementFinalityClaimed: false,
+  };
+  return {
+    ...receipt,
+    metadata: {
+      ...(receipt.metadata ?? {}),
+      ap2MandateRef: binding,
+    },
+  };
+}
+
+function deriveConstraints(mandate: Ap2MandateFixture, currency: BuyerAuthorityAsset): Ap2DerivedPolicyConstraints {
+  const maxAmountUnits = mandate.payment?.budgetCap
+    ?? mandate.payment?.amount
+    ?? mandate.cart?.total.amount
+    ?? '0';
+  const sellerIds = mandate.merchant?.id ? [`ap2-merchant:${mandate.merchant.id}`] : [];
+  const endpointIds = mandate.merchant?.id ? [`ap2-merchant-endpoint:${mandate.merchant.id}`] : [];
+  return {
+    allowedCurrencies: [currency],
+    spendCaps: [
+      {
+        asset: currency,
+        // (DRAFT/unverified — AP2) illustrative rail label; AP2 is not a settlement network.
+        network: 'ap2-authorization-fixture',
+        maxAmountUnits,
+        window: 'per_request',
+      },
+    ],
+    sellerAllowlistAdditions: { sellerIds, endpointIds },
+    expiresAt: mandate.expiresAt,
+    operatorApprovalRequired: mandate.humanPresent === false,
+  };
+}
+
+function buildMandateRef(mandate: Ap2MandateFixture, supportState: Ap2SupportState): Ap2MandateRef {
+  return {
+    schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+    draft: true,
+    mandateType: mandate.mandateType,
+    mandateHash: hashMandate(mandate),
+    supportState,
+    humanPresent: mandate.humanPresent,
+    vdcVerification: 'fixture-asserted',
+    settlementFinalityClaimed: false,
+  };
+}
+
+function failClosed(
+  mandate: unknown,
+  supportState: Ap2SupportState,
+  reasonCodes: Ap2IngestReasonCode[],
+  auditNotes: string[],
+): Ap2MandateIngestionResult {
+  const mandateType: Ap2MandateType = isStructuredMandate(mandate) ? mandate.mandateType : 'intent';
+  return {
+    schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+    draft: true,
+    supportState,
+    mandateRef: {
+      schemaVersion: AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+      draft: true,
+      mandateType,
+      mandateHash: hashMandate(mandate),
+      supportState,
+      humanPresent: isStructuredMandate(mandate) ? mandate.humanPresent : undefined,
+      vdcVerification: 'fixture-asserted',
+      settlementFinalityClaimed: false,
+    },
+    derived: null,
+    reasonCodes,
+    auditNotes,
+    guardrails: AP2_MANDATE_INGESTION_GUARDRAILS,
+  };
+}
+
+function isStructuredMandate(value: unknown): value is Ap2MandateFixture {
+  if (!isRecord(value)) return false;
+  const candidate = value as Partial<Ap2MandateFixture>;
+  const validType = typeof candidate.mandateType === 'string'
+    && [
+      'intent', 'cart', 'payment',
+      'checkout_open', 'checkout_closed', 'payment_open', 'payment_closed',
+    ].includes(candidate.mandateType);
+  const vdc = candidate.vdc;
+  const validVdc = isRecord(vdc)
+    && typeof (vdc as Ap2VerifiableDigitalCredential).signatureB64 === 'string'
+    && (vdc as Ap2VerifiableDigitalCredential).verification === 'fixture-asserted';
+  return validType && validVdc;
+}
+
+function stripSignature(mandate: Ap2MandateFixture): Record<string, unknown> {
+  const clone = structuredClone(mandate) as Record<string, unknown>;
+  if (isRecord(clone.vdc)) {
+    const vdc = clone.vdc as Record<string, unknown>;
+    delete vdc.signatureB64;
+  }
+  return clone;
+}
+
+function hashMandate(mandate: unknown): string {
+  const source = isStructuredMandate(mandate) ? stripSignature(mandate) : mandate;
+  return `sha256:${createHash('sha256').update(canonicalize(source)).digest('hex')}`;
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, nested]) => nested !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([key, nested]) => `${JSON.stringify(key)}:${canonicalize(nested)}`).join(',')}}`;
+}
+
+function mandateContainsCredentialMaterial(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return SENSITIVE_VALUE_PATTERN.test(value) || PAN_PATTERN.test(value);
+  }
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some(mandateContainsCredentialMaterial);
+  return Object.entries(value).some(([key, nested]) => (
+    SENSITIVE_KEY_PATTERN.test(key) || mandateContainsCredentialMaterial(nested)
+  ));
+}
+
+function serializedContainsMarker(value: unknown, markers: string[]): boolean {
+  const serialized = JSON.stringify(value).toLowerCase();
+  return markers.some((marker) => serialized.includes(marker));
+}
+
+function mapCurrency(mandate: Ap2MandateFixture): BuyerAuthorityAsset | null {
+  const currency = mandate.payment?.currency ?? mandate.cart?.total.currency;
+  if (typeof currency !== 'string') return null;
+  return AP2_CURRENCY_TO_RAP_ASSET[currency.trim().toUpperCase()] ?? null;
+}
+
+function mandateOverCap(mandate: Ap2MandateFixture): boolean {
+  const cap = mandate.payment?.budgetCap;
+  if (typeof cap !== 'string') return false;
+  const amount = mandate.payment?.amount ?? mandate.cart?.total.amount;
+  if (typeof amount !== 'string') return false;
+  const capValue = parseAmount(cap);
+  const amountValue = parseAmount(amount);
+  if (capValue === null || amountValue === null) return true; // unparseable -> fail closed
+  return amountValue > capValue;
+}
+
+function isExpired(expiresAt: string | undefined, now: string): boolean {
+  if (typeof expiresAt !== 'string') return false;
+  const expiry = Date.parse(expiresAt);
+  const nowMs = Date.parse(now);
+  if (Number.isNaN(expiry) || Number.isNaN(nowMs)) return true;
+  return nowMs > expiry;
+}
+
+function parseAmount(value: string): number | null {
+  if (!/^\d+(\.\d+)?$/.test(value.trim())) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+// ---------------------------------------------------------------------------
+// #338 rail support-state matrix — AP2 row (fixture representation).
+//
+// The #338 rail-neutral support-state vocabulary is expressed per-module as a
+// `supportState` union rather than a single central matrix object. There is no
+// central matrix table in code, so this fixture adds the AP2 row alongside the
+// existing rails, documenting the AP2 support states, their claim boundary, and
+// their DRAFT/low-confidence status.
+// ---------------------------------------------------------------------------
+
+export type Ap2RailSupportStateRow = {
+  rail: 'google-ap2';
+  standard: 'Google AP2 (Agent Payments Protocol)';
+  supportState: Ap2SupportState;
+  mandateTypes: Ap2MandateType[];
+  description: string;
+  /** Every AP2/FIDO/Visa/Mastercard field in this row is DRAFT/unverified (low confidence). */
+  draft: true;
+  confidence: 'low';
+  /** Governance lineage note — DRAFT/unverified (FIDO/Visa/Mastercard). */
+  governanceNote: string;
+  claimBoundary: string[];
+};
+
+export const AP2_RAIL_SUPPORT_STATE_MATRIX: Ap2RailSupportStateRow[] = [
+  {
+    rail: 'google-ap2',
+    standard: 'Google AP2 (Agent Payments Protocol)',
+    supportState: 'ap2_mandate_fixture',
+    mandateTypes: ['cart', 'payment', 'checkout_closed', 'payment_closed'],
+    description:
+      'Finalized Checkout/Cart + Payment mandate present; VDC signature treated as fixture-asserted (opaque, not verified live); buyer-authority constraints derivable; no settlement claim.',
+    draft: true,
+    confidence: 'low',
+    governanceNote:
+      '(DRAFT/unverified — FIDO/Visa/Mastercard) AP2 + Mastercard Verifiable Intent reportedly contributed to FIDO (~2026-05); Visa TAP and Mastercard Agent Pay are distinct downstream rails, NOT the mandate format. Confirm before relying.',
+    claimBoundary: [
+      'AP2 is a trust/authorization layer, not a settlement rail.',
+      'RAP claims no settlement finality, custody, or live payment from an AP2 mandate.',
+      'The VDC signature is opaque and is not verified against any live key.',
+    ],
+  },
+  {
+    rail: 'google-ap2',
+    standard: 'Google AP2 (Agent Payments Protocol)',
+    supportState: 'ap2_mandate_probe_only',
+    mandateTypes: ['intent', 'checkout_open', 'payment_open'],
+    description:
+      'Only an Open/Intent mandate (constraints, no finalized cart) — usable for preflight/planning and parser tests, not for authorizing a specific spend.',
+    draft: true,
+    confidence: 'low',
+    governanceNote:
+      '(DRAFT/unverified — AP2) Open/Closed staging read from ap2-protocol.org (medium confidence on the v0.2 rename).',
+    claimBoundary: [
+      'Probe-only mandates derive no spend authorization.',
+      'No settlement, custody, or live payment is implied.',
+    ],
+  },
+  {
+    rail: 'google-ap2',
+    standard: 'Google AP2 (Agent Payments Protocol)',
+    supportState: 'unsupported_live_ap2_settlement',
+    mandateTypes: ['cart', 'payment', 'checkout_closed', 'payment_closed'],
+    description:
+      'Any mandate asserting completed settlement, custody, or finality is rejected. A future live lane must first define live VDC signature verification, wallet custody, spend limits, replay handling, operator approval, and rollback.',
+    draft: true,
+    confidence: 'low',
+    governanceNote:
+      '(DRAFT/unverified — AP2/FIDO) live AP2 settlement is out of scope; no live VDC verification exists in this adapter.',
+    claimBoundary: [
+      'Live AP2 settlement is unsupported in this fixture corpus.',
+      'Settlement-finality and custody claims fail closed.',
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Illustrative fixtures (static, no I/O). DRAFT/unverified AP2 shapes.
+// ---------------------------------------------------------------------------
+
+const BASE_VDC: Ap2VerifiableDigitalCredential = {
+  alg: 'ES256',
+  signatureB64: 'Zml4dHVyZS1hc3NlcnRlZC1vcGFxdWUtdmRjLXNpZ25hdHVyZS1ub3QtdmVyaWZpZWQ',
+  verification: 'fixture-asserted',
+};
+
+const checkoutClosedPaymentClosedValid: Ap2MandateFixture = {
+  mandateType: 'payment_closed',
+  humanPresent: true,
+  merchant: { id: 'seller:listing-writer', name: 'Listing Writer' },
+  cart: {
+    items: [{ sku: 'listing-writeup', name: 'Property listing write-up', amount: '25.00' }],
+    total: { amount: '25.00', currency: 'USDC' },
+    cartHash: 'ap2-cart-hash:listing-writeup-fixture',
+  },
+  payment: {
+    amount: '25.00',
+    currency: 'USDC',
+    allowedInstruments: ['stablecoin'],
+    budgetCap: '50.00',
+  },
+  expiresAt: '2027-01-01T00:00:00.000Z',
+  vdc: BASE_VDC,
+};
+
+const paymentOpenProbeOnly: Ap2MandateFixture = {
+  mandateType: 'payment_open',
+  humanPresent: true,
+  merchant: { id: 'seller:listing-writer' },
+  payment: {
+    amount: '25.00',
+    currency: 'USDC',
+    allowedInstruments: ['stablecoin', 'card'],
+    budgetCap: '50.00',
+  },
+  expiresAt: '2027-01-01T00:00:00.000Z',
+  vdc: BASE_VDC,
+};
+
+const expiredMandate: Ap2MandateFixture = {
+  ...checkoutClosedPaymentClosedValid,
+  expiresAt: '2026-06-01T00:00:00.000Z',
+};
+
+const humanNotPresent: Ap2MandateFixture = {
+  ...checkoutClosedPaymentClosedValid,
+  humanPresent: false,
+};
+
+const overBudgetMandate: Ap2MandateFixture = {
+  ...checkoutClosedPaymentClosedValid,
+  cart: {
+    items: [{ sku: 'listing-writeup', name: 'Property listing write-up', amount: '75.00' }],
+    total: { amount: '75.00', currency: 'USDC' },
+    cartHash: 'ap2-cart-hash:over-budget-fixture',
+  },
+  payment: {
+    amount: '75.00',
+    currency: 'USDC',
+    allowedInstruments: ['stablecoin'],
+    budgetCap: '50.00',
+  },
+};
+
+const railMismatchMandate: Ap2MandateFixture = {
+  ...checkoutClosedPaymentClosedValid,
+  cart: {
+    items: [{ sku: 'listing-writeup', name: 'Property listing write-up', amount: '25.00' }],
+    total: { amount: '25.00', currency: 'EUR' },
+    cartHash: 'ap2-cart-hash:rail-mismatch-fixture',
+  },
+  payment: {
+    amount: '25.00',
+    currency: 'EUR',
+    allowedInstruments: ['card'],
+    budgetCap: '50.00',
+  },
+};
+
+// PAN embedded in an otherwise ordinary cart item name -> must fail closed.
+const panLeakMandate: Ap2MandateFixture = {
+  ...checkoutClosedPaymentClosedValid,
+  cart: {
+    items: [{ sku: 'listing-writeup', name: 'card on file 4111111111111111', amount: '25.00' }],
+    total: { amount: '25.00', currency: 'USDC' },
+    cartHash: 'ap2-cart-hash:pan-leak-fixture',
+  },
+};
+
+// Mandate asserting settlement finality via an out-of-schema `settled` flag -> rejected.
+const settlementClaimMandate = {
+  ...checkoutClosedPaymentClosedValid,
+  settled: true,
+} as unknown as Ap2MandateFixture;
+
+export const ap2MandateFixtures = {
+  checkoutClosedPaymentClosedValid,
+  paymentOpenProbeOnly,
+  expiredMandate,
+  humanNotPresent,
+  overBudgetMandate,
+  railMismatchMandate,
+  panLeakMandate,
+  settlementClaimMandate,
+} as const;
+
+export function listAp2MandateFixtures(): Array<{ key: string; mandate: Ap2MandateFixture }> {
+  return Object.entries(ap2MandateFixtures).map(([key, mandate]) => ({
+    key,
+    mandate: structuredClone(mandate) as Ap2MandateFixture,
+  }));
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -24,3 +24,4 @@ export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
 export * from './langgraph-rap-template.js';
+export * from './ap2-mandate-ingestion.js';

--- a/packages/agent-protocol/tests/ap2-mandate-ingestion.test.ts
+++ b/packages/agent-protocol/tests/ap2-mandate-ingestion.test.ts
@@ -1,0 +1,225 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  AP2_MANDATE_INGESTION_SCHEMA_VERSION,
+  AP2_MANDATE_INGESTION_DRAFT,
+  AP2_MANDATE_INGESTION_FIXTURE_NOW,
+  AP2_RAIL_SUPPORT_STATE_MATRIX,
+  ap2MandateFixtures,
+  bindMandateToReceipt,
+  evaluateBuyerAuthorityPolicy,
+  ingestAp2Mandate,
+  listAp2MandateFixtures,
+  reddiReceiptFixtures,
+  validateReddiReceipt,
+} from '../dist/index.js';
+
+const NOW = AP2_MANDATE_INGESTION_FIXTURE_NOW;
+
+test('is draft-flagged and exposes an AP2 support-state matrix row', () => {
+  assert.equal(AP2_MANDATE_INGESTION_SCHEMA_VERSION, 'reddi.ap2-mandate-ingestion.v1');
+  assert.equal(AP2_MANDATE_INGESTION_DRAFT, true);
+
+  assert.ok(AP2_RAIL_SUPPORT_STATE_MATRIX.length >= 3);
+  for (const row of AP2_RAIL_SUPPORT_STATE_MATRIX) {
+    assert.equal(row.rail, 'google-ap2');
+    assert.equal(row.draft, true);
+    assert.equal(row.confidence, 'low');
+    assert.ok(row.claimBoundary.length > 0);
+  }
+  const states = AP2_RAIL_SUPPORT_STATE_MATRIX.map((row) => row.supportState);
+  assert.ok(states.includes('ap2_mandate_fixture'));
+  assert.ok(states.includes('ap2_mandate_probe_only'));
+  assert.ok(states.includes('unsupported_live_ap2_settlement'));
+});
+
+test('ingests a finalized mandate into correct buyer-authority constraints', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.checkoutClosedPaymentClosedValid, NOW);
+
+  assert.equal(result.draft, true);
+  assert.equal(result.supportState, 'ap2_mandate_fixture');
+  assert.deepEqual(result.reasonCodes, ['ap2_mandate_ingested']);
+  assert.ok(result.derived);
+  if (!result.derived) return;
+
+  assert.deepEqual(result.derived.allowedCurrencies, ['USDC']);
+  assert.equal(result.derived.spendCaps.length, 1);
+  assert.equal(result.derived.spendCaps[0].asset, 'USDC');
+  assert.equal(result.derived.spendCaps[0].maxAmountUnits, '50.00'); // budgetCap
+  assert.equal(result.derived.spendCaps[0].window, 'per_request');
+  assert.deepEqual(result.derived.sellerAllowlistAdditions.sellerIds, ['ap2-merchant:seller:listing-writer']);
+  assert.equal(result.derived.expiresAt, '2027-01-01T00:00:00.000Z');
+  assert.equal(result.derived.operatorApprovalRequired, false);
+});
+
+test('treats the VDC signature as opaque and claims no settlement finality', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.checkoutClosedPaymentClosedValid, NOW);
+
+  assert.equal(result.mandateRef.vdcVerification, 'fixture-asserted');
+  assert.equal(result.mandateRef.settlementFinalityClaimed, false);
+  assert.match(result.mandateRef.mandateHash, /^sha256:[a-f0-9]{64}$/);
+  assert.equal(result.guardrails.vdcSignatureVerifiedLive, false);
+  assert.equal(result.guardrails.settlementFinalityClaim, false);
+  assert.equal(result.guardrails.livePaymentExecuted, false);
+
+  // The opaque signature bytes never leak into the derived output or the ref.
+  const serialized = JSON.stringify(result);
+  assert.doesNotMatch(serialized, new RegExp(ap2MandateFixtures.checkoutClosedPaymentClosedValid.vdc.signatureB64));
+});
+
+test('mandate hash is deterministic and independent of the opaque signature', () => {
+  const a = ingestAp2Mandate(ap2MandateFixtures.checkoutClosedPaymentClosedValid, NOW);
+  const withDifferentSignature = structuredClone(ap2MandateFixtures.checkoutClosedPaymentClosedValid);
+  withDifferentSignature.vdc.signatureB64 = 'YS1kaWZmZXJlbnQtb3BhcXVlLXNpZ25hdHVyZS12YWx1ZQ';
+  const b = ingestAp2Mandate(withDifferentSignature, NOW);
+
+  assert.equal(a.mandateRef.mandateHash, b.mandateRef.mandateHash);
+});
+
+test('binds the mandate ref onto a receipt with no settlement claim, keeping the receipt valid', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.checkoutClosedPaymentClosedValid, NOW);
+  const bound = bindMandateToReceipt(reddiReceiptFixtures.happyPath, result.mandateRef);
+
+  const binding = bound.metadata?.ap2MandateRef as Record<string, unknown>;
+  assert.ok(binding);
+  assert.equal(binding.mandateType, 'payment_closed');
+  assert.equal(binding.mandateHash, result.mandateRef.mandateHash);
+  assert.equal(binding.supportState, 'ap2_mandate_fixture');
+  assert.equal(binding.settlementFinalityClaimed, false);
+  assert.equal(binding.vdcVerification, 'fixture-asserted');
+
+  // Receipt must still validate (no credential leak, no settlement fields).
+  const validation = validateReddiReceipt(bound);
+  assert.equal(validation.ok, true);
+});
+
+test('open/cart-less mandates are probe-only with no derived authorization', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.paymentOpenProbeOnly, NOW);
+
+  assert.equal(result.supportState, 'ap2_mandate_probe_only');
+  assert.equal(result.derived, null);
+  assert.deepEqual(result.reasonCodes, ['probe_only_no_cart_binding']);
+});
+
+test('human-not-present mandate flags operator approval required', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.humanNotPresent, NOW);
+
+  assert.equal(result.supportState, 'ap2_mandate_fixture');
+  assert.ok(result.derived);
+  if (!result.derived) return;
+  assert.equal(result.derived.operatorApprovalRequired, true);
+});
+
+test('fails closed on an expired mandate', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.expiredMandate, NOW);
+
+  assert.equal(result.derived, null);
+  assert.equal(result.supportState, 'ap2_mandate_probe_only');
+  assert.ok(result.reasonCodes.includes('mandate_expired'));
+});
+
+test('fails closed on an over-cap mandate', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.overBudgetMandate, NOW);
+
+  assert.equal(result.derived, null);
+  assert.ok(result.reasonCodes.includes('mandate_over_cap'));
+});
+
+test('fails closed on a rail-mismatch (unsupported currency) mandate', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.railMismatchMandate, NOW);
+
+  assert.equal(result.derived, null);
+  assert.ok(result.reasonCodes.includes('unsupported_currency_rail'));
+});
+
+test('fails closed on a PAN/credential leak', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.panLeakMandate, NOW);
+
+  assert.equal(result.derived, null);
+  assert.equal(result.supportState, 'unsupported_live_ap2_settlement');
+  assert.ok(result.reasonCodes.includes('mandate_contains_credentials'));
+});
+
+test('rejects a settlement-finality claim into the unsupported live state', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.settlementClaimMandate, NOW);
+
+  assert.equal(result.derived, null);
+  assert.equal(result.supportState, 'unsupported_live_ap2_settlement');
+  assert.ok(result.reasonCodes.includes('settlement_finality_claim_rejected'));
+  assert.equal(result.mandateRef.settlementFinalityClaimed, false);
+});
+
+test('malformed mandate fails closed as mandate_malformed', () => {
+  const result = ingestAp2Mandate({ mandateType: 'nonsense' } as never, NOW);
+
+  assert.equal(result.derived, null);
+  assert.ok(result.reasonCodes.includes('mandate_malformed'));
+});
+
+test('derived constraints feed the buyer-authority gate end-to-end', () => {
+  const result = ingestAp2Mandate(ap2MandateFixtures.checkoutClosedPaymentClosedValid, NOW);
+  assert.ok(result.derived);
+  if (!result.derived) return;
+
+  // Build a minimal buyer-authority policy that consumes the derived constraints, then
+  // assert the existing gate denies an over-cap request against the AP2-derived cap.
+  const cap = result.derived.spendCaps[0];
+  const policy = {
+    schemaVersion: 'reddi.buyer-authority-policy.v1' as const,
+    issue: 549 as const,
+    policyId: 'buyer-authority:ap2-derived',
+    mode: 'allow' as const,
+    buyerAgentId: 'buyer-agent:ap2-demo',
+    expiresAt: result.derived.expiresAt ?? '2027-01-01T00:00:00.000Z',
+    allowedRails: [
+      { asset: cap.asset, network: cap.network, supportStates: ['proof-metadata-only' as const] },
+    ],
+    allowedCurrencies: result.derived.allowedCurrencies,
+    spendCaps: result.derived.spendCaps,
+    sellerAllowlist: {
+      sellerIds: result.derived.sellerAllowlistAdditions.sellerIds,
+      endpointIds: result.derived.sellerAllowlistAdditions.endpointIds,
+    },
+    receiptEvidence: { receiptRequired: true, evidenceRequired: true, evidenceArchiveRequired: true },
+    refundFailurePolicy: {
+      failureMode: 'no_charge_on_failure' as const,
+      refundMode: 'manual_review' as const,
+      operatorReviewRequired: true,
+    },
+    operatorApproval: { required: false, approvalState: 'not_required' as const },
+    supportStateConstraints: {
+      allowLivePayment: false as const,
+      allowedRuntimeStates: ['proof-metadata-only' as const],
+      forbidCustody: true as const,
+      forbidSettlementFinality: true as const,
+    },
+    notes: ['AP2-derived buyer-authority constraints, fixture-only, no live settlement.'],
+  };
+
+  const overCapRequest = {
+    sellerId: 'ap2-merchant:seller:listing-writer',
+    endpointId: 'ap2-merchant-endpoint:seller:listing-writer',
+    asset: cap.asset,
+    network: cap.network,
+    amountUnits: '51.00', // above the 50.00 derived cap
+    supportState: 'proof-metadata-only',
+    receiptPresented: true,
+    evidencePresented: true,
+    now: '2026-07-05T00:00:00.000Z',
+    operatorApprovalState: 'approved' as const,
+  };
+
+  const evaluation = evaluateBuyerAuthorityPolicy(policy, overCapRequest);
+  assert.equal(evaluation.allowed, false);
+  assert.ok(evaluation.reasonCodes.includes('spend_cap_exceeded'));
+});
+
+test('no fixture claims settlement finality or executes live payment', () => {
+  for (const { mandate } of listAp2MandateFixtures()) {
+    const result = ingestAp2Mandate(mandate, NOW);
+    assert.equal(result.mandateRef.settlementFinalityClaimed, false);
+    assert.equal(result.guardrails.livePaymentExecuted, false);
+    assert.equal(result.guardrails.vdcSignatureVerifiedLive, false);
+  }
+});


### PR DESCRIPTION
DRAFT v1 — AP2 field shapes are UNVERIFIED against the live standard; illustrative one-way mapping + fixtures only; NO live writes, NO settlement, NO signature verification against live keys. Review the external-standard assumptions before relying on them.

## What

Adds `packages/agent-protocol/src/ap2-mandate-ingestion.ts` (schema `reddi.ap2-mandate-ingestion.v1`, `draft: true`): a **pure, no-network** adapter that ingests a **static signed AP2 mandate fixture** and maps it onto the existing `reddi.buyer-authority-policy.v1` policy gate.

AP2 (Google Agent Payments Protocol) is a **trust/authorization layer, NOT a settlement rail**. This adapter treats an AP2 mandate as a buyer-authority policy input — the conceptually native mapping — and references it from the receipt as authorization-provenance only, with **zero settlement-finality claim** by construction.

Mirrors `buyer-authority-policy.ts` (policy-gate pattern) + `policy.ts` + `receipt-evidence-binding.ts`.

## Behaviour

- `ingestAp2Mandate(mandate, now)` derives `{ allowedCurrencies, spendCaps, sellerAllowlistAdditions, expiresAt, operatorApprovalRequired }` from a finalized Checkout/Cart + Payment mandate, plus a receipt-bindable `mandateRef` (hash + type + support-state).
- **Fails closed** on: credential/PAN leak, settlement-finality claim, custody claim, expiry, over-cap, unsupported currency rail, malformed mandate, and cart-less/open (probe-only) mandates.
- `bindMandateToReceipt(receipt, ref)` sets `receipt.metadata.ap2MandateRef` (hash/type/support-state only, no signature, no cart contents) — the receipt still passes `validateReddiReceipt`.
- **VDC signature is treated as OPAQUE, fixture-asserted** — never verified against a live key. Guardrails record `vdcSignatureVerifiedLive: false`, `livePaymentExecuted: false`, `settlementFinalityClaim: false`.

## #338 support-state row

No central #338 matrix object exists in code (each rail module carries its own `supportState` union), so this adds `AP2_RAIL_SUPPORT_STATE_MATRIX` — an AP2 row **fixture** with three states: `ap2_mandate_fixture`, `ap2_mandate_probe_only`, `unsupported_live_ap2_settlement`. Each row is tagged `draft: true`, `confidence: 'low'`.

## DRAFT discipline

- Schema carries a top-level `draft: true` flag; `AP2_MANDATE_INGESTION_DRAFT` exported.
- Every AP2 / FIDO / Visa / Mastercard structural field (mandate vocab, VDC envelope, currency codes, governance lineage) carries an inline `(DRAFT/unverified — <standard>, confirm field name/shape)` tag.
- Fixtures are illustrative, not authoritative. The Visa TAP / Mastercard Agent Pay vs AP2-donated-to-FIDO distinction is noted as unverified in the matrix `governanceNote`.

## Tests

`tests/ap2-mandate-ingestion.test.ts` (node:test) — 15 cases: derived constraints correct; expired / over-cap / rail-mismatch / PAN / settlement-claim / malformed all fail closed; signature treated opaque (deterministic hash independent of signature, no signature leakage); no settlement finality claimed; end-to-end into `evaluateBuyerAuthorityPolicy`.

**Full suite: 208/208 passing** (`npm test`).

## Boundaries

No custody, no escrow, no live settlement, no EVM/on-chain call, no live VDC verification, no network. Pure functions over static fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)