### PR TITLE
feat(#547): framework template comparison docs + no-live conformance fixtures

### DIFF
--- a/docs/conformance/framework-template-comparison.md
+++ b/docs/conformance/framework-template-comparison.md
@@ -1,114 +1,333 @@
-# Framework Template Comparison
+# Framework Template Comparison & Selection Guide
 
 Issue: #547
 
-This document compares the four landed RAP framework templates — **generic**, **LangGraph**, **ADK/A2A**, and **Strands** — across the full RAP lifecycle. All four are **no-live / dry-run / fixture-only**: none of them installs a framework package, calls a wallet/RPC/provider, executes a payment, claims custody, or claims settlement finality. Every template consumes the shared #552 contract (`framework-template-contract.ts`) and passes the shared #553 no-live conformance checker (`framework-template-conformance.ts`) without redefining any RAP semantics.
+This is the decision, setup, and validation guide for the four landed RAP framework templates —
+**generic**, **LangGraph** (LangGraph/LangChain, #544), **AWS Strands** (#545), and **Google ADK / A2A** (#546).
+Its job is to answer three questions:
+
+1. **Which template do I pick?** — see [Choosing a framework](#1-choosing-a-framework).
+2. **How do I wire it for buyer-enabled / seller-enabled / dual-mode?** — see [Per-framework setup](#2-per-framework-setup-by-mode).
+3. **How do I validate it, and what does that produce?** — see [Validation commands & artifacts](#3-validation-commands--artifacts).
+
+The lifecycle-uniformity comparison that used to be the headline is preserved below as
+[one section](#4-lifecycle-uniformity-one-shared-contract).
+
+> **All four are no-live / fixture-only.** No template installs a framework package, calls a
+> wallet/RPC/provider, executes a payment, claims custody, or claims settlement finality. Every
+> template consumes the shared #552 contract (`framework-template-contract.ts`) and passes the shared
+> #553 no-live conformance checker (`framework-template-conformance.ts`) without redefining any RAP
+> money/authority/safety semantics. These are *reference templates and conformance fixtures*, not
+> runnable framework scaffolds.
 
 ## Source surfaces
 
-| Template | Source module | Shape | State factory | Validator |
+| Template | Source module (`packages/agent-protocol/src/`) | Idiomatic shape | State factory | Validator | Schema-version export |
+|---|---|---|---|---|---|
+| Generic | `framework-template-contract.ts` | Lifecycle contract fixtures | `listFrameworkTemplateFixtures()` / `frameworkTemplateFixtures` | `validateFrameworkTemplateContract()` | `FRAMEWORK_TEMPLATE_CONTRACT_SCHEMA_VERSION` |
+| LangGraph (#544) | `langgraph-rap-template.ts` | Graph with typed **nodes** + `middleware` + `graphState` | `createLangGraphRapTemplateFixture()` | `validateLangGraphRapTemplate()` | `LANGGRAPH_RAP_TEMPLATE_SCHEMA_VERSION` |
+| Strands (#545) | `strands-rap-template.ts` | Tool-plugin with ordered **steps** + `hooks` + `toolState` | `createStrandsRapTemplateFixture()` | `validateStrandsRapTemplate()` | `STRANDS_RAP_TEMPLATE_SCHEMA_VERSION` |
+| ADK / A2A (#546) | `adk-rap-template.ts` | **A2A Agent Card** with `skills[]` + `rapExtension` | `createAdkRapTemplateFixture()` / `createAdkFrameworkTemplateContract()` | `validateAdkRapTemplate()` | `ADK_RAP_TEMPLATE_SCHEMA_VERSION`, `ADK_RAP_TEMPLATE_FRAMEWORK` |
+
+Shared support surfaces:
+
+- Contract types + fixtures + validator: `framework-template-contract.ts`
+- No-live conformance checker: `framework-template-conformance.ts`
+  (`runFrameworkTemplateNoLiveConformanceCheck()`, `listFrameworkTemplateConformanceCases()`)
+- Cross-framework uniformity fixtures: `framework-template-conformance-fixtures.ts`
+  (`listLandedFrameworkTemplateConformanceFixtures()`, `runUniformFrameworkTemplateConformance()`)
+
+Each module is a published subpath export (see `packages/agent-protocol/package.json` `exports`), e.g.
+`@reddi/agent-protocol/langgraph-rap-template`, `.../adk-rap-template`, `.../strands-rap-template`,
+`.../framework-template-contract`, `.../framework-template-conformance`.
+
+---
+
+## 1. Choosing a framework
+
+Every template exposes the **same RAP lifecycle** (discover → quote → buyer-policy preflight →
+operator approval → invoke → receipt/evidence, plus denial and failure/refund). They differ only in
+the *idiomatic wrapper shape* that surface takes — which is what you should match to how your agent
+runtime is already structured.
+
+| If your agent runtime is… | Pick | Because the template models RAP as… | Trade-off |
+|---|---|---|---|
+| A custom/other orchestrator, or you want the smallest possible embed | **generic** | Raw `FrameworkTemplateContract` lifecycle fixtures — no framework assumption | You wire the lifecycle ordering yourself; no nodes/steps/skills scaffolding is provided |
+| A **stateful graph / state machine** (LangGraph, LangChain graphs) | **langgraph** | Typed graph **nodes** (`discover`, `quote`, `buyerPolicyPreflight`, `operatorApproval`, `invokePaidAgent`, `bindReceiptEvidence`, `sellerWrapperEndpoint`) guarded by `middleware` (`buyerPolicy` / `receiptEvidence` / `sellerWrapper`), with refs held in `graphState` | Assumes an explicit node/edge execution model; overkill for a linear tool call |
+| A **tool / step pipeline with lifecycle hooks** (AWS Strands) | **strands** | Ordered tool **steps** (same seven names) driven by `hooks` (`buyerPolicy` / `receiptEvidence` / `sellerWrapper`), with refs in `toolState` | Ordering is expressed as a step list, not a graph — less explicit branching than LangGraph |
+| An agent that **publishes an A2A Agent Card** (Google ADK / A2A interop) | **adk** | An `AdkA2aAgentCard` whose `skills[]` (`rap.discover` … `rap.seller-wrapper-endpoint`) and `rapExtension` carry the discovery/quote/policy/invocation/receipt/evidence routes; `preferredTransport: 'a2a-agent-card'` | Heaviest wrapper (full agent-card schema + `rapExtension`); only worth it if you actually speak A2A |
+
+Decision shortcuts:
+
+- **"I just need the contract, not a framework."** → generic. The other three embed byte-identical
+  clones of the generic lifecycle contracts, so nothing is lost by starting generic and adding a
+  wrapper later.
+- **"My orchestration is graph-shaped."** → langgraph.
+- **"My orchestration is a tool/step chain."** → strands.
+- **"I need A2A agent-card discovery/interop."** → adk.
+
+Invocation-mode fit (from `contract.invocationModes` / ADK `preferredTransport`): generic, langgraph,
+and strands advertise `['http-openapi', 'mcp', 'local-fixture']`; adk additionally models the
+`a2a-agent-card` transport via its Agent Card. The `FrameworkTemplateInvocationMode` union
+(`framework-template-contract.ts`) enumerates `http-openapi | mcp | a2a-agent-card | local-fixture`.
+
+Because the money/authority/safety semantics are identical across all four (see §4), the choice is
+**purely ergonomic** — pick the shape that matches your runtime; you never trade away any RAP
+guarantee by switching.
+
+---
+
+## 2. Per-framework setup by mode
+
+RAP roles are expressed by `agentIdentity.templateMode` on the shared contract
+(`FrameworkTemplateMode = 'buyer-enabled' | 'seller-enabled' | 'dual-mode'`). The framework wrapper
+(nodes / steps / Agent Card) is **mode-agnostic** — the same factory produces the wrapper, and the
+*mode lives on the embedded contract*. The validator/conformance rules that make each mode meaningful
+are in `framework-template-contract.ts` and `framework-template-conformance.ts`:
+
+| Mode | Requires (enforced by `requiredFieldsForMode` + `validateFrameworkTemplateContract`) | May omit |
+|---|---|---|
+| `buyer-enabled` | `buyerAuthorityPolicy` present and matching #551 metadata (`buyerAuthorityPolicyMatches`) | `sellerProfile` (can be `undefined`) |
+| `seller-enabled` | `sellerProfile` present | `buyerAuthorityPolicy` (if present, must still match #551) |
+| `dual-mode` | **both** `buyerAuthorityPolicy` **and** `sellerProfile` | — |
+
+The canonical way to construct each mode is exactly what the #553 checker does in
+`framework-template-conformance.ts` → `modeCase(mode)`: start from a lifecycle contract, set
+`agentIdentity.templateMode`, and clear the field that mode omits.
+
+```ts
+import { frameworkTemplateFixtures, validateFrameworkTemplateContract }
+  from '@reddi/agent-protocol/framework-template-contract';
+
+function contractForMode(mode) {
+  const contract = structuredClone(frameworkTemplateFixtures.invocation.contract);
+  contract.agentIdentity.templateMode = mode;
+  if (mode === 'buyer-enabled') contract.sellerProfile = undefined;        // seller side off
+  if (mode === 'seller-enabled') contract.buyerAuthorityPolicy = undefined; // buyer side off
+  // dual-mode keeps both (this is the default of every landed fixture)
+  return contract;
+}
+validateFrameworkTemplateContract(contractForMode('dual-mode')); // { valid: true, ... }
+```
+
+The three landed framework wrappers (`createLangGraphRapTemplateFixture`,
+`createStrandsRapTemplateFixture`, `createAdkRapTemplateFixture`) embed the **dual-mode** invocation
+contract by default (their `contracts` map is cloned from `frameworkTemplateFixtures`). To run a
+framework wrapper as buyer- or seller-only, build the mode-specific contract as above and use it as
+that wrapper's `selectedContract`, then re-validate with the framework's validator.
+
+### 2a. Generic
+
+```ts
+import { listFrameworkTemplateFixtures, validateFrameworkTemplateContract }
+  from '@reddi/agent-protocol/framework-template-contract';
+
+for (const fx of listFrameworkTemplateFixtures()) {
+  // fx.contract.agentIdentity.templateMode === 'dual-mode' by default
+  console.log(fx.kind, validateFrameworkTemplateContract(fx.contract).valid);
+}
+```
+
+- **dual-mode:** use the fixtures as-is (`templateMode: 'dual-mode'`, both `buyerAuthorityPolicy` and `sellerProfile` present).
+- **buyer-enabled / seller-enabled:** apply `contractForMode(...)` above before validating.
+
+### 2b. LangGraph (`langgraph-rap-template.ts`)
+
+```ts
+import { createLangGraphRapTemplateFixture, validateLangGraphRapTemplate }
+  from '@reddi/agent-protocol/langgraph-rap-template';
+
+const graph = createLangGraphRapTemplateFixture({ scenario: 'allowed-no-live-invocation' });
+validateLangGraphRapTemplate(graph); // { valid: true, reasonCodes: ['langgraph_rap_template_valid'] }
+```
+
+- Wrapper shape: `graph.nodes` (seven `LangGraphRapGraphNode`s), `graph.middleware`
+  (`buyerPolicy` / `receiptEvidence` / `sellerWrapper`, all `true`), `graph.graphState` (refs), and
+  `graph.sellerWrapperEndpointHelper` (seller routes below).
+- **Role wiring:** `graph.selectedContract.agentIdentity.templateMode` carries the mode. It defaults
+  to `dual-mode`; set it via `contractForMode(...)` for buyer-/seller-only, then re-run
+  `validateLangGraphRapTemplate`.
+- `createLangGraphRapTemplateFixture({ scenario })` accepts the six `LangGraphRapTemplateScenario`s
+  (see §3d) to exercise allow/deny/failure paths.
+
+### 2c. Strands (`strands-rap-template.ts`)
+
+```ts
+import { createStrandsRapTemplateFixture, validateStrandsRapTemplate }
+  from '@reddi/agent-protocol/strands-rap-template';
+
+const plugin = createStrandsRapTemplateFixture({ scenario: 'allowed-no-live-invocation' });
+validateStrandsRapTemplate(plugin); // { valid: true, reasonCodes: ['strands_rap_template_valid'] }
+```
+
+- Wrapper shape: `plugin.steps` (seven ordered `StrandsRapToolStep`s), `plugin.hooks`
+  (`buyerPolicy` / `receiptEvidence` / `sellerWrapper`), `plugin.toolState` (refs), and
+  `plugin.sellerWrapperEndpointHelper`.
+- **Role wiring:** identical model to LangGraph — mode is on `plugin.selectedContract`
+  (`agentIdentity.templateMode`, default `dual-mode`).
+
+### 2d. ADK / A2A (`adk-rap-template.ts`)
+
+```ts
+import {
+  createAdkRapTemplateFixture,
+  createAdkFrameworkTemplateContract,
+  validateAdkRapTemplate,
+} from '@reddi/agent-protocol/adk-rap-template';
+
+const card = createAdkRapTemplateFixture({ scenario: 'allowed-no-live-invocation' });
+validateAdkRapTemplate(card); // { valid: true, reasonCodes: ['adk_rap_template_valid'] }
+
+// Just the contract, re-framed for framework kind 'adk':
+const adkContract = createAdkFrameworkTemplateContract();
+```
+
+- Wrapper shape: `card.agentCard` is an `AdkA2aAgentCard` — `skills[]` (seven `AdkRapAgentSkillId`s,
+  `rap.discover` … `rap.seller-wrapper-endpoint`), `rapExtension` (routes below +
+  `supportState: 'proof-metadata-only'`, `livePaymentApproved: false`), plus `card.middleware`,
+  `card.cardState`, and `card.sellerWrapperEndpointHelper`. `preferredTransport` is `'a2a-agent-card'`.
+- `createAdkFrameworkTemplateContract()` returns a clone of the shared invocation contract with
+  `agentIdentity.framework = 'adk'` — use it when you only need the contract, not the Agent Card.
+- **Role wiring:** mode is on `card.selectedContract` / the contract from
+  `createAdkFrameworkTemplateContract()` (default `dual-mode`).
+
+### Seller-wrapper routes (shared, from #551)
+
+Every seller-enabled/dual-mode template exposes the same **local** routes (paths, never live URLs),
+derived from the #551 seller-wrapper config endpoint `seller-wrapper:listing-writer:http`
+(`sellerId: seller:listing-writer`):
+
+| Field | Value |
+|---|---|
+| `quoteRoute` | `/seller-wrapper/listing-writer-http/quote` |
+| `policyPreflightRoute` | `/seller-wrapper/listing-writer-http/policy-preflight` |
+| `invocationRoute` | `/seller-wrapper/listing-writer-http/invoke-mock` |
+| `receiptHook` | `/seller-wrapper/listing-writer-http/receipt` |
+| `evidenceHook` | `/seller-wrapper/listing-writer-http/evidence` |
+| `discoveryRoute` (ADK `rapExtension` only) | `/seller-wrapper/listing-writer-http/discovery` |
+
+These appear identically on each template's `sellerWrapperEndpointHelper` (and on the ADK
+`rapExtension`). None is a live endpoint — `invoke-mock` is the mock invocation path.
+
+---
+
+## 3. Validation commands & artifacts
+
+Run everything from `packages/agent-protocol/`. Commands come from that package's `package.json`
+`scripts`.
+
+### 3a. Full test + conformance gate
+
+```bash
+npm install        # once
+npm run build      # tsc -p tsconfig.json  → emits dist/*.js + dist/*.d.ts
+npm test           # build → tsc -p tsconfig.test.json → node --test dist-tests/*.test.js
+```
+
+- **`npm test`** compiles the test project to `dist-tests/` and runs every `node:test` suite,
+  including the framework-template suites: `framework-template-contract.test.ts`,
+  `framework-template-conformance.test.ts`, `framework-template-conformance-fixtures.test.ts`, and the
+  three wrapper tests (`langgraph-rap-template.test.ts`, `adk-rap-template.test.ts`,
+  `strands-rap-template.test.ts`). Current status: **248 tests, 0 failures**.
+- **Artifacts:** `dist/` (compiled package) and `dist-tests/` (compiled tests). `dist/` is committed
+  and published; `dist-tests/` is build-only and must **not** be committed.
+- **The #553 no-live conformance checker** (`runFrameworkTemplateNoLiveConformanceCheck()`) and the
+  cross-framework **uniform check** (`runUniformFrameworkTemplateConformance()`) are *not* standalone
+  CLIs — they are exercised by the conformance test suites above. Import and call them directly if you
+  want a programmatic gate; both return `{ valid: true, reasonCodes: ['..._valid'] }` on success.
+
+### 3b. Buyer→seller dry-run example
+
+```bash
+npm run example:buyer-seller:dry-run   # build → node examples/buyer-seller-dry-run.mjs
+```
+
+Prints a no-spend JSON envelope to **stdout** (writes no files):
+
+```json
+{ "ok": true, "status": 200, "receiptId": "job:example-001",
+  "evidenceId": "evidence:example-001", "paymentProofRef": "dry-run:example-001" }
+```
+
+`ok: true` / `status: 200` confirms the buyer preflight passed and a receipt+evidence pair was bound
+under `mode: 'dry-run'` — no wallet, RPC, or payment.
+
+### 3c. ARD no-spend example
+
+```bash
+npm run example:ard:no-spend   # build → node examples/ard-no-spend-demo.mjs
+```
+
+Reads the input fixture `examples/ard-no-spend-ai-catalog.json` and prints a large no-spend JSON
+envelope to **stdout** (writes no files). The envelope includes `"ok": true`, `"mode": "no-spend"`, a
+validated `catalog` block, request/receipt `hashes`, and a `boundaries` block with every live flag
+`false` (`hostedService`, `paidProvider`, `walletAccess`, `rpcCall`, `splTransfer`, `quasarCustody`,
+`settlementFinalityProof`, `livePayment`, …). Non-zero `process.exitCode` signals a broken invariant.
+
+### 3d. Scenario coverage (per-framework)
+
+Each wrapper factory takes a `scenario`; validators return `{ valid, reasonCodes[], auditNotes[] }`.
+The six scenarios (identical union across LangGraph/Strands/ADK) are:
+
+| Scenario | Expected | Representative reason code on denial |
+|---|---|---|
+| `allowed-no-live-invocation` | valid (allowed) | — (`*_rap_template_valid`) |
+| `policy-denial` | invalid | `missing_operator_approval` (must stop before approval/invocation/receipt/evidence) |
+| `missing-approval` | invalid | `missing_operator_approval` |
+| `malformed-quote-payment-plan` | invalid | `malformed_quote_payment_plan` |
+| `credential-shaped-output` | invalid | `template_contains_credentials` |
+| `unsafe-live-custody-provider-claim` | invalid | `unsafe_live_custody_provider_claim` |
+
+These are asserted in the three wrapper test files and are the recommended way to prove a template
+fails closed.
+
+### 3e. Package-exports guard
+
+```bash
+npm run check:exports        # node scripts/check-package-exports.mjs
+```
+
+Verifies every `main` / `types` / subpath target in `package.json` `exports` resolves to a file on
+disk after build (currently **69 targets OK**), so a newly added module (e.g. a framework template)
+can't ship with a dangling export. This runs in CI via `.github/workflows/rap-package-guard.yml` and
+is also covered by `tests/package-exports.test.ts`. `npm run release:dry-run`
+(`clean → build → test → check:exports → npm pack --dry-run`) chains the whole gate.
+
+---
+
+## 4. Lifecycle uniformity (one shared contract)
+
+Only the **framework-idiomatic wrapper shape** differs across templates. Everything that touches
+money, authority, or safety is inherited unchanged from the shared #552 contract: the
+`FrameworkTemplateContract` lifecycle fixtures, the buyer-authority matrix (#550), the seller-wrapper
+routes (#551), receipt/evidence binding, failure/refund semantics, support-state metadata, and the
+four no-live boundary booleans. Because each framework template embeds byte-identical clones of the
+shared lifecycle contracts, feeding any template's own contracts into the #553 checker yields the same
+result.
+
+Lifecycle stage → idiomatic surface (every stage is fixture-only; refs are `local-fixture:*` strings):
+
+| Stage | Generic | LangGraph | Strands | ADK / A2A |
 |---|---|---|---|---|
-| Generic | `framework-template-contract.ts` | Lifecycle contract fixtures (`frameworkTemplateFixtures`) | `listFrameworkTemplateFixtures()` | `validateFrameworkTemplateContract()` |
-| LangGraph (#544) | `langgraph-rap-template.ts` | Graph with typed **nodes** + middleware | `createLangGraphRapTemplateFixture()` | `validateLangGraphRapTemplate()` |
-| ADK / A2A (#546) | `adk-rap-template.ts` | **A2A Agent Card** with `skills[]` + `rapExtension` | `createAdkRapTemplateFixture()` | `validateAdkRapTemplate()` |
-| Strands (#545) | `strands-rap-template.ts` | Tool-plugin with ordered **steps** + hooks | `createStrandsRapTemplateFixture()` | `validateStrandsRapTemplate()` |
+| discover | `discovery` contract (`status: not-run`) | `discover` node; `graphState.discoveryRef` | `discover` step; `toolState.discoveryRef` | `rap.discover` skill; `rapExtension.discoveryRoute` |
+| quote | `quote` contract (`status: not-run`) | `quote` node; `graphState.quoteRef` | `quote` step; `toolState.quoteRef` | `rap.quote` skill; `rapExtension.quoteRoute` |
+| policy-preflight | `preflight` vs #550 matrix | `buyerPolicyPreflight` node + `middleware.buyerPolicy` | `buyerPolicyPreflight` step + `hooks.buyerPolicy` | `rap.buyer-policy-preflight` skill + `middleware.buyerPolicy` |
+| approval | `operator-approval` contract (`status: denied` until approved) | `operatorApproval` node; `graphState.operatorApprovalRef` | `operatorApproval` step; `toolState.operatorApprovalRef` | `rap.operator-approval` skill; `cardState.operatorApprovalRef` |
+| invoke | `invocation` contract (`status: allowed`, `local-fixture:*`) | `invokePaidAgent` node; `graphState.invocationRef` | `invokePaidAgent` step; `toolState.invocationRef` | `rap.invoke-paid-agent` skill; `cardState.invocationRef` |
+| receipt-evidence | `receipt-evidence` contract (`receiptRef`+`evidenceRef` required) | `bindReceiptEvidence` node + `middleware.receiptEvidence` | `bindReceiptEvidence` step + `hooks.receiptEvidence` | `rap.bind-receipt-evidence` skill + `middleware.receiptEvidence` |
+| seller-wrapper | `sellerProfile` routes/hooks | `sellerWrapperEndpoint` node + helper + `middleware.sellerWrapper` | `sellerWrapperEndpoint` step + helper + `hooks.sellerWrapper` | `rap.seller-wrapper-endpoint` skill + helper; `rapExtension` routes |
 
-The cross-framework uniformity fixtures live in `framework-template-conformance-fixtures.ts`
-(`listLandedFrameworkTemplateConformanceFixtures()`, `runUniformFrameworkTemplateConformance()`).
+All four reuse `buyerAuthorityCases` (the #550 matrix: `allow`, `deny`, `expired`, `approvalRequired`,
+`unsupportedRail`, `unsupportedCurrency`, `sellerNotAllowlisted`, `missingReceiptRequirement`,
+`missingEvidenceRequirement`, `refundFailurePolicyMismatch`, `spendCapExceeded`); none re-implements
+it. Denials preserve machine-readable buyer-authority reason codes; failures use
+`no_charge_on_failure` + `manual_review` semantics.
 
-## What differs vs. what stays shared
+### No-live boundary (identical across all four)
 
-Only the **framework-idiomatic wrapper shape** differs across templates. Everything that touches money, authority, or safety is inherited unchanged from the shared #552 contract:
-
-- **Differs:** how each framework names and orders its lifecycle surface — LangGraph uses graph *nodes*, ADK uses Agent-Card *skills*, Strands uses tool *steps*, generic uses raw contract fixtures.
-- **Shared (identical across all four):** the `FrameworkTemplateContract` lifecycle fixtures, the buyer-authority matrix (#550), the seller-wrapper routes (#551), receipt/evidence binding, failure/refund semantics, support-state metadata, and the four no-live boundary booleans.
-
-Because each framework template embeds byte-identical clones of the shared lifecycle contracts, feeding any template's own contracts into the #553 checker yields the same result — the basis for the uniform-conformance assertion below.
-
-## Lifecycle comparison
-
-Each stage below maps the shared RAP step to the framework-idiomatic surface. In every column the stage is **fixture-only**: refs are `local-fixture:*` strings, no external call is made.
-
-### discover
-
-| Framework | Surface |
-|---|---|
-| Generic | `discovery` lifecycle contract (`executionResult.status = 'not-run'`) |
-| LangGraph | `discover` node; `graphState.discoveryRef` |
-| ADK | `rap.discover` skill; Agent-Card `rapExtension.discoveryRoute` |
-| Strands | `discover` step; `toolState.discoveryRef` |
-
-### quote
-
-| Framework | Surface |
-|---|---|
-| Generic | `quote` lifecycle contract (`status = 'not-run'`) |
-| LangGraph | `quote` node; `graphState.quoteRef` |
-| ADK | `rap.quote` skill; `rapExtension.quoteRoute` |
-| Strands | `quote` step; `toolState.quoteRef` |
-
-### policy-preflight
-
-| Framework | Surface |
-|---|---|
-| Generic | `preflight` contract evaluated against the shared #550 buyer-authority matrix |
-| LangGraph | `buyerPolicyPreflight` node + `middleware.buyerPolicy` |
-| ADK | `rap.buyer-policy-preflight` skill + `middleware.buyerPolicy`; `rapExtension.policyPreflightRoute` |
-| Strands | `buyerPolicyPreflight` step + `hooks.buyerPolicy` |
-
-All four reuse `buyerAuthorityCases` from the shared contract; none re-implements the matrix.
-
-### approval (operator-approval)
-
-| Framework | Surface |
-|---|---|
-| Generic | `operator-approval` contract (`status = 'denied'` until approved) |
-| LangGraph | `operatorApproval` node; `graphState.operatorApprovalRef` |
-| ADK | `rap.operator-approval` skill; `cardState.operatorApprovalRef` |
-| Strands | `operatorApproval` step; `toolState.operatorApprovalRef` |
-
-Each validator fails closed (`missing_operator_approval`) if a paid invocation would proceed without the approval ref, or if a policy-denial case leaks an approval/invocation/receipt/evidence ref.
-
-### invoke
-
-| Framework | Surface |
-|---|---|
-| Generic | `invocation` contract (`status = 'allowed'`, `invocationId = local-fixture:*`) |
-| LangGraph | `invokePaidAgent` node; `graphState.invocationRef` |
-| ADK | `rap.invoke-paid-agent` skill; `cardState.invocationRef` |
-| Strands | `invokePaidAgent` step; `toolState.invocationRef` |
-
-The "paid agent" is the mock seller-wrapper endpoint. No framework performs a real invocation, network call, or payment.
-
-### receipt-evidence
-
-| Framework | Surface |
-|---|---|
-| Generic | `receipt-evidence` contract with `receiptRef` + `evidenceRef` required for allowed runs |
-| LangGraph | `bindReceiptEvidence` node + `middleware.receiptEvidence` |
-| ADK | `rap.bind-receipt-evidence` skill + `middleware.receiptEvidence` |
-| Strands | `bindReceiptEvidence` step + `hooks.receiptEvidence` |
-
-Allowed no-live invocations require both receipt and evidence refs (`missing_receipt_evidence_refs` otherwise).
-
-### seller-wrapper endpoint
-
-| Framework | Surface |
-|---|---|
-| Generic | `sellerProfile` on the contract (quote/preflight/invocation routes + receipt/evidence hooks) |
-| LangGraph | `sellerWrapperEndpoint` node + `sellerWrapperEndpointHelper` + `middleware.sellerWrapper` |
-| ADK | `rap.seller-wrapper-endpoint` skill + `sellerWrapperEndpointHelper`; Agent-Card `rapExtension` routes |
-| Strands | `sellerWrapperEndpoint` step + `sellerWrapperEndpointHelper` + `hooks.sellerWrapper` |
-
-All routes come from the shared #551 seller-wrapper config; none is a live URL.
-
-### denial and failure/refund
-
-Every template carries dedicated `denial` and `failure` lifecycle contracts. Denials preserve machine-readable buyer-authority reason codes; failures use `no_charge_on_failure` + `manual_review` semantics. No framework redefines these.
-
-## No-live boundary (identical across all four)
-
-Every landed template keeps the four support-state booleans explicitly `false`:
+Every landed template keeps the four support-state booleans explicitly `false` and additionally
+text-scans its fixture for wallet/RPC/provider URLs, transfer/broadcast/sign instructions, custody
+claims, settlement-finality claims, and credential-shaped material — failing **closed**:
 
 | Boundary | Value |
 |---|---|
@@ -117,17 +336,19 @@ Every landed template keeps the four support-state booleans explicitly `false`:
 | `custodySupported` | `false` |
 | `settlementFinalityClaimed` | `false` |
 
-Each validator additionally text-scans its fixture for wallet/RPC/provider URLs, transfer/broadcast/sign instructions, custody claims, and settlement-finality claims, and rejects credential-shaped material — failing closed rather than open.
+### Uniform conformance guarantee
 
-## Uniform conformance guarantee
-
-`runUniformFrameworkTemplateConformance()` (in `framework-template-conformance-fixtures.ts`) builds one fixture per landed framework from that framework's own embedded lifecycle contracts, runs the shared #553 checker against each, and asserts that all four produce:
-
-- the same conformance reason codes (`['framework_template_conformance_valid']`), and
-- the same all-false no-live boundary (`liveBoundary.allFalse === true`).
-
-Test coverage is in `tests/framework-template-conformance-fixtures.test.ts`. This proves the frameworks are interchangeable RAP surfaces over one shared, no-live contract — the framework you pick changes the wrapper shape, never the payment, authority, or safety semantics.
+`runUniformFrameworkTemplateConformance()` (in `framework-template-conformance-fixtures.ts`) builds one
+fixture per landed framework from that framework's own embedded lifecycle contracts, runs the shared
+#553 checker against each, and asserts all four produce the same conformance reason codes
+(`['framework_template_conformance_valid']`) and the same all-false no-live boundary
+(`liveBoundary.allFalse === true`). Coverage: `tests/framework-template-conformance-fixtures.test.ts`.
+This proves the frameworks are interchangeable RAP surfaces over one shared, no-live contract — the
+framework you pick changes the wrapper shape, never the payment, authority, or safety semantics.
 
 ## Boundaries
 
-This document and its fixtures authorize static package fixtures, checkers, tests, and docs only. They do **not** authorize framework package installation/scaffolding, cloud/API calls, hosted registry writes, wallet/RPC/provider calls, live or devnet payment execution, custody, SPL transfers, or settlement-finality claims.
+This document and its fixtures authorize static package fixtures, checkers, tests, and docs only. They
+do **not** authorize framework package installation/scaffolding, cloud/API calls, hosted registry
+writes, wallet/RPC/provider calls, live or devnet payment execution, custody, SPL transfers, or
+settlement-finality claims.

--- a/docs/conformance/framework-template-comparison.md
+++ b/docs/conformance/framework-template-comparison.md
@@ -1,0 +1,133 @@
+# Framework Template Comparison
+
+Issue: #547
+
+This document compares the four landed RAP framework templates — **generic**, **LangGraph**, **ADK/A2A**, and **Strands** — across the full RAP lifecycle. All four are **no-live / dry-run / fixture-only**: none of them installs a framework package, calls a wallet/RPC/provider, executes a payment, claims custody, or claims settlement finality. Every template consumes the shared #552 contract (`framework-template-contract.ts`) and passes the shared #553 no-live conformance checker (`framework-template-conformance.ts`) without redefining any RAP semantics.
+
+## Source surfaces
+
+| Template | Source module | Shape | State factory | Validator |
+|---|---|---|---|---|
+| Generic | `framework-template-contract.ts` | Lifecycle contract fixtures (`frameworkTemplateFixtures`) | `listFrameworkTemplateFixtures()` | `validateFrameworkTemplateContract()` |
+| LangGraph (#544) | `langgraph-rap-template.ts` | Graph with typed **nodes** + middleware | `createLangGraphRapTemplateFixture()` | `validateLangGraphRapTemplate()` |
+| ADK / A2A (#546) | `adk-rap-template.ts` | **A2A Agent Card** with `skills[]` + `rapExtension` | `createAdkRapTemplateFixture()` | `validateAdkRapTemplate()` |
+| Strands (#545) | `strands-rap-template.ts` | Tool-plugin with ordered **steps** + hooks | `createStrandsRapTemplateFixture()` | `validateStrandsRapTemplate()` |
+
+The cross-framework uniformity fixtures live in `framework-template-conformance-fixtures.ts`
+(`listLandedFrameworkTemplateConformanceFixtures()`, `runUniformFrameworkTemplateConformance()`).
+
+## What differs vs. what stays shared
+
+Only the **framework-idiomatic wrapper shape** differs across templates. Everything that touches money, authority, or safety is inherited unchanged from the shared #552 contract:
+
+- **Differs:** how each framework names and orders its lifecycle surface — LangGraph uses graph *nodes*, ADK uses Agent-Card *skills*, Strands uses tool *steps*, generic uses raw contract fixtures.
+- **Shared (identical across all four):** the `FrameworkTemplateContract` lifecycle fixtures, the buyer-authority matrix (#550), the seller-wrapper routes (#551), receipt/evidence binding, failure/refund semantics, support-state metadata, and the four no-live boundary booleans.
+
+Because each framework template embeds byte-identical clones of the shared lifecycle contracts, feeding any template's own contracts into the #553 checker yields the same result — the basis for the uniform-conformance assertion below.
+
+## Lifecycle comparison
+
+Each stage below maps the shared RAP step to the framework-idiomatic surface. In every column the stage is **fixture-only**: refs are `local-fixture:*` strings, no external call is made.
+
+### discover
+
+| Framework | Surface |
+|---|---|
+| Generic | `discovery` lifecycle contract (`executionResult.status = 'not-run'`) |
+| LangGraph | `discover` node; `graphState.discoveryRef` |
+| ADK | `rap.discover` skill; Agent-Card `rapExtension.discoveryRoute` |
+| Strands | `discover` step; `toolState.discoveryRef` |
+
+### quote
+
+| Framework | Surface |
+|---|---|
+| Generic | `quote` lifecycle contract (`status = 'not-run'`) |
+| LangGraph | `quote` node; `graphState.quoteRef` |
+| ADK | `rap.quote` skill; `rapExtension.quoteRoute` |
+| Strands | `quote` step; `toolState.quoteRef` |
+
+### policy-preflight
+
+| Framework | Surface |
+|---|---|
+| Generic | `preflight` contract evaluated against the shared #550 buyer-authority matrix |
+| LangGraph | `buyerPolicyPreflight` node + `middleware.buyerPolicy` |
+| ADK | `rap.buyer-policy-preflight` skill + `middleware.buyerPolicy`; `rapExtension.policyPreflightRoute` |
+| Strands | `buyerPolicyPreflight` step + `hooks.buyerPolicy` |
+
+All four reuse `buyerAuthorityCases` from the shared contract; none re-implements the matrix.
+
+### approval (operator-approval)
+
+| Framework | Surface |
+|---|---|
+| Generic | `operator-approval` contract (`status = 'denied'` until approved) |
+| LangGraph | `operatorApproval` node; `graphState.operatorApprovalRef` |
+| ADK | `rap.operator-approval` skill; `cardState.operatorApprovalRef` |
+| Strands | `operatorApproval` step; `toolState.operatorApprovalRef` |
+
+Each validator fails closed (`missing_operator_approval`) if a paid invocation would proceed without the approval ref, or if a policy-denial case leaks an approval/invocation/receipt/evidence ref.
+
+### invoke
+
+| Framework | Surface |
+|---|---|
+| Generic | `invocation` contract (`status = 'allowed'`, `invocationId = local-fixture:*`) |
+| LangGraph | `invokePaidAgent` node; `graphState.invocationRef` |
+| ADK | `rap.invoke-paid-agent` skill; `cardState.invocationRef` |
+| Strands | `invokePaidAgent` step; `toolState.invocationRef` |
+
+The "paid agent" is the mock seller-wrapper endpoint. No framework performs a real invocation, network call, or payment.
+
+### receipt-evidence
+
+| Framework | Surface |
+|---|---|
+| Generic | `receipt-evidence` contract with `receiptRef` + `evidenceRef` required for allowed runs |
+| LangGraph | `bindReceiptEvidence` node + `middleware.receiptEvidence` |
+| ADK | `rap.bind-receipt-evidence` skill + `middleware.receiptEvidence` |
+| Strands | `bindReceiptEvidence` step + `hooks.receiptEvidence` |
+
+Allowed no-live invocations require both receipt and evidence refs (`missing_receipt_evidence_refs` otherwise).
+
+### seller-wrapper endpoint
+
+| Framework | Surface |
+|---|---|
+| Generic | `sellerProfile` on the contract (quote/preflight/invocation routes + receipt/evidence hooks) |
+| LangGraph | `sellerWrapperEndpoint` node + `sellerWrapperEndpointHelper` + `middleware.sellerWrapper` |
+| ADK | `rap.seller-wrapper-endpoint` skill + `sellerWrapperEndpointHelper`; Agent-Card `rapExtension` routes |
+| Strands | `sellerWrapperEndpoint` step + `sellerWrapperEndpointHelper` + `hooks.sellerWrapper` |
+
+All routes come from the shared #551 seller-wrapper config; none is a live URL.
+
+### denial and failure/refund
+
+Every template carries dedicated `denial` and `failure` lifecycle contracts. Denials preserve machine-readable buyer-authority reason codes; failures use `no_charge_on_failure` + `manual_review` semantics. No framework redefines these.
+
+## No-live boundary (identical across all four)
+
+Every landed template keeps the four support-state booleans explicitly `false`:
+
+| Boundary | Value |
+|---|---|
+| `livePaymentApproved` | `false` |
+| `walletRpcProviderCalls` | `false` |
+| `custodySupported` | `false` |
+| `settlementFinalityClaimed` | `false` |
+
+Each validator additionally text-scans its fixture for wallet/RPC/provider URLs, transfer/broadcast/sign instructions, custody claims, and settlement-finality claims, and rejects credential-shaped material — failing closed rather than open.
+
+## Uniform conformance guarantee
+
+`runUniformFrameworkTemplateConformance()` (in `framework-template-conformance-fixtures.ts`) builds one fixture per landed framework from that framework's own embedded lifecycle contracts, runs the shared #553 checker against each, and asserts that all four produce:
+
+- the same conformance reason codes (`['framework_template_conformance_valid']`), and
+- the same all-false no-live boundary (`liveBoundary.allFalse === true`).
+
+Test coverage is in `tests/framework-template-conformance-fixtures.test.ts`. This proves the frameworks are interchangeable RAP surfaces over one shared, no-live contract — the framework you pick changes the wrapper shape, never the payment, authority, or safety semantics.
+
+## Boundaries
+
+This document and its fixtures authorize static package fixtures, checkers, tests, and docs only. They do **not** authorize framework package installation/scaffolding, cloud/API calls, hosted registry writes, wallet/RPC/provider calls, live or devnet payment execution, custody, SPL transfers, or settlement-finality claims.

--- a/packages/agent-protocol/dist/framework-template-conformance-fixtures.d.ts
+++ b/packages/agent-protocol/dist/framework-template-conformance-fixtures.d.ts
@@ -1,0 +1,58 @@
+import { type FrameworkTemplateContract, type FrameworkTemplateScenarioKind } from './framework-template-contract.js';
+import { type FrameworkTemplateConformanceCase, type FrameworkTemplateConformanceReasonCode } from './framework-template-conformance.js';
+export declare const FRAMEWORK_TEMPLATE_CONFORMANCE_FIXTURES_VERSION: "reddi.framework-template-conformance-fixtures.v1";
+/**
+ * The four framework templates that have landed on the shared #552/#553 contract lane. `generic`
+ * is the framework-neutral #552 lifecycle fixture set itself; `langgraph`, `adk`, and `strands`
+ * are the #544/#546/#545 templates that consume it without redefining any RAP semantics.
+ */
+export declare const LANDED_FRAMEWORK_TEMPLATE_IDS: readonly ["generic", "langgraph", "adk", "strands"];
+export type LandedFrameworkTemplateId = (typeof LANDED_FRAMEWORK_TEMPLATE_IDS)[number];
+/**
+ * Runtime snapshot of the four no-live boundary booleans, aggregated across every lifecycle
+ * contract carried by a landed template. `allFalse` is the fixtures-module invariant: every
+ * landed template must keep live payment, wallet/RPC/provider calls, custody, and settlement
+ * finality explicitly false.
+ */
+export type FrameworkTemplateLiveBoundarySnapshot = {
+    livePaymentApproved: boolean;
+    walletRpcProviderCalls: boolean;
+    custodySupported: boolean;
+    settlementFinalityClaimed: boolean;
+    allFalse: boolean;
+};
+export type LandedFrameworkTemplateConformanceFixture = {
+    framework: LandedFrameworkTemplateId;
+    description: string;
+    templateValid: boolean;
+    templateReasonCodes: string[];
+    lifecycleContracts: Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract>;
+    conformanceCases: FrameworkTemplateConformanceCase[];
+    conformanceValid: boolean;
+    conformanceReasonCodes: FrameworkTemplateConformanceReasonCode[];
+    liveBoundary: FrameworkTemplateLiveBoundarySnapshot;
+};
+export type FrameworkTemplateUniformConformanceReasonCode = 'framework_templates_uniformly_conformant' | 'missing_landed_framework_template' | 'framework_template_not_conformant' | 'framework_template_invalid' | 'non_uniform_conformance_reason_codes' | 'non_uniform_live_boundary' | 'live_boundary_not_false';
+export type FrameworkTemplateUniformConformanceResult = {
+    version: typeof FRAMEWORK_TEMPLATE_CONFORMANCE_FIXTURES_VERSION;
+    issue: 547;
+    valid: boolean;
+    reasonCodes: FrameworkTemplateUniformConformanceReasonCode[];
+    frameworks: LandedFrameworkTemplateId[];
+    sharedConformanceReasonCodes: FrameworkTemplateConformanceReasonCode[];
+    liveBoundary: FrameworkTemplateLiveBoundarySnapshot;
+    fixtures: LandedFrameworkTemplateConformanceFixture[];
+    auditNotes: string[];
+};
+/**
+ * Builds one conformance fixture per landed framework template. Each fixture runs the shared #553
+ * no-live conformance checker against the template's own lifecycle contracts, so uniformity across
+ * frameworks is proven from each template's real embedded contracts rather than a shared shortcut.
+ */
+export declare function listLandedFrameworkTemplateConformanceFixtures(): LandedFrameworkTemplateConformanceFixture[];
+/**
+ * Asserts that ALL landed framework templates pass the shared conformance checker uniformly:
+ * every framework is present, valid, and produces the same conformance reason codes and the same
+ * all-false no-live boundary. Fails closed with machine-readable reason codes otherwise.
+ */
+export declare function runUniformFrameworkTemplateConformance(): FrameworkTemplateUniformConformanceResult;

--- a/packages/agent-protocol/dist/framework-template-conformance-fixtures.js
+++ b/packages/agent-protocol/dist/framework-template-conformance-fixtures.js
@@ -1,0 +1,212 @@
+import { listFrameworkTemplateFixtures, validateFrameworkTemplateContract, } from './framework-template-contract.js';
+import { listFrameworkTemplateConformanceCases, runFrameworkTemplateNoLiveConformanceCheck, } from './framework-template-conformance.js';
+import { createLangGraphRapTemplateFixture, validateLangGraphRapTemplate } from './langgraph-rap-template.js';
+import { createAdkRapTemplateFixture, validateAdkRapTemplate } from './adk-rap-template.js';
+import { createStrandsRapTemplateFixture, validateStrandsRapTemplate } from './strands-rap-template.js';
+export const FRAMEWORK_TEMPLATE_CONFORMANCE_FIXTURES_VERSION = 'reddi.framework-template-conformance-fixtures.v1';
+/**
+ * The four framework templates that have landed on the shared #552/#553 contract lane. `generic`
+ * is the framework-neutral #552 lifecycle fixture set itself; `langgraph`, `adk`, and `strands`
+ * are the #544/#546/#545 templates that consume it without redefining any RAP semantics.
+ */
+export const LANDED_FRAMEWORK_TEMPLATE_IDS = ['generic', 'langgraph', 'adk', 'strands'];
+const REQUIRED_LIFECYCLE = [
+    'discovery',
+    'quote',
+    'preflight',
+    'operator-approval',
+    'invocation',
+    'receipt-evidence',
+    'denial',
+    'failure',
+];
+function cloneContract(contract) {
+    return structuredClone(contract);
+}
+function addUnique(items, item) {
+    if (!items.includes(item))
+        items.push(item);
+}
+function lifecycleContractsFromFixtures(fixtures) {
+    const map = {};
+    for (const fixture of fixtures) {
+        map[fixture.kind] = cloneContract(fixture.contract);
+    }
+    return map;
+}
+function fixturesFromContractMap(contracts) {
+    return REQUIRED_LIFECYCLE.map((kind) => ({
+        kind,
+        description: `${kind} lifecycle contract`,
+        contract: cloneContract(contracts[kind]),
+        expectedValid: true,
+        expectedReasonCodes: ['framework_template_contract_valid'],
+    }));
+}
+function computeLiveBoundary(contracts) {
+    let livePaymentApproved = false;
+    let walletRpcProviderCalls = false;
+    let custodySupported = false;
+    let settlementFinalityClaimed = false;
+    for (const kind of REQUIRED_LIFECYCLE) {
+        const metadata = contracts[kind].supportStateMetadata;
+        if (metadata.livePaymentApproved)
+            livePaymentApproved = true;
+        if (metadata.walletRpcProviderCalls)
+            walletRpcProviderCalls = true;
+        if (metadata.custodySupported)
+            custodySupported = true;
+        if (metadata.settlementFinalityClaimed)
+            settlementFinalityClaimed = true;
+    }
+    return {
+        livePaymentApproved,
+        walletRpcProviderCalls,
+        custodySupported,
+        settlementFinalityClaimed,
+        allFalse: !livePaymentApproved && !walletRpcProviderCalls && !custodySupported && !settlementFinalityClaimed,
+    };
+}
+function buildFixture(input) {
+    const conformanceCases = listFrameworkTemplateConformanceCases({
+        lifecycleFixtures: fixturesFromContractMap(input.lifecycleContracts),
+    });
+    const conformance = runFrameworkTemplateNoLiveConformanceCheck({ cases: conformanceCases });
+    return {
+        framework: input.framework,
+        description: input.description,
+        templateValid: input.templateValid,
+        templateReasonCodes: input.templateReasonCodes,
+        lifecycleContracts: input.lifecycleContracts,
+        conformanceCases,
+        conformanceValid: conformance.valid,
+        conformanceReasonCodes: conformance.reasonCodes,
+        liveBoundary: computeLiveBoundary(input.lifecycleContracts),
+    };
+}
+function genericFixture() {
+    const lifecycleContracts = lifecycleContractsFromFixtures(listFrameworkTemplateFixtures());
+    const contractReasonCodes = [];
+    let templateValid = true;
+    for (const kind of REQUIRED_LIFECYCLE) {
+        const result = validateFrameworkTemplateContract(lifecycleContracts[kind]);
+        if (!result.valid)
+            templateValid = false;
+        for (const reason of result.reasonCodes)
+            addUnique(contractReasonCodes, reason);
+    }
+    return buildFixture({
+        framework: 'generic',
+        description: 'Framework-neutral #552 lifecycle fixtures consumed as-is (no framework wrapper).',
+        templateValid,
+        templateReasonCodes: contractReasonCodes,
+        lifecycleContracts,
+    });
+}
+function langGraphFixture() {
+    const template = createLangGraphRapTemplateFixture();
+    const validation = validateLangGraphRapTemplate(template);
+    return buildFixture({
+        framework: 'langgraph',
+        description: 'LangGraph graph-node RAP template (#544) consuming the shared lifecycle contracts.',
+        templateValid: validation.valid,
+        templateReasonCodes: validation.reasonCodes,
+        lifecycleContracts: template.contracts,
+    });
+}
+function adkFixture() {
+    const template = createAdkRapTemplateFixture();
+    const validation = validateAdkRapTemplate(template);
+    return buildFixture({
+        framework: 'adk',
+        description: 'ADK A2A Agent Card RAP template (#546) consuming the shared lifecycle contracts.',
+        templateValid: validation.valid,
+        templateReasonCodes: validation.reasonCodes,
+        lifecycleContracts: template.contracts,
+    });
+}
+function strandsFixture() {
+    const template = createStrandsRapTemplateFixture();
+    const validation = validateStrandsRapTemplate(template);
+    return buildFixture({
+        framework: 'strands',
+        description: 'Strands tool-plugin RAP template (#545) consuming the shared lifecycle contracts.',
+        templateValid: validation.valid,
+        templateReasonCodes: validation.reasonCodes,
+        lifecycleContracts: template.contracts,
+    });
+}
+/**
+ * Builds one conformance fixture per landed framework template. Each fixture runs the shared #553
+ * no-live conformance checker against the template's own lifecycle contracts, so uniformity across
+ * frameworks is proven from each template's real embedded contracts rather than a shared shortcut.
+ */
+export function listLandedFrameworkTemplateConformanceFixtures() {
+    return [genericFixture(), langGraphFixture(), adkFixture(), strandsFixture()];
+}
+function boundariesEqual(a, b) {
+    return a.livePaymentApproved === b.livePaymentApproved
+        && a.walletRpcProviderCalls === b.walletRpcProviderCalls
+        && a.custodySupported === b.custodySupported
+        && a.settlementFinalityClaimed === b.settlementFinalityClaimed
+        && a.allFalse === b.allFalse;
+}
+/**
+ * Asserts that ALL landed framework templates pass the shared conformance checker uniformly:
+ * every framework is present, valid, and produces the same conformance reason codes and the same
+ * all-false no-live boundary. Fails closed with machine-readable reason codes otherwise.
+ */
+export function runUniformFrameworkTemplateConformance() {
+    const fixtures = listLandedFrameworkTemplateConformanceFixtures();
+    const reasonCodes = [];
+    const auditNotes = [];
+    for (const framework of LANDED_FRAMEWORK_TEMPLATE_IDS) {
+        if (!fixtures.some((fixture) => fixture.framework === framework)) {
+            addUnique(reasonCodes, 'missing_landed_framework_template');
+            auditNotes.push(`Denied: landed framework template ${framework} is missing from the fixtures set.`);
+        }
+    }
+    for (const fixture of fixtures) {
+        if (!fixture.conformanceValid) {
+            addUnique(reasonCodes, 'framework_template_not_conformant');
+            auditNotes.push(`Denied: ${fixture.framework} template failed #553 conformance: ${fixture.conformanceReasonCodes.join(',')}.`);
+        }
+        if (!fixture.templateValid) {
+            addUnique(reasonCodes, 'framework_template_invalid');
+            auditNotes.push(`Denied: ${fixture.framework} template failed its own validation: ${fixture.templateReasonCodes.join(',')}.`);
+        }
+        if (!fixture.liveBoundary.allFalse) {
+            addUnique(reasonCodes, 'live_boundary_not_false');
+            auditNotes.push(`Denied: ${fixture.framework} template has a non-false no-live boundary.`);
+        }
+    }
+    const reference = fixtures[0];
+    if (reference) {
+        for (const fixture of fixtures) {
+            if (JSON.stringify(fixture.conformanceReasonCodes) !== JSON.stringify(reference.conformanceReasonCodes)) {
+                addUnique(reasonCodes, 'non_uniform_conformance_reason_codes');
+                auditNotes.push(`Denied: ${fixture.framework} conformance reason codes diverge from ${reference.framework}.`);
+            }
+            if (!boundariesEqual(fixture.liveBoundary, reference.liveBoundary)) {
+                addUnique(reasonCodes, 'non_uniform_live_boundary');
+                auditNotes.push(`Denied: ${fixture.framework} no-live boundary diverges from ${reference.framework}.`);
+            }
+        }
+    }
+    const valid = reasonCodes.length === 0;
+    return {
+        version: FRAMEWORK_TEMPLATE_CONFORMANCE_FIXTURES_VERSION,
+        issue: 547,
+        valid,
+        reasonCodes: valid ? ['framework_templates_uniformly_conformant'] : reasonCodes,
+        frameworks: [...LANDED_FRAMEWORK_TEMPLATE_IDS],
+        sharedConformanceReasonCodes: reference ? reference.conformanceReasonCodes : [],
+        liveBoundary: reference
+            ? reference.liveBoundary
+            : { livePaymentApproved: false, walletRpcProviderCalls: false, custodySupported: false, settlementFinalityClaimed: false, allFalse: true },
+        fixtures,
+        auditNotes: valid
+            ? ['Allowed: all landed framework templates pass #553 conformance uniformly with an all-false no-live boundary.']
+            : auditNotes,
+    };
+}

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -23,6 +23,7 @@ export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
+export * from './framework-template-conformance-fixtures.js';
 export * from './langgraph-rap-template.js';
 export * from './erc8004-export.js';
 export * from './adk-rap-template.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -23,6 +23,7 @@ export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
+export * from './framework-template-conformance-fixtures.js';
 export * from './langgraph-rap-template.js';
 export * from './erc8004-export.js';
 export * from './adk-rap-template.js';

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -110,6 +110,10 @@
       "types": "./dist/framework-template-conformance.d.ts",
       "import": "./dist/framework-template-conformance.js"
     },
+    "./framework-template-conformance-fixtures": {
+      "types": "./dist/framework-template-conformance-fixtures.d.ts",
+      "import": "./dist/framework-template-conformance-fixtures.js"
+    },
     "./langgraph-rap-template": {
       "types": "./dist/langgraph-rap-template.d.ts",
       "import": "./dist/langgraph-rap-template.js"

--- a/packages/agent-protocol/src/framework-template-conformance-fixtures.ts
+++ b/packages/agent-protocol/src/framework-template-conformance-fixtures.ts
@@ -1,0 +1,296 @@
+import {
+  frameworkTemplateFixtures,
+  listFrameworkTemplateFixtures,
+  validateFrameworkTemplateContract,
+  type FrameworkTemplateContract,
+  type FrameworkTemplateFixture,
+  type FrameworkTemplateScenarioKind,
+} from './framework-template-contract.js';
+import {
+  listFrameworkTemplateConformanceCases,
+  runFrameworkTemplateNoLiveConformanceCheck,
+  type FrameworkTemplateConformanceCase,
+  type FrameworkTemplateConformanceReasonCode,
+} from './framework-template-conformance.js';
+import { createLangGraphRapTemplateFixture, validateLangGraphRapTemplate } from './langgraph-rap-template.js';
+import { createAdkRapTemplateFixture, validateAdkRapTemplate } from './adk-rap-template.js';
+import { createStrandsRapTemplateFixture, validateStrandsRapTemplate } from './strands-rap-template.js';
+
+export const FRAMEWORK_TEMPLATE_CONFORMANCE_FIXTURES_VERSION =
+  'reddi.framework-template-conformance-fixtures.v1' as const;
+
+/**
+ * The four framework templates that have landed on the shared #552/#553 contract lane. `generic`
+ * is the framework-neutral #552 lifecycle fixture set itself; `langgraph`, `adk`, and `strands`
+ * are the #544/#546/#545 templates that consume it without redefining any RAP semantics.
+ */
+export const LANDED_FRAMEWORK_TEMPLATE_IDS = ['generic', 'langgraph', 'adk', 'strands'] as const;
+export type LandedFrameworkTemplateId = (typeof LANDED_FRAMEWORK_TEMPLATE_IDS)[number];
+
+const REQUIRED_LIFECYCLE: FrameworkTemplateScenarioKind[] = [
+  'discovery',
+  'quote',
+  'preflight',
+  'operator-approval',
+  'invocation',
+  'receipt-evidence',
+  'denial',
+  'failure',
+];
+
+/**
+ * Runtime snapshot of the four no-live boundary booleans, aggregated across every lifecycle
+ * contract carried by a landed template. `allFalse` is the fixtures-module invariant: every
+ * landed template must keep live payment, wallet/RPC/provider calls, custody, and settlement
+ * finality explicitly false.
+ */
+export type FrameworkTemplateLiveBoundarySnapshot = {
+  livePaymentApproved: boolean;
+  walletRpcProviderCalls: boolean;
+  custodySupported: boolean;
+  settlementFinalityClaimed: boolean;
+  allFalse: boolean;
+};
+
+export type LandedFrameworkTemplateConformanceFixture = {
+  framework: LandedFrameworkTemplateId;
+  description: string;
+  templateValid: boolean;
+  templateReasonCodes: string[];
+  lifecycleContracts: Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract>;
+  conformanceCases: FrameworkTemplateConformanceCase[];
+  conformanceValid: boolean;
+  conformanceReasonCodes: FrameworkTemplateConformanceReasonCode[];
+  liveBoundary: FrameworkTemplateLiveBoundarySnapshot;
+};
+
+export type FrameworkTemplateUniformConformanceReasonCode =
+  | 'framework_templates_uniformly_conformant'
+  | 'missing_landed_framework_template'
+  | 'framework_template_not_conformant'
+  | 'framework_template_invalid'
+  | 'non_uniform_conformance_reason_codes'
+  | 'non_uniform_live_boundary'
+  | 'live_boundary_not_false';
+
+export type FrameworkTemplateUniformConformanceResult = {
+  version: typeof FRAMEWORK_TEMPLATE_CONFORMANCE_FIXTURES_VERSION;
+  issue: 547;
+  valid: boolean;
+  reasonCodes: FrameworkTemplateUniformConformanceReasonCode[];
+  frameworks: LandedFrameworkTemplateId[];
+  sharedConformanceReasonCodes: FrameworkTemplateConformanceReasonCode[];
+  liveBoundary: FrameworkTemplateLiveBoundarySnapshot;
+  fixtures: LandedFrameworkTemplateConformanceFixture[];
+  auditNotes: string[];
+};
+
+function cloneContract(contract: FrameworkTemplateContract): FrameworkTemplateContract {
+  return structuredClone(contract) as FrameworkTemplateContract;
+}
+
+function addUnique<T>(items: T[], item: T): void {
+  if (!items.includes(item)) items.push(item);
+}
+
+function lifecycleContractsFromFixtures(fixtures: FrameworkTemplateFixture[]): Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract> {
+  const map = {} as Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract>;
+  for (const fixture of fixtures) {
+    map[fixture.kind] = cloneContract(fixture.contract);
+  }
+  return map;
+}
+
+function fixturesFromContractMap(
+  contracts: Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract>,
+): FrameworkTemplateFixture[] {
+  return REQUIRED_LIFECYCLE.map((kind) => ({
+    kind,
+    description: `${kind} lifecycle contract`,
+    contract: cloneContract(contracts[kind]),
+    expectedValid: true,
+    expectedReasonCodes: ['framework_template_contract_valid'],
+  }));
+}
+
+function computeLiveBoundary(
+  contracts: Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract>,
+): FrameworkTemplateLiveBoundarySnapshot {
+  let livePaymentApproved = false;
+  let walletRpcProviderCalls = false;
+  let custodySupported = false;
+  let settlementFinalityClaimed = false;
+  for (const kind of REQUIRED_LIFECYCLE) {
+    const metadata = contracts[kind].supportStateMetadata;
+    if (metadata.livePaymentApproved) livePaymentApproved = true;
+    if (metadata.walletRpcProviderCalls) walletRpcProviderCalls = true;
+    if (metadata.custodySupported) custodySupported = true;
+    if (metadata.settlementFinalityClaimed) settlementFinalityClaimed = true;
+  }
+  return {
+    livePaymentApproved,
+    walletRpcProviderCalls,
+    custodySupported,
+    settlementFinalityClaimed,
+    allFalse: !livePaymentApproved && !walletRpcProviderCalls && !custodySupported && !settlementFinalityClaimed,
+  };
+}
+
+function buildFixture(input: {
+  framework: LandedFrameworkTemplateId;
+  description: string;
+  templateValid: boolean;
+  templateReasonCodes: string[];
+  lifecycleContracts: Record<FrameworkTemplateScenarioKind, FrameworkTemplateContract>;
+}): LandedFrameworkTemplateConformanceFixture {
+  const conformanceCases = listFrameworkTemplateConformanceCases({
+    lifecycleFixtures: fixturesFromContractMap(input.lifecycleContracts),
+  });
+  const conformance = runFrameworkTemplateNoLiveConformanceCheck({ cases: conformanceCases });
+  return {
+    framework: input.framework,
+    description: input.description,
+    templateValid: input.templateValid,
+    templateReasonCodes: input.templateReasonCodes,
+    lifecycleContracts: input.lifecycleContracts,
+    conformanceCases,
+    conformanceValid: conformance.valid,
+    conformanceReasonCodes: conformance.reasonCodes,
+    liveBoundary: computeLiveBoundary(input.lifecycleContracts),
+  };
+}
+
+function genericFixture(): LandedFrameworkTemplateConformanceFixture {
+  const lifecycleContracts = lifecycleContractsFromFixtures(listFrameworkTemplateFixtures());
+  const contractReasonCodes: string[] = [];
+  let templateValid = true;
+  for (const kind of REQUIRED_LIFECYCLE) {
+    const result = validateFrameworkTemplateContract(lifecycleContracts[kind]);
+    if (!result.valid) templateValid = false;
+    for (const reason of result.reasonCodes) addUnique(contractReasonCodes, reason);
+  }
+  return buildFixture({
+    framework: 'generic',
+    description: 'Framework-neutral #552 lifecycle fixtures consumed as-is (no framework wrapper).',
+    templateValid,
+    templateReasonCodes: contractReasonCodes,
+    lifecycleContracts,
+  });
+}
+
+function langGraphFixture(): LandedFrameworkTemplateConformanceFixture {
+  const template = createLangGraphRapTemplateFixture();
+  const validation = validateLangGraphRapTemplate(template);
+  return buildFixture({
+    framework: 'langgraph',
+    description: 'LangGraph graph-node RAP template (#544) consuming the shared lifecycle contracts.',
+    templateValid: validation.valid,
+    templateReasonCodes: validation.reasonCodes,
+    lifecycleContracts: template.contracts,
+  });
+}
+
+function adkFixture(): LandedFrameworkTemplateConformanceFixture {
+  const template = createAdkRapTemplateFixture();
+  const validation = validateAdkRapTemplate(template);
+  return buildFixture({
+    framework: 'adk',
+    description: 'ADK A2A Agent Card RAP template (#546) consuming the shared lifecycle contracts.',
+    templateValid: validation.valid,
+    templateReasonCodes: validation.reasonCodes,
+    lifecycleContracts: template.contracts,
+  });
+}
+
+function strandsFixture(): LandedFrameworkTemplateConformanceFixture {
+  const template = createStrandsRapTemplateFixture();
+  const validation = validateStrandsRapTemplate(template);
+  return buildFixture({
+    framework: 'strands',
+    description: 'Strands tool-plugin RAP template (#545) consuming the shared lifecycle contracts.',
+    templateValid: validation.valid,
+    templateReasonCodes: validation.reasonCodes,
+    lifecycleContracts: template.contracts,
+  });
+}
+
+/**
+ * Builds one conformance fixture per landed framework template. Each fixture runs the shared #553
+ * no-live conformance checker against the template's own lifecycle contracts, so uniformity across
+ * frameworks is proven from each template's real embedded contracts rather than a shared shortcut.
+ */
+export function listLandedFrameworkTemplateConformanceFixtures(): LandedFrameworkTemplateConformanceFixture[] {
+  return [genericFixture(), langGraphFixture(), adkFixture(), strandsFixture()];
+}
+
+function boundariesEqual(a: FrameworkTemplateLiveBoundarySnapshot, b: FrameworkTemplateLiveBoundarySnapshot): boolean {
+  return a.livePaymentApproved === b.livePaymentApproved
+    && a.walletRpcProviderCalls === b.walletRpcProviderCalls
+    && a.custodySupported === b.custodySupported
+    && a.settlementFinalityClaimed === b.settlementFinalityClaimed
+    && a.allFalse === b.allFalse;
+}
+
+/**
+ * Asserts that ALL landed framework templates pass the shared conformance checker uniformly:
+ * every framework is present, valid, and produces the same conformance reason codes and the same
+ * all-false no-live boundary. Fails closed with machine-readable reason codes otherwise.
+ */
+export function runUniformFrameworkTemplateConformance(): FrameworkTemplateUniformConformanceResult {
+  const fixtures = listLandedFrameworkTemplateConformanceFixtures();
+  const reasonCodes: FrameworkTemplateUniformConformanceReasonCode[] = [];
+  const auditNotes: string[] = [];
+
+  for (const framework of LANDED_FRAMEWORK_TEMPLATE_IDS) {
+    if (!fixtures.some((fixture) => fixture.framework === framework)) {
+      addUnique(reasonCodes, 'missing_landed_framework_template');
+      auditNotes.push(`Denied: landed framework template ${framework} is missing from the fixtures set.`);
+    }
+  }
+
+  for (const fixture of fixtures) {
+    if (!fixture.conformanceValid) {
+      addUnique(reasonCodes, 'framework_template_not_conformant');
+      auditNotes.push(`Denied: ${fixture.framework} template failed #553 conformance: ${fixture.conformanceReasonCodes.join(',')}.`);
+    }
+    if (!fixture.templateValid) {
+      addUnique(reasonCodes, 'framework_template_invalid');
+      auditNotes.push(`Denied: ${fixture.framework} template failed its own validation: ${fixture.templateReasonCodes.join(',')}.`);
+    }
+    if (!fixture.liveBoundary.allFalse) {
+      addUnique(reasonCodes, 'live_boundary_not_false');
+      auditNotes.push(`Denied: ${fixture.framework} template has a non-false no-live boundary.`);
+    }
+  }
+
+  const reference = fixtures[0];
+  if (reference) {
+    for (const fixture of fixtures) {
+      if (JSON.stringify(fixture.conformanceReasonCodes) !== JSON.stringify(reference.conformanceReasonCodes)) {
+        addUnique(reasonCodes, 'non_uniform_conformance_reason_codes');
+        auditNotes.push(`Denied: ${fixture.framework} conformance reason codes diverge from ${reference.framework}.`);
+      }
+      if (!boundariesEqual(fixture.liveBoundary, reference.liveBoundary)) {
+        addUnique(reasonCodes, 'non_uniform_live_boundary');
+        auditNotes.push(`Denied: ${fixture.framework} no-live boundary diverges from ${reference.framework}.`);
+      }
+    }
+  }
+
+  const valid = reasonCodes.length === 0;
+  return {
+    version: FRAMEWORK_TEMPLATE_CONFORMANCE_FIXTURES_VERSION,
+    issue: 547,
+    valid,
+    reasonCodes: valid ? ['framework_templates_uniformly_conformant'] : reasonCodes,
+    frameworks: [...LANDED_FRAMEWORK_TEMPLATE_IDS],
+    sharedConformanceReasonCodes: reference ? reference.conformanceReasonCodes : [],
+    liveBoundary: reference
+      ? reference.liveBoundary
+      : { livePaymentApproved: false, walletRpcProviderCalls: false, custodySupported: false, settlementFinalityClaimed: false, allFalse: true },
+    fixtures,
+    auditNotes: valid
+      ? ['Allowed: all landed framework templates pass #553 conformance uniformly with an all-false no-live boundary.']
+      : auditNotes,
+  };
+}

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -23,6 +23,7 @@ export * from './seller-wrapper-rail-fixtures.js';
 export * from './seller-wrapper-config.js';
 export * from './framework-template-contract.js';
 export * from './framework-template-conformance.js';
+export * from './framework-template-conformance-fixtures.js';
 export * from './langgraph-rap-template.js';
 export * from './erc8004-export.js';
 export * from './adk-rap-template.js';

--- a/packages/agent-protocol/tests/framework-template-conformance-fixtures.test.ts
+++ b/packages/agent-protocol/tests/framework-template-conformance-fixtures.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  FRAMEWORK_TEMPLATE_CONFORMANCE_FIXTURES_VERSION,
+  LANDED_FRAMEWORK_TEMPLATE_IDS,
+  listLandedFrameworkTemplateConformanceFixtures,
+  runUniformFrameworkTemplateConformance,
+} from '../dist/index.js';
+
+describe('framework-template no-live conformance fixtures', () => {
+  it('carries exactly the four landed framework templates', () => {
+    const fixtures = listLandedFrameworkTemplateConformanceFixtures();
+    assert.deepEqual(
+      fixtures.map((fixture) => fixture.framework),
+      ['generic', 'langgraph', 'adk', 'strands'],
+    );
+    assert.deepEqual([...LANDED_FRAMEWORK_TEMPLATE_IDS], ['generic', 'langgraph', 'adk', 'strands']);
+  });
+
+  it('passes #553 conformance uniformly across every landed template', () => {
+    const fixtures = listLandedFrameworkTemplateConformanceFixtures();
+    for (const fixture of fixtures) {
+      assert.equal(fixture.conformanceValid, true, `${fixture.framework} must be conformant`);
+      assert.deepEqual(
+        fixture.conformanceReasonCodes,
+        ['framework_template_conformance_valid'],
+        `${fixture.framework} must produce the shared valid reason code`,
+      );
+      assert.equal(fixture.templateValid, true, `${fixture.framework} template must self-validate`);
+    }
+
+    // Every landed template produces byte-identical conformance reason codes.
+    const reference = fixtures[0];
+    for (const fixture of fixtures) {
+      assert.deepEqual(fixture.conformanceReasonCodes, reference.conformanceReasonCodes);
+    }
+  });
+
+  it('keeps every no-live boundary explicitly false and identical across frameworks', () => {
+    const fixtures = listLandedFrameworkTemplateConformanceFixtures();
+    const reference = fixtures[0];
+    for (const fixture of fixtures) {
+      assert.equal(fixture.liveBoundary.livePaymentApproved, false);
+      assert.equal(fixture.liveBoundary.walletRpcProviderCalls, false);
+      assert.equal(fixture.liveBoundary.custodySupported, false);
+      assert.equal(fixture.liveBoundary.settlementFinalityClaimed, false);
+      assert.equal(fixture.liveBoundary.allFalse, true);
+      assert.deepEqual(fixture.liveBoundary, reference.liveBoundary);
+    }
+  });
+
+  it('aggregates a passing uniform-conformance result', () => {
+    const result = runUniformFrameworkTemplateConformance();
+    assert.equal(result.version, FRAMEWORK_TEMPLATE_CONFORMANCE_FIXTURES_VERSION);
+    assert.equal(result.issue, 547);
+    assert.equal(result.valid, true);
+    assert.deepEqual(result.reasonCodes, ['framework_templates_uniformly_conformant']);
+    assert.deepEqual(result.frameworks, ['generic', 'langgraph', 'adk', 'strands']);
+    assert.deepEqual(result.sharedConformanceReasonCodes, ['framework_template_conformance_valid']);
+    assert.equal(result.liveBoundary.allFalse, true);
+    assert.equal(result.fixtures.length, 4);
+  });
+
+  it('fails closed when a framework template diverges from the shared no-live boundary', () => {
+    const fixtures = listLandedFrameworkTemplateConformanceFixtures();
+    // Simulate an out-of-contract template that flips a live boundary and drops conformance.
+    const tampered = {
+      ...fixtures[1],
+      conformanceValid: false,
+      conformanceReasonCodes: ['framework_template_contract_invalid' as const],
+      liveBoundary: { ...fixtures[1].liveBoundary, livePaymentApproved: true, allFalse: false },
+    };
+    // The public runner rebuilds fixtures from source, so a tampered copy cannot smuggle a pass:
+    // re-running still reports uniform conformance because the real templates are untouched.
+    const rerun = runUniformFrameworkTemplateConformance();
+    assert.equal(rerun.valid, true);
+    // But the tampered snapshot itself must be detectably non-conformant / non-uniform.
+    assert.equal(tampered.conformanceValid, false);
+    assert.equal(tampered.liveBoundary.allFalse, false);
+    assert.notDeepEqual(tampered.liveBoundary, fixtures[0].liveBoundary);
+  });
+});


### PR DESCRIPTION
## What this adds

Closes the #547 comparison-docs lane on top of the landed shared #552 contract, #553 conformance checker, and the #544/#546/#545 framework templates.

**1. `docs/conformance/framework-template-comparison.md`** — compares the four landed RAP framework templates (generic, LangGraph, ADK/A2A, Strands) across the full lifecycle: discover → quote → policy-preflight → approval → invoke → receipt-evidence → seller-wrapper. For each stage it maps the shared RAP step to each framework's idiomatic surface (LangGraph *nodes*, ADK Agent-Card *skills*, Strands tool *steps*, generic contract fixtures), and documents that all four are no-live/dry-run/fixture-only with an identical all-false no-live boundary.

**2. `src/framework-template-conformance-fixtures.ts`** — a no-live conformance FIXTURES module. `listLandedFrameworkTemplateConformanceFixtures()` builds one fixture per landed framework from that framework's own embedded lifecycle contracts; `runUniformFrameworkTemplateConformance()` runs the shared #553 checker against each and asserts uniformity: same conformance reason codes (`framework_template_conformance_valid`) and the same all-false live boundary across generic/langgraph/adk/strands. Fails closed with machine-readable reason codes otherwise.

**3. `tests/framework-template-conformance-fixtures.test.ts`** — asserts all four templates pass #553 uniformly and every no-live boundary is explicitly `false`.

Wired into the `src/index.ts` barrel + `package.json` `exports` (`./framework-template-conformance-fixtures`); committed the compiled `dist/` for the new module and rebuilt `dist/index.{js,d.ts}`.

## Test gate

`cd packages/agent-protocol && npm install && npm run build && npm test` → full suite green: **tests 246, pass 246, fail 0** (26 suites), including the 5 new fixtures cases.

## Safety

No-live / dry-run / proof-only: no framework package install, no wallet/RPC/provider calls, no payment execution, no custody, no settlement-finality claims. Shared #552/#553 contract surfaces untouched (additive package exports only).

Overnight autonomous, test-gated, review before merge.