### PR TITLE
feat(okf): knowledge-bundle conformance diagnostics (#504)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,24 @@
 # Reddi Agent Protocol — Status
 
+## Latest Update — OKF/OpenKB knowledge-bundle conformance diagnostics (2026-07-06 AEST)
+
+Implemented GitHub issue #504 in isolated worktree `projects/reddi-agent-protocol-worktree-504-okf-conformance-diagnostics` on branch `feat/504-okf-conformance-diagnostics`.
+
+Delivered:
+- Added `packages/agent-protocol/src/okf-conformance.ts` (`reddi.okf-conformance.v1`, exported as `@reddi/agent-protocol/okf-conformance`) — deterministic, PURE static-analysis conformance diagnostics for OKF/OpenKB-style knowledge bundles, built directly on the #511 adapter spike (`okf-adapter.ts`) and the #503 fixture corpus vocabulary (no re-invention): parseable YAML frontmatter (conservative subset, fail-closed), non-empty concept `type`, standard markdown links vs Obsidian wikilinks (deterministic wikilinks reported adaptable/info; embeds/heading/block refs unadaptable warnings), `index.md`/`log.md` semantics where applicable, unknown-frontmatter preservation as untrusted review metadata, and source/provenance completeness (escalatable via `requireProvenance`).
+- Explicit unsafe/generated-instruction classes for producer-toolchain artifacts (AGENTS.md, SKILL.md, prompts, scripts, skills, tools, agent definitions) via `artifactClass`, all blocked-severity `generated_instruction_untrusted`; scripts/tools additionally `execution_not_allowed`. Per-document statuses use the #504 vocabulary (valid, warning, blocked, untrusted_generated_instruction, unsupported_link_syntax, missing_provenance, malformed_frontmatter, execution_not_allowed); diagnostic severities stay aligned with the repo static-analysis vocab (info/warning/blocked).
+- Every report carries an identical review-only boundary (permitted: static review/analysis, operator review payload, conformance reporting; denied: skill installation, agent registration/onboarding, marketplace publication, hosted registry write, LLM/provider call, script/tool execution, URL ingestion, payment activation, trust/reputation mutation) plus hard-false guardrails; fail-closed on malformed bundles and on any execute/install/ingestUrl/invokeLlm/generateSkill request.
+- `conformanceInputFromOkfOpenKbFixture` bridges #503 corpus fixtures read-only (contentSha256 digests proven preserved in tests); `OKF_FIXTURE_DIAGNOSTIC_CODE_MAP` maps corpus expectedDiagnostics codes onto the conformance vocabulary. Six in-module conformance fixtures extend corpus coverage (valid OKF, wikilinks needing adaptation, missing provenance, malformed frontmatter, generated instructions, script/tool artifacts).
+- Tests: `packages/agent-protocol/tests/okf-conformance.test.ts` (25 tests) — report shape/boundary, determinism, all diagnostic lanes, both #503 corpus fixtures (minimal bundle valid; generated bundle blocked with every expectedDiagnostic covered), fail-closed cases, offline/no-async source guard, DRAFT-tag guard. Wired into the barrel + package exports with rebuilt dist committed.
+- Docs: `docs/conformance/okf-openkb/README.md` gained a "#504 Conformance Diagnostics" section (coverage, vocabulary, review-only boundary). BDD: new `@S5.16` scenario in `docs/bdd/features/bucket-s-source-adapters.feature` + FEATURE-INDEX bucket-S verify command.
+
+Validation:
+- `cd packages/agent-protocol && npm test` PASS (347 tests, incl. 25 new; exports-resolution guard in-suite).
+- `npm run check:okf-openkb:fixtures` PASS (corpus untouched). `node scripts/check-package-exports.mjs` PASS (77 targets).
+- `npm run check:rap:naming` PASS. `npm run test:bdd:index` PASS. `git diff --check` PASS.
+
+Boundary note: passing conformance permits review/analysis ONLY — no skill installation, agent registration, marketplace publication, hosted writes, LLM/provider calls, or execution of bundle content. The OKF/OpenKB scope decision itself stays with #513.
+
 ## Latest Update — x402 reference workflow no-live rehearsal + operator runbook (2026-07-06 AEST)
 
 Prepared GitHub issue #564 up to (but not including) the live devnet run, in isolated worktree `projects/reddi-agent-protocol-worktree-564-devnet-run-prep` on branch `feat/564-devnet-run-prep`.

--- a/docs/bdd/FEATURE-INDEX.md
+++ b/docs/bdd/FEATURE-INDEX.md
@@ -50,10 +50,11 @@ Purpose: single lookup from BDD feature file -> bucket -> executable verificatio
 ### Bucket S — Source Adapter Onboarding
 - Feature: `docs/bdd/features/bucket-s-source-adapters.feature`
 - Static agent-stack conformance reference: `docs/conformance/static-agent-stack/README.md`
-- OKF/OpenKB static fixture reference: `docs/conformance/okf-openkb/README.md`
+- OKF/OpenKB static fixture + conformance diagnostics reference: `docs/conformance/okf-openkb/README.md`
 - Verify:
   - `npm run check:rap:naming`
   - `npm run check:okf-openkb:fixtures`
+  - `cd packages/agent-protocol && npm test -- --test-name-pattern "OKF/OpenKB conformance diagnostics"`
   - `npx jest lib/__tests__/source-adapter-schema.test.ts lib/__tests__/register-probe-route.test.ts lib/__tests__/source-adapter-openclaw-profile.test.ts lib/__tests__/source-adapter-openclaw-connector.test.ts lib/__tests__/source-adapter-hermes-profile.test.ts lib/__tests__/source-adapter-hermes-attestor.test.ts lib/__tests__/source-adapter-pi-profile.test.ts lib/__tests__/source-adapter-pi-extension-bundle.test.ts lib/__tests__/source-adapter-circle-x402-profile.test.ts lib/__tests__/circle-x402-catalog-route.test.ts lib/__tests__/circle-x402-quote-preview-route.test.ts lib/__tests__/source-adapter-pay-sh-profile.test.ts lib/__tests__/pay-sh-catalog-route.test.ts lib/__tests__/pay-sh-quote-preview-route.test.ts lib/__tests__/pay-sh-mcp-inspection.test.ts lib/__tests__/pay-sh-policy-plan.test.ts lib/__tests__/pay-sh-policy-plan-route.test.ts lib/__tests__/source-adapter-routing-policy.test.ts lib/__tests__/planner-resolve-route.test.ts --runInBand`
   - `npm run test:source:conformance`
   - `./scripts/run-source-conformance.sh --source hermes --mode smoke`

--- a/docs/bdd/features/bucket-s-source-adapters.feature
+++ b/docs/bdd/features/bucket-s-source-adapters.feature
@@ -155,3 +155,12 @@ Feature: Bucket S Source Adapter Onboarding
     And generated AGENTS SKILL prompt tool script and agent definition artifacts are marked untrusted
     And fixture validation rejects generated install execution hosted publication payment trust mutation and reputation mutation paths
     And no OpenKB install URL ingestion provider call MCP call wallet RPC paid call marketplace publication or agent onboarding occurs
+
+  @S5.16 @conformance @okf-openkb @static-analysis
+  Scenario: OKF and OpenKB knowledge-bundle conformance diagnostics stay deterministic and review-only
+    When conformance diagnostics run over an OKF-shaped or OpenKB-style knowledge bundle fixture
+    Then frontmatter parseability concept type link syntax index and log semantics unknown frontmatter preservation and provenance completeness are reported deterministically
+    And generated AGENTS SKILL prompt script skill tool and agent definition artifacts are classified untrusted with explicit artifact classes and blocked severity
+    And script and tool artifacts are additionally reported as execution not allowed
+    And a passing verdict permits static review and analysis only with no skill installation agent registration marketplace publication hosted write provider call or execution
+    And malformed bundles and any execute install ingest or provider request fail closed

--- a/docs/conformance/okf-openkb/README.md
+++ b/docs/conformance/okf-openkb/README.md
@@ -1,6 +1,6 @@
-# OKF/OpenKB Static Fixture Corpus
+# OKF/OpenKB Static Fixture Corpus & Conformance Diagnostics
 
-Issue: [#503](https://github.com/nissan/reddi-agent-protocol/issues/503)
+Issues: [#503](https://github.com/nissan/reddi-agent-protocol/issues/503) (fixture corpus), [#504](https://github.com/nissan/reddi-agent-protocol/issues/504) (conformance diagnostics)
 
 This corpus gives RAP a static, no-network fixture lane for reviewing Google OKF-shaped and OpenKB-style knowledge bundles. It is an evidence input for future diagnostics and adapter work, not a runtime ingestion path.
 
@@ -30,6 +30,32 @@ Models a small OKF-shaped markdown/frontmatter bundle with `index.md`, a concept
 ### `openkb-style-generated-agent-bundle`
 
 Models an OpenKB-style producer output that includes wikilinks plus generated agent instructions, generated skill text, and a generated script. It intentionally expects blocking diagnostics for generated instructions and execution-not-allowed artifacts.
+
+## Conformance Diagnostics (#504)
+
+`packages/agent-protocol/src/okf-conformance.ts` (`reddi.okf-conformance.v1`, exported as `@reddi/agent-protocol/okf-conformance`) provides deterministic, pure static-analysis conformance diagnostics over OKF/OpenKB-style knowledge bundles. It builds directly on the #511 adapter spike (`okf-adapter.ts`) and this corpus — same document roles, trust classifications, and reason-code vocabulary.
+
+Run `runOkfConformanceDiagnostics(input, options)` over an in-memory bundle (raw markdown `source` per document, or the adapter's pre-split input shape). `conformanceInputFromOkfOpenKbFixture(fixture)` bridges a #503 corpus fixture into the input shape read-only, preserving `contentSha256` behavior.
+
+### What the diagnostics cover
+
+- Parseable YAML frontmatter (conservative subset: scalars, comments, flat lists); unparseable content is skipped fail-closed and reported as `malformed_frontmatter`.
+- Non-empty `type` for concept documents (`concept_type_missing`).
+- Standard markdown links vs Obsidian/OpenKB wikilinks (`unsupported_link_syntax`): deterministic wikilinks are reported as adaptable (info); embeds/heading/block refs are unadaptable warnings.
+- `index.md`/`log.md` semantics where applicable (`index_semantics_normalized`, `log_semantics_normalized`; `index_missing`/`log_missing` when expected).
+- Unknown-frontmatter preservation (`unknown_frontmatter_preserved`, info) — preserved verbatim as untrusted review metadata, never policy/runtime configuration.
+- Source/provenance completeness (`missing_provenance`; escalates to blocked with `requireProvenance`).
+- Explicit unsafe/generated-instruction classes for producer-toolchain artifacts — `AGENTS.md`, `SKILL.md`, prompts, scripts, skills, tools, agent definitions — via `artifactClass` (`agent_definition`, `skill_definition`, `prompt`, `script`, `tool`, `generated_instruction_other`), all `generated_instruction_untrusted` at blocked severity; scripts/tools additionally `execution_not_allowed`.
+
+### Severity and status vocabulary
+
+Diagnostic severities are `info` / `warning` / `blocked`, aligned with the repo's static-analysis severity vocabulary (`agent-stack-fixtures.ts`, `okf-adapter.ts`). Per-document statuses use the #504 vocabulary: `valid`, `warning`, `blocked`, `untrusted_generated_instruction`, `unsupported_link_syntax`, `missing_provenance`, `malformed_frontmatter`, `execution_not_allowed`. The bundle verdict is `valid` / `warning` / `blocked`. Corpus `expectedDiagnostics` codes map via `OKF_FIXTURE_DIAGNOSTIC_CODE_MAP` (e.g. `unsupported_wikilink_syntax` → `unsupported_link_syntax`, `script_execution_not_allowed` → `execution_not_allowed`).
+
+### Review-only boundary
+
+**Passing conformance permits review/analysis ONLY.** A `valid` verdict never permits skill installation, agent registration/onboarding, marketplace publication, hosted writes, LLM/provider calls, or execution of any bundle content. Every report carries an identical `reviewBoundary` (permitted: static review/analysis, operator review payloads, conformance reporting; denied: installation, registration, publication, hosted writes, provider calls, execution, URL ingestion, payment activation, trust/reputation mutation) plus hard-false guardrails. The module itself is pure: no network, no filesystem, no async, fail-closed on malformed input and on any execute/install/ingest/LLM/skill-generation request.
+
+Verify with `cd packages/agent-protocol && npm test -- --test-name-pattern "OKF/OpenKB conformance diagnostics"`.
 
 ## Downstream Use
 

--- a/packages/agent-protocol/dist/index.d.ts
+++ b/packages/agent-protocol/dist/index.d.ts
@@ -31,5 +31,6 @@ export * from './reputation-credential-export.js';
 export * from './ap2-mandate-ingestion.js';
 export * from './strands-rap-template.js';
 export * from './okf-adapter.js';
+export * from './okf-conformance.js';
 export * from './onboarding-analyser-handoff.js';
 export * from './onboarding-state-machine.js';

--- a/packages/agent-protocol/dist/index.js
+++ b/packages/agent-protocol/dist/index.js
@@ -31,5 +31,6 @@ export * from './reputation-credential-export.js';
 export * from './ap2-mandate-ingestion.js';
 export * from './strands-rap-template.js';
 export * from './okf-adapter.js';
+export * from './okf-conformance.js';
 export * from './onboarding-analyser-handoff.js';
 export * from './onboarding-state-machine.js';

--- a/packages/agent-protocol/dist/okf-conformance.d.ts
+++ b/packages/agent-protocol/dist/okf-conformance.d.ts
@@ -1,0 +1,208 @@
+/**
+ * OKF/OpenKB knowledge-bundle conformance diagnostics (#504, epic #468).
+ *
+ * Deterministic, PURE static-analysis diagnostics that decide whether an
+ * OKF-shaped / OpenKB-style knowledge bundle is acceptable as REVIEW/ANALYSIS
+ * input for RAP — and nothing more. This module builds directly on the #511
+ * adapter spike (`okf-adapter.ts`) and the #503 static fixture corpus
+ * (`data/okf-openkb-fixtures/okf-openkb-fixture-corpus.v1.json`): same document
+ * roles, trust classifications, and reason-code vocabulary. It does not
+ * re-invent either.
+ *
+ * This module is PURE: no network, no filesystem access, no URL ingestion, no
+ * OpenKB install, no LLM/provider call, no MCP/tool call, no script or tool
+ * execution, no skill installation, no agent registration, no hosted write,
+ * no marketplace publication, no wallet/RPC, no payment activation, no
+ * trust/reputation mutation. It only analyses in-memory text the caller
+ * already holds. Fail-closed on malformed input and on any request to
+ * execute/install/ingest/invoke/generate.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * REVIEW-ONLY BOUNDARY: a `valid` conformance verdict permits static
+ * review/analysis ONLY. It never permits skill installation, agent
+ * registration/onboarding, marketplace publication, hosted writes,
+ * LLM/provider calls, or execution of any bundle content. Those remain denied
+ * regardless of verdict — see `reviewBoundary` on every report.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * DRAFT/unverified — like the #511 spike, OKF (Open Knowledge Format) is an
+ * EXTERNAL format and every OKF-semantic claim below (concept `type`
+ * requirement, `index.md`/`log.md` semantics, standard-markdown-link
+ * requirement) is illustrative and unconfirmed against the live spec.
+ * (DRAFT/unverified — OKF, confirm field semantics before relying on them.)
+ */
+import { type OkfDocumentRole, type OkfIndex, type OkfLog, type OkfTrustClassification, type OpenKbDocumentInput } from './okf-adapter.js';
+export declare const OKF_CONFORMANCE_SCHEMA_VERSION: "reddi.okf-conformance.v1";
+/** The OKF semantics this module enforces are unverified against the live external spec. */
+export declare const OKF_CONFORMANCE_IS_DRAFT: true;
+/** Severity vocabulary — aligned with the repo's static-analysis severity vocab
+ * (`agent-stack-fixtures.ts` and `okf-adapter.ts` both use info/warning/blocked). */
+export type OkfConformanceSeverity = 'info' | 'warning' | 'blocked';
+/** Deterministic conformance diagnostic codes. Reuses the #511 adapter reason-code
+ * vocabulary wherever one exists; adds only index/log expectation codes. */
+export type OkfConformanceCode = 'malformed_frontmatter' | 'concept_type_missing' | 'unsupported_link_syntax' | 'missing_provenance' | 'unknown_frontmatter_preserved' | 'generated_instruction_untrusted' | 'execution_not_allowed' | 'index_missing' | 'log_missing' | 'index_semantics_normalized' | 'log_semantics_normalized' | 'bundle_malformed' | 'document_malformed' | 'operation_not_permitted';
+/**
+ * Per-document conformance status — the #504 acceptance-criteria vocabulary:
+ * valid, warning, blocked, untrusted_generated_instruction,
+ * unsupported_link_syntax, missing_provenance, malformed_frontmatter,
+ * execution_not_allowed. The named statuses surface the dominant finding;
+ * `valid`/`warning`/`blocked` are the fallbacks by max severity.
+ */
+export type OkfConformanceStatus = 'valid' | 'warning' | 'blocked' | 'untrusted_generated_instruction' | 'unsupported_link_syntax' | 'missing_provenance' | 'malformed_frontmatter' | 'execution_not_allowed';
+/** Bundle-level verdict. Even `valid` permits review/analysis only. */
+export type OkfConformanceVerdict = 'valid' | 'warning' | 'blocked';
+/**
+ * Explicit unsafe/generated-instruction artifact classes for producer-toolchain
+ * output (AGENTS.md, SKILL.md, prompts, scripts, skills, tools, agent
+ * definitions). Mirrors the #503 corpus `generatedArtifacts[].artifactKind`
+ * vocabulary (`agent_definition`, `skill_definition`, `script`).
+ */
+export type OkfGeneratedArtifactClass = 'agent_definition' | 'skill_definition' | 'prompt' | 'script' | 'tool' | 'generated_instruction_other';
+export type OkfConformanceDiagnostic = {
+    severity: OkfConformanceSeverity;
+    code: OkfConformanceCode;
+    /** Document id/path the diagnostic is scoped to, when document-scoped. */
+    documentId?: string;
+    summary: string;
+    action?: string;
+    /**
+     * For `unsupported_link_syntax`: true when the finding is deterministically
+     * adaptable (simple `[[wikilink]]` → standard markdown link, already
+     * converted by the #511 adapter); false when it is not (embeds, heading/block
+     * refs, empty targets) and must be rewritten at the source.
+     */
+    adaptable?: boolean;
+    /** For generated-instruction / execution findings: the artifact class. */
+    artifactClass?: OkfGeneratedArtifactClass;
+};
+export type OkfConformanceDocumentReport = {
+    documentId: string;
+    documentRole: OkfDocumentRole;
+    trustClassification: OkfTrustClassification;
+    /** Non-null only for generated-instruction artifacts. */
+    artifactClass: OkfGeneratedArtifactClass | null;
+    status: OkfConformanceStatus;
+    diagnostics: OkfConformanceDiagnostic[];
+};
+/** What a passing (or any) conformance report permits — and permanently denies. */
+export declare const OKF_CONFORMANCE_PERMITTED_USE: readonly ["static_review", "static_analysis", "operator_review_payload", "conformance_reporting"];
+export declare const OKF_CONFORMANCE_DENIED_USE: readonly ["skill_installation", "agent_registration", "agent_onboarding", "marketplace_publication", "hosted_registry_write", "llm_or_provider_call", "script_or_tool_execution", "url_ingestion", "payment_activation", "trust_or_reputation_mutation"];
+export type OkfConformanceReport = {
+    schemaVersion: typeof OKF_CONFORMANCE_SCHEMA_VERSION;
+    /** OKF-semantic checks are drafted against an unverified external format. */
+    draft: true;
+    verdict: OkfConformanceVerdict;
+    bundleId: string | null;
+    documents: OkfConformanceDocumentReport[];
+    /** Bundle-level + aggregated per-document diagnostics, in deterministic order. */
+    diagnostics: OkfConformanceDiagnostic[];
+    /** Deduped codes across all diagnostics. */
+    codes: OkfConformanceCode[];
+    /** Normalized `index.md` semantics from the #511 adapter, when present. */
+    index: OkfIndex | null;
+    /** Normalized `log.md` semantics from the #511 adapter, when present. */
+    log: OkfLog | null;
+    /**
+     * REVIEW-ONLY boundary: identical on every report, independent of verdict.
+     * Passing conformance permits review/analysis only — never installation,
+     * registration, publication, hosted writes, provider calls, or execution.
+     */
+    reviewBoundary: {
+        permittedUse: typeof OKF_CONFORMANCE_PERMITTED_USE;
+        deniedUse: typeof OKF_CONFORMANCE_DENIED_USE;
+    };
+    /** Hard-coded false guardrails — this module never touches any live rail. */
+    guardrails: {
+        network: false;
+        fileSystemRead: false;
+        executed: false;
+        installed: false;
+        urlIngested: false;
+        llmInvoked: false;
+        mcpInvoked: false;
+        skillInstalled: false;
+        agentRegistered: false;
+        hostedWrite: false;
+        marketplacePublished: false;
+        paymentActivated: false;
+        trustMutated: false;
+        instructionsTrusted: false;
+    };
+    notes: string[];
+};
+/**
+ * Input document. Either provide `source` (raw markdown text, optionally
+ * starting with a `---` YAML frontmatter fence) or the already-split
+ * `frontmatter`/`rawFrontmatter`/`body` fields from the #511 adapter input
+ * shape. When `source` is present it wins.
+ */
+export type OkfConformanceDocumentInput = OpenKbDocumentInput & {
+    source?: string;
+};
+export type OkfConformanceBundleInput = {
+    bundleId?: string;
+    documents: OkfConformanceDocumentInput[];
+};
+export type OkfConformanceOptions = {
+    /** Escalate `missing_provenance` to `blocked` instead of `warning`. */
+    requireProvenance?: boolean;
+    /** Emit a warning when the bundle has no `index.md`. */
+    expectIndex?: boolean;
+    /** Emit a warning when the bundle has no `log.md`. */
+    expectLog?: boolean;
+    /**
+     * FAIL-CLOSED: any attempt to execute, install, ingest a URL, invoke an LLM,
+     * or generate/install a skill is rejected with `operation_not_permitted`.
+     * These flags exist only so requests can be refused deterministically.
+     */
+    execute?: boolean;
+    install?: boolean;
+    ingestUrl?: boolean;
+    invokeLlm?: boolean;
+    generateSkill?: boolean;
+};
+/**
+ * Maps the #503 corpus `expectedDiagnostics[].code` vocabulary onto the
+ * conformance code vocabulary (which follows the #511 adapter reason codes).
+ */
+export declare const OKF_FIXTURE_DIAGNOSTIC_CODE_MAP: {
+    readonly unsupported_wikilink_syntax: "unsupported_link_syntax";
+    readonly generated_instruction_untrusted: "generated_instruction_untrusted";
+    readonly generated_skill_untrusted: "generated_instruction_untrusted";
+    readonly script_execution_not_allowed: "execution_not_allowed";
+};
+/** Maps #503 corpus `expectedDiagnostics[].severity` onto acceptable conformance severities. */
+export declare const OKF_FIXTURE_DIAGNOSTIC_SEVERITY_MAP: Record<string, readonly OkfConformanceSeverity[]>;
+/**
+ * Builds a conformance bundle input from one fixture of the #503 corpus
+ * (`reddi.okf-openkb-fixture-corpus.v1`). Read-only over the fixture object:
+ * file previews are consumed as static text and never mutated, so the
+ * fixture's `contentSha256` digests are preserved. Fail-closed: a fixture that
+ * does not carry a usable `files` array yields an empty-documents input, which
+ * `runOkfConformanceDiagnostics` blocks as `bundle_malformed`.
+ */
+export declare function conformanceInputFromOkfOpenKbFixture(fixture: unknown): OkfConformanceBundleInput;
+export type OkfParsedDocumentSource = {
+    /** Parsed frontmatter object, or undefined when the source has no fence. */
+    frontmatter: Record<string, unknown> | undefined;
+    body: string;
+    diagnostics: OkfConformanceDiagnostic[];
+};
+/**
+ * Deterministically splits raw markdown into YAML frontmatter and body.
+ * Conservative YAML subset only: `key: value` scalars, `# comments`, and
+ * `key:` followed by indented `- item` list lines. Anything else raises
+ * `malformed_frontmatter` and is skipped (fail-closed: unparseable content is
+ * never trusted). An unterminated fence is also `malformed_frontmatter`; the
+ * whole source is then treated as body with no trusted frontmatter.
+ */
+export declare function parseOkfDocumentSource(documentId: string, source: string): OkfParsedDocumentSource;
+/**
+ * Runs deterministic OKF/OpenKB conformance diagnostics over an in-memory
+ * bundle. Pure static analysis: delegates document projection to the #511
+ * adapter, then layers the #504 conformance vocabulary (statuses, escalated
+ * generated-instruction severities, adaptable-wikilink reporting, index/log
+ * expectations, review-only boundary) on top.
+ */
+export declare function runOkfConformanceDiagnostics(input: unknown, options?: OkfConformanceOptions): OkfConformanceReport;
+export declare const okfConformanceFixtures: Record<string, OkfConformanceBundleInput>;

--- a/packages/agent-protocol/dist/okf-conformance.js
+++ b/packages/agent-protocol/dist/okf-conformance.js
@@ -1,0 +1,651 @@
+/**
+ * OKF/OpenKB knowledge-bundle conformance diagnostics (#504, epic #468).
+ *
+ * Deterministic, PURE static-analysis diagnostics that decide whether an
+ * OKF-shaped / OpenKB-style knowledge bundle is acceptable as REVIEW/ANALYSIS
+ * input for RAP — and nothing more. This module builds directly on the #511
+ * adapter spike (`okf-adapter.ts`) and the #503 static fixture corpus
+ * (`data/okf-openkb-fixtures/okf-openkb-fixture-corpus.v1.json`): same document
+ * roles, trust classifications, and reason-code vocabulary. It does not
+ * re-invent either.
+ *
+ * This module is PURE: no network, no filesystem access, no URL ingestion, no
+ * OpenKB install, no LLM/provider call, no MCP/tool call, no script or tool
+ * execution, no skill installation, no agent registration, no hosted write,
+ * no marketplace publication, no wallet/RPC, no payment activation, no
+ * trust/reputation mutation. It only analyses in-memory text the caller
+ * already holds. Fail-closed on malformed input and on any request to
+ * execute/install/ingest/invoke/generate.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * REVIEW-ONLY BOUNDARY: a `valid` conformance verdict permits static
+ * review/analysis ONLY. It never permits skill installation, agent
+ * registration/onboarding, marketplace publication, hosted writes,
+ * LLM/provider calls, or execution of any bundle content. Those remain denied
+ * regardless of verdict — see `reviewBoundary` on every report.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * DRAFT/unverified — like the #511 spike, OKF (Open Knowledge Format) is an
+ * EXTERNAL format and every OKF-semantic claim below (concept `type`
+ * requirement, `index.md`/`log.md` semantics, standard-markdown-link
+ * requirement) is illustrative and unconfirmed against the live spec.
+ * (DRAFT/unverified — OKF, confirm field semantics before relying on them.)
+ */
+import { adaptOpenKbBundleToOkf, } from './okf-adapter.js';
+export const OKF_CONFORMANCE_SCHEMA_VERSION = 'reddi.okf-conformance.v1';
+/** The OKF semantics this module enforces are unverified against the live external spec. */
+export const OKF_CONFORMANCE_IS_DRAFT = true;
+/** What a passing (or any) conformance report permits — and permanently denies. */
+export const OKF_CONFORMANCE_PERMITTED_USE = [
+    'static_review',
+    'static_analysis',
+    'operator_review_payload',
+    'conformance_reporting',
+];
+export const OKF_CONFORMANCE_DENIED_USE = [
+    'skill_installation',
+    'agent_registration',
+    'agent_onboarding',
+    'marketplace_publication',
+    'hosted_registry_write',
+    'llm_or_provider_call',
+    'script_or_tool_execution',
+    'url_ingestion',
+    'payment_activation',
+    'trust_or_reputation_mutation',
+];
+/* ────────────────────────────────────────────────────────────────────────────
+ * #503 fixture-corpus bridge
+ * ──────────────────────────────────────────────────────────────────────────── */
+/**
+ * Maps the #503 corpus `expectedDiagnostics[].code` vocabulary onto the
+ * conformance code vocabulary (which follows the #511 adapter reason codes).
+ */
+export const OKF_FIXTURE_DIAGNOSTIC_CODE_MAP = {
+    unsupported_wikilink_syntax: 'unsupported_link_syntax',
+    generated_instruction_untrusted: 'generated_instruction_untrusted',
+    generated_skill_untrusted: 'generated_instruction_untrusted',
+    script_execution_not_allowed: 'execution_not_allowed',
+};
+/** Maps #503 corpus `expectedDiagnostics[].severity` onto acceptable conformance severities. */
+export const OKF_FIXTURE_DIAGNOSTIC_SEVERITY_MAP = {
+    review: ['info', 'warning'],
+    blocking: ['blocked'],
+};
+/**
+ * Builds a conformance bundle input from one fixture of the #503 corpus
+ * (`reddi.okf-openkb-fixture-corpus.v1`). Read-only over the fixture object:
+ * file previews are consumed as static text and never mutated, so the
+ * fixture's `contentSha256` digests are preserved. Fail-closed: a fixture that
+ * does not carry a usable `files` array yields an empty-documents input, which
+ * `runOkfConformanceDiagnostics` blocks as `bundle_malformed`.
+ */
+export function conformanceInputFromOkfOpenKbFixture(fixture) {
+    if (!isPlainObject(fixture)) {
+        return { documents: [] };
+    }
+    const bundleId = isNonEmptyString(fixture['id']) ? fixture['id'] : undefined;
+    const source = isPlainObject(fixture['source']) ? fixture['source'] : {};
+    const provenance = {};
+    if (isNonEmptyString(source['sourceUrl']))
+        provenance.sourceUri = source['sourceUrl'];
+    if (isNonEmptyString(source['retrievedAt']))
+        provenance.retrievedAt = source['retrievedAt'];
+    const files = fixture['files'];
+    if (!Array.isArray(files)) {
+        return bundleId === undefined ? { documents: [] } : { bundleId, documents: [] };
+    }
+    const documents = [];
+    for (const file of files) {
+        if (!isPlainObject(file) || !isNonEmptyString(file['path']))
+            continue;
+        const doc = {
+            path: file['path'].trim(),
+            source: typeof file['contentPreview'] === 'string' ? file['contentPreview'] : '',
+        };
+        if (provenance.sourceUri !== undefined) {
+            doc.provenance = { ...provenance };
+        }
+        documents.push(doc);
+    }
+    return bundleId === undefined ? { documents } : { bundleId, documents };
+}
+/**
+ * Deterministically splits raw markdown into YAML frontmatter and body.
+ * Conservative YAML subset only: `key: value` scalars, `# comments`, and
+ * `key:` followed by indented `- item` list lines. Anything else raises
+ * `malformed_frontmatter` and is skipped (fail-closed: unparseable content is
+ * never trusted). An unterminated fence is also `malformed_frontmatter`; the
+ * whole source is then treated as body with no trusted frontmatter.
+ */
+export function parseOkfDocumentSource(documentId, source) {
+    const lines = source.split(/\r?\n/);
+    if ((lines[0] ?? '').trim() !== '---') {
+        return { frontmatter: undefined, body: source, diagnostics: [] };
+    }
+    let closing = -1;
+    for (let i = 1; i < lines.length; i += 1) {
+        if (lines[i].trim() === '---') {
+            closing = i;
+            break;
+        }
+    }
+    if (closing === -1) {
+        return {
+            frontmatter: undefined,
+            body: source,
+            diagnostics: [
+                {
+                    severity: 'warning',
+                    code: 'malformed_frontmatter',
+                    documentId,
+                    summary: `${documentId} opens a YAML frontmatter fence that never closes; the whole document was treated as body (fail-closed).`,
+                    action: 'Close the frontmatter fence with a `---` line.',
+                },
+            ],
+        };
+    }
+    const { frontmatter, diagnostics } = parseYamlSubset(lines.slice(1, closing), documentId);
+    let bodyStart = closing + 1;
+    if (lines[bodyStart] !== undefined && lines[bodyStart].trim() === '')
+        bodyStart += 1;
+    return { frontmatter, body: lines.slice(bodyStart).join('\n'), diagnostics };
+}
+function parseYamlSubset(lines, documentId) {
+    const frontmatter = {};
+    const diagnostics = [];
+    const keyPattern = /^([A-Za-z0-9_.-]+)\s*:\s*(.*)$/;
+    const listItemPattern = /^\s+-\s+(.*)$/;
+    let currentListKey = null;
+    for (const line of lines) {
+        if (line.trim().length === 0)
+            continue;
+        if (/^\s*#/.test(line))
+            continue;
+        const listMatch = listItemPattern.exec(line);
+        if (listMatch !== null && currentListKey !== null) {
+            const existing = frontmatter[currentListKey];
+            const list = Array.isArray(existing) ? existing : [];
+            list.push(coerceScalar(listMatch[1].trim()));
+            frontmatter[currentListKey] = list;
+            continue;
+        }
+        const keyMatch = keyPattern.exec(line);
+        if (keyMatch === null) {
+            currentListKey = null;
+            diagnostics.push({
+                severity: 'warning',
+                code: 'malformed_frontmatter',
+                documentId,
+                summary: `${documentId} has an unparseable YAML frontmatter line; it was skipped (fail-closed).`,
+                action: 'Use `key: value` scalars or `key:` with indented `- item` list lines.',
+            });
+            continue;
+        }
+        const key = keyMatch[1];
+        const value = keyMatch[2].trim();
+        if (value.length === 0) {
+            frontmatter[key] = null;
+            currentListKey = key;
+        }
+        else {
+            frontmatter[key] = coerceScalar(value);
+            currentListKey = null;
+        }
+    }
+    return { frontmatter, diagnostics };
+}
+function coerceScalar(value) {
+    if (value === 'true')
+        return true;
+    if (value === 'false')
+        return false;
+    if (value === 'null')
+        return null;
+    if (/^-?\d+$/.test(value))
+        return Number(value);
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1);
+    }
+    return value;
+}
+/* ────────────────────────────────────────────────────────────────────────────
+ * Conformance run
+ * ──────────────────────────────────────────────────────────────────────────── */
+/**
+ * Runs deterministic OKF/OpenKB conformance diagnostics over an in-memory
+ * bundle. Pure static analysis: delegates document projection to the #511
+ * adapter, then layers the #504 conformance vocabulary (statuses, escalated
+ * generated-instruction severities, adaptable-wikilink reporting, index/log
+ * expectations, review-only boundary) on top.
+ */
+export function runOkfConformanceDiagnostics(input, options = {}) {
+    // Preprocess raw `source` documents into the adapter's input shape, collecting
+    // deterministic frontmatter-parse diagnostics per document id.
+    const sourceDiagnostics = new Map();
+    const adapterInput = preprocessInput(input, sourceDiagnostics);
+    const adapterBundle = adaptOpenKbBundleToOkf(adapterInput, {
+        requireProvenance: options.requireProvenance,
+        execute: options.execute,
+        install: options.install,
+        ingestUrl: options.ingestUrl,
+        invokeLlm: options.invokeLlm,
+        generateSkill: options.generateSkill,
+    });
+    const bundleDiagnostics = [];
+    // Bundle-level adapter diagnostics (no documentId): malformed bundle/documents,
+    // refused operations. All are blocking for conformance.
+    for (const diag of adapterBundle.diagnostics) {
+        if (diag.documentId !== undefined)
+            continue;
+        bundleDiagnostics.push({
+            severity: 'blocked',
+            code: toConformanceCode(diag),
+            summary: diag.summary,
+            ...(diag.action === undefined ? {} : { action: diag.action }),
+        });
+    }
+    const documents = adapterBundle.documents.map((doc) => buildDocumentReport(doc, sourceDiagnostics.get(doc.id) ?? []));
+    // index.md / log.md semantics where applicable.
+    bundleDiagnostics.push(...indexLogDiagnostics(adapterBundle, options));
+    const allDiagnostics = [
+        ...bundleDiagnostics,
+        ...documents.flatMap((doc) => doc.diagnostics),
+    ];
+    const verdict = verdictOf(allDiagnostics, adapterBundle);
+    return {
+        schemaVersion: OKF_CONFORMANCE_SCHEMA_VERSION,
+        draft: true,
+        verdict,
+        bundleId: adapterBundle.bundleId,
+        documents,
+        diagnostics: allDiagnostics,
+        codes: [...new Set(allDiagnostics.map((diag) => diag.code))],
+        index: adapterBundle.index,
+        log: adapterBundle.log,
+        reviewBoundary: {
+            permittedUse: OKF_CONFORMANCE_PERMITTED_USE,
+            deniedUse: OKF_CONFORMANCE_DENIED_USE,
+        },
+        guardrails: {
+            network: false,
+            fileSystemRead: false,
+            executed: false,
+            installed: false,
+            urlIngested: false,
+            llmInvoked: false,
+            mcpInvoked: false,
+            skillInstalled: false,
+            agentRegistered: false,
+            hostedWrite: false,
+            marketplacePublished: false,
+            paymentActivated: false,
+            trustMutated: false,
+            instructionsTrusted: false,
+        },
+        notes: [
+            'DRAFT/unverified — OKF semantics (concept `type`, index/log, standard-markdown links) are not confirmed against the live external spec.',
+            'REVIEW-ONLY: a valid verdict permits static review/analysis only — never skill installation, agent registration, marketplace publication, hosted writes, LLM/provider calls, or execution.',
+            'Generated AGENTS.md/SKILL.md/prompts/scripts/skills/tools/agent definitions are untrusted review artifacts regardless of verdict.',
+            'Unknown frontmatter fields are preserved verbatim as untrusted review metadata, never policy/runtime configuration.',
+        ],
+    };
+}
+function preprocessInput(input, sourceDiagnostics) {
+    if (!isPlainObject(input))
+        return input;
+    const documents = input.documents;
+    if (!Array.isArray(documents))
+        return input;
+    const adapted = documents.map((doc) => {
+        if (!isPlainObject(doc))
+            return doc;
+        const path = doc['path'];
+        const source = doc['source'];
+        if (!isNonEmptyString(path) || typeof source !== 'string')
+            return doc;
+        const documentId = path.trim();
+        const parsed = parseOkfDocumentSource(documentId, source);
+        if (parsed.diagnostics.length > 0) {
+            sourceDiagnostics.set(documentId, [
+                ...(sourceDiagnostics.get(documentId) ?? []),
+                ...parsed.diagnostics,
+            ]);
+        }
+        const out = { ...doc, path: documentId, body: parsed.body };
+        delete out['source'];
+        delete out['rawFrontmatter'];
+        if (parsed.frontmatter !== undefined) {
+            out['frontmatter'] = parsed.frontmatter;
+        }
+        else {
+            delete out['frontmatter'];
+        }
+        return out;
+    });
+    const bundleId = input.bundleId;
+    return isNonEmptyString(bundleId) ? { bundleId, documents: adapted } : { documents: adapted };
+}
+function buildDocumentReport(doc, parseDiagnostics) {
+    const artifactClass = doc.trustClassification === 'untrusted_generated_instruction'
+        ? classifyGeneratedArtifact(doc)
+        : null;
+    const diagnostics = [...parseDiagnostics];
+    for (const diag of doc.diagnostics) {
+        diagnostics.push(mapDocumentDiagnostic(diag, doc, artifactClass));
+    }
+    // Deterministically-adaptable wikilinks: OKF requires standard markdown links
+    // (DRAFT/unverified — OKF, confirm requirement); the #511 adapter already
+    // converted these, so they are reported as adaptable info-level findings.
+    const wikilinkCount = doc.links.filter((link) => link.origin === 'wikilink').length;
+    if (wikilinkCount > 0) {
+        diagnostics.push({
+            severity: 'info',
+            code: 'unsupported_link_syntax',
+            documentId: doc.id,
+            adaptable: true,
+            summary: `${doc.id} used ${wikilinkCount} OpenKB wikilink(s); each was deterministically adapted to a standard markdown link and is reported here.`,
+            action: 'Prefer standard markdown links at the source; deterministic adaptation is available via the #511 adapter.',
+        });
+    }
+    return {
+        documentId: doc.id,
+        documentRole: doc.documentRole,
+        trustClassification: doc.trustClassification,
+        artifactClass,
+        status: statusOf(diagnostics),
+        diagnostics,
+    };
+}
+function mapDocumentDiagnostic(diag, doc, artifactClass) {
+    const base = {
+        severity: diag.severity,
+        code: toConformanceCode(diag),
+        documentId: doc.id,
+        summary: diag.summary,
+        ...(diag.action === undefined ? {} : { action: diag.action }),
+    };
+    switch (diag.code) {
+        case 'generated_instruction_untrusted':
+            // Conformance escalates generated-instruction findings to blocked: the
+            // artifact is quarantined from any use beyond static review (matches the
+            // #503 corpus `blocking` expectation).
+            return {
+                ...base,
+                severity: 'blocked',
+                ...(artifactClass === null ? {} : { artifactClass }),
+            };
+        case 'execution_not_allowed':
+            return {
+                ...base,
+                severity: 'blocked',
+                ...(artifactClass === null ? {} : { artifactClass }),
+            };
+        case 'unsupported_link_syntax':
+            // Adapter-level link diagnostics are the NON-deterministic cases (embeds,
+            // heading/block refs, empty targets) — not adaptable.
+            return { ...base, severity: 'warning', adaptable: false };
+        default:
+            return base;
+    }
+}
+function toConformanceCode(diag) {
+    switch (diag.code) {
+        case 'bundle_malformed':
+            return 'bundle_malformed';
+        case 'document_malformed':
+            return 'document_malformed';
+        case 'operation_not_permitted':
+            return 'operation_not_permitted';
+        case 'unsupported_link_syntax':
+            return 'unsupported_link_syntax';
+        case 'malformed_frontmatter':
+            return 'malformed_frontmatter';
+        case 'missing_provenance':
+            return 'missing_provenance';
+        case 'generated_instruction_untrusted':
+            return 'generated_instruction_untrusted';
+        case 'execution_not_allowed':
+            return 'execution_not_allowed';
+        case 'concept_type_missing':
+            return 'concept_type_missing';
+        case 'unknown_frontmatter_preserved':
+            return 'unknown_frontmatter_preserved';
+        default:
+            // Any future adapter code without a conformance mapping is treated as a
+            // malformed-document finding (fail-closed rather than silently dropped).
+            return 'document_malformed';
+    }
+}
+/** Directory segments / basenames / extensions mirror the #511 adapter's
+ * instruction-artifact classification vocabulary. */
+const ARTIFACT_EXECUTABLE_EXTENSIONS = new Set(['sh', 'bash', 'zsh', 'js', 'mjs', 'cjs', 'ts', 'py', 'rb', 'ps1', 'bat', 'cmd']);
+function classifyGeneratedArtifact(doc) {
+    const basename = doc.id.split('/').pop()?.toLowerCase() ?? doc.id.toLowerCase();
+    if (basename === 'agents.md')
+        return 'agent_definition';
+    if (basename === 'skill.md' || basename === 'skills.md')
+        return 'skill_definition';
+    const dirs = doc.id.split('/').slice(0, -1).map((segment) => segment.toLowerCase());
+    if (dirs.includes('prompts'))
+        return 'prompt';
+    if (dirs.includes('scripts'))
+        return 'script';
+    if (dirs.includes('tools'))
+        return 'tool';
+    if (dirs.includes('agents'))
+        return 'agent_definition';
+    if (dirs.includes('skills'))
+        return 'skill_definition';
+    const fmType = typeof doc.frontmatter['type'] === 'string'
+        ? doc.frontmatter['type'].toLowerCase()
+        : '';
+    if (fmType === 'agent')
+        return 'agent_definition';
+    if (fmType === 'skill')
+        return 'skill_definition';
+    if (fmType === 'prompt')
+        return 'prompt';
+    if (fmType === 'tool')
+        return 'tool';
+    const dot = basename.lastIndexOf('.');
+    const extension = dot > 0 && dot < basename.length - 1 ? basename.slice(dot + 1) : '';
+    if (ARTIFACT_EXECUTABLE_EXTENSIONS.has(extension))
+        return 'script';
+    return 'generated_instruction_other';
+}
+function indexLogDiagnostics(bundle, options) {
+    const diagnostics = [];
+    if (bundle.index !== null) {
+        diagnostics.push({
+            severity: 'info',
+            code: 'index_semantics_normalized',
+            documentId: bundle.index.documentId,
+            summary: `index.md normalized: ${bundle.index.entries.length} table-of-contents entr(y/ies); not trusted routing/policy.`,
+        });
+    }
+    else if (options.expectIndex === true) {
+        diagnostics.push({
+            severity: 'warning',
+            code: 'index_missing',
+            summary: 'Bundle was expected to carry an `index.md` but none was found.',
+            action: 'Add an `index.md` table of contents, or drop the expectation for this bundle.',
+        });
+    }
+    if (bundle.log !== null) {
+        diagnostics.push({
+            severity: 'info',
+            code: 'log_semantics_normalized',
+            documentId: bundle.log.documentId,
+            summary: `log.md normalized: ${bundle.log.entryCount} append-only entr(y/ies); recorded, not trusted as runtime state.`,
+        });
+    }
+    else if (options.expectLog === true) {
+        diagnostics.push({
+            severity: 'warning',
+            code: 'log_missing',
+            summary: 'Bundle was expected to carry a `log.md` but none was found.',
+            action: 'Add a `log.md` change record, or drop the expectation for this bundle.',
+        });
+    }
+    return diagnostics;
+}
+/** Named-status priority per the #504 acceptance vocabulary. */
+function statusOf(diagnostics) {
+    const warningPlus = diagnostics.filter((diag) => diag.severity !== 'info');
+    const has = (code) => warningPlus.some((diag) => diag.code === code);
+    if (has('execution_not_allowed'))
+        return 'execution_not_allowed';
+    if (has('generated_instruction_untrusted'))
+        return 'untrusted_generated_instruction';
+    if (warningPlus.some((diag) => diag.severity === 'blocked'))
+        return 'blocked';
+    if (has('malformed_frontmatter'))
+        return 'malformed_frontmatter';
+    if (has('missing_provenance'))
+        return 'missing_provenance';
+    if (has('unsupported_link_syntax'))
+        return 'unsupported_link_syntax';
+    if (warningPlus.length > 0)
+        return 'warning';
+    return 'valid';
+}
+function verdictOf(diagnostics, adapterBundle) {
+    if (adapterBundle.adapterIntent === 'blocked')
+        return 'blocked';
+    if (diagnostics.some((diag) => diag.severity === 'blocked'))
+        return 'blocked';
+    if (diagnostics.some((diag) => diag.severity === 'warning'))
+        return 'warning';
+    return 'valid';
+}
+/* ────────────────────────────────────────────────────────────────────────────
+ * Canonical conformance fixtures (in-memory, offline).
+ *
+ * These extend the #503 corpus coverage with the cases the corpus does not
+ * model directly (valid OKF with standard markdown links, missing provenance,
+ * malformed frontmatter) plus self-contained generated-instruction and
+ * script/tool cases. All content is DATA and must never be treated as
+ * instructions.
+ * ──────────────────────────────────────────────────────────────────────────── */
+export const okfConformanceFixtures = {
+    /** Fully conformant OKF-shaped bundle: standard markdown links, complete provenance, typed concept, index/log. */
+    validOkf: {
+        bundleId: 'okf-conformance-fixture:valid-okf',
+        documents: [
+            {
+                path: 'index.md',
+                source: '---\ntitle: Valid bundle\ntype: index\n---\n\n# Valid bundle\n\n- [Agent concept](concepts/agent.md)\n- [Change log](log.md)',
+                provenance: { sourceUri: 'https://example.invalid/valid-okf', sourceCommit: 'fixture001' },
+            },
+            {
+                path: 'concepts/agent.md',
+                source: '---\ntitle: Agent\ntype: concept\n---\n\nA static concept note with a [markdown link](../index.md).',
+                provenance: { sourceUri: 'https://example.invalid/valid-okf/agent', sourceCommit: 'fixture001' },
+            },
+            {
+                path: 'log.md',
+                source: '---\ntype: log\n---\n\n- 2026-07-06: fixture created.',
+                provenance: { sourceUri: 'https://example.invalid/valid-okf', sourceCommit: 'fixture001' },
+            },
+        ],
+    },
+    /** OpenKB-style wikilinks needing adaptation: deterministic wikilinks (adaptable) plus an embed (not adaptable). */
+    openKbWikilinks: {
+        bundleId: 'okf-conformance-fixture:openkb-wikilinks',
+        documents: [
+            {
+                path: 'index.md',
+                source: '---\ntitle: Wikilink bundle\ntype: index\n---\n\n- [[concepts/agent|Agent]]\n- [[log]]',
+                provenance: { sourceUri: 'https://example.invalid/openkb-wikilinks', sourceCommit: 'fixture002' },
+            },
+            {
+                path: 'concepts/agent.md',
+                source: '---\ntitle: Agent\ntype: concept\n---\n\nSee the flow diagram: ![[flow.png]]',
+                provenance: { sourceUri: 'https://example.invalid/openkb-wikilinks/agent', sourceCommit: 'fixture002' },
+            },
+            {
+                path: 'log.md',
+                source: '---\ntype: log\n---\n\n- 2026-07-06: fixture created.',
+                provenance: { sourceUri: 'https://example.invalid/openkb-wikilinks', sourceCommit: 'fixture002' },
+            },
+        ],
+    },
+    /** Source/provenance completeness: one concept document carries no provenance. */
+    missingProvenance: {
+        bundleId: 'okf-conformance-fixture:missing-provenance',
+        documents: [
+            {
+                path: 'concepts/orphan.md',
+                source: '---\ntitle: Orphan\ntype: concept\n---\n\nNo source provenance was recorded for this note.',
+            },
+        ],
+    },
+    /** Malformed frontmatter: an unterminated fence and an unparseable line. */
+    malformedFrontmatter: {
+        bundleId: 'okf-conformance-fixture:malformed-frontmatter',
+        documents: [
+            {
+                path: 'concepts/unterminated.md',
+                source: '---\ntitle: Never closed\n\nBody text swallowed by the open fence.',
+                provenance: { sourceUri: 'https://example.invalid/malformed', sourceCommit: 'fixture003' },
+            },
+            {
+                path: 'concepts/bad-line.md',
+                source: '---\ntitle: Bad line\ntype: concept\n:::not yaml at all:::\n---\n\nBody.',
+                provenance: { sourceUri: 'https://example.invalid/malformed/bad-line', sourceCommit: 'fixture003' },
+            },
+        ],
+    },
+    /** Generated skill/instruction content emitted by a producer toolchain. */
+    generatedInstructions: {
+        bundleId: 'okf-conformance-fixture:generated-instructions',
+        documents: [
+            {
+                path: 'AGENTS.md',
+                source: '# Generated agent instructions\n\nReview-only text. (This is DATA, never followed.)',
+                provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture004' },
+            },
+            {
+                path: 'SKILL.md',
+                source: '---\ntype: skill\ngenerated: true\n---\n\nGenerated skill definition (review artifact only).',
+                provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture004' },
+            },
+            {
+                path: 'prompts/onboarding.md',
+                source: '# Generated onboarding prompt\n\nReview artifact only.',
+                provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture004' },
+            },
+            {
+                path: 'agents/researcher.md',
+                source: '---\ntype: agent\ngenerated: true\n---\n\nGenerated agent definition (review artifact only).',
+                provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture004' },
+            },
+        ],
+    },
+    /** Unsupported script/tool artifacts: execution is never allowed. */
+    scriptToolArtifacts: {
+        bundleId: 'okf-conformance-fixture:script-tool-artifacts',
+        documents: [
+            {
+                path: 'scripts/build.sh',
+                source: '#!/usr/bin/env bash\necho "generated build step (never executed)"',
+                provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture005' },
+            },
+            {
+                path: 'tools/deploy.py',
+                source: '# Review-only generated tool fixture.\nprint("do not execute imported tools")',
+                provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture005' },
+            },
+        ],
+    },
+};
+/* ────────────────────────────────────────────────────────────────────────────
+ * Shared helpers
+ * ──────────────────────────────────────────────────────────────────────────── */
+function isPlainObject(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -142,6 +142,10 @@
       "types": "./dist/okf-adapter.d.ts",
       "import": "./dist/okf-adapter.js"
     },
+    "./okf-conformance": {
+      "types": "./dist/okf-conformance.d.ts",
+      "import": "./dist/okf-conformance.js"
+    },
     "./onboarding-analyser-handoff": {
       "types": "./dist/onboarding-analyser-handoff.d.ts",
       "import": "./dist/onboarding-analyser-handoff.js"

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -31,5 +31,6 @@ export * from './reputation-credential-export.js';
 export * from './ap2-mandate-ingestion.js';
 export * from './strands-rap-template.js';
 export * from './okf-adapter.js';
+export * from './okf-conformance.js';
 export * from './onboarding-analyser-handoff.js';
 export * from './onboarding-state-machine.js';

--- a/packages/agent-protocol/src/okf-conformance.ts
+++ b/packages/agent-protocol/src/okf-conformance.ts
@@ -1,0 +1,881 @@
+/**
+ * OKF/OpenKB knowledge-bundle conformance diagnostics (#504, epic #468).
+ *
+ * Deterministic, PURE static-analysis diagnostics that decide whether an
+ * OKF-shaped / OpenKB-style knowledge bundle is acceptable as REVIEW/ANALYSIS
+ * input for RAP — and nothing more. This module builds directly on the #511
+ * adapter spike (`okf-adapter.ts`) and the #503 static fixture corpus
+ * (`data/okf-openkb-fixtures/okf-openkb-fixture-corpus.v1.json`): same document
+ * roles, trust classifications, and reason-code vocabulary. It does not
+ * re-invent either.
+ *
+ * This module is PURE: no network, no filesystem access, no URL ingestion, no
+ * OpenKB install, no LLM/provider call, no MCP/tool call, no script or tool
+ * execution, no skill installation, no agent registration, no hosted write,
+ * no marketplace publication, no wallet/RPC, no payment activation, no
+ * trust/reputation mutation. It only analyses in-memory text the caller
+ * already holds. Fail-closed on malformed input and on any request to
+ * execute/install/ingest/invoke/generate.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * REVIEW-ONLY BOUNDARY: a `valid` conformance verdict permits static
+ * review/analysis ONLY. It never permits skill installation, agent
+ * registration/onboarding, marketplace publication, hosted writes,
+ * LLM/provider calls, or execution of any bundle content. Those remain denied
+ * regardless of verdict — see `reviewBoundary` on every report.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * DRAFT/unverified — like the #511 spike, OKF (Open Knowledge Format) is an
+ * EXTERNAL format and every OKF-semantic claim below (concept `type`
+ * requirement, `index.md`/`log.md` semantics, standard-markdown-link
+ * requirement) is illustrative and unconfirmed against the live spec.
+ * (DRAFT/unverified — OKF, confirm field semantics before relying on them.)
+ */
+
+import {
+  adaptOpenKbBundleToOkf,
+  type OkfAdapterBundle,
+  type OkfDiagnostic,
+  type OkfDocument,
+  type OkfDocumentRole,
+  type OkfIndex,
+  type OkfLog,
+  type OkfProvenance,
+  type OkfTrustClassification,
+  type OpenKbDocumentInput,
+} from './okf-adapter.js';
+
+export const OKF_CONFORMANCE_SCHEMA_VERSION = 'reddi.okf-conformance.v1' as const;
+
+/** The OKF semantics this module enforces are unverified against the live external spec. */
+export const OKF_CONFORMANCE_IS_DRAFT = true as const;
+
+/** Severity vocabulary — aligned with the repo's static-analysis severity vocab
+ * (`agent-stack-fixtures.ts` and `okf-adapter.ts` both use info/warning/blocked). */
+export type OkfConformanceSeverity = 'info' | 'warning' | 'blocked';
+
+/** Deterministic conformance diagnostic codes. Reuses the #511 adapter reason-code
+ * vocabulary wherever one exists; adds only index/log expectation codes. */
+export type OkfConformanceCode =
+  | 'malformed_frontmatter'
+  | 'concept_type_missing'
+  | 'unsupported_link_syntax'
+  | 'missing_provenance'
+  | 'unknown_frontmatter_preserved'
+  | 'generated_instruction_untrusted'
+  | 'execution_not_allowed'
+  | 'index_missing'
+  | 'log_missing'
+  | 'index_semantics_normalized'
+  | 'log_semantics_normalized'
+  | 'bundle_malformed'
+  | 'document_malformed'
+  | 'operation_not_permitted';
+
+/**
+ * Per-document conformance status — the #504 acceptance-criteria vocabulary:
+ * valid, warning, blocked, untrusted_generated_instruction,
+ * unsupported_link_syntax, missing_provenance, malformed_frontmatter,
+ * execution_not_allowed. The named statuses surface the dominant finding;
+ * `valid`/`warning`/`blocked` are the fallbacks by max severity.
+ */
+export type OkfConformanceStatus =
+  | 'valid'
+  | 'warning'
+  | 'blocked'
+  | 'untrusted_generated_instruction'
+  | 'unsupported_link_syntax'
+  | 'missing_provenance'
+  | 'malformed_frontmatter'
+  | 'execution_not_allowed';
+
+/** Bundle-level verdict. Even `valid` permits review/analysis only. */
+export type OkfConformanceVerdict = 'valid' | 'warning' | 'blocked';
+
+/**
+ * Explicit unsafe/generated-instruction artifact classes for producer-toolchain
+ * output (AGENTS.md, SKILL.md, prompts, scripts, skills, tools, agent
+ * definitions). Mirrors the #503 corpus `generatedArtifacts[].artifactKind`
+ * vocabulary (`agent_definition`, `skill_definition`, `script`).
+ */
+export type OkfGeneratedArtifactClass =
+  | 'agent_definition'
+  | 'skill_definition'
+  | 'prompt'
+  | 'script'
+  | 'tool'
+  | 'generated_instruction_other';
+
+export type OkfConformanceDiagnostic = {
+  severity: OkfConformanceSeverity;
+  code: OkfConformanceCode;
+  /** Document id/path the diagnostic is scoped to, when document-scoped. */
+  documentId?: string;
+  summary: string;
+  action?: string;
+  /**
+   * For `unsupported_link_syntax`: true when the finding is deterministically
+   * adaptable (simple `[[wikilink]]` → standard markdown link, already
+   * converted by the #511 adapter); false when it is not (embeds, heading/block
+   * refs, empty targets) and must be rewritten at the source.
+   */
+  adaptable?: boolean;
+  /** For generated-instruction / execution findings: the artifact class. */
+  artifactClass?: OkfGeneratedArtifactClass;
+};
+
+export type OkfConformanceDocumentReport = {
+  documentId: string;
+  documentRole: OkfDocumentRole;
+  trustClassification: OkfTrustClassification;
+  /** Non-null only for generated-instruction artifacts. */
+  artifactClass: OkfGeneratedArtifactClass | null;
+  status: OkfConformanceStatus;
+  diagnostics: OkfConformanceDiagnostic[];
+};
+
+/** What a passing (or any) conformance report permits — and permanently denies. */
+export const OKF_CONFORMANCE_PERMITTED_USE = [
+  'static_review',
+  'static_analysis',
+  'operator_review_payload',
+  'conformance_reporting',
+] as const;
+
+export const OKF_CONFORMANCE_DENIED_USE = [
+  'skill_installation',
+  'agent_registration',
+  'agent_onboarding',
+  'marketplace_publication',
+  'hosted_registry_write',
+  'llm_or_provider_call',
+  'script_or_tool_execution',
+  'url_ingestion',
+  'payment_activation',
+  'trust_or_reputation_mutation',
+] as const;
+
+export type OkfConformanceReport = {
+  schemaVersion: typeof OKF_CONFORMANCE_SCHEMA_VERSION;
+  /** OKF-semantic checks are drafted against an unverified external format. */
+  draft: true;
+  verdict: OkfConformanceVerdict;
+  bundleId: string | null;
+  documents: OkfConformanceDocumentReport[];
+  /** Bundle-level + aggregated per-document diagnostics, in deterministic order. */
+  diagnostics: OkfConformanceDiagnostic[];
+  /** Deduped codes across all diagnostics. */
+  codes: OkfConformanceCode[];
+  /** Normalized `index.md` semantics from the #511 adapter, when present. */
+  index: OkfIndex | null;
+  /** Normalized `log.md` semantics from the #511 adapter, when present. */
+  log: OkfLog | null;
+  /**
+   * REVIEW-ONLY boundary: identical on every report, independent of verdict.
+   * Passing conformance permits review/analysis only — never installation,
+   * registration, publication, hosted writes, provider calls, or execution.
+   */
+  reviewBoundary: {
+    permittedUse: typeof OKF_CONFORMANCE_PERMITTED_USE;
+    deniedUse: typeof OKF_CONFORMANCE_DENIED_USE;
+  };
+  /** Hard-coded false guardrails — this module never touches any live rail. */
+  guardrails: {
+    network: false;
+    fileSystemRead: false;
+    executed: false;
+    installed: false;
+    urlIngested: false;
+    llmInvoked: false;
+    mcpInvoked: false;
+    skillInstalled: false;
+    agentRegistered: false;
+    hostedWrite: false;
+    marketplacePublished: false;
+    paymentActivated: false;
+    trustMutated: false;
+    instructionsTrusted: false;
+  };
+  notes: string[];
+};
+
+/**
+ * Input document. Either provide `source` (raw markdown text, optionally
+ * starting with a `---` YAML frontmatter fence) or the already-split
+ * `frontmatter`/`rawFrontmatter`/`body` fields from the #511 adapter input
+ * shape. When `source` is present it wins.
+ */
+export type OkfConformanceDocumentInput = OpenKbDocumentInput & {
+  source?: string;
+};
+
+export type OkfConformanceBundleInput = {
+  bundleId?: string;
+  documents: OkfConformanceDocumentInput[];
+};
+
+export type OkfConformanceOptions = {
+  /** Escalate `missing_provenance` to `blocked` instead of `warning`. */
+  requireProvenance?: boolean;
+  /** Emit a warning when the bundle has no `index.md`. */
+  expectIndex?: boolean;
+  /** Emit a warning when the bundle has no `log.md`. */
+  expectLog?: boolean;
+  /**
+   * FAIL-CLOSED: any attempt to execute, install, ingest a URL, invoke an LLM,
+   * or generate/install a skill is rejected with `operation_not_permitted`.
+   * These flags exist only so requests can be refused deterministically.
+   */
+  execute?: boolean;
+  install?: boolean;
+  ingestUrl?: boolean;
+  invokeLlm?: boolean;
+  generateSkill?: boolean;
+};
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * #503 fixture-corpus bridge
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Maps the #503 corpus `expectedDiagnostics[].code` vocabulary onto the
+ * conformance code vocabulary (which follows the #511 adapter reason codes).
+ */
+export const OKF_FIXTURE_DIAGNOSTIC_CODE_MAP = {
+  unsupported_wikilink_syntax: 'unsupported_link_syntax',
+  generated_instruction_untrusted: 'generated_instruction_untrusted',
+  generated_skill_untrusted: 'generated_instruction_untrusted',
+  script_execution_not_allowed: 'execution_not_allowed',
+} as const satisfies Record<string, OkfConformanceCode>;
+
+/** Maps #503 corpus `expectedDiagnostics[].severity` onto acceptable conformance severities. */
+export const OKF_FIXTURE_DIAGNOSTIC_SEVERITY_MAP: Record<string, readonly OkfConformanceSeverity[]> = {
+  review: ['info', 'warning'],
+  blocking: ['blocked'],
+};
+
+/**
+ * Builds a conformance bundle input from one fixture of the #503 corpus
+ * (`reddi.okf-openkb-fixture-corpus.v1`). Read-only over the fixture object:
+ * file previews are consumed as static text and never mutated, so the
+ * fixture's `contentSha256` digests are preserved. Fail-closed: a fixture that
+ * does not carry a usable `files` array yields an empty-documents input, which
+ * `runOkfConformanceDiagnostics` blocks as `bundle_malformed`.
+ */
+export function conformanceInputFromOkfOpenKbFixture(fixture: unknown): OkfConformanceBundleInput {
+  if (!isPlainObject(fixture)) {
+    return { documents: [] };
+  }
+  const bundleId = isNonEmptyString(fixture['id']) ? (fixture['id'] as string) : undefined;
+  const source = isPlainObject(fixture['source']) ? (fixture['source'] as Record<string, unknown>) : {};
+  const provenance: OkfProvenance = {};
+  if (isNonEmptyString(source['sourceUrl'])) provenance.sourceUri = source['sourceUrl'] as string;
+  if (isNonEmptyString(source['retrievedAt'])) provenance.retrievedAt = source['retrievedAt'] as string;
+
+  const files = fixture['files'];
+  if (!Array.isArray(files)) {
+    return bundleId === undefined ? { documents: [] } : { bundleId, documents: [] };
+  }
+
+  const documents: OkfConformanceDocumentInput[] = [];
+  for (const file of files) {
+    if (!isPlainObject(file) || !isNonEmptyString(file['path'])) continue;
+    const doc: OkfConformanceDocumentInput = {
+      path: (file['path'] as string).trim(),
+      source: typeof file['contentPreview'] === 'string' ? (file['contentPreview'] as string) : '',
+    };
+    if (provenance.sourceUri !== undefined) {
+      doc.provenance = { ...provenance };
+    }
+    documents.push(doc);
+  }
+  return bundleId === undefined ? { documents } : { bundleId, documents };
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Raw-source parsing (YAML frontmatter fence + conservative YAML subset)
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+export type OkfParsedDocumentSource = {
+  /** Parsed frontmatter object, or undefined when the source has no fence. */
+  frontmatter: Record<string, unknown> | undefined;
+  body: string;
+  diagnostics: OkfConformanceDiagnostic[];
+};
+
+/**
+ * Deterministically splits raw markdown into YAML frontmatter and body.
+ * Conservative YAML subset only: `key: value` scalars, `# comments`, and
+ * `key:` followed by indented `- item` list lines. Anything else raises
+ * `malformed_frontmatter` and is skipped (fail-closed: unparseable content is
+ * never trusted). An unterminated fence is also `malformed_frontmatter`; the
+ * whole source is then treated as body with no trusted frontmatter.
+ */
+export function parseOkfDocumentSource(documentId: string, source: string): OkfParsedDocumentSource {
+  const lines = source.split(/\r?\n/);
+  if ((lines[0] ?? '').trim() !== '---') {
+    return { frontmatter: undefined, body: source, diagnostics: [] };
+  }
+
+  let closing = -1;
+  for (let i = 1; i < lines.length; i += 1) {
+    if (lines[i].trim() === '---') {
+      closing = i;
+      break;
+    }
+  }
+
+  if (closing === -1) {
+    return {
+      frontmatter: undefined,
+      body: source,
+      diagnostics: [
+        {
+          severity: 'warning',
+          code: 'malformed_frontmatter',
+          documentId,
+          summary: `${documentId} opens a YAML frontmatter fence that never closes; the whole document was treated as body (fail-closed).`,
+          action: 'Close the frontmatter fence with a `---` line.',
+        },
+      ],
+    };
+  }
+
+  const { frontmatter, diagnostics } = parseYamlSubset(lines.slice(1, closing), documentId);
+  let bodyStart = closing + 1;
+  if (lines[bodyStart] !== undefined && lines[bodyStart].trim() === '') bodyStart += 1;
+  return { frontmatter, body: lines.slice(bodyStart).join('\n'), diagnostics };
+}
+
+function parseYamlSubset(
+  lines: string[],
+  documentId: string,
+): { frontmatter: Record<string, unknown>; diagnostics: OkfConformanceDiagnostic[] } {
+  const frontmatter: Record<string, unknown> = {};
+  const diagnostics: OkfConformanceDiagnostic[] = [];
+  const keyPattern = /^([A-Za-z0-9_.-]+)\s*:\s*(.*)$/;
+  const listItemPattern = /^\s+-\s+(.*)$/;
+  let currentListKey: string | null = null;
+
+  for (const line of lines) {
+    if (line.trim().length === 0) continue;
+    if (/^\s*#/.test(line)) continue;
+
+    const listMatch = listItemPattern.exec(line);
+    if (listMatch !== null && currentListKey !== null) {
+      const existing = frontmatter[currentListKey];
+      const list = Array.isArray(existing) ? existing : [];
+      list.push(coerceScalar(listMatch[1].trim()));
+      frontmatter[currentListKey] = list;
+      continue;
+    }
+
+    const keyMatch = keyPattern.exec(line);
+    if (keyMatch === null) {
+      currentListKey = null;
+      diagnostics.push({
+        severity: 'warning',
+        code: 'malformed_frontmatter',
+        documentId,
+        summary: `${documentId} has an unparseable YAML frontmatter line; it was skipped (fail-closed).`,
+        action: 'Use `key: value` scalars or `key:` with indented `- item` list lines.',
+      });
+      continue;
+    }
+
+    const key = keyMatch[1];
+    const value = keyMatch[2].trim();
+    if (value.length === 0) {
+      frontmatter[key] = null;
+      currentListKey = key;
+    } else {
+      frontmatter[key] = coerceScalar(value);
+      currentListKey = null;
+    }
+  }
+
+  return { frontmatter, diagnostics };
+}
+
+function coerceScalar(value: string): unknown {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (value === 'null') return null;
+  if (/^-?\d+$/.test(value)) return Number(value);
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Conformance run
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Runs deterministic OKF/OpenKB conformance diagnostics over an in-memory
+ * bundle. Pure static analysis: delegates document projection to the #511
+ * adapter, then layers the #504 conformance vocabulary (statuses, escalated
+ * generated-instruction severities, adaptable-wikilink reporting, index/log
+ * expectations, review-only boundary) on top.
+ */
+export function runOkfConformanceDiagnostics(
+  input: unknown,
+  options: OkfConformanceOptions = {},
+): OkfConformanceReport {
+  // Preprocess raw `source` documents into the adapter's input shape, collecting
+  // deterministic frontmatter-parse diagnostics per document id.
+  const sourceDiagnostics = new Map<string, OkfConformanceDiagnostic[]>();
+  const adapterInput = preprocessInput(input, sourceDiagnostics);
+
+  const adapterBundle = adaptOpenKbBundleToOkf(adapterInput, {
+    requireProvenance: options.requireProvenance,
+    execute: options.execute,
+    install: options.install,
+    ingestUrl: options.ingestUrl,
+    invokeLlm: options.invokeLlm,
+    generateSkill: options.generateSkill,
+  });
+
+  const bundleDiagnostics: OkfConformanceDiagnostic[] = [];
+
+  // Bundle-level adapter diagnostics (no documentId): malformed bundle/documents,
+  // refused operations. All are blocking for conformance.
+  for (const diag of adapterBundle.diagnostics) {
+    if (diag.documentId !== undefined) continue;
+    bundleDiagnostics.push({
+      severity: 'blocked',
+      code: toConformanceCode(diag),
+      summary: diag.summary,
+      ...(diag.action === undefined ? {} : { action: diag.action }),
+    });
+  }
+
+  const documents = adapterBundle.documents.map((doc) =>
+    buildDocumentReport(doc, sourceDiagnostics.get(doc.id) ?? []),
+  );
+
+  // index.md / log.md semantics where applicable.
+  bundleDiagnostics.push(...indexLogDiagnostics(adapterBundle, options));
+
+  const allDiagnostics = [
+    ...bundleDiagnostics,
+    ...documents.flatMap((doc) => doc.diagnostics),
+  ];
+
+  const verdict = verdictOf(allDiagnostics, adapterBundle);
+
+  return {
+    schemaVersion: OKF_CONFORMANCE_SCHEMA_VERSION,
+    draft: true,
+    verdict,
+    bundleId: adapterBundle.bundleId,
+    documents,
+    diagnostics: allDiagnostics,
+    codes: [...new Set(allDiagnostics.map((diag) => diag.code))],
+    index: adapterBundle.index,
+    log: adapterBundle.log,
+    reviewBoundary: {
+      permittedUse: OKF_CONFORMANCE_PERMITTED_USE,
+      deniedUse: OKF_CONFORMANCE_DENIED_USE,
+    },
+    guardrails: {
+      network: false,
+      fileSystemRead: false,
+      executed: false,
+      installed: false,
+      urlIngested: false,
+      llmInvoked: false,
+      mcpInvoked: false,
+      skillInstalled: false,
+      agentRegistered: false,
+      hostedWrite: false,
+      marketplacePublished: false,
+      paymentActivated: false,
+      trustMutated: false,
+      instructionsTrusted: false,
+    },
+    notes: [
+      'DRAFT/unverified — OKF semantics (concept `type`, index/log, standard-markdown links) are not confirmed against the live external spec.',
+      'REVIEW-ONLY: a valid verdict permits static review/analysis only — never skill installation, agent registration, marketplace publication, hosted writes, LLM/provider calls, or execution.',
+      'Generated AGENTS.md/SKILL.md/prompts/scripts/skills/tools/agent definitions are untrusted review artifacts regardless of verdict.',
+      'Unknown frontmatter fields are preserved verbatim as untrusted review metadata, never policy/runtime configuration.',
+    ],
+  };
+}
+
+function preprocessInput(
+  input: unknown,
+  sourceDiagnostics: Map<string, OkfConformanceDiagnostic[]>,
+): unknown {
+  if (!isPlainObject(input)) return input;
+  const documents = (input as { documents?: unknown }).documents;
+  if (!Array.isArray(documents)) return input;
+
+  const adapted: unknown[] = documents.map((doc) => {
+    if (!isPlainObject(doc)) return doc;
+    const path = doc['path'];
+    const source = doc['source'];
+    if (!isNonEmptyString(path) || typeof source !== 'string') return doc;
+
+    const documentId = (path as string).trim();
+    const parsed = parseOkfDocumentSource(documentId, source);
+    if (parsed.diagnostics.length > 0) {
+      sourceDiagnostics.set(documentId, [
+        ...(sourceDiagnostics.get(documentId) ?? []),
+        ...parsed.diagnostics,
+      ]);
+    }
+
+    const out: Record<string, unknown> = { ...doc, path: documentId, body: parsed.body };
+    delete out['source'];
+    delete out['rawFrontmatter'];
+    if (parsed.frontmatter !== undefined) {
+      out['frontmatter'] = parsed.frontmatter;
+    } else {
+      delete out['frontmatter'];
+    }
+    return out;
+  });
+
+  const bundleId = (input as { bundleId?: unknown }).bundleId;
+  return isNonEmptyString(bundleId) ? { bundleId, documents: adapted } : { documents: adapted };
+}
+
+function buildDocumentReport(
+  doc: OkfDocument,
+  parseDiagnostics: OkfConformanceDiagnostic[],
+): OkfConformanceDocumentReport {
+  const artifactClass = doc.trustClassification === 'untrusted_generated_instruction'
+    ? classifyGeneratedArtifact(doc)
+    : null;
+
+  const diagnostics: OkfConformanceDiagnostic[] = [...parseDiagnostics];
+
+  for (const diag of doc.diagnostics) {
+    diagnostics.push(mapDocumentDiagnostic(diag, doc, artifactClass));
+  }
+
+  // Deterministically-adaptable wikilinks: OKF requires standard markdown links
+  // (DRAFT/unverified — OKF, confirm requirement); the #511 adapter already
+  // converted these, so they are reported as adaptable info-level findings.
+  const wikilinkCount = doc.links.filter((link) => link.origin === 'wikilink').length;
+  if (wikilinkCount > 0) {
+    diagnostics.push({
+      severity: 'info',
+      code: 'unsupported_link_syntax',
+      documentId: doc.id,
+      adaptable: true,
+      summary: `${doc.id} used ${wikilinkCount} OpenKB wikilink(s); each was deterministically adapted to a standard markdown link and is reported here.`,
+      action: 'Prefer standard markdown links at the source; deterministic adaptation is available via the #511 adapter.',
+    });
+  }
+
+  return {
+    documentId: doc.id,
+    documentRole: doc.documentRole,
+    trustClassification: doc.trustClassification,
+    artifactClass,
+    status: statusOf(diagnostics),
+    diagnostics,
+  };
+}
+
+function mapDocumentDiagnostic(
+  diag: OkfDiagnostic,
+  doc: OkfDocument,
+  artifactClass: OkfGeneratedArtifactClass | null,
+): OkfConformanceDiagnostic {
+  const base: OkfConformanceDiagnostic = {
+    severity: diag.severity,
+    code: toConformanceCode(diag),
+    documentId: doc.id,
+    summary: diag.summary,
+    ...(diag.action === undefined ? {} : { action: diag.action }),
+  };
+
+  switch (diag.code) {
+    case 'generated_instruction_untrusted':
+      // Conformance escalates generated-instruction findings to blocked: the
+      // artifact is quarantined from any use beyond static review (matches the
+      // #503 corpus `blocking` expectation).
+      return {
+        ...base,
+        severity: 'blocked',
+        ...(artifactClass === null ? {} : { artifactClass }),
+      };
+    case 'execution_not_allowed':
+      return {
+        ...base,
+        severity: 'blocked',
+        ...(artifactClass === null ? {} : { artifactClass }),
+      };
+    case 'unsupported_link_syntax':
+      // Adapter-level link diagnostics are the NON-deterministic cases (embeds,
+      // heading/block refs, empty targets) — not adaptable.
+      return { ...base, severity: 'warning', adaptable: false };
+    default:
+      return base;
+  }
+}
+
+function toConformanceCode(diag: OkfDiagnostic): OkfConformanceCode {
+  switch (diag.code) {
+    case 'bundle_malformed':
+      return 'bundle_malformed';
+    case 'document_malformed':
+      return 'document_malformed';
+    case 'operation_not_permitted':
+      return 'operation_not_permitted';
+    case 'unsupported_link_syntax':
+      return 'unsupported_link_syntax';
+    case 'malformed_frontmatter':
+      return 'malformed_frontmatter';
+    case 'missing_provenance':
+      return 'missing_provenance';
+    case 'generated_instruction_untrusted':
+      return 'generated_instruction_untrusted';
+    case 'execution_not_allowed':
+      return 'execution_not_allowed';
+    case 'concept_type_missing':
+      return 'concept_type_missing';
+    case 'unknown_frontmatter_preserved':
+      return 'unknown_frontmatter_preserved';
+    default:
+      // Any future adapter code without a conformance mapping is treated as a
+      // malformed-document finding (fail-closed rather than silently dropped).
+      return 'document_malformed';
+  }
+}
+
+/** Directory segments / basenames / extensions mirror the #511 adapter's
+ * instruction-artifact classification vocabulary. */
+const ARTIFACT_EXECUTABLE_EXTENSIONS = new Set(['sh', 'bash', 'zsh', 'js', 'mjs', 'cjs', 'ts', 'py', 'rb', 'ps1', 'bat', 'cmd']);
+
+function classifyGeneratedArtifact(doc: OkfDocument): OkfGeneratedArtifactClass {
+  const basename = doc.id.split('/').pop()?.toLowerCase() ?? doc.id.toLowerCase();
+  if (basename === 'agents.md') return 'agent_definition';
+  if (basename === 'skill.md' || basename === 'skills.md') return 'skill_definition';
+
+  const dirs = doc.id.split('/').slice(0, -1).map((segment) => segment.toLowerCase());
+  if (dirs.includes('prompts')) return 'prompt';
+  if (dirs.includes('scripts')) return 'script';
+  if (dirs.includes('tools')) return 'tool';
+  if (dirs.includes('agents')) return 'agent_definition';
+  if (dirs.includes('skills')) return 'skill_definition';
+
+  const fmType = typeof doc.frontmatter['type'] === 'string'
+    ? (doc.frontmatter['type'] as string).toLowerCase()
+    : '';
+  if (fmType === 'agent') return 'agent_definition';
+  if (fmType === 'skill') return 'skill_definition';
+  if (fmType === 'prompt') return 'prompt';
+  if (fmType === 'tool') return 'tool';
+
+  const dot = basename.lastIndexOf('.');
+  const extension = dot > 0 && dot < basename.length - 1 ? basename.slice(dot + 1) : '';
+  if (ARTIFACT_EXECUTABLE_EXTENSIONS.has(extension)) return 'script';
+
+  return 'generated_instruction_other';
+}
+
+function indexLogDiagnostics(
+  bundle: OkfAdapterBundle,
+  options: OkfConformanceOptions,
+): OkfConformanceDiagnostic[] {
+  const diagnostics: OkfConformanceDiagnostic[] = [];
+
+  if (bundle.index !== null) {
+    diagnostics.push({
+      severity: 'info',
+      code: 'index_semantics_normalized',
+      documentId: bundle.index.documentId,
+      summary: `index.md normalized: ${bundle.index.entries.length} table-of-contents entr(y/ies); not trusted routing/policy.`,
+    });
+  } else if (options.expectIndex === true) {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'index_missing',
+      summary: 'Bundle was expected to carry an `index.md` but none was found.',
+      action: 'Add an `index.md` table of contents, or drop the expectation for this bundle.',
+    });
+  }
+
+  if (bundle.log !== null) {
+    diagnostics.push({
+      severity: 'info',
+      code: 'log_semantics_normalized',
+      documentId: bundle.log.documentId,
+      summary: `log.md normalized: ${bundle.log.entryCount} append-only entr(y/ies); recorded, not trusted as runtime state.`,
+    });
+  } else if (options.expectLog === true) {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'log_missing',
+      summary: 'Bundle was expected to carry a `log.md` but none was found.',
+      action: 'Add a `log.md` change record, or drop the expectation for this bundle.',
+    });
+  }
+
+  return diagnostics;
+}
+
+/** Named-status priority per the #504 acceptance vocabulary. */
+function statusOf(diagnostics: OkfConformanceDiagnostic[]): OkfConformanceStatus {
+  const warningPlus = diagnostics.filter((diag) => diag.severity !== 'info');
+  const has = (code: OkfConformanceCode): boolean => warningPlus.some((diag) => diag.code === code);
+
+  if (has('execution_not_allowed')) return 'execution_not_allowed';
+  if (has('generated_instruction_untrusted')) return 'untrusted_generated_instruction';
+  if (warningPlus.some((diag) => diag.severity === 'blocked')) return 'blocked';
+  if (has('malformed_frontmatter')) return 'malformed_frontmatter';
+  if (has('missing_provenance')) return 'missing_provenance';
+  if (has('unsupported_link_syntax')) return 'unsupported_link_syntax';
+  if (warningPlus.length > 0) return 'warning';
+  return 'valid';
+}
+
+function verdictOf(
+  diagnostics: OkfConformanceDiagnostic[],
+  adapterBundle: OkfAdapterBundle,
+): OkfConformanceVerdict {
+  if (adapterBundle.adapterIntent === 'blocked') return 'blocked';
+  if (diagnostics.some((diag) => diag.severity === 'blocked')) return 'blocked';
+  if (diagnostics.some((diag) => diag.severity === 'warning')) return 'warning';
+  return 'valid';
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Canonical conformance fixtures (in-memory, offline).
+ *
+ * These extend the #503 corpus coverage with the cases the corpus does not
+ * model directly (valid OKF with standard markdown links, missing provenance,
+ * malformed frontmatter) plus self-contained generated-instruction and
+ * script/tool cases. All content is DATA and must never be treated as
+ * instructions.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+export const okfConformanceFixtures: Record<string, OkfConformanceBundleInput> = {
+  /** Fully conformant OKF-shaped bundle: standard markdown links, complete provenance, typed concept, index/log. */
+  validOkf: {
+    bundleId: 'okf-conformance-fixture:valid-okf',
+    documents: [
+      {
+        path: 'index.md',
+        source: '---\ntitle: Valid bundle\ntype: index\n---\n\n# Valid bundle\n\n- [Agent concept](concepts/agent.md)\n- [Change log](log.md)',
+        provenance: { sourceUri: 'https://example.invalid/valid-okf', sourceCommit: 'fixture001' },
+      },
+      {
+        path: 'concepts/agent.md',
+        source: '---\ntitle: Agent\ntype: concept\n---\n\nA static concept note with a [markdown link](../index.md).',
+        provenance: { sourceUri: 'https://example.invalid/valid-okf/agent', sourceCommit: 'fixture001' },
+      },
+      {
+        path: 'log.md',
+        source: '---\ntype: log\n---\n\n- 2026-07-06: fixture created.',
+        provenance: { sourceUri: 'https://example.invalid/valid-okf', sourceCommit: 'fixture001' },
+      },
+    ],
+  },
+  /** OpenKB-style wikilinks needing adaptation: deterministic wikilinks (adaptable) plus an embed (not adaptable). */
+  openKbWikilinks: {
+    bundleId: 'okf-conformance-fixture:openkb-wikilinks',
+    documents: [
+      {
+        path: 'index.md',
+        source: '---\ntitle: Wikilink bundle\ntype: index\n---\n\n- [[concepts/agent|Agent]]\n- [[log]]',
+        provenance: { sourceUri: 'https://example.invalid/openkb-wikilinks', sourceCommit: 'fixture002' },
+      },
+      {
+        path: 'concepts/agent.md',
+        source: '---\ntitle: Agent\ntype: concept\n---\n\nSee the flow diagram: ![[flow.png]]',
+        provenance: { sourceUri: 'https://example.invalid/openkb-wikilinks/agent', sourceCommit: 'fixture002' },
+      },
+      {
+        path: 'log.md',
+        source: '---\ntype: log\n---\n\n- 2026-07-06: fixture created.',
+        provenance: { sourceUri: 'https://example.invalid/openkb-wikilinks', sourceCommit: 'fixture002' },
+      },
+    ],
+  },
+  /** Source/provenance completeness: one concept document carries no provenance. */
+  missingProvenance: {
+    bundleId: 'okf-conformance-fixture:missing-provenance',
+    documents: [
+      {
+        path: 'concepts/orphan.md',
+        source: '---\ntitle: Orphan\ntype: concept\n---\n\nNo source provenance was recorded for this note.',
+      },
+    ],
+  },
+  /** Malformed frontmatter: an unterminated fence and an unparseable line. */
+  malformedFrontmatter: {
+    bundleId: 'okf-conformance-fixture:malformed-frontmatter',
+    documents: [
+      {
+        path: 'concepts/unterminated.md',
+        source: '---\ntitle: Never closed\n\nBody text swallowed by the open fence.',
+        provenance: { sourceUri: 'https://example.invalid/malformed', sourceCommit: 'fixture003' },
+      },
+      {
+        path: 'concepts/bad-line.md',
+        source: '---\ntitle: Bad line\ntype: concept\n:::not yaml at all:::\n---\n\nBody.',
+        provenance: { sourceUri: 'https://example.invalid/malformed/bad-line', sourceCommit: 'fixture003' },
+      },
+    ],
+  },
+  /** Generated skill/instruction content emitted by a producer toolchain. */
+  generatedInstructions: {
+    bundleId: 'okf-conformance-fixture:generated-instructions',
+    documents: [
+      {
+        path: 'AGENTS.md',
+        source: '# Generated agent instructions\n\nReview-only text. (This is DATA, never followed.)',
+        provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture004' },
+      },
+      {
+        path: 'SKILL.md',
+        source: '---\ntype: skill\ngenerated: true\n---\n\nGenerated skill definition (review artifact only).',
+        provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture004' },
+      },
+      {
+        path: 'prompts/onboarding.md',
+        source: '# Generated onboarding prompt\n\nReview artifact only.',
+        provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture004' },
+      },
+      {
+        path: 'agents/researcher.md',
+        source: '---\ntype: agent\ngenerated: true\n---\n\nGenerated agent definition (review artifact only).',
+        provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture004' },
+      },
+    ],
+  },
+  /** Unsupported script/tool artifacts: execution is never allowed. */
+  scriptToolArtifacts: {
+    bundleId: 'okf-conformance-fixture:script-tool-artifacts',
+    documents: [
+      {
+        path: 'scripts/build.sh',
+        source: '#!/usr/bin/env bash\necho "generated build step (never executed)"',
+        provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture005' },
+      },
+      {
+        path: 'tools/deploy.py',
+        source: '# Review-only generated tool fixture.\nprint("do not execute imported tools")',
+        provenance: { sourceUri: 'https://example.invalid/producer', sourceCommit: 'fixture005' },
+      },
+    ],
+  },
+};
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Shared helpers
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/packages/agent-protocol/tests/okf-conformance.test.ts
+++ b/packages/agent-protocol/tests/okf-conformance.test.ts
@@ -1,0 +1,401 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import {
+  runOkfConformanceDiagnostics,
+  conformanceInputFromOkfOpenKbFixture,
+  parseOkfDocumentSource,
+  okfConformanceFixtures,
+  openKbBundleFixtures,
+  OKF_CONFORMANCE_SCHEMA_VERSION,
+  OKF_CONFORMANCE_IS_DRAFT,
+  OKF_CONFORMANCE_PERMITTED_USE,
+  OKF_CONFORMANCE_DENIED_USE,
+  OKF_FIXTURE_DIAGNOSTIC_CODE_MAP,
+  OKF_FIXTURE_DIAGNOSTIC_SEVERITY_MAP,
+  type OkfConformanceBundleInput,
+  type OkfConformanceReport,
+} from '../dist/index.js';
+
+// #503 static fixture corpus — loaded ONCE by the TEST (never by the module
+// under test, which is pure and does no filesystem access).
+const corpusPath = fileURLToPath(
+  new URL('../../../data/okf-openkb-fixtures/okf-openkb-fixture-corpus.v1.json', import.meta.url),
+);
+const corpusRaw = readFileSync(corpusPath, 'utf8');
+
+type CorpusFile = {
+  path: string;
+  type: string;
+  contentClass: string;
+  trustBoundary: string;
+  contentPreview: string;
+};
+type CorpusFixture = {
+  id: string;
+  files: CorpusFile[];
+  expectedDiagnostics: Array<{ code: string; severity: string; path: string }>;
+  contentSha256: string;
+};
+type Corpus = { fixtures: CorpusFixture[] };
+
+function loadCorpus(): Corpus {
+  return JSON.parse(corpusRaw) as Corpus;
+}
+
+function corpusFixture(corpus: Corpus, id: string): CorpusFixture {
+  const fixture = corpus.fixtures.find((f) => f.id === id);
+  assert.ok(fixture, `expected corpus fixture ${id}`);
+  return fixture;
+}
+
+/** Same digest recipe as scripts/check-okf-openkb-fixture-corpus.mjs. */
+function fixtureContentHash(files: CorpusFile[]): string {
+  const hashInput = JSON.stringify(files.map((file) => ({
+    path: file.path,
+    type: file.type,
+    contentClass: file.contentClass,
+    trustBoundary: file.trustBoundary,
+    contentPreview: file.contentPreview,
+  })), null, 2);
+  return createHash('sha256').update(hashInput).digest('hex');
+}
+
+function fixture(name: keyof typeof okfConformanceFixtures): OkfConformanceBundleInput {
+  return structuredClone(okfConformanceFixtures[name]);
+}
+
+function docReport(report: OkfConformanceReport, documentId: string) {
+  const doc = report.documents.find((d) => d.documentId === documentId);
+  assert.ok(doc, `expected document report for ${documentId}`);
+  return doc;
+}
+
+describe('OKF/OpenKB conformance diagnostics (#504)', () => {
+  describe('report shape and review-only boundary', () => {
+    it('emits the schema version, draft flag, and hard-false guardrails', () => {
+      const report = runOkfConformanceDiagnostics(fixture('validOkf'));
+      assert.equal(report.schemaVersion, OKF_CONFORMANCE_SCHEMA_VERSION);
+      assert.equal(report.schemaVersion, 'reddi.okf-conformance.v1');
+      assert.equal(report.draft, true);
+      assert.equal(OKF_CONFORMANCE_IS_DRAFT, true);
+      for (const [key, value] of Object.entries(report.guardrails)) {
+        assert.equal(value, false, `guardrail ${key} must be hard-false`);
+      }
+    });
+
+    it('permits review/analysis only — denied uses are identical on every verdict', () => {
+      const valid = runOkfConformanceDiagnostics(fixture('validOkf'));
+      const blocked = runOkfConformanceDiagnostics(fixture('generatedInstructions'));
+      assert.equal(valid.verdict, 'valid');
+      assert.equal(blocked.verdict, 'blocked');
+      for (const report of [valid, blocked]) {
+        assert.deepEqual(report.reviewBoundary.permittedUse, OKF_CONFORMANCE_PERMITTED_USE);
+        assert.deepEqual(report.reviewBoundary.deniedUse, OKF_CONFORMANCE_DENIED_USE);
+        for (const denied of [
+          'skill_installation',
+          'agent_registration',
+          'marketplace_publication',
+          'hosted_registry_write',
+          'llm_or_provider_call',
+          'script_or_tool_execution',
+        ]) {
+          assert.ok(
+            (report.reviewBoundary.deniedUse as readonly string[]).includes(denied),
+            `deniedUse must include ${denied}`,
+          );
+        }
+      }
+    });
+
+    it('is deterministic — identical input yields identical output', () => {
+      const a = runOkfConformanceDiagnostics(fixture('openKbWikilinks'));
+      const b = runOkfConformanceDiagnostics(fixture('openKbWikilinks'));
+      assert.deepEqual(a, b);
+    });
+  });
+
+  describe('valid OKF bundle', () => {
+    it('reports every document valid with a valid verdict', () => {
+      const report = runOkfConformanceDiagnostics(fixture('validOkf'));
+      assert.equal(report.verdict, 'valid');
+      assert.equal(report.documents.length, 3);
+      for (const doc of report.documents) {
+        assert.equal(doc.status, 'valid', `${doc.documentId} should be valid`);
+        assert.equal(doc.trustClassification, 'static_source');
+        assert.equal(doc.artifactClass, null);
+      }
+    });
+
+    it('normalizes index.md and log.md semantics', () => {
+      const report = runOkfConformanceDiagnostics(fixture('validOkf'));
+      assert.ok(report.index);
+      assert.equal(report.index.documentId, 'index.md');
+      assert.equal(report.index.entries.length, 2);
+      assert.ok(report.log);
+      assert.equal(report.log.documentId, 'log.md');
+      assert.ok(report.codes.includes('index_semantics_normalized'));
+      assert.ok(report.codes.includes('log_semantics_normalized'));
+    });
+
+    it('warns when an expected index.md or log.md is absent', () => {
+      const input = fixture('missingProvenance');
+      const report = runOkfConformanceDiagnostics(input, { expectIndex: true, expectLog: true });
+      assert.ok(report.codes.includes('index_missing'));
+      assert.ok(report.codes.includes('log_missing'));
+      assert.notEqual(report.verdict, 'valid');
+    });
+
+    it('preserves unknown frontmatter verbatim as untrusted review metadata (info only)', () => {
+      const input = fixture('validOkf');
+      input.documents[1].source = '---\ntitle: Agent\ntype: concept\ncustom_unknown_field: preserved-verbatim\n---\n\nBody.';
+      const report = runOkfConformanceDiagnostics(input);
+      assert.equal(report.verdict, 'valid');
+      const doc = docReport(report, 'concepts/agent.md');
+      const preserved = doc.diagnostics.find((d) => d.code === 'unknown_frontmatter_preserved');
+      assert.ok(preserved);
+      assert.equal(preserved.severity, 'info');
+    });
+
+    it('flags concept documents with no non-empty type', () => {
+      const input = fixture('validOkf');
+      input.documents[1].source = '---\ntitle: Agent\n---\n\nBody with no type.';
+      const report = runOkfConformanceDiagnostics(input);
+      assert.equal(report.verdict, 'warning');
+      assert.ok(report.codes.includes('concept_type_missing'));
+    });
+  });
+
+  describe('link syntax', () => {
+    it('reports deterministic wikilinks as adaptable info without failing conformance', () => {
+      const report = runOkfConformanceDiagnostics(fixture('openKbWikilinks'));
+      const indexDoc = docReport(report, 'index.md');
+      const linkDiag = indexDoc.diagnostics.find((d) => d.code === 'unsupported_link_syntax');
+      assert.ok(linkDiag);
+      assert.equal(linkDiag.severity, 'info');
+      assert.equal(linkDiag.adaptable, true);
+      assert.equal(indexDoc.status, 'valid');
+    });
+
+    it('reports non-deterministic wikilink syntax as an unadaptable warning', () => {
+      const report = runOkfConformanceDiagnostics(fixture('openKbWikilinks'));
+      const conceptDoc = docReport(report, 'concepts/agent.md');
+      const embed = conceptDoc.diagnostics.find(
+        (d) => d.code === 'unsupported_link_syntax' && d.severity === 'warning',
+      );
+      assert.ok(embed, 'embed ![[...]] must raise a warning');
+      assert.equal(embed.adaptable, false);
+      assert.equal(conceptDoc.status, 'unsupported_link_syntax');
+      assert.equal(report.verdict, 'warning');
+    });
+  });
+
+  describe('provenance', () => {
+    it('warns on documents with no source provenance', () => {
+      const report = runOkfConformanceDiagnostics(fixture('missingProvenance'));
+      assert.equal(report.verdict, 'warning');
+      const doc = docReport(report, 'concepts/orphan.md');
+      assert.equal(doc.status, 'missing_provenance');
+    });
+
+    it('escalates missing provenance to blocked when required', () => {
+      const report = runOkfConformanceDiagnostics(fixture('missingProvenance'), { requireProvenance: true });
+      assert.equal(report.verdict, 'blocked');
+      const diag = report.diagnostics.find((d) => d.code === 'missing_provenance');
+      assert.ok(diag);
+      assert.equal(diag.severity, 'blocked');
+    });
+  });
+
+  describe('frontmatter parsing', () => {
+    it('parses a YAML frontmatter fence with scalars and list values', () => {
+      const parsed = parseOkfDocumentSource(
+        'concepts/x.md',
+        '---\ntitle: X\ntype: concept\nsourceRefs:\n  - index.md\n  - log.md\ncount: 3\nflag: true\n---\n\nBody.',
+      );
+      assert.deepEqual(parsed.frontmatter, {
+        title: 'X',
+        type: 'concept',
+        sourceRefs: ['index.md', 'log.md'],
+        count: 3,
+        flag: true,
+      });
+      assert.equal(parsed.body, 'Body.');
+      assert.equal(parsed.diagnostics.length, 0);
+    });
+
+    it('fails closed on an unterminated fence and on unparseable lines', () => {
+      const report = runOkfConformanceDiagnostics(fixture('malformedFrontmatter'));
+      assert.equal(report.verdict, 'warning');
+      assert.equal(docReport(report, 'concepts/unterminated.md').status, 'malformed_frontmatter');
+      assert.equal(docReport(report, 'concepts/bad-line.md').status, 'malformed_frontmatter');
+      // The bad line is skipped, not trusted; parsed keys around it survive.
+      const badLine = docReport(report, 'concepts/bad-line.md');
+      assert.ok(badLine.diagnostics.some((d) => d.code === 'malformed_frontmatter' && d.severity === 'warning'));
+    });
+  });
+
+  describe('generated instruction and execution safety', () => {
+    it('classifies producer-toolchain artifacts with explicit unsafe classes and blocks them', () => {
+      const report = runOkfConformanceDiagnostics(fixture('generatedInstructions'));
+      assert.equal(report.verdict, 'blocked');
+      assert.equal(docReport(report, 'AGENTS.md').artifactClass, 'agent_definition');
+      assert.equal(docReport(report, 'SKILL.md').artifactClass, 'skill_definition');
+      assert.equal(docReport(report, 'prompts/onboarding.md').artifactClass, 'prompt');
+      assert.equal(docReport(report, 'agents/researcher.md').artifactClass, 'agent_definition');
+      for (const doc of report.documents) {
+        assert.equal(doc.trustClassification, 'untrusted_generated_instruction');
+        assert.equal(doc.status, 'untrusted_generated_instruction');
+        const diag = doc.diagnostics.find((d) => d.code === 'generated_instruction_untrusted');
+        assert.ok(diag, `${doc.documentId} must carry generated_instruction_untrusted`);
+        assert.equal(diag.severity, 'blocked');
+      }
+    });
+
+    it('marks script and tool artifacts execution_not_allowed', () => {
+      const report = runOkfConformanceDiagnostics(fixture('scriptToolArtifacts'));
+      assert.equal(report.verdict, 'blocked');
+      const script = docReport(report, 'scripts/build.sh');
+      const tool = docReport(report, 'tools/deploy.py');
+      assert.equal(script.status, 'execution_not_allowed');
+      assert.equal(script.artifactClass, 'script');
+      assert.equal(tool.status, 'execution_not_allowed');
+      assert.equal(tool.artifactClass, 'tool');
+      for (const doc of [script, tool]) {
+        const diag = doc.diagnostics.find((d) => d.code === 'execution_not_allowed');
+        assert.ok(diag);
+        assert.equal(diag.severity, 'blocked');
+      }
+    });
+
+    it('handles the #511 adapter representative fixture without re-inventing its vocabulary', () => {
+      const report = runOkfConformanceDiagnostics(structuredClone(openKbBundleFixtures.representative));
+      assert.equal(report.verdict, 'blocked');
+      assert.equal(docReport(report, 'AGENTS.md').status, 'untrusted_generated_instruction');
+      assert.equal(docReport(report, 'scripts/build.sh').status, 'execution_not_allowed');
+      assert.equal(docReport(report, 'concepts/payment.md').status, 'unsupported_link_syntax');
+      assert.equal(docReport(report, 'AGENTS.md').artifactClass, 'agent_definition');
+    });
+  });
+
+  describe('fail-closed behaviour', () => {
+    it('blocks non-bundle input and empty bundles', () => {
+      for (const bad of [null, 42, 'bundle', { documents: [] }, {}]) {
+        const report = runOkfConformanceDiagnostics(bad);
+        assert.equal(report.verdict, 'blocked');
+        assert.ok(report.codes.includes('bundle_malformed'));
+        assert.equal(report.documents.length, 0);
+      }
+    });
+
+    it('rejects every execute/install/ingest/LLM/skill-generation request', () => {
+      for (const opt of [
+        { execute: true },
+        { install: true },
+        { ingestUrl: true },
+        { invokeLlm: true },
+        { generateSkill: true },
+      ] as const) {
+        const report = runOkfConformanceDiagnostics(fixture('validOkf'), opt);
+        assert.equal(report.verdict, 'blocked');
+        assert.deepEqual(report.codes, ['operation_not_permitted']);
+        assert.equal(report.documents.length, 0);
+      }
+    });
+  });
+
+  describe('#503 fixture corpus integration', () => {
+    it('accepts the okf-minimal-concept-bundle fixture as valid (review-only)', () => {
+      const corpus = loadCorpus();
+      const minimal = corpusFixture(corpus, 'okf-minimal-concept-bundle');
+      const report = runOkfConformanceDiagnostics(conformanceInputFromOkfOpenKbFixture(minimal));
+      assert.equal(report.verdict, 'valid');
+      assert.equal(report.documents.length, 3);
+      assert.ok(report.index, 'index.md semantics must normalize');
+      assert.ok(report.log, 'log.md semantics must normalize');
+      assert.equal(docReport(report, 'concepts/agent-marketplace.md').documentRole, 'concept');
+      // Deterministic wikilinks are reported (adaptable) without failing conformance.
+      const indexDoc = docReport(report, 'index.md');
+      assert.ok(indexDoc.diagnostics.some((d) => d.code === 'unsupported_link_syntax' && d.adaptable === true));
+    });
+
+    it('covers every expectedDiagnostic of the openkb-style-generated-agent-bundle fixture', () => {
+      const corpus = loadCorpus();
+      const generated = corpusFixture(corpus, 'openkb-style-generated-agent-bundle');
+      const report = runOkfConformanceDiagnostics(conformanceInputFromOkfOpenKbFixture(generated));
+      assert.equal(report.verdict, 'blocked');
+
+      for (const expected of generated.expectedDiagnostics) {
+        const mappedCode = OKF_FIXTURE_DIAGNOSTIC_CODE_MAP[
+          expected.code as keyof typeof OKF_FIXTURE_DIAGNOSTIC_CODE_MAP
+        ];
+        assert.ok(mappedCode, `corpus code ${expected.code} must map to a conformance code`);
+        const allowedSeverities = OKF_FIXTURE_DIAGNOSTIC_SEVERITY_MAP[expected.severity];
+        assert.ok(allowedSeverities, `corpus severity ${expected.severity} must map`);
+        const match = report.diagnostics.find(
+          (d) => d.code === mappedCode
+            && d.documentId === expected.path
+            && (allowedSeverities as readonly string[]).includes(d.severity),
+        );
+        assert.ok(
+          match,
+          `expected ${expected.code}@${expected.path} (${expected.severity}) to surface as ${mappedCode}`,
+        );
+      }
+
+      assert.equal(docReport(report, 'AGENTS.md').artifactClass, 'agent_definition');
+      assert.equal(docReport(report, 'SKILL.md').artifactClass, 'skill_definition');
+      assert.equal(docReport(report, 'scripts/refresh.py').status, 'execution_not_allowed');
+    });
+
+    it('consumes fixture previews read-only and preserves contentSha256 digests', () => {
+      const corpus = loadCorpus();
+      const before = structuredClone(corpus);
+      for (const f of corpus.fixtures) {
+        runOkfConformanceDiagnostics(conformanceInputFromOkfOpenKbFixture(f));
+        assert.equal(
+          fixtureContentHash(f.files),
+          f.contentSha256,
+          `${f.id} contentSha256 must still match the checker recipe after conformance consumption`,
+        );
+      }
+      assert.deepEqual(corpus, before, 'conformance must never mutate the corpus fixtures');
+    });
+
+    it('fails closed on a fixture without usable files', () => {
+      const report = runOkfConformanceDiagnostics(conformanceInputFromOkfOpenKbFixture({ id: 'broken' }));
+      assert.equal(report.verdict, 'blocked');
+      assert.ok(report.codes.includes('bundle_malformed'));
+    });
+  });
+
+  it('is offline-only: the module imports nothing from network/fs/exec and contains no async surface', () => {
+    const sourcePath = fileURLToPath(new URL('../src/okf-conformance.ts', import.meta.url));
+    const source = readFileSync(sourcePath, 'utf8');
+    for (const banned of [
+      'ethers',
+      'web3',
+      'viem',
+      'node:net',
+      'node:http',
+      'node:https',
+      'node:fs',
+      'node:child_process',
+      'child_process',
+      'fetch(',
+      'XMLHttpRequest',
+    ]) {
+      assert.ok(!source.includes(banned), `module must not reference ${banned}`);
+    }
+    assert.ok(!/\basync\b/.test(source), 'module must not contain async code');
+    assert.ok(!/\bawait\b/.test(source), 'module must not contain await');
+  });
+
+  it('tags OKF-semantic claims as DRAFT/unverified in source', () => {
+    const sourcePath = fileURLToPath(new URL('../src/okf-conformance.ts', import.meta.url));
+    const source = readFileSync(sourcePath, 'utf8');
+    assert.ok(source.includes('DRAFT/unverified — OKF'), 'OKF semantics must carry the draft/unverified tag');
+  });
+});


### PR DESCRIPTION
Closes #504

## What this adds

Deterministic **OKF/OpenKB knowledge-bundle conformance diagnostics** (`reddi.okf-conformance.v1`, exported as `@reddi/agent-protocol/okf-conformance`) — the missing dependency for the #513 OKF/OpenKB scope decision, under epic #468. Pure static analysis over in-memory text and the #503 fixture corpus: **no live network calls, no LLM/provider calls, no execution of bundle content.**

Builds directly on what already landed — the #503 static fixture corpus (`data/okf-openkb-fixtures/okf-openkb-fixture-corpus.v1.json`) and the #511/PR #574 adapter spike (`okf-adapter.ts`) — reusing their document roles, trust classifications, and reason-code vocabulary rather than re-inventing them. Stays compatible with (but does not implement) the #505 generated-instruction safety-review lane.

### Diagnostics coverage (acceptance criteria)

- **Parseable YAML frontmatter** — conservative deterministic subset (scalars, comments, flat lists); unparseable lines/fences are skipped fail-closed and reported `malformed_frontmatter`.
- **Non-empty `type` for concept documents** (`concept_type_missing`).
- **Standard markdown links vs Obsidian wikilinks** (`unsupported_link_syntax`) — deterministic wikilinks reported as *adaptable* (info, already convertible via the #511 adapter); embeds `![[...]]`, heading/block refs, and empty targets are unadaptable warnings.
- **`index.md`/`log.md` semantics where applicable** — normalized via the adapter (`index_semantics_normalized`/`log_semantics_normalized`); `index_missing`/`log_missing` warnings when expected via options.
- **Unknown-frontmatter preservation** (`unknown_frontmatter_preserved`, info) — preserved verbatim as untrusted review metadata, never policy/runtime configuration.
- **Source/provenance completeness** (`missing_provenance`; escalates to blocked with `requireProvenance`).
- **Explicit unsafe/generated-instruction classes** for producer-toolchain artifacts — AGENTS.md, SKILL.md, prompts, scripts, skills, tools, agent definitions — via `artifactClass` (`agent_definition`, `skill_definition`, `prompt`, `script`, `tool`, `generated_instruction_other`); all `generated_instruction_untrusted` at **blocked** severity, scripts/tools additionally `execution_not_allowed`.

### Severity/status vocabulary

- Diagnostic severities `info`/`warning`/`blocked` — aligned with the repo's existing static-analysis severity vocab (`agent-stack-fixtures.ts`, `okf-adapter.ts`).
- Per-document statuses use the #504 acceptance vocabulary exactly: `valid`, `warning`, `blocked`, `untrusted_generated_instruction`, `unsupported_link_syntax`, `missing_provenance`, `malformed_frontmatter`, `execution_not_allowed`. Bundle verdict: `valid`/`warning`/`blocked`.
- `OKF_FIXTURE_DIAGNOSTIC_CODE_MAP` maps the #503 corpus `expectedDiagnostics` codes (`unsupported_wikilink_syntax`, `generated_skill_untrusted`, `script_execution_not_allowed`, ...) onto this vocabulary.

### #503 corpus integration

`conformanceInputFromOkfOpenKbFixture()` bridges corpus fixtures **read-only**; tests recompute `contentSha256` with the checker recipe after consumption and deep-compare the corpus to prove no drift/mutation. The minimal OKF fixture passes `valid`; the OpenKB-style generated bundle is `blocked` with every corpus `expectedDiagnostic` covered. Six in-module fixtures extend coverage: valid OKF, wikilinks needing adaptation, missing provenance, malformed frontmatter, generated skill/instruction content, unsupported script/tool artifacts.

### Review-only boundary

**Passing conformance permits review/analysis ONLY.** A `valid` verdict never permits skill installation, agent registration/onboarding, marketplace publication, hosted writes, LLM/provider calls, or execution of any bundle content. Every report carries an identical `reviewBoundary` + hard-false guardrails, and the module fails closed on any `execute`/`install`/`ingestUrl`/`invokeLlm`/`generateSkill` request (`operation_not_permitted`). The OKF/OpenKB product scope decision itself remains with #513.

### Docs / BDD

- `docs/conformance/okf-openkb/README.md` — new "#504 Conformance Diagnostics" section (coverage, vocabulary, review-only boundary, verify command).
- `docs/bdd/features/bucket-s-source-adapters.feature` — new `@S5.16` scenario; FEATURE-INDEX bucket-S verify command added.

## Validation

- `cd packages/agent-protocol && npm test` — **347/347 pass** (25 new in `tests/okf-conformance.test.ts`, incl. offline/no-async source guard and DRAFT-tag guard).
- `npm run check:okf-openkb:fixtures` PASS (corpus untouched).
- `node scripts/check-package-exports.mjs` PASS (77 targets; rebuilt `dist/okf-conformance.*` + `dist/index.*` committed).
- `npm run check:rap:naming` PASS. `npm run test:bdd:index` PASS. `git diff --check` PASS. `npx eslint` on new files PASS.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
