### PR TITLE
feat(release): per-package LICENSE files + v0.1.0 release notes (#449 §5 follow-ups)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,21 @@
 # Reddi Agent Protocol — Status
 
+## Latest Update — Per-package LICENSE files + v0.1.0 release notes (#449 §5 follow-ups) (2026-07-06 AEST)
+
+Closed the two remaining §5 pre-publish follow-ups from `docs/RAP-V0.1-RELEASE-CHECKLIST.md` (established in PRs #592/#595) in isolated worktree `projects/reddi-agent-protocol-worktree-license-relnotes` on branch `feat/449-license-release-notes`, branched from `origin/main` at `cca7ec29`.
+
+Delivered:
+- **Per-package `LICENSE`:** copied the root MIT `LICENSE` (Redditech Pty Ltd) into `packages/agent-protocol/` and `packages/x402-solana/` — the two publishable candidates per checklist §1 (`@reddi/sendai-x402` / `@reddi/eliza-plugin-x402` are deferred; `demo-agents` / `testing-specialists` are `private: true`). npm auto-includes `LICENSE*` from the package dir, so no `files` change was needed for it; verified present in both `npm pack --dry-run --json` outputs.
+- **Per-package `CHANGELOG.md` (v0.1.0, dated 2026-07-06):** module areas + subpath-export families (export counts deferred to the exports guard rather than hardcoded), the no-spend/no-custody/no-live-settlement boundary statement, quickstart commands (`npm run example:ard:no-spend`; repo-local test/build for x402-solana), the consolidated conformance command (`npm run check:conformance:public`), and honest draft labels — Airwallex hosted-checkout rail is DRAFT v1 (`AIRWALLEX_HOSTED_CHECKOUT_RAIL_DRAFT = true`); ERC-8004/AP2 RAP-side contracts are promoted (#562/#563) while the external standards remain drafts with inline `(unverified — …)` tags. Added `CHANGELOG.md` to both `files` whitelists so the notes ship in the tarball. Root app-focused `CHANGELOG.md` untouched; no version bump, no publish, no tag.
+- **Checklist updates:** §5 rows flipped to done-with-evidence, §3 required-contents list now includes `LICENSE` + `CHANGELOG.md`, §10 launch-gate line updated, and a second §11 executed dry-run record added (branch/commit/verdicts).
+
+Validation (all offline/no-spend):
+- `packages/agent-protocol` `npm run release:dry-run` PASS — 448 tests 0 fail; exports guard OK (89 targets on disk); artifact guard OK; pack = 93 files (~247 kB) with `LICENSE` + `CHANGELOG.md` at top level.
+- `packages/x402-solana` `npm run release:dry-run` PASS — Jest 3 suites / 45 tests; artifact guard OK; pack = 20 files (~18 kB) with `LICENSE` + `CHANGELOG.md`.
+- Root `npm run check:package:artifacts` PASS (93 + 20 files, bounded); `npm run check:conformance:public` PASS (9 areas, 119 composed tests + packed-artifact guard); `npm run check:rap:naming` PASS; `git diff --check` clean.
+
+RESUME FROM HERE: §5 is fully green. Remaining path to v0.1 publish is operational only: re-run the §2 gates at the release-candidate commit and follow the separate approved publication issue (no publish/tag/version bump happened in this loop).
+
 ## Latest Update — Public developer quickstart + consolidated conformance suite (#353) (2026-07-06 AEST)
 
 Implemented the remaining GitHub issue #353 scope (public conformance-suite packaging, per checklist §10) in isolated worktree `projects/reddi-agent-protocol-worktree-353-public-conformance` on branch `feat/353-public-quickstart-conformance`, branched from `origin/main` at `e1d8dca3` (post-#593 tip).

--- a/docs/RAP-V0.1-RELEASE-CHECKLIST.md
+++ b/docs/RAP-V0.1-RELEASE-CHECKLIST.md
@@ -33,8 +33,10 @@ CI coverage: the `rap-package-guard` workflow (`.github/workflows/rap-package-gu
 
 The packed artifact for each candidate package must contain exactly:
 
-- `package.json` — with `name`, `version`, `main`, `types`, `exports`, `files` whitelist (`dist` + `README.md`, plus `examples` for `@reddi/agent-protocol`), declared `license`, and no `private: true`.
+- `package.json` — with `name`, `version`, `main`, `types`, `exports`, `files` whitelist (`dist` + `README.md` + `CHANGELOG.md`, plus `examples` for `@reddi/agent-protocol`), declared `license`, and no `private: true`.
 - `README.md` — coverage requirements in §4.
+- `LICENSE` — per-package MIT copy (npm auto-includes `LICENSE*` from the package directory; the repo-root file never lands in the tarball).
+- `CHANGELOG.md` — per-package v0.1.0 release notes (§5), included via the `files` whitelist.
 - `dist/` — compiled JS + `.d.ts` for every exported subpath. `dist/` is committed for these packages; the exports guard exists precisely because a source-only commit would ship broken subpaths.
 - `examples/` (`@reddi/agent-protocol` only) — the no-spend runnable examples (`ard-no-spend-demo.mjs`, `buyer-seller-dry-run.mjs`, `ard-no-spend-ai-catalog.json`).
 
@@ -52,10 +54,10 @@ Nothing else. Presence is enforced by `scripts/check-package-artifact-contents.m
 | --- | --- | --- |
 | Repo `LICENSE` (MIT) | ✅ present | Root `LICENSE`, MIT, Redditech Pty Ltd |
 | `license` field in each candidate `package.json` | ✅ present | `@reddi/x402-solana` gained its MIT declaration with #449; guard now enforces the field |
-| Per-package `LICENSE` file in tarball | ⬜ open | npm only auto-includes `LICENSE*` from the package directory, not the repo root. Copy `LICENSE` into each package dir before first publish. |
+| Per-package `LICENSE` file in tarball | ✅ done 2026-07-06 | Root MIT `LICENSE` copied into `packages/agent-protocol/` and `packages/x402-solana/`. Verified via `npm pack --dry-run --json`: `LICENSE` present in both tarballs (agent-protocol 93 files, x402-solana 20 files); `npm run check:package:artifacts` PASS. |
 | `SECURITY.md` | ✅ present | Repo root |
 | `CONTRIBUTING.md` | ✅ present | Repo root |
-| Package-level release notes | ⬜ open | Root `CHANGELOG.md` is app-focused and stale (last entry 2026-04-18). Before publish: add a `@reddi/agent-protocol` v0.1.0 changelog section (or per-package `CHANGELOG.md`) summarising the exported surfaces and the no-spend boundary, and keep it consistent with the README boundary claims. |
+| Package-level release notes | ✅ done 2026-07-06 | Per-package `CHANGELOG.md` added for both candidates (v0.1.0, 2026-07-06), added to each `files` whitelist so they ship in the tarball. Content grounded in the package READMEs: module areas + subpath-export families (counts deferred to the exports guard), the no-spend/no-custody/no-live-settlement boundary statement, quickstart commands, `npm run check:conformance:public`, and honest draft/unverified labels (Airwallex rail DRAFT v1; ERC-8004/AP2 external drafts with promoted RAP-side contracts). Root `CHANGELOG.md` remains app-focused and untouched. |
 
 ## 6. Artifact Exclusions (package artifact guard)
 
@@ -133,7 +135,7 @@ Live status as of 2026-07-06:
 
 Supporting machinery already landed: #512/#523 clean-checkout OSS smoke gate, #521/#573 exports-resolution guard + `rap-package-guard` CI lane.
 
-**Launch gate:** every required checklist input (#353/#357/#416/#417/#450/#451/#452) is now CLOSED (2026-07-06). RAP v0.1 is ready when every §2 gate passes and the §5 pre-publish follow-ups land (per-package `LICENSE` files in tarballs, package-level v0.1.0 release notes). The checklist itself, and every executable gate in it, is complete and runnable today.
+**Launch gate:** every required checklist input (#353/#357/#416/#417/#450/#451/#452) is now CLOSED (2026-07-06). The §5 pre-publish follow-ups (per-package `LICENSE` files in tarballs, package-level v0.1.0 release notes) landed 2026-07-06 — see §5 rows and the §11 record. RAP v0.1 is ready when every §2 gate passes. The checklist itself, and every executable gate in it, is complete and runnable today.
 
 ## 11. Executed Dry-Run Record
 
@@ -149,3 +151,15 @@ First executed pass — **2026-07-06 (AEST)**, branch `feat/449-v01-release-chec
 - `npm run check:rap:naming` → PASS. No publish occurred; no network, wallet, RPC, or hosted service was touched.
 
 Record subsequent passes here (date, commit, verdict) whenever the release candidate is re-cut.
+
+Second executed pass — **2026-07-06 (AEST)**, branch `feat/449-license-release-notes`, clean worktree from `origin/main` @ `cca7ec29`, after adding per-package `LICENSE` + `CHANGELOG.md` (§5 follow-ups):
+
+- `cd packages/agent-protocol && npm run release:dry-run` → **PASS**
+  - `npm test`: 448 tests, 0 fail.
+  - `check-package-exports`: OK — all 89 export/main/types targets exist on disk (use the command, not this number).
+  - `check-package-artifact-contents`: OK — dry-run pack = 93 files, all bounded.
+  - `npm pack --dry-run`: 93 files, ~247 kB tarball / ~1.1 MB unpacked; `LICENSE` and `CHANGELOG.md` now present at tarball top level alongside `package.json`, `README.md`, `dist/`, `examples/`.
+- `cd packages/x402-solana && npm run release:dry-run` → **PASS** (Jest: 3 suites, 45 tests, 0 fail; pack = 20 files, ~18 kB, `LICENSE` + `CHANGELOG.md` included).
+- `npm run check:package:artifacts` (root, both candidates) → **PASS** (agent-protocol 93 files; x402-solana 20 files).
+- `npm run check:conformance:public` (root) → **PASS** — all 9 conformance areas passed (119 composed tests), packed-artifact guard OK.
+- `npm run check:rap:naming` → PASS (new `CHANGELOG.md` files scanned). No publish occurred; no network, wallet, RPC, or hosted service was touched.

--- a/packages/agent-protocol/CHANGELOG.md
+++ b/packages/agent-protocol/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog — @reddi/agent-protocol
+
+All notable changes to this package are documented here. Dates are AEST.
+
+## 0.1.0 — 2026-07-06
+
+First release-candidate cut of the public RAP (Reddi Agent Protocol) primitives package. Everything below runs locally on deterministic fixtures — see Boundaries.
+
+### Added
+
+Module areas (each area maps to one or more declared subpath exports; the full export map lives in `package.json` and every target is verified by the exports guard, `npm run check:exports` — do not treat any list here as exhaustive):
+
+- **Receipts and policy** — receipt envelope validation, policy decisions, buyer-authority policy, and seller wrapper configuration for paid-agent-work workflows.
+- **Discovery and catalog ingestion** — AI Catalog ingestion, discovery source candidates, provider trust records, and the static agent-stack fixture corpora. Static ingestion is metadata transformation only: publication stays disabled, payment activation stays disabled, provider trust stays unverified, and imported content stays untrusted until later operator and readiness gates pass.
+- **Evidence and proof surfaces** — EvidenceArchive, receipt–evidence binding, rail-neutral payment receipts and the rail-neutral proof-chain fixture, Pay.sh sandbox evidence (fixture refs only), source-aware diagnostics, and the source/trust conformance matrix.
+- **Attestation and reputation** — attestation/reputation primitives, off-chain reputation preview (projection only — it does not mutate reputation state), reputation credential export, and the hosted attestation claim shape (fails closed as `publication_gate_pending` without operator approval and publication-gate metadata).
+- **Quasar registry compatibility** — metadata-only compatibility surface; no custody or program-execution claims.
+- **Buyer client and seller middleware** — local buyer/seller flow helpers, including the buyer–seller dry-run example.
+- **AUDD/Solana payment plans** — preflight-only planning helpers. These do not contact Airwallex, invoke providers, call wallets/RPC endpoints, transfer SPL tokens, activate Pay.sh, or settle funds.
+- **Framework templates** — the framework template contract, framework-template conformance suite and fixtures, and the LangGraph, ADK, and Strands RAP templates.
+- **Interop exports (external-standard status noted below)** — ERC-8004 export + conformance, AP2 mandate ingestion + conformance, Airwallex hosted-checkout rail + webhook receipt normalization, OKF adapter/conformance/instruction-safety, and MPP/Tempo receipt shapes.
+- **Onboarding** — onboarding-analyser handoff and onboarding state machine surfaces.
+- **Runnable no-spend examples** — `examples/ard-no-spend-demo.mjs`, `examples/buyer-seller-dry-run.mjs`, and the `examples/ard-no-spend-ai-catalog.json` fixture, shipped in the package tarball.
+
+### Draft / unverified labels (honest status)
+
+- The RAP-side ERC-8004 mapping and the RAP-side AP2 adapter contract are promoted specs (#562/#563), but **ERC-8004 and AP2 are external draft standards** — external-standard field references carry inline `(unverified — <standard> draft)` tags in the source and type docs, and promotion of the RAP-side contract does not upgrade confidence in the external drafts.
+- The **Airwallex hosted-checkout rail surface is DRAFT v1** (`AIRWALLEX_HOSTED_CHECKOUT_RAIL_DRAFT = true`): draft/unverified external-rail shapes, with the fiat asset kept in a draft namespace outside the frozen buyer-authority asset union.
+
+### Quickstart and conformance
+
+```bash
+# ARD No-Spend Quickstart (Discover -> Decide -> Prove on fixtures)
+npm run example:ard:no-spend
+
+# Consolidated public conformance suite (from the repo root: npm run check:conformance:public)
+npm run conformance
+
+# Full local release gate
+npm run release:dry-run
+```
+
+### Boundaries
+
+All v0.1.0 surfaces are local-first and fail closed: **no spend, no custody, no live settlement**. The package does not require or perform live payments, does not hold or move funds, and makes no settlement-finality claims. It runs without hosted Reddi infrastructure, ARD registry access, wallet keys, RPC calls, SPL transfers, paid provider calls, secrets, marketplace publication, or trust/reputation mutation. Discovery relevance is never trust, budget, payment, or publication approval. These boundaries are consistent with the README and are enforced mechanically by the claim-boundary scan in `npm run check:oss-release-smoke`.

--- a/packages/agent-protocol/LICENSE
+++ b/packages/agent-protocol/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Redditech Pty Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -183,7 +183,8 @@
   "files": [
     "dist",
     "examples",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "sideEffects": false,
   "scripts": {

--- a/packages/x402-solana/CHANGELOG.md
+++ b/packages/x402-solana/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog — @reddi/x402-solana
+
+All notable changes to this package are documented here. Dates are AEST.
+
+## 0.1.0 — 2026-07-06
+
+First release-candidate cut of the HTTP 402 payment primitives for Solana-oriented RAP (Reddi Agent Protocol) workflows. This package is a repo-local v0.1 OSS candidate: it is not yet published on npm and must not be treated as production payment, custody, escrow-finality, or mainnet infrastructure.
+
+### Added
+
+Module areas (one subpath export per module, plus the root export — see `exports` in `package.json`):
+
+- **`./types`** — x402 request/challenge/receipt type definitions.
+- **`./payment`** — x402 header parsing and validation (`parseX402Header`, `createX402Header`, challenge building, payment-address format validation).
+- **`./nonce`** — nonce-based replay protection (`checkAndStoreNonce`).
+- **`./middleware`** — Express middleware (`createX402Middleware`) that parses the `x402-request` header, checks nonces, verifies demo or explicitly approved receipts per configured policy, and sets the `x402-payment` response header.
+- **`./budget-policy`** — pure local buyer budget preflight (`evaluateBudgetPolicy`): per-request, per-session, per-source, per-specialist, per-asset/network, and call-count limits, evaluated before any signer, hosted facilitator, or downstream call is used.
+- **`./client`** — fail-closed devnet USDC helpers. Any real devnet payment path is explicit (gated behind a literal approval phrase), capped, allowlisted, and outside the default OSS smoke.
+- **`./jupiter`** — swap-client interface abstraction (mock-friendly; tests do not require Solana devnet access).
+
+The legacy `sendPayment` demo helper remains for local tests only — it is not a production payment path.
+
+### Quickstart
+
+The package is repo-local until the OSS release smoke and package-publication gates are complete:
+
+```bash
+npm --prefix packages/x402-solana test -- --runInBand
+npm --prefix packages/x402-solana run build
+
+# Full local release gate (from packages/x402-solana)
+npm run release:dry-run
+```
+
+### Boundaries
+
+**No spend, no custody, no live settlement.** Clean-checkout OSS success must not require wallet material, RPC calls, Pay.sh activation, hosted Reddi infrastructure, paid providers, marketplace publication, trust/reputation mutation, mainnet, custody, or settlement-finality claims. These boundaries match the README and are enforced mechanically by the claim-boundary scan in `npm run check:oss-release-smoke`.

--- a/packages/x402-solana/LICENSE
+++ b/packages/x402-solana/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Redditech Pty Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/x402-solana/package.json
+++ b/packages/x402-solana/package.json
@@ -49,7 +49,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
Follow-up to #449 (closed) — lands the two remaining §5 pre-publish items from `docs/RAP-V0.1-RELEASE-CHECKLIST.md` (established in #592/#595) for the v0.1 publishable candidate set (`@reddi/agent-protocol`, `@reddi/x402-solana`; deferred/private packages untouched).

## What

- **Per-package `LICENSE` in tarballs** — root MIT `LICENSE` copied into `packages/agent-protocol/` and `packages/x402-solana/`. npm auto-includes `LICENSE*` from the package directory but never the repo root; verified via `npm pack --dry-run --json` that `LICENSE` lands in both tarballs.
- **Per-package `CHANGELOG.md` v0.1.0 release notes (2026-07-06)** — grounded in each package README: module areas + subpath-export families (export counts deferred to the exports guard, not hardcoded), the no-spend / no-custody / no-live-settlement boundary statement, the quickstart commands, the consolidated conformance command (`npm run check:conformance:public`), and honest draft/unverified labels (Airwallex hosted-checkout rail is DRAFT v1; ERC-8004/AP2 RAP-side contracts promoted per #562/#563 while the external standards remain drafts). `CHANGELOG.md` added to both `files` whitelists so the notes ship in the tarball. Root app-focused `CHANGELOG.md` untouched.
- **Checklist** — §5 rows flipped to done-with-evidence, §3 required-contents list gains `LICENSE` + `CHANGELOG.md`, §10 launch-gate line updated, §11 gains a second executed dry-run record (this branch, `origin/main` @ `cca7ec29`).
- **STATUS.md** rolling-log entry.

## Validation (offline, no-spend)

- `packages/agent-protocol` `npm run release:dry-run` **PASS** — 448 tests / 0 fail; exports guard OK (89 targets on disk); artifact guard OK; pack = 93 files (~247 kB) with `LICENSE` + `CHANGELOG.md` at top level.
- `packages/x402-solana` `npm run release:dry-run` **PASS** — Jest 3 suites / 45 tests; artifact guard OK; pack = 20 files (~18 kB) with `LICENSE` + `CHANGELOG.md`.
- Root: `npm run check:package:artifacts` **PASS**; `npm run check:conformance:public` **PASS** (9 areas, 119 composed tests + packed-artifact guard); `npm run check:rap:naming` **PASS**; `git diff --check` clean.

No version bump, no publish, no tag, no live calls, no new claims beyond existing package docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)