### PR TITLE
feat(agent-protocol): npm publication readiness + exports-resolution guard (#521)

### DIFF
--- a/.github/workflows/rap-package-guard.yml
+++ b/.github/workflows/rap-package-guard.yml
@@ -1,0 +1,38 @@
+name: RAP Package Publication Guard
+
+on:
+  pull_request:
+    paths:
+      - "packages/agent-protocol/**"
+  workflow_dispatch:
+
+jobs:
+  rap-package-guard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: packages/agent-protocol/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: packages/agent-protocol
+
+      - name: Build
+        run: npm run build
+        working-directory: packages/agent-protocol
+
+      - name: Test
+        run: npm test
+        working-directory: packages/agent-protocol
+
+      - name: Verify package exports resolution
+        run: node scripts/check-package-exports.mjs
+        working-directory: packages/agent-protocol

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -148,7 +148,9 @@
     "test": "npm run build && tsc -p tsconfig.test.json && node --test dist-tests/*.test.js",
     "example:buyer-seller:dry-run": "npm run build && node examples/buyer-seller-dry-run.mjs",
     "example:ard:no-spend": "npm run build && node examples/ard-no-spend-demo.mjs",
-    "release:dry-run": "npm run clean && npm run build && npm test && npm pack --dry-run"
+    "check:exports": "node scripts/check-package-exports.mjs",
+    "prepublishOnly": "npm run build && node scripts/check-package-exports.mjs",
+    "release:dry-run": "npm run clean && npm run build && npm test && node scripts/check-package-exports.mjs && npm pack --dry-run"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/agent-protocol/scripts/check-package-exports.mjs
+++ b/packages/agent-protocol/scripts/check-package-exports.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// check-package-exports.mjs
+//
+// npm publication readiness guard.
+//
+// Root-cause fix for a defect where a change could commit source but not the
+// compiled dist/, leaving package.json "exports" pointing at files that do not
+// exist. A publish would then ship broken subpaths (e.g. `import ... from
+// "@reddi/agent-protocol/receipts"` resolving to a missing ./dist/receipts.js),
+// and the ordinary test suite would stay green because it imports from dist via
+// paths TypeScript happens to have emitted for the modules under test.
+//
+// This script reads package.json "exports" (plus top-level "main"/"types") and
+// asserts EVERY declared target file exists on disk. It is meant to run AFTER
+// `npm run build`. Node built-ins only, no dependencies, fully offline.
+//
+// Exit 0 when every target resolves; non-zero with a clear listing otherwise.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const pkgDir = resolve(scriptDir, '..');
+const pkgPath = join(pkgDir, 'package.json');
+
+/** Collected problems: { source, target, resolved } */
+const missing = [];
+/** Every (source -> resolved) pair we verified, for the success summary. */
+let checkedCount = 0;
+
+function resolveTarget(relTarget) {
+  // Exports/main/types targets are package-relative POSIX-ish paths like
+  // "./dist/receipts.js". resolve() normalises them against the package dir.
+  return resolve(pkgDir, relTarget);
+}
+
+function checkTarget(source, relTarget) {
+  if (typeof relTarget !== 'string') {
+    missing.push({
+      source,
+      target: String(relTarget),
+      resolved: '(not a string target)',
+    });
+    return;
+  }
+  const resolved = resolveTarget(relTarget);
+  checkedCount += 1;
+  if (!existsSync(resolved)) {
+    missing.push({ source, target: relTarget, resolved });
+  }
+}
+
+function main() {
+  if (!existsSync(pkgPath)) {
+    console.error(`check-package-exports: cannot find package.json at ${pkgPath}`);
+    process.exit(1);
+  }
+
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  } catch (err) {
+    console.error(`check-package-exports: package.json is not valid JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  // 1. Top-level "main" and "types" must resolve.
+  if (typeof pkg.main === 'string') {
+    checkTarget('main', pkg.main);
+  }
+  if (typeof pkg.types === 'string') {
+    checkTarget('types', pkg.types);
+  }
+
+  // 2. Every "exports" subpath: assert each "types" and "import" (and any other
+  //    string condition, e.g. "require"/"default", or a bare string target)
+  //    points at an existing file.
+  const exportsField = pkg.exports;
+  if (exportsField && typeof exportsField === 'object') {
+    for (const [subpath, entry] of Object.entries(exportsField)) {
+      if (typeof entry === 'string') {
+        // e.g. "./package.json": "./package.json"
+        checkTarget(`exports["${subpath}"]`, entry);
+      } else if (entry && typeof entry === 'object') {
+        for (const [condition, target] of Object.entries(entry)) {
+          checkTarget(`exports["${subpath}"].${condition}`, target);
+        }
+      } else {
+        missing.push({
+          source: `exports["${subpath}"]`,
+          target: String(entry),
+          resolved: '(unsupported exports entry shape)',
+        });
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error('check-package-exports: FAIL — package.json points at files that do not exist on disk.');
+    console.error('This usually means the build has not run or compiled dist/ was not committed.');
+    console.error('');
+    for (const m of missing) {
+      console.error(`  MISSING  ${m.source}`);
+      console.error(`           declared: ${m.target}`);
+      console.error(`           resolved: ${m.resolved}`);
+    }
+    console.error('');
+    console.error(`check-package-exports: ${missing.length} missing target(s) out of ${checkedCount} checked.`);
+    console.error('Run `npm run build` and ensure dist/ is committed, then re-run this check.');
+    process.exit(1);
+  }
+
+  console.log(`check-package-exports: OK — all ${checkedCount} export/main/types target(s) exist on disk.`);
+}
+
+main();

--- a/packages/agent-protocol/tests/package-exports.test.ts
+++ b/packages/agent-protocol/tests/package-exports.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// This test is the in-suite half of the npm-publication-readiness guard
+// (the CLI half is scripts/check-package-exports.mjs). It makes `npm test`
+// ITSELF catch the defect where package.json "exports" points at compiled
+// files that were never built or committed, so a publish would ship broken
+// subpaths. `npm test` runs the build first, so dist/ is present here.
+//
+// Compiled test runs from dist-tests/*.test.js, so the package root is one
+// directory up from this file's location at runtime.
+const testDir = dirname(fileURLToPath(import.meta.url));
+const pkgDir = resolve(testDir, '..');
+const pkgPath = join(pkgDir, 'package.json');
+
+type ExportsField = Record<string, string | Record<string, string> | unknown>;
+
+interface Pkg {
+  main?: string;
+  types?: string;
+  exports?: ExportsField;
+}
+
+function loadPkg(): Pkg {
+  return JSON.parse(readFileSync(pkgPath, 'utf8')) as Pkg;
+}
+
+/** Every declared (source label -> package-relative target) pair. */
+function collectTargets(pkg: Pkg): Array<{ source: string; target: string }> {
+  const targets: Array<{ source: string; target: string }> = [];
+
+  if (typeof pkg.main === 'string') {
+    targets.push({ source: 'main', target: pkg.main });
+  }
+  if (typeof pkg.types === 'string') {
+    targets.push({ source: 'types', target: pkg.types });
+  }
+
+  const exportsField = pkg.exports;
+  if (exportsField && typeof exportsField === 'object') {
+    for (const [subpath, entry] of Object.entries(exportsField)) {
+      if (typeof entry === 'string') {
+        targets.push({ source: `exports["${subpath}"]`, target: entry });
+      } else if (entry && typeof entry === 'object') {
+        for (const [condition, target] of Object.entries(entry as Record<string, unknown>)) {
+          assert.equal(
+            typeof target,
+            'string',
+            `exports["${subpath}"].${condition} must be a string target`,
+          );
+          targets.push({
+            source: `exports["${subpath}"].${condition}`,
+            target: target as string,
+          });
+        }
+      } else {
+        assert.fail(`exports["${subpath}"] has an unsupported shape: ${String(entry)}`);
+      }
+    }
+  }
+
+  return targets;
+}
+
+describe('package.json exports resolution guard', () => {
+  it('resolves every declared target to a file that exists in dist/', () => {
+    const pkg = loadPkg();
+    const targets = collectTargets(pkg);
+
+    // Sanity: the package must declare a non-trivial set of targets, otherwise
+    // an empty/broken exports map would vacuously "pass".
+    assert.ok(targets.length > 0, 'package.json declares no export/main/types targets');
+
+    const missing: string[] = [];
+    for (const { source, target } of targets) {
+      const resolved = resolve(pkgDir, target);
+      if (!existsSync(resolved)) {
+        missing.push(`${source} -> ${target} (resolved: ${resolved})`);
+      }
+    }
+
+    assert.deepEqual(
+      missing,
+      [],
+      `package.json points at ${missing.length} file(s) that do not exist on disk:\n  ${missing.join('\n  ')}\n` +
+        'Run `npm run build` and commit dist/.',
+    );
+  });
+
+  it('declares every top-level exports subpath with a resolvable types+import (or string) target', () => {
+    const pkg = loadPkg();
+    assert.ok(pkg.exports && typeof pkg.exports === 'object', 'package.json has no exports map');
+
+    for (const [subpath, entry] of Object.entries(pkg.exports as ExportsField)) {
+      if (typeof entry === 'string') {
+        // bare-string targets (e.g. "./package.json") are checked in the other test
+        continue;
+      }
+      assert.ok(entry && typeof entry === 'object', `exports["${subpath}"] must be an object or string`);
+      const conditions = entry as Record<string, string>;
+      // Module-shaped subpaths must expose both a types and an import target so
+      // consumers get typings and ESM resolution; missing either breaks tooling.
+      assert.ok(
+        typeof conditions.types === 'string',
+        `exports["${subpath}"] is missing a "types" target`,
+      );
+      assert.ok(
+        typeof conditions.import === 'string',
+        `exports["${subpath}"] is missing an "import" target`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## What this adds

Fixes the **root cause** of a defect where a change could commit source but not the compiled `dist/`, so `package.json` `"exports"` pointed at nonexistent files and a publish would ship broken subpaths (e.g. `@reddi/agent-protocol/receipts` resolving to a missing `./dist/receipts.js`). Ordinary green tests masked it.

- **`scripts/check-package-exports.mjs`** — offline, zero-dependency Node script (built-ins only). Reads `package.json` `"exports"` plus top-level `"main"`/`"types"` and asserts **every** `types`/`import` (and bare-string) target file exists on disk post-build. Non-zero exit with a clear listing of any missing targets.
- **`package.json`** — adds `"prepublishOnly"` (`npm run build && node scripts/check-package-exports.mjs`) and `"check:exports"`; `"release:dry-run"` now also runs the check before `npm pack`. Valid JSON.
- **`tests/package-exports.test.ts`** (`node:test`) — asserts every exports subpath target exists in `dist/`, so **`npm test` itself now catches the defect**. Verified: hiding a `dist/*.js` turns the suite red.
- **`.github/workflows/rap-package-guard.yml`** — on PRs touching `packages/agent-protocol/**`, runs `npm ci` + `npm run build` + `npm test` + the export check. Mirrors the existing workflow style.

## Verification

- Full suite green: **tests 243, pass 243, fail 0** (was 241; +2 new).
- `node scripts/check-package-exports.mjs` passes on the current (correct) tree: `OK — all 67 export/main/types target(s) exist on disk`.
- Failure path confirmed for both the script and the test (removing a `dist/*.js` target → non-zero / red).
- No new runtime deps. No `dist/` change needed (no module added). `dist-tests/` not committed.

Proof-only / no live rails, no settlement or custody. Overnight autonomous, test-gated — please review before merge.