### PR TITLE
fix(tests): align manager-marketplace-public-search blocked-reason expectations with fixture contract (#578)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,9 @@
 # Reddi Agent Protocol — Status
 
+## Latest Update — Fix #578: public-search blocked-reason assertion aligned with fixture contract (2026-07-06 AEST)
+
+Fixed GitHub issue #578 in isolated worktree `projects/reddi-agent-protocol-worktree-578-public-search-test-fix` on branch `fix/578-public-search-blocked-reasons`. Pre-existing failure on main: `lib/__tests__/manager-marketplace-public-search.test.ts` expected 2 blocked reasons for the `rejectedMalformedConnector` fixture, but the fixture emits 4. Root cause: intentional contract evolution — `unsafe_metadata` was added by the publication eligibility matrix (`dea92764`) and `publish_audit_malformed` by publication lifecycle audit evidence (#466, `bd649701`); both commits updated the eligibility/export/approval-actions tests but missed the search test. Fix: test-only — assertion now expects the exact 4-reason set. Validation: suite 4/4 PASS, `npm run check:rap:naming` PASS, `git diff --check` PASS.
+
 ## Latest Update — x402 reference workflow no-live rehearsal + operator runbook (2026-07-06 AEST)
 
 Prepared GitHub issue #564 up to (but not including) the live devnet run, in isolated worktree `projects/reddi-agent-protocol-worktree-564-devnet-run-prep` on branch `feat/564-devnet-run-prep`.

--- a/lib/__tests__/manager-marketplace-public-search.test.ts
+++ b/lib/__tests__/manager-marketplace-public-search.test.ts
@@ -83,6 +83,8 @@ describe("hosted marketplace catalog search", () => {
     expect(result.blocked.find((item) => item.fixtureKey === "rejectedMalformedConnector")?.reasons).toEqual([
       "readiness_not_publish_ready:blocked",
       "publication_not_allowed",
+      "publish_audit_malformed",
+      "unsafe_metadata",
     ]);
   });
 


### PR DESCRIPTION
Closes #578

## Root cause

Intentional fixture-contract evolution, not a regression. The public-search suite was added in #436 (`aca81b4e`) when the `rejectedMalformedConnector` fixture emitted two blocked reasons. Two later commits each intentionally extended the publication-eligibility contract but missed updating this one assertion:

- `dea92764` ("Add marketplace publication eligibility matrix") added the `unsafe_metadata` reason code (fires when the `safe_metadata` readiness gate fails)
- `bd649701` (#466, "Add publication lifecycle audit evidence") added `publish_audit_malformed` and gave the fixture a deliberately forged `auditHistory` ("Forged publish fixture for blocked export diagnostics")

Both commits updated `manager-marketplace-publication-eligibility.test.ts`, `manager-marketplace-public-export.test.ts`, and `manager-marketplace-approval-actions.test.ts` — but not the search test. The 4-reason set is the canonical contract for this fixture.

## Change

Test-only, minimal diff: the assertion now expects the exact 4-reason set:

```
readiness_not_publish_ready:blocked
publication_not_allowed
publish_audit_malformed
unsafe_metadata
```

Plus a STATUS.md rolling-log entry.

## Validation

- `npx jest lib/__tests__/manager-marketplace-public-search.test.ts` — 4/4 PASS (was 3/4 on main)
- `npm run check:rap:naming` — PASS
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)