### PR TITLE
feat(agent-protocol): onboarding assistant state-machine read model (#510)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,26 @@
 # Reddi Agent Protocol — Status
 
+## Latest Update — Onboarding assistant state-machine read model (2026-07-06 AEST)
+
+Implemented GitHub issue #510 in isolated worktree `projects/reddi-agent-protocol-worktree-510-onboarding-state-machine` on branch `feat/510-onboarding-state-machine-read-model`.
+
+Delivered:
+- Added `@reddi/agent-protocol/onboarding-state-machine` — the backend/read-model state machine for AI onboarding assistant drafts, projecting #509 analyser outputs and operator decisions into a local, append-only audit history with no UI, publication side effects, or live execution.
+- Supports all twelve required states: draft, probe_failed, needs_provider_input, payment_setup_required, dry_run_required, risk_review_required, pending_operator_approval, approved_unpublished, changes_requested, rejected, suspended, published_candidate. `rejected` is terminal; `suspended` only reinstates to draft or moves to rejected, operator-driven.
+- Every transition carries the audit reason, actor type (operator/provider/analyser/system), caller-supplied RFC3339 UTC timestamp (deterministic replay), source snapshot reference, readiness result reference (mirroring the #509 `OnboardingOverallReadiness` summary), and the blocking gates still open after the transition; gate-shaped states require their matching open gate on entry.
+- `published_candidate` stays an internal candidate state only: the read model's publication ledger (hosted registry write, public catalog write, trust mutation, reputation mutation, payment activation, endpoint invocation, wallet/RPC) is hard-coded false, guardrails are all false by construction, and any `requestedSideEffects` entry on an event is rejected fail-closed.
+- Invalid transitions fail closed with structured `{code, path, message}` reasons (invalid_transition, terminal_state, missing_audit_reason, operator_action_required, blocked_readiness, unresolved_blocking_gates, missing_blocking_gate, invalid_timestamp, timestamp_regression, missing refs, publication_side_effect_rejected) and never change state.
+- Operator actions (approval, rejection, change requests, suspension, reinstatement, candidate publication) are recorded as local/read-model events only — every audit record carries `scope: 'local_read_model_only'`.
+- Kept the module pure and offline-only in the #509 self-contained pattern: zero imports, no async surface, and a forbidden-import source guard test proving no network/fs/exec/wallet/payment references.
+
+Validation:
+- `npm test` in `packages/agent-protocol` PASS (322/322, 29 new).
+- `npm run check:exports` in `packages/agent-protocol` PASS (75 targets).
+- `npm run check:rap:naming` PASS.
+- `git diff --check` PASS.
+
+RESUME FROM HERE: #510 unblocks the #384/#385/#386 UI flows and future listing preview/approval UI against `onboarding-state-machine` shapes; #374 guided-workflow implementation should build on this read model rather than re-encoding the transition graph.
+
 ## Latest Update — Onboarding analyser handoff contracts + no-network fixture matrix (2026-07-06 AEST)
 
 Implemented GitHub issue #509 in isolated worktree `projects/reddi-agent-protocol-worktree-509-onboarding-handoff-contracts` on branch `feat/509-onboarding-handoff-contracts`.

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -32,3 +32,4 @@ export * from './ap2-mandate-ingestion.js';
 export * from './strands-rap-template.js';
 export * from './okf-adapter.js';
 export * from './onboarding-analyser-handoff.js';
+export * from './onboarding-state-machine.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -32,3 +32,4 @@ export * from './ap2-mandate-ingestion.js';
 export * from './strands-rap-template.js';
 export * from './okf-adapter.js';
 export * from './onboarding-analyser-handoff.js';
+export * from './onboarding-state-machine.js';

--- a/packages/agent-protocol/dist/onboarding-state-machine.d.ts
+++ b/packages/agent-protocol/dist/onboarding-state-machine.d.ts
@@ -1,0 +1,228 @@
+/**
+ * Onboarding assistant state-machine read model (#510).
+ *
+ * Defines the backend/read-model state machine for AI onboarding assistant
+ * drafts. It projects analyser outputs (#509 handoff contracts) and operator
+ * decisions into a local, append-only audit history without UI, publication
+ * side effects, or live execution.
+ *
+ * Twelve states are supported:
+ *
+ *   draft -> probe_failed / needs_provider_input / payment_setup_required
+ *         -> dry_run_required -> risk_review_required
+ *         -> pending_operator_approval -> approved_unpublished
+ *         -> published_candidate (INTERNAL candidate only)
+ *   plus changes_requested, rejected (terminal), and suspended.
+ *
+ * This module is PURE and offline-only. It performs no network fetch, hosted
+ * registry write, public catalog write, trust or reputation mutation, payment
+ * activation, endpoint invocation, wallet/RPC call, secret read, or command
+ * execution. Every transition is a local/read-model event: it only re-shapes
+ * an in-memory read model the caller already holds. Timestamps are
+ * caller-supplied so replays are deterministic.
+ *
+ * `published_candidate` is an internal candidate state only. Reaching it never
+ * writes hosted registry output, public catalog output, trust/reputation
+ * mutations, or payment activation; those remain gated behind #395 publication
+ * surfaces outside this module.
+ */
+export declare const ONBOARDING_STATE_MACHINE_SCHEMA_VERSION: "reddi.onboarding-state-machine.v1";
+export declare const ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION: "reddi.onboarding-state-transition-event.v1";
+export declare const ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION: "reddi.onboarding-assistant-read-model.v1";
+/** Issue anchors so downstream implementations can trace contract ownership. */
+export declare const ONBOARDING_STATE_MACHINE_ISSUE: 510;
+export declare const ONBOARDING_STATE_MACHINE_RELATED_ISSUES: Readonly<{
+    readonly onboardingAssistantEpic: 370;
+    readonly guidedWorkflowFeature: 374;
+    readonly discoverabilityPackageFeature: 376;
+    readonly publicationGateFeature: 395;
+    readonly analyserHandoffContracts: 509;
+}>;
+/**
+ * Hard no-live boundary. Every guardrail is `false` by construction and every
+ * read model carries this object so downstream consumers can assert the
+ * boundary instead of trusting prose.
+ */
+export declare const ONBOARDING_STATE_MACHINE_GUARDRAILS: Readonly<{
+    readonly hostedRegistryWriteAllowed: false;
+    readonly publicCatalogWriteAllowed: false;
+    readonly trustMutationAllowed: false;
+    readonly reputationMutationAllowed: false;
+    readonly paymentActivationAllowed: false;
+    readonly endpointInvocationAllowed: false;
+    readonly walletOrRpcAllowed: false;
+    readonly networkFetchAllowed: false;
+    readonly hostedWriteAllowed: false;
+    readonly publicationAllowed: false;
+    readonly secretReadAllowed: false;
+    readonly liveExecutionAllowed: false;
+}>;
+export type OnboardingStateMachineGuardrails = typeof ONBOARDING_STATE_MACHINE_GUARDRAILS;
+export type OnboardingAssistantState = 'draft' | 'probe_failed' | 'needs_provider_input' | 'payment_setup_required' | 'dry_run_required' | 'risk_review_required' | 'pending_operator_approval' | 'approved_unpublished' | 'changes_requested' | 'rejected' | 'suspended' | 'published_candidate';
+export declare const ONBOARDING_ASSISTANT_STATES: readonly OnboardingAssistantState[];
+/**
+ * Allowed transitions. Anything not listed here fails closed. `rejected` is
+ * terminal: a rejected draft can only be re-onboarded as a brand new draft
+ * with a fresh intake, never mutated back into the flow.
+ */
+export declare const ONBOARDING_STATE_TRANSITION_GRAPH: Readonly<Record<OnboardingAssistantState, readonly OnboardingAssistantState[]>>;
+export type OnboardingStateActorType = 'operator' | 'provider' | 'analyser' | 'system';
+export declare const ONBOARDING_STATE_ACTOR_TYPES: readonly OnboardingStateActorType[];
+/**
+ * Target states an operator must drive. Approval, rejection, change requests,
+ * suspension, reinstatement out of suspension, and internal candidate
+ * publication are review decisions — they are recorded as local/read-model
+ * events only and never invoke any external system.
+ */
+export declare const ONBOARDING_OPERATOR_ONLY_TARGET_STATES: readonly OnboardingAssistantState[];
+export type OnboardingBlockingGateKey = 'probe' | 'provider_input' | 'payment_setup' | 'dry_run' | 'risk_review' | 'operator_approval' | 'readiness';
+export declare const ONBOARDING_BLOCKING_GATE_KEYS: readonly OnboardingBlockingGateKey[];
+/**
+ * Gate reason codes. The first eight mirror the #509 fail-closed reasons so
+ * readiness lane output can be projected directly onto blocking gates; the
+ * rest are state-machine-native reasons.
+ */
+export type OnboardingGateReasonCode = 'private_url_blocked' | 'credential_leakage_rejected' | 'command_execution_rejected' | 'paid_call_rejected' | 'wallet_rpc_rejected' | 'missing_payment_metadata' | 'missing_evidence' | 'untrusted_imported_content_rejected' | 'probe_failure_recorded' | 'provider_input_required' | 'dry_run_receipt_required' | 'risk_review_pending' | 'operator_approval_pending' | 'readiness_blocked';
+export type OnboardingBlockingGate = {
+    gate: OnboardingBlockingGateKey;
+    reasonCodes: OnboardingGateReasonCode[];
+    note?: string;
+};
+/** Gate that must still be open when entering each gate-shaped state. */
+export declare const ONBOARDING_STATE_REQUIRED_GATES: Readonly<Partial<Record<OnboardingAssistantState, OnboardingBlockingGateKey>>>;
+/**
+ * Readiness summary carried on every transition. Mirrors the #509
+ * `OnboardingOverallReadiness` union; re-declared locally so this module stays
+ * import-free while remaining structurally compatible.
+ */
+export type OnboardingStateReadinessSummary = 'blocked' | 'needs_operator_review' | 'publish_ready';
+export type OnboardingStateTransitionErrorCode = 'malformed_transition_event' | 'malformed_read_model' | 'unknown_state' | 'invalid_transition' | 'terminal_state' | 'missing_audit_reason' | 'invalid_actor_type' | 'operator_action_required' | 'invalid_timestamp' | 'timestamp_regression' | 'missing_source_snapshot_ref' | 'missing_readiness_result_ref' | 'blocked_readiness' | 'missing_blocking_gate' | 'unresolved_blocking_gates' | 'publication_side_effect_rejected';
+export type OnboardingStateTransitionError = {
+    code: OnboardingStateTransitionErrorCode;
+    path: string;
+    message: string;
+};
+/**
+ * A requested transition. Every transition carries the audit reason, actor
+ * type, caller-supplied timestamp, source snapshot reference, readiness result
+ * reference, and the blocking gates that remain open after the transition.
+ *
+ * `requestedSideEffects` exists only so imported/queued events that ask for a
+ * live side effect (hosted write, publication, payment activation, wallet/RPC,
+ * endpoint invocation, trust/reputation mutation, ...) can be rejected fail-
+ * closed. This module never executes any side effect.
+ */
+export type OnboardingStateTransitionEvent = {
+    schemaVersion: typeof ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION;
+    eventId: string;
+    to: OnboardingAssistantState;
+    /** Human-auditable reason for the transition. Required, non-empty. */
+    reason: string;
+    actorType: OnboardingStateActorType;
+    /** Opaque local reference to the acting operator/provider/analyser. */
+    actorRef?: string;
+    /** RFC3339 UTC timestamp, caller-supplied for deterministic replay. */
+    occurredAt: string;
+    /** Reference to the static source snapshot backing this transition. */
+    sourceSnapshotRef: string;
+    /** Reference to the #509 readiness result backing this transition. */
+    readinessResultRef: string;
+    /** Overall readiness recorded on the referenced readiness result. */
+    readinessOverall: OnboardingStateReadinessSummary;
+    /** Gates still blocking after this transition. */
+    blockingGates: OnboardingBlockingGate[];
+    requestedSideEffects?: string[];
+};
+/** An applied transition as recorded in the read-model audit history. */
+export type OnboardingStateTransitionRecord = {
+    sequence: number;
+    from: OnboardingAssistantState;
+    to: OnboardingAssistantState;
+    eventId: string;
+    reason: string;
+    actorType: OnboardingStateActorType;
+    actorRef?: string;
+    occurredAt: string;
+    sourceSnapshotRef: string;
+    readinessResultRef: string;
+    readinessOverall: OnboardingStateReadinessSummary;
+    blockingGates: OnboardingBlockingGate[];
+    /** Every recorded action is a local/read-model event only. */
+    scope: 'local_read_model_only';
+};
+export type OnboardingAssistantReadModel = {
+    schemaVersion: typeof ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION;
+    stateMachineVersion: typeof ONBOARDING_STATE_MACHINE_SCHEMA_VERSION;
+    draftId: string;
+    state: OnboardingAssistantState;
+    /** Timestamp of the event that produced the current state. */
+    stateSince: string;
+    sourceSnapshotRef: string;
+    readinessResultRef: string;
+    readinessOverall: OnboardingStateReadinessSummary;
+    blockingGates: OnboardingBlockingGate[];
+    history: OnboardingStateTransitionRecord[];
+    /**
+     * `published_candidate` (and every other state) stays internal: nothing in
+     * this read model is a hosted, public, trusted, or payable surface.
+     */
+    internalCandidateOnly: true;
+    /** Side-effect ledger. Every entry is hard-coded false by construction. */
+    publication: {
+        hostedRegistryWritePerformed: false;
+        publicCatalogWritePerformed: false;
+        trustMutationPerformed: false;
+        reputationMutationPerformed: false;
+        paymentActivationPerformed: false;
+        endpointInvocationPerformed: false;
+        walletOrRpcCallPerformed: false;
+    };
+    guardrails: OnboardingStateMachineGuardrails;
+    localReadModelOnly: true;
+    staticOnly: true;
+};
+export type OnboardingStateTransitionResult = {
+    ok: true;
+    readModel: OnboardingAssistantReadModel;
+    record: OnboardingStateTransitionRecord;
+} | {
+    ok: false;
+    failClosed: true;
+    errors: OnboardingStateTransitionError[];
+};
+export type OnboardingReadModelInitResult = {
+    ok: true;
+    readModel: OnboardingAssistantReadModel;
+} | {
+    ok: false;
+    failClosed: true;
+    errors: OnboardingStateTransitionError[];
+};
+export type OnboardingReadModelInit = {
+    draftId: string;
+    sourceSnapshotRef: string;
+    readinessResultRef: string;
+    readinessOverall: OnboardingStateReadinessSummary;
+    /** RFC3339 UTC timestamp, caller-supplied for deterministic replay. */
+    createdAt: string;
+    blockingGates?: OnboardingBlockingGate[];
+};
+/**
+ * Create a read model for a new onboarding draft. Drafts always start in
+ * `draft`; there is no way to construct a read model already approved or
+ * published.
+ */
+export declare function createOnboardingAssistantReadModel(init: unknown): OnboardingReadModelInitResult;
+/**
+ * Apply a transition event to a read model. Pure and deterministic: the input
+ * read model is never mutated; a new read model with the appended audit record
+ * is returned. Invalid transitions fail closed with structured reasons and no
+ * state change.
+ */
+export declare function applyOnboardingStateTransition(readModel: OnboardingAssistantReadModel, event: unknown): OnboardingStateTransitionResult;
+/**
+ * List the allowed target states from a given state. Useful for read-model
+ * consumers (UI lanes in #384/#385/#386) that need to render next actions
+ * without re-encoding the graph.
+ */
+export declare function listOnboardingStateTransitions(from: OnboardingAssistantState): readonly OnboardingAssistantState[];

--- a/packages/agent-protocol/dist/onboarding-state-machine.js
+++ b/packages/agent-protocol/dist/onboarding-state-machine.js
@@ -1,0 +1,432 @@
+/**
+ * Onboarding assistant state-machine read model (#510).
+ *
+ * Defines the backend/read-model state machine for AI onboarding assistant
+ * drafts. It projects analyser outputs (#509 handoff contracts) and operator
+ * decisions into a local, append-only audit history without UI, publication
+ * side effects, or live execution.
+ *
+ * Twelve states are supported:
+ *
+ *   draft -> probe_failed / needs_provider_input / payment_setup_required
+ *         -> dry_run_required -> risk_review_required
+ *         -> pending_operator_approval -> approved_unpublished
+ *         -> published_candidate (INTERNAL candidate only)
+ *   plus changes_requested, rejected (terminal), and suspended.
+ *
+ * This module is PURE and offline-only. It performs no network fetch, hosted
+ * registry write, public catalog write, trust or reputation mutation, payment
+ * activation, endpoint invocation, wallet/RPC call, secret read, or command
+ * execution. Every transition is a local/read-model event: it only re-shapes
+ * an in-memory read model the caller already holds. Timestamps are
+ * caller-supplied so replays are deterministic.
+ *
+ * `published_candidate` is an internal candidate state only. Reaching it never
+ * writes hosted registry output, public catalog output, trust/reputation
+ * mutations, or payment activation; those remain gated behind #395 publication
+ * surfaces outside this module.
+ */
+export const ONBOARDING_STATE_MACHINE_SCHEMA_VERSION = 'reddi.onboarding-state-machine.v1';
+export const ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION = 'reddi.onboarding-state-transition-event.v1';
+export const ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION = 'reddi.onboarding-assistant-read-model.v1';
+/** Issue anchors so downstream implementations can trace contract ownership. */
+export const ONBOARDING_STATE_MACHINE_ISSUE = 510;
+export const ONBOARDING_STATE_MACHINE_RELATED_ISSUES = Object.freeze({
+    onboardingAssistantEpic: 370,
+    guidedWorkflowFeature: 374,
+    discoverabilityPackageFeature: 376,
+    publicationGateFeature: 395,
+    analyserHandoffContracts: 509,
+});
+/**
+ * Hard no-live boundary. Every guardrail is `false` by construction and every
+ * read model carries this object so downstream consumers can assert the
+ * boundary instead of trusting prose.
+ */
+export const ONBOARDING_STATE_MACHINE_GUARDRAILS = Object.freeze({
+    hostedRegistryWriteAllowed: false,
+    publicCatalogWriteAllowed: false,
+    trustMutationAllowed: false,
+    reputationMutationAllowed: false,
+    paymentActivationAllowed: false,
+    endpointInvocationAllowed: false,
+    walletOrRpcAllowed: false,
+    networkFetchAllowed: false,
+    hostedWriteAllowed: false,
+    publicationAllowed: false,
+    secretReadAllowed: false,
+    liveExecutionAllowed: false,
+});
+export const ONBOARDING_ASSISTANT_STATES = Object.freeze([
+    'draft',
+    'probe_failed',
+    'needs_provider_input',
+    'payment_setup_required',
+    'dry_run_required',
+    'risk_review_required',
+    'pending_operator_approval',
+    'approved_unpublished',
+    'changes_requested',
+    'rejected',
+    'suspended',
+    'published_candidate',
+]);
+/**
+ * Allowed transitions. Anything not listed here fails closed. `rejected` is
+ * terminal: a rejected draft can only be re-onboarded as a brand new draft
+ * with a fresh intake, never mutated back into the flow.
+ */
+export const ONBOARDING_STATE_TRANSITION_GRAPH = Object.freeze({
+    draft: [
+        'probe_failed',
+        'needs_provider_input',
+        'payment_setup_required',
+        'dry_run_required',
+        'risk_review_required',
+        'pending_operator_approval',
+        'rejected',
+        'suspended',
+    ],
+    probe_failed: ['draft', 'needs_provider_input', 'rejected', 'suspended'],
+    needs_provider_input: ['draft', 'payment_setup_required', 'rejected', 'suspended'],
+    payment_setup_required: ['draft', 'dry_run_required', 'rejected', 'suspended'],
+    dry_run_required: ['probe_failed', 'risk_review_required', 'pending_operator_approval', 'rejected', 'suspended'],
+    risk_review_required: ['pending_operator_approval', 'changes_requested', 'rejected', 'suspended'],
+    pending_operator_approval: ['approved_unpublished', 'changes_requested', 'rejected', 'suspended'],
+    approved_unpublished: ['published_candidate', 'changes_requested', 'suspended'],
+    changes_requested: ['draft', 'pending_operator_approval', 'rejected', 'suspended'],
+    rejected: [],
+    suspended: ['draft', 'rejected'],
+    published_candidate: ['changes_requested', 'suspended'],
+});
+export const ONBOARDING_STATE_ACTOR_TYPES = Object.freeze([
+    'operator',
+    'provider',
+    'analyser',
+    'system',
+]);
+/**
+ * Target states an operator must drive. Approval, rejection, change requests,
+ * suspension, reinstatement out of suspension, and internal candidate
+ * publication are review decisions — they are recorded as local/read-model
+ * events only and never invoke any external system.
+ */
+export const ONBOARDING_OPERATOR_ONLY_TARGET_STATES = Object.freeze([
+    'approved_unpublished',
+    'changes_requested',
+    'rejected',
+    'suspended',
+    'published_candidate',
+]);
+export const ONBOARDING_BLOCKING_GATE_KEYS = Object.freeze([
+    'probe',
+    'provider_input',
+    'payment_setup',
+    'dry_run',
+    'risk_review',
+    'operator_approval',
+    'readiness',
+]);
+const GATE_REASON_CODES = [
+    'private_url_blocked',
+    'credential_leakage_rejected',
+    'command_execution_rejected',
+    'paid_call_rejected',
+    'wallet_rpc_rejected',
+    'missing_payment_metadata',
+    'missing_evidence',
+    'untrusted_imported_content_rejected',
+    'probe_failure_recorded',
+    'provider_input_required',
+    'dry_run_receipt_required',
+    'risk_review_pending',
+    'operator_approval_pending',
+    'readiness_blocked',
+];
+/** Gate that must still be open when entering each gate-shaped state. */
+export const ONBOARDING_STATE_REQUIRED_GATES = Object.freeze({
+    probe_failed: 'probe',
+    needs_provider_input: 'provider_input',
+    payment_setup_required: 'payment_setup',
+    dry_run_required: 'dry_run',
+    risk_review_required: 'risk_review',
+    pending_operator_approval: 'operator_approval',
+});
+const READINESS_SUMMARIES = [
+    'blocked',
+    'needs_operator_review',
+    'publish_ready',
+];
+// ---------------------------------------------------------------------------
+// Validation internals
+// ---------------------------------------------------------------------------
+const RFC3339_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+function transitionError(code, path, message) {
+    return { code, path, message };
+}
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+function isKnownState(value) {
+    return ONBOARDING_ASSISTANT_STATES.includes(value);
+}
+function parseUtcMillis(timestamp) {
+    return new Date(timestamp).getTime();
+}
+function validateBlockingGates(value, path, errors) {
+    if (!Array.isArray(value)) {
+        errors.push(transitionError('malformed_transition_event', path, 'blockingGates must be an array'));
+        return [];
+    }
+    const gates = [];
+    value.forEach((entry, index) => {
+        const entryPath = `${path}[${index}]`;
+        if (!isPlainObject(entry)) {
+            errors.push(transitionError('malformed_transition_event', entryPath, 'blocking gate must be an object'));
+            return;
+        }
+        if (!ONBOARDING_BLOCKING_GATE_KEYS.includes(entry.gate)) {
+            errors.push(transitionError('malformed_transition_event', `${entryPath}.gate`, 'blocking gate key is unsupported'));
+            return;
+        }
+        if (!Array.isArray(entry.reasonCodes)
+            || !entry.reasonCodes.every((code) => GATE_REASON_CODES.includes(code))) {
+            errors.push(transitionError('malformed_transition_event', `${entryPath}.reasonCodes`, 'reasonCodes must be an array of recognised gate reason codes'));
+            return;
+        }
+        if (entry.note !== undefined && !isNonEmptyString(entry.note)) {
+            errors.push(transitionError('malformed_transition_event', `${entryPath}.note`, 'note must be a non-empty string when present'));
+            return;
+        }
+        gates.push({
+            gate: entry.gate,
+            reasonCodes: [...entry.reasonCodes],
+            ...(entry.note !== undefined ? { note: entry.note } : {}),
+        });
+    });
+    return gates;
+}
+function validateTransitionEventShape(input, errors) {
+    if (!isPlainObject(input)) {
+        errors.push(transitionError('malformed_transition_event', '$', 'transition event must be a plain object'));
+        return undefined;
+    }
+    if (input.schemaVersion !== ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION) {
+        errors.push(transitionError('malformed_transition_event', '$.schemaVersion', `expected ${ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION}`));
+    }
+    if (!isNonEmptyString(input.eventId)) {
+        errors.push(transitionError('malformed_transition_event', '$.eventId', 'eventId must be a non-empty string'));
+    }
+    if (!isKnownState(input.to)) {
+        errors.push(transitionError('unknown_state', '$.to', 'target state is not one of the twelve onboarding assistant states'));
+    }
+    if (!isNonEmptyString(input.reason)) {
+        errors.push(transitionError('missing_audit_reason', '$.reason', 'every transition must carry a non-empty audit reason'));
+    }
+    if (!ONBOARDING_STATE_ACTOR_TYPES.includes(input.actorType)) {
+        errors.push(transitionError('invalid_actor_type', '$.actorType', 'actorType must be operator, provider, analyser, or system'));
+    }
+    if (input.actorRef !== undefined && !isNonEmptyString(input.actorRef)) {
+        errors.push(transitionError('malformed_transition_event', '$.actorRef', 'actorRef must be a non-empty string when present'));
+    }
+    if (!isNonEmptyString(input.occurredAt) || !RFC3339_UTC_PATTERN.test(input.occurredAt)) {
+        errors.push(transitionError('invalid_timestamp', '$.occurredAt', 'occurredAt must be a caller-supplied RFC3339 UTC timestamp'));
+    }
+    if (!isNonEmptyString(input.sourceSnapshotRef)) {
+        errors.push(transitionError('missing_source_snapshot_ref', '$.sourceSnapshotRef', 'every transition must reference the static source snapshot'));
+    }
+    if (!isNonEmptyString(input.readinessResultRef)) {
+        errors.push(transitionError('missing_readiness_result_ref', '$.readinessResultRef', 'every transition must reference the readiness result backing it'));
+    }
+    if (!READINESS_SUMMARIES.includes(input.readinessOverall)) {
+        errors.push(transitionError('malformed_transition_event', '$.readinessOverall', 'readinessOverall must be blocked, needs_operator_review, or publish_ready'));
+    }
+    const blockingGates = validateBlockingGates(input.blockingGates, '$.blockingGates', errors);
+    if (input.requestedSideEffects !== undefined) {
+        if (!Array.isArray(input.requestedSideEffects) || !input.requestedSideEffects.every((item) => typeof item === 'string')) {
+            errors.push(transitionError('malformed_transition_event', '$.requestedSideEffects', 'requestedSideEffects must be a string array when present'));
+        }
+        else {
+            input.requestedSideEffects.forEach((effect, index) => {
+                errors.push(transitionError('publication_side_effect_rejected', `$.requestedSideEffects[${index}]`, `requested side effect "${effect}" is rejected fail-closed: transitions are local/read-model events only`));
+            });
+        }
+    }
+    if (errors.length > 0)
+        return undefined;
+    return {
+        eventId: input.eventId,
+        to: input.to,
+        reason: input.reason,
+        actorType: input.actorType,
+        ...(input.actorRef !== undefined ? { actorRef: input.actorRef } : {}),
+        occurredAt: input.occurredAt,
+        sourceSnapshotRef: input.sourceSnapshotRef,
+        readinessResultRef: input.readinessResultRef,
+        readinessOverall: input.readinessOverall,
+        blockingGates,
+    };
+}
+const READ_MODEL_PUBLICATION_LEDGER = Object.freeze({
+    hostedRegistryWritePerformed: false,
+    publicCatalogWritePerformed: false,
+    trustMutationPerformed: false,
+    reputationMutationPerformed: false,
+    paymentActivationPerformed: false,
+    endpointInvocationPerformed: false,
+    walletOrRpcCallPerformed: false,
+});
+/**
+ * Create a read model for a new onboarding draft. Drafts always start in
+ * `draft`; there is no way to construct a read model already approved or
+ * published.
+ */
+export function createOnboardingAssistantReadModel(init) {
+    const errors = [];
+    if (!isPlainObject(init)) {
+        return { ok: false, failClosed: true, errors: [transitionError('malformed_read_model', '$', 'read model init must be a plain object')] };
+    }
+    if (!isNonEmptyString(init.draftId)) {
+        errors.push(transitionError('malformed_read_model', '$.draftId', 'draftId must be a non-empty string'));
+    }
+    if (!isNonEmptyString(init.sourceSnapshotRef)) {
+        errors.push(transitionError('missing_source_snapshot_ref', '$.sourceSnapshotRef', 'sourceSnapshotRef must be a non-empty string'));
+    }
+    if (!isNonEmptyString(init.readinessResultRef)) {
+        errors.push(transitionError('missing_readiness_result_ref', '$.readinessResultRef', 'readinessResultRef must be a non-empty string'));
+    }
+    if (!READINESS_SUMMARIES.includes(init.readinessOverall)) {
+        errors.push(transitionError('malformed_read_model', '$.readinessOverall', 'readinessOverall must be blocked, needs_operator_review, or publish_ready'));
+    }
+    if (!isNonEmptyString(init.createdAt) || !RFC3339_UTC_PATTERN.test(init.createdAt)) {
+        errors.push(transitionError('invalid_timestamp', '$.createdAt', 'createdAt must be a caller-supplied RFC3339 UTC timestamp'));
+    }
+    const blockingGates = init.blockingGates === undefined
+        ? []
+        : validateBlockingGates(init.blockingGates, '$.blockingGates', errors);
+    if (errors.length > 0) {
+        return { ok: false, failClosed: true, errors };
+    }
+    return {
+        ok: true,
+        readModel: {
+            schemaVersion: ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION,
+            stateMachineVersion: ONBOARDING_STATE_MACHINE_SCHEMA_VERSION,
+            draftId: init.draftId,
+            state: 'draft',
+            stateSince: init.createdAt,
+            sourceSnapshotRef: init.sourceSnapshotRef,
+            readinessResultRef: init.readinessResultRef,
+            readinessOverall: init.readinessOverall,
+            blockingGates,
+            history: [],
+            internalCandidateOnly: true,
+            publication: { ...READ_MODEL_PUBLICATION_LEDGER },
+            guardrails: ONBOARDING_STATE_MACHINE_GUARDRAILS,
+            localReadModelOnly: true,
+            staticOnly: true,
+        },
+    };
+}
+// ---------------------------------------------------------------------------
+// Transition application
+// ---------------------------------------------------------------------------
+/**
+ * Apply a transition event to a read model. Pure and deterministic: the input
+ * read model is never mutated; a new read model with the appended audit record
+ * is returned. Invalid transitions fail closed with structured reasons and no
+ * state change.
+ */
+export function applyOnboardingStateTransition(readModel, event) {
+    if (!isPlainObject(readModel) || !isKnownState(readModel.state)) {
+        return {
+            ok: false,
+            failClosed: true,
+            errors: [transitionError('malformed_read_model', '$.readModel.state', 'read model must carry a known onboarding assistant state')],
+        };
+    }
+    const errors = [];
+    const core = validateTransitionEventShape(event, errors);
+    if (!core) {
+        return { ok: false, failClosed: true, errors };
+    }
+    const from = readModel.state;
+    const allowed = ONBOARDING_STATE_TRANSITION_GRAPH[from];
+    if (allowed.length === 0) {
+        errors.push(transitionError('terminal_state', '$.to', `state "${from}" is terminal; a rejected draft must be re-onboarded as a new draft`));
+    }
+    else if (!allowed.includes(core.to)) {
+        errors.push(transitionError('invalid_transition', '$.to', `transition ${from} -> ${core.to} is not allowed by the onboarding state machine`));
+    }
+    const operatorRequired = ONBOARDING_OPERATOR_ONLY_TARGET_STATES.includes(core.to) || from === 'suspended';
+    if (operatorRequired && core.actorType !== 'operator') {
+        errors.push(transitionError('operator_action_required', '$.actorType', `transition ${from} -> ${core.to} is an operator review decision and must be recorded by an operator actor`));
+    }
+    const requiredGate = ONBOARDING_STATE_REQUIRED_GATES[core.to];
+    if (requiredGate && !core.blockingGates.some((gate) => gate.gate === requiredGate)) {
+        errors.push(transitionError('missing_blocking_gate', '$.blockingGates', `entering ${core.to} requires the open "${requiredGate}" blocking gate to be carried on the transition`));
+    }
+    if (core.to === 'approved_unpublished' || core.to === 'published_candidate') {
+        if (core.readinessOverall === 'blocked') {
+            errors.push(transitionError('blocked_readiness', '$.readinessOverall', `cannot enter ${core.to} while the referenced readiness result is blocked`));
+        }
+        if (core.blockingGates.length > 0) {
+            errors.push(transitionError('unresolved_blocking_gates', '$.blockingGates', `cannot enter ${core.to} while blocking gates remain open: ${core.blockingGates.map((gate) => gate.gate).join(', ')}`));
+        }
+    }
+    if (RFC3339_UTC_PATTERN.test(core.occurredAt)
+        && parseUtcMillis(core.occurredAt) < parseUtcMillis(readModel.stateSince)) {
+        errors.push(transitionError('timestamp_regression', '$.occurredAt', 'occurredAt must not be earlier than the timestamp of the current state'));
+    }
+    if (errors.length > 0) {
+        return { ok: false, failClosed: true, errors };
+    }
+    const record = {
+        sequence: readModel.history.length + 1,
+        from,
+        to: core.to,
+        eventId: core.eventId,
+        reason: core.reason,
+        actorType: core.actorType,
+        ...(core.actorRef !== undefined ? { actorRef: core.actorRef } : {}),
+        occurredAt: core.occurredAt,
+        sourceSnapshotRef: core.sourceSnapshotRef,
+        readinessResultRef: core.readinessResultRef,
+        readinessOverall: core.readinessOverall,
+        blockingGates: core.blockingGates.map((gate) => ({ ...gate, reasonCodes: [...gate.reasonCodes] })),
+        scope: 'local_read_model_only',
+    };
+    return {
+        ok: true,
+        readModel: {
+            ...readModel,
+            state: core.to,
+            stateSince: core.occurredAt,
+            sourceSnapshotRef: core.sourceSnapshotRef,
+            readinessResultRef: core.readinessResultRef,
+            readinessOverall: core.readinessOverall,
+            blockingGates: record.blockingGates.map((gate) => ({ ...gate, reasonCodes: [...gate.reasonCodes] })),
+            history: [...readModel.history, record],
+            internalCandidateOnly: true,
+            publication: { ...READ_MODEL_PUBLICATION_LEDGER },
+            guardrails: ONBOARDING_STATE_MACHINE_GUARDRAILS,
+            localReadModelOnly: true,
+            staticOnly: true,
+        },
+        record,
+    };
+}
+/**
+ * List the allowed target states from a given state. Useful for read-model
+ * consumers (UI lanes in #384/#385/#386) that need to render next actions
+ * without re-encoding the graph.
+ */
+export function listOnboardingStateTransitions(from) {
+    return ONBOARDING_STATE_TRANSITION_GRAPH[from] ?? Object.freeze([]);
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -146,6 +146,10 @@
       "types": "./dist/onboarding-analyser-handoff.d.ts",
       "import": "./dist/onboarding-analyser-handoff.js"
     },
+    "./onboarding-state-machine": {
+      "types": "./dist/onboarding-state-machine.d.ts",
+      "import": "./dist/onboarding-state-machine.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -32,3 +32,4 @@ export * from './ap2-mandate-ingestion.js';
 export * from './strands-rap-template.js';
 export * from './okf-adapter.js';
 export * from './onboarding-analyser-handoff.js';
+export * from './onboarding-state-machine.js';

--- a/packages/agent-protocol/src/onboarding-state-machine.ts
+++ b/packages/agent-protocol/src/onboarding-state-machine.ts
@@ -1,0 +1,729 @@
+/**
+ * Onboarding assistant state-machine read model (#510).
+ *
+ * Defines the backend/read-model state machine for AI onboarding assistant
+ * drafts. It projects analyser outputs (#509 handoff contracts) and operator
+ * decisions into a local, append-only audit history without UI, publication
+ * side effects, or live execution.
+ *
+ * Twelve states are supported:
+ *
+ *   draft -> probe_failed / needs_provider_input / payment_setup_required
+ *         -> dry_run_required -> risk_review_required
+ *         -> pending_operator_approval -> approved_unpublished
+ *         -> published_candidate (INTERNAL candidate only)
+ *   plus changes_requested, rejected (terminal), and suspended.
+ *
+ * This module is PURE and offline-only. It performs no network fetch, hosted
+ * registry write, public catalog write, trust or reputation mutation, payment
+ * activation, endpoint invocation, wallet/RPC call, secret read, or command
+ * execution. Every transition is a local/read-model event: it only re-shapes
+ * an in-memory read model the caller already holds. Timestamps are
+ * caller-supplied so replays are deterministic.
+ *
+ * `published_candidate` is an internal candidate state only. Reaching it never
+ * writes hosted registry output, public catalog output, trust/reputation
+ * mutations, or payment activation; those remain gated behind #395 publication
+ * surfaces outside this module.
+ */
+
+export const ONBOARDING_STATE_MACHINE_SCHEMA_VERSION = 'reddi.onboarding-state-machine.v1' as const;
+export const ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION = 'reddi.onboarding-state-transition-event.v1' as const;
+export const ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION = 'reddi.onboarding-assistant-read-model.v1' as const;
+
+/** Issue anchors so downstream implementations can trace contract ownership. */
+export const ONBOARDING_STATE_MACHINE_ISSUE = 510 as const;
+export const ONBOARDING_STATE_MACHINE_RELATED_ISSUES = Object.freeze({
+  onboardingAssistantEpic: 370,
+  guidedWorkflowFeature: 374,
+  discoverabilityPackageFeature: 376,
+  publicationGateFeature: 395,
+  analyserHandoffContracts: 509,
+} as const);
+
+/**
+ * Hard no-live boundary. Every guardrail is `false` by construction and every
+ * read model carries this object so downstream consumers can assert the
+ * boundary instead of trusting prose.
+ */
+export const ONBOARDING_STATE_MACHINE_GUARDRAILS = Object.freeze({
+  hostedRegistryWriteAllowed: false,
+  publicCatalogWriteAllowed: false,
+  trustMutationAllowed: false,
+  reputationMutationAllowed: false,
+  paymentActivationAllowed: false,
+  endpointInvocationAllowed: false,
+  walletOrRpcAllowed: false,
+  networkFetchAllowed: false,
+  hostedWriteAllowed: false,
+  publicationAllowed: false,
+  secretReadAllowed: false,
+  liveExecutionAllowed: false,
+} as const);
+
+export type OnboardingStateMachineGuardrails = typeof ONBOARDING_STATE_MACHINE_GUARDRAILS;
+
+// ---------------------------------------------------------------------------
+// States
+// ---------------------------------------------------------------------------
+
+export type OnboardingAssistantState =
+  | 'draft'
+  | 'probe_failed'
+  | 'needs_provider_input'
+  | 'payment_setup_required'
+  | 'dry_run_required'
+  | 'risk_review_required'
+  | 'pending_operator_approval'
+  | 'approved_unpublished'
+  | 'changes_requested'
+  | 'rejected'
+  | 'suspended'
+  | 'published_candidate';
+
+export const ONBOARDING_ASSISTANT_STATES: readonly OnboardingAssistantState[] = Object.freeze([
+  'draft',
+  'probe_failed',
+  'needs_provider_input',
+  'payment_setup_required',
+  'dry_run_required',
+  'risk_review_required',
+  'pending_operator_approval',
+  'approved_unpublished',
+  'changes_requested',
+  'rejected',
+  'suspended',
+  'published_candidate',
+]);
+
+/**
+ * Allowed transitions. Anything not listed here fails closed. `rejected` is
+ * terminal: a rejected draft can only be re-onboarded as a brand new draft
+ * with a fresh intake, never mutated back into the flow.
+ */
+export const ONBOARDING_STATE_TRANSITION_GRAPH: Readonly<Record<OnboardingAssistantState, readonly OnboardingAssistantState[]>> = Object.freeze({
+  draft: [
+    'probe_failed',
+    'needs_provider_input',
+    'payment_setup_required',
+    'dry_run_required',
+    'risk_review_required',
+    'pending_operator_approval',
+    'rejected',
+    'suspended',
+  ],
+  probe_failed: ['draft', 'needs_provider_input', 'rejected', 'suspended'],
+  needs_provider_input: ['draft', 'payment_setup_required', 'rejected', 'suspended'],
+  payment_setup_required: ['draft', 'dry_run_required', 'rejected', 'suspended'],
+  dry_run_required: ['probe_failed', 'risk_review_required', 'pending_operator_approval', 'rejected', 'suspended'],
+  risk_review_required: ['pending_operator_approval', 'changes_requested', 'rejected', 'suspended'],
+  pending_operator_approval: ['approved_unpublished', 'changes_requested', 'rejected', 'suspended'],
+  approved_unpublished: ['published_candidate', 'changes_requested', 'suspended'],
+  changes_requested: ['draft', 'pending_operator_approval', 'rejected', 'suspended'],
+  rejected: [],
+  suspended: ['draft', 'rejected'],
+  published_candidate: ['changes_requested', 'suspended'],
+} as const);
+
+// ---------------------------------------------------------------------------
+// Actors, gates, and reason codes
+// ---------------------------------------------------------------------------
+
+export type OnboardingStateActorType = 'operator' | 'provider' | 'analyser' | 'system';
+
+export const ONBOARDING_STATE_ACTOR_TYPES: readonly OnboardingStateActorType[] = Object.freeze([
+  'operator',
+  'provider',
+  'analyser',
+  'system',
+]);
+
+/**
+ * Target states an operator must drive. Approval, rejection, change requests,
+ * suspension, reinstatement out of suspension, and internal candidate
+ * publication are review decisions — they are recorded as local/read-model
+ * events only and never invoke any external system.
+ */
+export const ONBOARDING_OPERATOR_ONLY_TARGET_STATES: readonly OnboardingAssistantState[] = Object.freeze([
+  'approved_unpublished',
+  'changes_requested',
+  'rejected',
+  'suspended',
+  'published_candidate',
+]);
+
+export type OnboardingBlockingGateKey =
+  | 'probe'
+  | 'provider_input'
+  | 'payment_setup'
+  | 'dry_run'
+  | 'risk_review'
+  | 'operator_approval'
+  | 'readiness';
+
+export const ONBOARDING_BLOCKING_GATE_KEYS: readonly OnboardingBlockingGateKey[] = Object.freeze([
+  'probe',
+  'provider_input',
+  'payment_setup',
+  'dry_run',
+  'risk_review',
+  'operator_approval',
+  'readiness',
+]);
+
+/**
+ * Gate reason codes. The first eight mirror the #509 fail-closed reasons so
+ * readiness lane output can be projected directly onto blocking gates; the
+ * rest are state-machine-native reasons.
+ */
+export type OnboardingGateReasonCode =
+  | 'private_url_blocked'
+  | 'credential_leakage_rejected'
+  | 'command_execution_rejected'
+  | 'paid_call_rejected'
+  | 'wallet_rpc_rejected'
+  | 'missing_payment_metadata'
+  | 'missing_evidence'
+  | 'untrusted_imported_content_rejected'
+  | 'probe_failure_recorded'
+  | 'provider_input_required'
+  | 'dry_run_receipt_required'
+  | 'risk_review_pending'
+  | 'operator_approval_pending'
+  | 'readiness_blocked';
+
+const GATE_REASON_CODES: readonly OnboardingGateReasonCode[] = [
+  'private_url_blocked',
+  'credential_leakage_rejected',
+  'command_execution_rejected',
+  'paid_call_rejected',
+  'wallet_rpc_rejected',
+  'missing_payment_metadata',
+  'missing_evidence',
+  'untrusted_imported_content_rejected',
+  'probe_failure_recorded',
+  'provider_input_required',
+  'dry_run_receipt_required',
+  'risk_review_pending',
+  'operator_approval_pending',
+  'readiness_blocked',
+];
+
+export type OnboardingBlockingGate = {
+  gate: OnboardingBlockingGateKey;
+  reasonCodes: OnboardingGateReasonCode[];
+  note?: string;
+};
+
+/** Gate that must still be open when entering each gate-shaped state. */
+export const ONBOARDING_STATE_REQUIRED_GATES: Readonly<Partial<Record<OnboardingAssistantState, OnboardingBlockingGateKey>>> = Object.freeze({
+  probe_failed: 'probe',
+  needs_provider_input: 'provider_input',
+  payment_setup_required: 'payment_setup',
+  dry_run_required: 'dry_run',
+  risk_review_required: 'risk_review',
+  pending_operator_approval: 'operator_approval',
+} as const);
+
+/**
+ * Readiness summary carried on every transition. Mirrors the #509
+ * `OnboardingOverallReadiness` union; re-declared locally so this module stays
+ * import-free while remaining structurally compatible.
+ */
+export type OnboardingStateReadinessSummary = 'blocked' | 'needs_operator_review' | 'publish_ready';
+
+const READINESS_SUMMARIES: readonly OnboardingStateReadinessSummary[] = [
+  'blocked',
+  'needs_operator_review',
+  'publish_ready',
+];
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export type OnboardingStateTransitionErrorCode =
+  | 'malformed_transition_event'
+  | 'malformed_read_model'
+  | 'unknown_state'
+  | 'invalid_transition'
+  | 'terminal_state'
+  | 'missing_audit_reason'
+  | 'invalid_actor_type'
+  | 'operator_action_required'
+  | 'invalid_timestamp'
+  | 'timestamp_regression'
+  | 'missing_source_snapshot_ref'
+  | 'missing_readiness_result_ref'
+  | 'blocked_readiness'
+  | 'missing_blocking_gate'
+  | 'unresolved_blocking_gates'
+  | 'publication_side_effect_rejected';
+
+export type OnboardingStateTransitionError = {
+  code: OnboardingStateTransitionErrorCode;
+  path: string;
+  message: string;
+};
+
+// ---------------------------------------------------------------------------
+// Events and read model
+// ---------------------------------------------------------------------------
+
+/**
+ * A requested transition. Every transition carries the audit reason, actor
+ * type, caller-supplied timestamp, source snapshot reference, readiness result
+ * reference, and the blocking gates that remain open after the transition.
+ *
+ * `requestedSideEffects` exists only so imported/queued events that ask for a
+ * live side effect (hosted write, publication, payment activation, wallet/RPC,
+ * endpoint invocation, trust/reputation mutation, ...) can be rejected fail-
+ * closed. This module never executes any side effect.
+ */
+export type OnboardingStateTransitionEvent = {
+  schemaVersion: typeof ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION;
+  eventId: string;
+  to: OnboardingAssistantState;
+  /** Human-auditable reason for the transition. Required, non-empty. */
+  reason: string;
+  actorType: OnboardingStateActorType;
+  /** Opaque local reference to the acting operator/provider/analyser. */
+  actorRef?: string;
+  /** RFC3339 UTC timestamp, caller-supplied for deterministic replay. */
+  occurredAt: string;
+  /** Reference to the static source snapshot backing this transition. */
+  sourceSnapshotRef: string;
+  /** Reference to the #509 readiness result backing this transition. */
+  readinessResultRef: string;
+  /** Overall readiness recorded on the referenced readiness result. */
+  readinessOverall: OnboardingStateReadinessSummary;
+  /** Gates still blocking after this transition. */
+  blockingGates: OnboardingBlockingGate[];
+  requestedSideEffects?: string[];
+};
+
+/** An applied transition as recorded in the read-model audit history. */
+export type OnboardingStateTransitionRecord = {
+  sequence: number;
+  from: OnboardingAssistantState;
+  to: OnboardingAssistantState;
+  eventId: string;
+  reason: string;
+  actorType: OnboardingStateActorType;
+  actorRef?: string;
+  occurredAt: string;
+  sourceSnapshotRef: string;
+  readinessResultRef: string;
+  readinessOverall: OnboardingStateReadinessSummary;
+  blockingGates: OnboardingBlockingGate[];
+  /** Every recorded action is a local/read-model event only. */
+  scope: 'local_read_model_only';
+};
+
+export type OnboardingAssistantReadModel = {
+  schemaVersion: typeof ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION;
+  stateMachineVersion: typeof ONBOARDING_STATE_MACHINE_SCHEMA_VERSION;
+  draftId: string;
+  state: OnboardingAssistantState;
+  /** Timestamp of the event that produced the current state. */
+  stateSince: string;
+  sourceSnapshotRef: string;
+  readinessResultRef: string;
+  readinessOverall: OnboardingStateReadinessSummary;
+  blockingGates: OnboardingBlockingGate[];
+  history: OnboardingStateTransitionRecord[];
+  /**
+   * `published_candidate` (and every other state) stays internal: nothing in
+   * this read model is a hosted, public, trusted, or payable surface.
+   */
+  internalCandidateOnly: true;
+  /** Side-effect ledger. Every entry is hard-coded false by construction. */
+  publication: {
+    hostedRegistryWritePerformed: false;
+    publicCatalogWritePerformed: false;
+    trustMutationPerformed: false;
+    reputationMutationPerformed: false;
+    paymentActivationPerformed: false;
+    endpointInvocationPerformed: false;
+    walletOrRpcCallPerformed: false;
+  };
+  guardrails: OnboardingStateMachineGuardrails;
+  localReadModelOnly: true;
+  staticOnly: true;
+};
+
+export type OnboardingStateTransitionResult =
+  | { ok: true; readModel: OnboardingAssistantReadModel; record: OnboardingStateTransitionRecord }
+  | { ok: false; failClosed: true; errors: OnboardingStateTransitionError[] };
+
+export type OnboardingReadModelInitResult =
+  | { ok: true; readModel: OnboardingAssistantReadModel }
+  | { ok: false; failClosed: true; errors: OnboardingStateTransitionError[] };
+
+// ---------------------------------------------------------------------------
+// Validation internals
+// ---------------------------------------------------------------------------
+
+const RFC3339_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+
+function transitionError(
+  code: OnboardingStateTransitionErrorCode,
+  path: string,
+  message: string,
+): OnboardingStateTransitionError {
+  return { code, path, message };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isKnownState(value: unknown): value is OnboardingAssistantState {
+  return ONBOARDING_ASSISTANT_STATES.includes(value as OnboardingAssistantState);
+}
+
+function parseUtcMillis(timestamp: string): number {
+  return new Date(timestamp).getTime();
+}
+
+function validateBlockingGates(
+  value: unknown,
+  path: string,
+  errors: OnboardingStateTransitionError[],
+): OnboardingBlockingGate[] {
+  if (!Array.isArray(value)) {
+    errors.push(transitionError('malformed_transition_event', path, 'blockingGates must be an array'));
+    return [];
+  }
+  const gates: OnboardingBlockingGate[] = [];
+  value.forEach((entry, index) => {
+    const entryPath = `${path}[${index}]`;
+    if (!isPlainObject(entry)) {
+      errors.push(transitionError('malformed_transition_event', entryPath, 'blocking gate must be an object'));
+      return;
+    }
+    if (!ONBOARDING_BLOCKING_GATE_KEYS.includes(entry.gate as OnboardingBlockingGateKey)) {
+      errors.push(transitionError('malformed_transition_event', `${entryPath}.gate`, 'blocking gate key is unsupported'));
+      return;
+    }
+    if (!Array.isArray(entry.reasonCodes)
+      || !entry.reasonCodes.every((code) => GATE_REASON_CODES.includes(code as OnboardingGateReasonCode))) {
+      errors.push(transitionError('malformed_transition_event', `${entryPath}.reasonCodes`, 'reasonCodes must be an array of recognised gate reason codes'));
+      return;
+    }
+    if (entry.note !== undefined && !isNonEmptyString(entry.note)) {
+      errors.push(transitionError('malformed_transition_event', `${entryPath}.note`, 'note must be a non-empty string when present'));
+      return;
+    }
+    gates.push({
+      gate: entry.gate as OnboardingBlockingGateKey,
+      reasonCodes: [...(entry.reasonCodes as OnboardingGateReasonCode[])],
+      ...(entry.note !== undefined ? { note: entry.note as string } : {}),
+    });
+  });
+  return gates;
+}
+
+type ValidatedEventCore = {
+  eventId: string;
+  to: OnboardingAssistantState;
+  reason: string;
+  actorType: OnboardingStateActorType;
+  actorRef?: string;
+  occurredAt: string;
+  sourceSnapshotRef: string;
+  readinessResultRef: string;
+  readinessOverall: OnboardingStateReadinessSummary;
+  blockingGates: OnboardingBlockingGate[];
+};
+
+function validateTransitionEventShape(
+  input: unknown,
+  errors: OnboardingStateTransitionError[],
+): ValidatedEventCore | undefined {
+  if (!isPlainObject(input)) {
+    errors.push(transitionError('malformed_transition_event', '$', 'transition event must be a plain object'));
+    return undefined;
+  }
+  if (input.schemaVersion !== ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION) {
+    errors.push(transitionError('malformed_transition_event', '$.schemaVersion', `expected ${ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION}`));
+  }
+  if (!isNonEmptyString(input.eventId)) {
+    errors.push(transitionError('malformed_transition_event', '$.eventId', 'eventId must be a non-empty string'));
+  }
+  if (!isKnownState(input.to)) {
+    errors.push(transitionError('unknown_state', '$.to', 'target state is not one of the twelve onboarding assistant states'));
+  }
+  if (!isNonEmptyString(input.reason)) {
+    errors.push(transitionError('missing_audit_reason', '$.reason', 'every transition must carry a non-empty audit reason'));
+  }
+  if (!ONBOARDING_STATE_ACTOR_TYPES.includes(input.actorType as OnboardingStateActorType)) {
+    errors.push(transitionError('invalid_actor_type', '$.actorType', 'actorType must be operator, provider, analyser, or system'));
+  }
+  if (input.actorRef !== undefined && !isNonEmptyString(input.actorRef)) {
+    errors.push(transitionError('malformed_transition_event', '$.actorRef', 'actorRef must be a non-empty string when present'));
+  }
+  if (!isNonEmptyString(input.occurredAt) || !RFC3339_UTC_PATTERN.test(input.occurredAt)) {
+    errors.push(transitionError('invalid_timestamp', '$.occurredAt', 'occurredAt must be a caller-supplied RFC3339 UTC timestamp'));
+  }
+  if (!isNonEmptyString(input.sourceSnapshotRef)) {
+    errors.push(transitionError('missing_source_snapshot_ref', '$.sourceSnapshotRef', 'every transition must reference the static source snapshot'));
+  }
+  if (!isNonEmptyString(input.readinessResultRef)) {
+    errors.push(transitionError('missing_readiness_result_ref', '$.readinessResultRef', 'every transition must reference the readiness result backing it'));
+  }
+  if (!READINESS_SUMMARIES.includes(input.readinessOverall as OnboardingStateReadinessSummary)) {
+    errors.push(transitionError('malformed_transition_event', '$.readinessOverall', 'readinessOverall must be blocked, needs_operator_review, or publish_ready'));
+  }
+  const blockingGates = validateBlockingGates(input.blockingGates, '$.blockingGates', errors);
+  if (input.requestedSideEffects !== undefined) {
+    if (!Array.isArray(input.requestedSideEffects) || !input.requestedSideEffects.every((item) => typeof item === 'string')) {
+      errors.push(transitionError('malformed_transition_event', '$.requestedSideEffects', 'requestedSideEffects must be a string array when present'));
+    } else {
+      (input.requestedSideEffects as string[]).forEach((effect, index) => {
+        errors.push(transitionError(
+          'publication_side_effect_rejected',
+          `$.requestedSideEffects[${index}]`,
+          `requested side effect "${effect}" is rejected fail-closed: transitions are local/read-model events only`,
+        ));
+      });
+    }
+  }
+  if (errors.length > 0) return undefined;
+  return {
+    eventId: input.eventId as string,
+    to: input.to as OnboardingAssistantState,
+    reason: input.reason as string,
+    actorType: input.actorType as OnboardingStateActorType,
+    ...(input.actorRef !== undefined ? { actorRef: input.actorRef as string } : {}),
+    occurredAt: input.occurredAt as string,
+    sourceSnapshotRef: input.sourceSnapshotRef as string,
+    readinessResultRef: input.readinessResultRef as string,
+    readinessOverall: input.readinessOverall as OnboardingStateReadinessSummary,
+    blockingGates,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Read-model construction
+// ---------------------------------------------------------------------------
+
+export type OnboardingReadModelInit = {
+  draftId: string;
+  sourceSnapshotRef: string;
+  readinessResultRef: string;
+  readinessOverall: OnboardingStateReadinessSummary;
+  /** RFC3339 UTC timestamp, caller-supplied for deterministic replay. */
+  createdAt: string;
+  blockingGates?: OnboardingBlockingGate[];
+};
+
+const READ_MODEL_PUBLICATION_LEDGER = Object.freeze({
+  hostedRegistryWritePerformed: false,
+  publicCatalogWritePerformed: false,
+  trustMutationPerformed: false,
+  reputationMutationPerformed: false,
+  paymentActivationPerformed: false,
+  endpointInvocationPerformed: false,
+  walletOrRpcCallPerformed: false,
+} as const);
+
+/**
+ * Create a read model for a new onboarding draft. Drafts always start in
+ * `draft`; there is no way to construct a read model already approved or
+ * published.
+ */
+export function createOnboardingAssistantReadModel(init: unknown): OnboardingReadModelInitResult {
+  const errors: OnboardingStateTransitionError[] = [];
+  if (!isPlainObject(init)) {
+    return { ok: false, failClosed: true, errors: [transitionError('malformed_read_model', '$', 'read model init must be a plain object')] };
+  }
+  if (!isNonEmptyString(init.draftId)) {
+    errors.push(transitionError('malformed_read_model', '$.draftId', 'draftId must be a non-empty string'));
+  }
+  if (!isNonEmptyString(init.sourceSnapshotRef)) {
+    errors.push(transitionError('missing_source_snapshot_ref', '$.sourceSnapshotRef', 'sourceSnapshotRef must be a non-empty string'));
+  }
+  if (!isNonEmptyString(init.readinessResultRef)) {
+    errors.push(transitionError('missing_readiness_result_ref', '$.readinessResultRef', 'readinessResultRef must be a non-empty string'));
+  }
+  if (!READINESS_SUMMARIES.includes(init.readinessOverall as OnboardingStateReadinessSummary)) {
+    errors.push(transitionError('malformed_read_model', '$.readinessOverall', 'readinessOverall must be blocked, needs_operator_review, or publish_ready'));
+  }
+  if (!isNonEmptyString(init.createdAt) || !RFC3339_UTC_PATTERN.test(init.createdAt)) {
+    errors.push(transitionError('invalid_timestamp', '$.createdAt', 'createdAt must be a caller-supplied RFC3339 UTC timestamp'));
+  }
+  const blockingGates = init.blockingGates === undefined
+    ? []
+    : validateBlockingGates(init.blockingGates, '$.blockingGates', errors);
+  if (errors.length > 0) {
+    return { ok: false, failClosed: true, errors };
+  }
+  return {
+    ok: true,
+    readModel: {
+      schemaVersion: ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION,
+      stateMachineVersion: ONBOARDING_STATE_MACHINE_SCHEMA_VERSION,
+      draftId: init.draftId as string,
+      state: 'draft',
+      stateSince: init.createdAt as string,
+      sourceSnapshotRef: init.sourceSnapshotRef as string,
+      readinessResultRef: init.readinessResultRef as string,
+      readinessOverall: init.readinessOverall as OnboardingStateReadinessSummary,
+      blockingGates,
+      history: [],
+      internalCandidateOnly: true,
+      publication: { ...READ_MODEL_PUBLICATION_LEDGER },
+      guardrails: ONBOARDING_STATE_MACHINE_GUARDRAILS,
+      localReadModelOnly: true,
+      staticOnly: true,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transition application
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a transition event to a read model. Pure and deterministic: the input
+ * read model is never mutated; a new read model with the appended audit record
+ * is returned. Invalid transitions fail closed with structured reasons and no
+ * state change.
+ */
+export function applyOnboardingStateTransition(
+  readModel: OnboardingAssistantReadModel,
+  event: unknown,
+): OnboardingStateTransitionResult {
+  if (!isPlainObject(readModel) || !isKnownState(readModel.state)) {
+    return {
+      ok: false,
+      failClosed: true,
+      errors: [transitionError('malformed_read_model', '$.readModel.state', 'read model must carry a known onboarding assistant state')],
+    };
+  }
+
+  const errors: OnboardingStateTransitionError[] = [];
+  const core = validateTransitionEventShape(event, errors);
+  if (!core) {
+    return { ok: false, failClosed: true, errors };
+  }
+
+  const from = readModel.state;
+  const allowed = ONBOARDING_STATE_TRANSITION_GRAPH[from];
+
+  if (allowed.length === 0) {
+    errors.push(transitionError(
+      'terminal_state',
+      '$.to',
+      `state "${from}" is terminal; a rejected draft must be re-onboarded as a new draft`,
+    ));
+  } else if (!allowed.includes(core.to)) {
+    errors.push(transitionError(
+      'invalid_transition',
+      '$.to',
+      `transition ${from} -> ${core.to} is not allowed by the onboarding state machine`,
+    ));
+  }
+
+  const operatorRequired = ONBOARDING_OPERATOR_ONLY_TARGET_STATES.includes(core.to) || from === 'suspended';
+  if (operatorRequired && core.actorType !== 'operator') {
+    errors.push(transitionError(
+      'operator_action_required',
+      '$.actorType',
+      `transition ${from} -> ${core.to} is an operator review decision and must be recorded by an operator actor`,
+    ));
+  }
+
+  const requiredGate = ONBOARDING_STATE_REQUIRED_GATES[core.to];
+  if (requiredGate && !core.blockingGates.some((gate) => gate.gate === requiredGate)) {
+    errors.push(transitionError(
+      'missing_blocking_gate',
+      '$.blockingGates',
+      `entering ${core.to} requires the open "${requiredGate}" blocking gate to be carried on the transition`,
+    ));
+  }
+
+  if (core.to === 'approved_unpublished' || core.to === 'published_candidate') {
+    if (core.readinessOverall === 'blocked') {
+      errors.push(transitionError(
+        'blocked_readiness',
+        '$.readinessOverall',
+        `cannot enter ${core.to} while the referenced readiness result is blocked`,
+      ));
+    }
+    if (core.blockingGates.length > 0) {
+      errors.push(transitionError(
+        'unresolved_blocking_gates',
+        '$.blockingGates',
+        `cannot enter ${core.to} while blocking gates remain open: ${core.blockingGates.map((gate) => gate.gate).join(', ')}`,
+      ));
+    }
+  }
+
+  if (RFC3339_UTC_PATTERN.test(core.occurredAt)
+    && parseUtcMillis(core.occurredAt) < parseUtcMillis(readModel.stateSince)) {
+    errors.push(transitionError(
+      'timestamp_regression',
+      '$.occurredAt',
+      'occurredAt must not be earlier than the timestamp of the current state',
+    ));
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, failClosed: true, errors };
+  }
+
+  const record: OnboardingStateTransitionRecord = {
+    sequence: readModel.history.length + 1,
+    from,
+    to: core.to,
+    eventId: core.eventId,
+    reason: core.reason,
+    actorType: core.actorType,
+    ...(core.actorRef !== undefined ? { actorRef: core.actorRef } : {}),
+    occurredAt: core.occurredAt,
+    sourceSnapshotRef: core.sourceSnapshotRef,
+    readinessResultRef: core.readinessResultRef,
+    readinessOverall: core.readinessOverall,
+    blockingGates: core.blockingGates.map((gate) => ({ ...gate, reasonCodes: [...gate.reasonCodes] })),
+    scope: 'local_read_model_only',
+  };
+
+  return {
+    ok: true,
+    readModel: {
+      ...readModel,
+      state: core.to,
+      stateSince: core.occurredAt,
+      sourceSnapshotRef: core.sourceSnapshotRef,
+      readinessResultRef: core.readinessResultRef,
+      readinessOverall: core.readinessOverall,
+      blockingGates: record.blockingGates.map((gate) => ({ ...gate, reasonCodes: [...gate.reasonCodes] })),
+      history: [...readModel.history, record],
+      internalCandidateOnly: true,
+      publication: { ...READ_MODEL_PUBLICATION_LEDGER },
+      guardrails: ONBOARDING_STATE_MACHINE_GUARDRAILS,
+      localReadModelOnly: true,
+      staticOnly: true,
+    },
+    record,
+  };
+}
+
+/**
+ * List the allowed target states from a given state. Useful for read-model
+ * consumers (UI lanes in #384/#385/#386) that need to render next actions
+ * without re-encoding the graph.
+ */
+export function listOnboardingStateTransitions(
+  from: OnboardingAssistantState,
+): readonly OnboardingAssistantState[] {
+  return ONBOARDING_STATE_TRANSITION_GRAPH[from] ?? Object.freeze([]);
+}

--- a/packages/agent-protocol/tests/onboarding-state-machine.test.ts
+++ b/packages/agent-protocol/tests/onboarding-state-machine.test.ts
@@ -1,0 +1,595 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION,
+  ONBOARDING_ASSISTANT_STATES,
+  ONBOARDING_BLOCKING_GATE_KEYS,
+  ONBOARDING_OPERATOR_ONLY_TARGET_STATES,
+  ONBOARDING_STATE_ACTOR_TYPES,
+  ONBOARDING_STATE_MACHINE_GUARDRAILS,
+  ONBOARDING_STATE_MACHINE_ISSUE,
+  ONBOARDING_STATE_MACHINE_RELATED_ISSUES,
+  ONBOARDING_STATE_MACHINE_SCHEMA_VERSION,
+  ONBOARDING_STATE_REQUIRED_GATES,
+  ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION,
+  ONBOARDING_STATE_TRANSITION_GRAPH,
+  applyOnboardingStateTransition,
+  createOnboardingAssistantReadModel,
+  listOnboardingStateTransitions,
+  type OnboardingAssistantReadModel,
+  type OnboardingAssistantState,
+  type OnboardingStateTransitionError,
+  type OnboardingStateTransitionEvent,
+} from '../dist/index.js';
+
+const T0 = '2026-07-06T00:00:00Z';
+const SNAPSHOT_REF = 'fixtures/onboarding/state-machine-draft-1.json';
+const READINESS_REF = 'draft-profile:state-machine-draft-1#readiness';
+
+function newReadModel(): OnboardingAssistantReadModel {
+  const created = createOnboardingAssistantReadModel({
+    draftId: 'state-machine-draft-1',
+    sourceSnapshotRef: SNAPSHOT_REF,
+    readinessResultRef: READINESS_REF,
+    readinessOverall: 'needs_operator_review',
+    createdAt: T0,
+  });
+  assert.ok(created.ok, 'baseline read model must initialise');
+  return created.readModel;
+}
+
+let eventCounter = 0;
+
+function event(overrides: Partial<OnboardingStateTransitionEvent> & Pick<OnboardingStateTransitionEvent, 'to'>): OnboardingStateTransitionEvent {
+  eventCounter += 1;
+  return {
+    schemaVersion: ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION,
+    eventId: `event-${eventCounter}`,
+    reason: `test transition to ${overrides.to}`,
+    actorType: 'operator',
+    occurredAt: '2026-07-06T01:00:00Z',
+    sourceSnapshotRef: SNAPSHOT_REF,
+    readinessResultRef: READINESS_REF,
+    readinessOverall: 'needs_operator_review',
+    blockingGates: [],
+    ...overrides,
+  };
+}
+
+function apply(readModel: OnboardingAssistantReadModel, overrides: Partial<OnboardingStateTransitionEvent> & Pick<OnboardingStateTransitionEvent, 'to'>): OnboardingAssistantReadModel {
+  const result = applyOnboardingStateTransition(readModel, event(overrides));
+  assert.ok(result.ok, `transition to ${overrides.to} must succeed: ${JSON.stringify(!result.ok ? result.errors : [])}`);
+  return result.readModel;
+}
+
+function failCodes(readModel: OnboardingAssistantReadModel, overrides: Partial<OnboardingStateTransitionEvent> & Pick<OnboardingStateTransitionEvent, 'to'>): string[] {
+  const result = applyOnboardingStateTransition(readModel, event(overrides));
+  assert.ok(!result.ok, `transition to ${overrides.to} must fail closed`);
+  assert.equal(result.failClosed, true);
+  for (const error of result.errors) {
+    assert.ok(error.code.length > 0 && error.path.startsWith('$') && error.message.length > 0, 'errors must be structured');
+  }
+  return [...new Set(result.errors.map((error: OnboardingStateTransitionError) => error.code))].sort();
+}
+
+/** Drive the happy path up to a given state with fully-cleared gates. */
+function readModelAt(state: OnboardingAssistantState): OnboardingAssistantReadModel {
+  let model = newReadModel();
+  if (state === 'draft') return model;
+  const path: Array<Partial<OnboardingStateTransitionEvent> & Pick<OnboardingStateTransitionEvent, 'to'>> = [
+    {
+      to: 'payment_setup_required',
+      eventId: 'happy-path-1',
+      actorType: 'analyser',
+      occurredAt: '2026-07-06T01:00:00Z',
+      blockingGates: [{ gate: 'payment_setup', reasonCodes: ['missing_payment_metadata'] }],
+    },
+    {
+      to: 'dry_run_required',
+      eventId: 'happy-path-2',
+      actorType: 'provider',
+      occurredAt: '2026-07-06T02:00:00Z',
+      blockingGates: [{ gate: 'dry_run', reasonCodes: ['dry_run_receipt_required'] }],
+    },
+    {
+      to: 'risk_review_required',
+      eventId: 'happy-path-3',
+      actorType: 'analyser',
+      occurredAt: '2026-07-06T03:00:00Z',
+      blockingGates: [{ gate: 'risk_review', reasonCodes: ['risk_review_pending'] }],
+    },
+    {
+      to: 'pending_operator_approval',
+      eventId: 'happy-path-4',
+      actorType: 'analyser',
+      occurredAt: '2026-07-06T04:00:00Z',
+      blockingGates: [{ gate: 'operator_approval', reasonCodes: ['operator_approval_pending'] }],
+    },
+    {
+      to: 'approved_unpublished',
+      eventId: 'happy-path-5',
+      actorType: 'operator',
+      actorRef: 'operator:reviewer-1',
+      reason: 'operator approved after review of readiness result and gates',
+      occurredAt: '2026-07-06T05:00:00Z',
+      blockingGates: [],
+    },
+    {
+      to: 'published_candidate',
+      eventId: 'happy-path-6',
+      actorType: 'operator',
+      actorRef: 'operator:reviewer-1',
+      reason: 'operator marked draft as internal publication candidate',
+      occurredAt: '2026-07-06T06:00:00Z',
+      blockingGates: [],
+    },
+  ];
+  for (const step of path) {
+    model = apply(model, step);
+    if (model.state === state) return model;
+  }
+  assert.fail(`state ${state} is not on the happy path`);
+}
+
+describe('onboarding assistant state-machine read model (#510)', () => {
+  it('anchors the state machine to its issue map', () => {
+    assert.equal(ONBOARDING_STATE_MACHINE_ISSUE, 510);
+    assert.equal(ONBOARDING_STATE_MACHINE_RELATED_ISSUES.onboardingAssistantEpic, 370);
+    assert.equal(ONBOARDING_STATE_MACHINE_RELATED_ISSUES.guidedWorkflowFeature, 374);
+    assert.equal(ONBOARDING_STATE_MACHINE_RELATED_ISSUES.discoverabilityPackageFeature, 376);
+    assert.equal(ONBOARDING_STATE_MACHINE_RELATED_ISSUES.publicationGateFeature, 395);
+    assert.equal(ONBOARDING_STATE_MACHINE_RELATED_ISSUES.analyserHandoffContracts, 509);
+    assert.equal(ONBOARDING_STATE_MACHINE_SCHEMA_VERSION, 'reddi.onboarding-state-machine.v1');
+    assert.equal(ONBOARDING_STATE_TRANSITION_EVENT_SCHEMA_VERSION, 'reddi.onboarding-state-transition-event.v1');
+    assert.equal(ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION, 'reddi.onboarding-assistant-read-model.v1');
+  });
+
+  it('keeps every no-live guardrail explicitly false', () => {
+    const values = Object.values(ONBOARDING_STATE_MACHINE_GUARDRAILS);
+    assert.ok(values.length >= 12);
+    for (const value of values) {
+      assert.equal(value, false);
+    }
+    assert.equal(ONBOARDING_STATE_MACHINE_GUARDRAILS.hostedRegistryWriteAllowed, false);
+    assert.equal(ONBOARDING_STATE_MACHINE_GUARDRAILS.publicCatalogWriteAllowed, false);
+    assert.equal(ONBOARDING_STATE_MACHINE_GUARDRAILS.trustMutationAllowed, false);
+    assert.equal(ONBOARDING_STATE_MACHINE_GUARDRAILS.reputationMutationAllowed, false);
+    assert.equal(ONBOARDING_STATE_MACHINE_GUARDRAILS.paymentActivationAllowed, false);
+    assert.equal(ONBOARDING_STATE_MACHINE_GUARDRAILS.endpointInvocationAllowed, false);
+    assert.equal(ONBOARDING_STATE_MACHINE_GUARDRAILS.walletOrRpcAllowed, false);
+  });
+
+  describe('states and transition graph', () => {
+    it('supports exactly the twelve required states', () => {
+      assert.deepEqual([...ONBOARDING_ASSISTANT_STATES], [
+        'draft',
+        'probe_failed',
+        'needs_provider_input',
+        'payment_setup_required',
+        'dry_run_required',
+        'risk_review_required',
+        'pending_operator_approval',
+        'approved_unpublished',
+        'changes_requested',
+        'rejected',
+        'suspended',
+        'published_candidate',
+      ]);
+      assert.equal(ONBOARDING_ASSISTANT_STATES.length, 12);
+    });
+
+    it('defines a graph entry for every state and only known target states', () => {
+      assert.deepEqual(Object.keys(ONBOARDING_STATE_TRANSITION_GRAPH).sort(), [...ONBOARDING_ASSISTANT_STATES].sort());
+      for (const [from, targets] of Object.entries(ONBOARDING_STATE_TRANSITION_GRAPH)) {
+        for (const target of targets) {
+          assert.ok(ONBOARDING_ASSISTANT_STATES.includes(target), `${from} -> ${target} must target a known state`);
+          assert.notEqual(target, from, `${from} must not self-transition`);
+        }
+        assert.deepEqual(listOnboardingStateTransitions(from as OnboardingAssistantState), targets);
+      }
+    });
+
+    it('keeps rejected terminal and published_candidate internal-recall-only', () => {
+      assert.deepEqual([...ONBOARDING_STATE_TRANSITION_GRAPH.rejected], []);
+      assert.deepEqual([...ONBOARDING_STATE_TRANSITION_GRAPH.published_candidate].sort(), ['changes_requested', 'suspended']);
+      assert.equal(ONBOARDING_BLOCKING_GATE_KEYS.length, 7);
+      assert.equal(ONBOARDING_STATE_ACTOR_TYPES.length, 4);
+    });
+  });
+
+  describe('read model construction', () => {
+    it('initialises a draft read model with a caller-supplied timestamp', () => {
+      const model = newReadModel();
+      assert.equal(model.schemaVersion, ONBOARDING_ASSISTANT_READ_MODEL_SCHEMA_VERSION);
+      assert.equal(model.stateMachineVersion, ONBOARDING_STATE_MACHINE_SCHEMA_VERSION);
+      assert.equal(model.state, 'draft');
+      assert.equal(model.stateSince, T0);
+      assert.equal(model.sourceSnapshotRef, SNAPSHOT_REF);
+      assert.equal(model.readinessResultRef, READINESS_REF);
+      assert.deepEqual(model.history, []);
+      assert.equal(model.localReadModelOnly, true);
+      assert.equal(model.staticOnly, true);
+      assert.equal(model.internalCandidateOnly, true);
+      assert.deepEqual(model.guardrails, ONBOARDING_STATE_MACHINE_GUARDRAILS);
+    });
+
+    it('fails closed on malformed init input', () => {
+      const missing = createOnboardingAssistantReadModel({});
+      assert.ok(!missing.ok);
+      const codes = new Set(missing.errors.map((error) => error.code));
+      assert.ok(codes.has('malformed_read_model'));
+      assert.ok(codes.has('missing_source_snapshot_ref'));
+      assert.ok(codes.has('missing_readiness_result_ref'));
+      assert.ok(codes.has('invalid_timestamp'));
+
+      const badTimestamp = createOnboardingAssistantReadModel({
+        draftId: 'x',
+        sourceSnapshotRef: SNAPSHOT_REF,
+        readinessResultRef: READINESS_REF,
+        readinessOverall: 'needs_operator_review',
+        createdAt: 'yesterday around noon',
+      });
+      assert.ok(!badTimestamp.ok);
+      assert.ok(badTimestamp.errors.some((error) => error.code === 'invalid_timestamp'));
+    });
+  });
+
+  describe('valid transitions', () => {
+    it('walks the full happy path to published_candidate with a complete audit trail', () => {
+      const model = readModelAt('published_candidate');
+      assert.equal(model.state, 'published_candidate');
+      assert.equal(model.history.length, 6);
+      assert.deepEqual(
+        model.history.map((record) => [record.from, record.to]),
+        [
+          ['draft', 'payment_setup_required'],
+          ['payment_setup_required', 'dry_run_required'],
+          ['dry_run_required', 'risk_review_required'],
+          ['risk_review_required', 'pending_operator_approval'],
+          ['pending_operator_approval', 'approved_unpublished'],
+          ['approved_unpublished', 'published_candidate'],
+        ],
+      );
+      model.history.forEach((record, index) => {
+        assert.equal(record.sequence, index + 1);
+        assert.ok(record.reason.length > 0, 'every transition carries an audit reason');
+        assert.ok(ONBOARDING_STATE_ACTOR_TYPES.includes(record.actorType), 'every transition carries an actor type');
+        assert.match(record.occurredAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+        assert.equal(record.sourceSnapshotRef, SNAPSHOT_REF);
+        assert.equal(record.readinessResultRef, READINESS_REF);
+        assert.ok(Array.isArray(record.blockingGates), 'every transition carries blocking gates');
+        assert.equal(record.scope, 'local_read_model_only');
+      });
+      assert.equal(model.stateSince, '2026-07-06T06:00:00Z');
+    });
+
+    it('supports remediation loops: probe_failed and needs_provider_input back to draft', () => {
+      let model = newReadModel();
+      model = apply(model, {
+        to: 'probe_failed',
+        actorType: 'analyser',
+        occurredAt: '2026-07-06T01:00:00Z',
+        blockingGates: [{ gate: 'probe', reasonCodes: ['probe_failure_recorded'], note: 'static probe evidence recorded a failing check' }],
+      });
+      assert.equal(model.state, 'probe_failed');
+      model = apply(model, {
+        to: 'needs_provider_input',
+        actorType: 'system',
+        occurredAt: '2026-07-06T02:00:00Z',
+        blockingGates: [{ gate: 'provider_input', reasonCodes: ['provider_input_required'] }],
+      });
+      assert.equal(model.state, 'needs_provider_input');
+      model = apply(model, {
+        to: 'draft',
+        actorType: 'provider',
+        occurredAt: '2026-07-06T03:00:00Z',
+        reason: 'provider supplied the missing descriptor fields',
+      });
+      assert.equal(model.state, 'draft');
+      assert.equal(model.history.length, 3);
+    });
+
+    it('supports changes_requested loops back through review', () => {
+      let model = readModelAt('pending_operator_approval');
+      model = apply(model, {
+        to: 'changes_requested',
+        actorType: 'operator',
+        occurredAt: '2026-07-06T05:00:00Z',
+        reason: 'operator requested pricing description changes',
+      });
+      assert.equal(model.state, 'changes_requested');
+      model = apply(model, {
+        to: 'pending_operator_approval',
+        actorType: 'provider',
+        occurredAt: '2026-07-06T06:00:00Z',
+        blockingGates: [{ gate: 'operator_approval', reasonCodes: ['operator_approval_pending'] }],
+      });
+      assert.equal(model.state, 'pending_operator_approval');
+    });
+
+    it('does not mutate the input read model', () => {
+      const model = newReadModel();
+      const before = JSON.stringify(model);
+      const result = applyOnboardingStateTransition(model, event({
+        to: 'payment_setup_required',
+        actorType: 'analyser',
+        blockingGates: [{ gate: 'payment_setup', reasonCodes: ['missing_payment_metadata'] }],
+      }));
+      assert.ok(result.ok);
+      assert.equal(JSON.stringify(model), before);
+      assert.equal(model.state, 'draft');
+    });
+
+    it('is deterministic: replaying the same events produces identical read models', () => {
+      assert.deepEqual(readModelAt('published_candidate'), readModelAt('published_candidate'));
+    });
+  });
+
+  describe('invalid transitions fail closed with structured reasons', () => {
+    it('rejects edges not present in the graph', () => {
+      assert.deepEqual(failCodes(newReadModel(), { to: 'published_candidate' }), ['invalid_transition']);
+      assert.deepEqual(failCodes(newReadModel(), { to: 'approved_unpublished' }), ['invalid_transition']);
+      assert.deepEqual(
+        failCodes(readModelAt('published_candidate'), { to: 'approved_unpublished', occurredAt: '2026-07-06T07:00:00Z' }),
+        ['invalid_transition'],
+      );
+      assert.deepEqual(
+        failCodes(readModelAt('approved_unpublished'), { to: 'draft', occurredAt: '2026-07-06T06:00:00Z' }),
+        ['invalid_transition'],
+      );
+    });
+
+    it('rejects unknown target states', () => {
+      const result = applyOnboardingStateTransition(newReadModel(), {
+        ...event({ to: 'draft' }),
+        to: 'published',
+      });
+      assert.ok(!result.ok);
+      assert.ok(result.errors.some((error) => error.code === 'unknown_state'));
+    });
+
+    it('rejects malformed transition events without state change', () => {
+      const model = newReadModel();
+      const result = applyOnboardingStateTransition(model, { schemaVersion: 'nope' });
+      assert.ok(!result.ok);
+      assert.equal(result.failClosed, true);
+      assert.ok(result.errors.length >= 5);
+      assert.equal(model.state, 'draft');
+    });
+
+    it('rejects transitions missing the source snapshot or readiness result reference', () => {
+      const codes = failCodes(newReadModel(), {
+        to: 'payment_setup_required',
+        actorType: 'analyser',
+        sourceSnapshotRef: '',
+        readinessResultRef: '  ',
+        blockingGates: [{ gate: 'payment_setup', reasonCodes: ['missing_payment_metadata'] }],
+      });
+      assert.deepEqual(codes, ['missing_readiness_result_ref', 'missing_source_snapshot_ref']);
+    });
+
+    it('rejects gate states entered without their open blocking gate', () => {
+      assert.deepEqual(
+        failCodes(newReadModel(), { to: 'payment_setup_required', actorType: 'analyser', blockingGates: [] }),
+        ['missing_blocking_gate'],
+      );
+      assert.deepEqual(
+        failCodes(newReadModel(), { to: 'risk_review_required', actorType: 'analyser', blockingGates: [{ gate: 'probe', reasonCodes: [] }] }),
+        ['missing_blocking_gate'],
+      );
+      assert.equal(Object.keys(ONBOARDING_STATE_REQUIRED_GATES).length, 6);
+    });
+
+    it('rejects caller timestamps that are malformed or regress', () => {
+      assert.deepEqual(
+        failCodes(newReadModel(), { to: 'suspended', occurredAt: '06/07/2026 10:00' }),
+        ['invalid_timestamp'],
+      );
+      assert.deepEqual(
+        failCodes(newReadModel(), { to: 'suspended', occurredAt: '2026-07-05T23:59:59Z' }),
+        ['timestamp_regression'],
+      );
+    });
+  });
+
+  describe('operator approval discipline', () => {
+    it('fails closed on a missing approval reason', () => {
+      const codes = failCodes(readModelAt('pending_operator_approval'), {
+        to: 'approved_unpublished',
+        actorType: 'operator',
+        reason: '   ',
+        occurredAt: '2026-07-06T05:00:00Z',
+      });
+      assert.deepEqual(codes, ['missing_audit_reason']);
+    });
+
+    it('fails closed on approval while readiness is blocked', () => {
+      const codes = failCodes(readModelAt('pending_operator_approval'), {
+        to: 'approved_unpublished',
+        actorType: 'operator',
+        occurredAt: '2026-07-06T05:00:00Z',
+        readinessOverall: 'blocked',
+      });
+      assert.deepEqual(codes, ['blocked_readiness']);
+    });
+
+    it('fails closed on approval while blocking gates remain open', () => {
+      const codes = failCodes(readModelAt('pending_operator_approval'), {
+        to: 'approved_unpublished',
+        actorType: 'operator',
+        occurredAt: '2026-07-06T05:00:00Z',
+        blockingGates: [{ gate: 'payment_setup', reasonCodes: ['missing_payment_metadata'] }],
+      });
+      assert.deepEqual(codes, ['unresolved_blocking_gates']);
+    });
+
+    it('requires an operator actor for review decisions', () => {
+      for (const target of ONBOARDING_OPERATOR_ONLY_TARGET_STATES) {
+        assert.ok(['approved_unpublished', 'changes_requested', 'rejected', 'suspended', 'published_candidate'].includes(target));
+      }
+      const codes = failCodes(readModelAt('pending_operator_approval'), {
+        to: 'approved_unpublished',
+        actorType: 'analyser',
+        occurredAt: '2026-07-06T05:00:00Z',
+      });
+      assert.deepEqual(codes, ['operator_action_required']);
+      assert.deepEqual(
+        failCodes(newReadModel(), { to: 'rejected', actorType: 'system' }),
+        ['operator_action_required'],
+      );
+    });
+  });
+
+  describe('rejected state', () => {
+    it('records an operator rejection with reason and refs', () => {
+      const model = apply(readModelAt('pending_operator_approval'), {
+        to: 'rejected',
+        actorType: 'operator',
+        actorRef: 'operator:reviewer-1',
+        reason: 'capability descriptions conflict with the source snapshot',
+        occurredAt: '2026-07-06T05:00:00Z',
+      });
+      assert.equal(model.state, 'rejected');
+      const record = model.history[model.history.length - 1];
+      assert.ok(record);
+      assert.equal(record.actorType, 'operator');
+      assert.equal(record.reason, 'capability descriptions conflict with the source snapshot');
+      assert.equal(record.sourceSnapshotRef, SNAPSHOT_REF);
+      assert.equal(record.readinessResultRef, READINESS_REF);
+    });
+
+    it('is terminal: every outgoing transition fails closed', () => {
+      const model = apply(newReadModel(), {
+        to: 'rejected',
+        actorType: 'operator',
+        reason: 'operator rejected the draft outright',
+      });
+      for (const target of ONBOARDING_ASSISTANT_STATES.filter((state) => state !== 'rejected')) {
+        const codes = failCodes(model, {
+          to: target,
+          actorType: 'operator',
+          occurredAt: '2026-07-06T09:00:00Z',
+          blockingGates: [],
+        });
+        assert.ok(codes.includes('terminal_state'), `rejected -> ${target} must be terminal`);
+      }
+    });
+  });
+
+  describe('suspended state', () => {
+    it('suspends from active states and reinstates to draft via an operator', () => {
+      let model = readModelAt('published_candidate');
+      model = apply(model, {
+        to: 'suspended',
+        actorType: 'operator',
+        reason: 'operator suspended the candidate pending re-review',
+        occurredAt: '2026-07-06T07:00:00Z',
+      });
+      assert.equal(model.state, 'suspended');
+      assert.deepEqual(
+        failCodes(model, { to: 'draft', actorType: 'provider', occurredAt: '2026-07-06T08:00:00Z' }),
+        ['operator_action_required'],
+      );
+      model = apply(model, {
+        to: 'draft',
+        actorType: 'operator',
+        reason: 'operator reinstated the draft for a fresh review pass',
+        occurredAt: '2026-07-06T08:00:00Z',
+      });
+      assert.equal(model.state, 'draft');
+    });
+
+    it('only allows reinstatement or rejection out of suspension', () => {
+      const model = apply(newReadModel(), {
+        to: 'suspended',
+        actorType: 'operator',
+        reason: 'operator suspended the draft',
+      });
+      assert.deepEqual([...ONBOARDING_STATE_TRANSITION_GRAPH.suspended].sort(), ['draft', 'rejected']);
+      assert.deepEqual(
+        failCodes(model, { to: 'published_candidate', actorType: 'operator', occurredAt: '2026-07-06T02:00:00Z' }),
+        ['invalid_transition'],
+      );
+    });
+  });
+
+  describe('published_candidate stays internal-only', () => {
+    it('never records any hosted write, catalog write, trust/reputation mutation, or payment activation', () => {
+      const model = readModelAt('published_candidate');
+      assert.equal(model.state, 'published_candidate');
+      assert.equal(model.internalCandidateOnly, true);
+      assert.equal(model.localReadModelOnly, true);
+      assert.equal(model.staticOnly, true);
+      assert.deepEqual(model.publication, {
+        hostedRegistryWritePerformed: false,
+        publicCatalogWritePerformed: false,
+        trustMutationPerformed: false,
+        reputationMutationPerformed: false,
+        paymentActivationPerformed: false,
+        endpointInvocationPerformed: false,
+        walletOrRpcCallPerformed: false,
+      });
+      assert.deepEqual(model.guardrails, ONBOARDING_STATE_MACHINE_GUARDRAILS);
+      for (const record of model.history) {
+        assert.equal(record.scope, 'local_read_model_only');
+      }
+    });
+
+    it('rejects any requested live side effect fail-closed', () => {
+      for (const effect of [
+        'hosted_registry_write',
+        'public_catalog_write',
+        'trust_mutation',
+        'reputation_mutation',
+        'payment_activation',
+        'endpoint_invocation',
+        'wallet_rpc',
+        'network_fetch',
+        'totally_unknown_side_effect',
+      ]) {
+        const codes = failCodes(readModelAt('approved_unpublished'), {
+          to: 'published_candidate',
+          actorType: 'operator',
+          occurredAt: '2026-07-06T06:00:00Z',
+          requestedSideEffects: [effect],
+        });
+        assert.ok(codes.includes('publication_side_effect_rejected'), `${effect} must be rejected`);
+      }
+    });
+  });
+
+  describe('forbidden import / no-live route-graph guard', () => {
+    it('is offline-only: the state machine module imports nothing and references no network/fs/exec/payment surface', () => {
+      const sourcePath = fileURLToPath(new URL('../src/onboarding-state-machine.ts', import.meta.url));
+      const source = readFileSync(sourcePath, 'utf8');
+      assert.ok(!/^\s*import\s/m.test(source), 'state machine module must have zero imports');
+      assert.ok(!/\brequire\s*\(/.test(source), 'state machine module must not use require()');
+      for (const banned of [
+        'node:http',
+        'node:https',
+        'node:net',
+        'node:fs',
+        'node:child_process',
+        'child_process',
+        'fetch(',
+        'XMLHttpRequest',
+        'WebSocket',
+        '@solana/web3.js',
+        'Connection(',
+        'sendTransaction',
+        'signTransaction',
+        'ethers',
+        'viem',
+        'process.env',
+        'localStorage',
+        'indexedDB',
+      ]) {
+        assert.ok(!source.includes(banned), `state machine module must not reference ${banned}`);
+      }
+      assert.ok(!/\basync\b/.test(source), 'state machine module must not contain async code');
+      assert.ok(!/\bawait\b/.test(source), 'state machine module must not contain await');
+    });
+  });
+});


### PR DESCRIPTION
Closes #510

## Scope
Adds `@reddi/agent-protocol/onboarding-state-machine` — the backend/read-model state machine for AI onboarding assistant drafts (depends on the #509 handoff contracts merged in #575). Scoped to onboarding state/read-model files only (`src/onboarding-state-machine.ts`, its test, index/exports wiring, committed dist, STATUS.md), per the issue's parallel-safety constraints.

- **All twelve states:** draft, probe_failed, needs_provider_input, payment_setup_required, dry_run_required, risk_review_required, pending_operator_approval, approved_unpublished, changes_requested, rejected (terminal), suspended, published_candidate.
- **Transitions carry** audit reason, actor type (operator/provider/analyser/system), caller-supplied RFC3339 UTC timestamp (deterministic replay), source snapshot reference, readiness result reference (mirrors the #509 `OnboardingOverallReadiness` summary), and the blocking gates still open after the transition; gate-shaped states require their matching open gate on entry.
- **`published_candidate` is internal-only:** the read model's publication ledger (hosted registry write, public catalog write, trust mutation, reputation mutation, payment activation, endpoint invocation, wallet/RPC) is hard-coded false; any `requestedSideEffects` entry on an event is rejected fail-closed.
- **Invalid transitions fail closed** with structured `{code, path, message}` reasons and no state change (invalid_transition, terminal_state, missing_audit_reason, operator_action_required, blocked_readiness, unresolved_blocking_gates, missing_blocking_gate, invalid/regressing timestamp, missing snapshot/readiness refs, publication_side_effect_rejected).
- **Operator actions are local/read-model events only** — every audit record carries `scope: 'local_read_model_only'`.

## Validation
- `npm test` in `packages/agent-protocol`: **322/322 pass** (29 new).
- `npm run check:exports`: PASS (75 targets, dist committed).
- `npm run check:rap:naming`: PASS.
- `git diff --check`: clean.
- Tests cover valid transitions (full happy path + remediation/changes-requested loops), invalid transitions, missing approval reason, blocked readiness, unresolved gates, rejected (terminal), suspended (operator reinstate), candidate-published, and requested-side-effect rejection.

## No-live boundary
This module is pure and offline-only in the #509 self-contained pattern: zero imports, no async surface, no network fetch, hosted write, publication, payment activation, wallet/RPC, endpoint invocation, or trust/reputation mutation. A forbidden-import source guard test proves the boundary; guardrails are hard-coded false on every read model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)