### PR TITLE
Add ADL whitepaper, review intake, and payment-flow demos

### DIFF
--- a/app/adl/page.tsx
+++ b/app/adl/page.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { CheckCircle2, ExternalLink, FileText, MessageSquare, Play, ShieldCheck } from "lucide-react";
+
+import {
+  adlUseCases,
+  buildAdlLivePayload,
+  getAdlUseCase,
+  type AdlPaymentStepState,
+} from "@/lib/adl/demo-use-cases";
+
+type DemoMode = "mock" | "live";
+type RunState = "idle" | "running" | "complete" | "error";
+
+function stateClass(state: AdlPaymentStepState) {
+  if (state === "complete") return "border-[#14F195]/40 bg-[#14F195]/10 text-[#14F195]";
+  if (state === "blocked") return "border-red-400/40 bg-red-400/10 text-red-200";
+  if (state === "mocked") return "border-accent-purple/40 bg-accent-purple/10 text-accent-purple";
+  return "border-white/15 bg-white/5 text-gray-300";
+}
+
+export default function AdlPage() {
+  const [selectedId, setSelectedId] = useState(adlUseCases[0].id);
+  const [mode, setMode] = useState<DemoMode>("mock");
+  const [agentApiAddress, setAgentApiAddress] = useState("");
+  const [reviewName, setReviewName] = useState("");
+  const [reviewFocus, setReviewFocus] = useState("");
+  const [runState, setRunState] = useState<RunState>("idle");
+  const [runOutput, setRunOutput] = useState("");
+  const [error, setError] = useState("");
+
+  const selected = useMemo(() => getAdlUseCase(selectedId), [selectedId]);
+  const livePayload = useMemo(
+    () => buildAdlLivePayload(selected, agentApiAddress.trim()),
+    [agentApiAddress, selected],
+  );
+  const reviewBody = useMemo(() => {
+    const focus = reviewFocus.trim() || "I want to review the ADL whitepaper and payment-flow demo.";
+    const name = reviewName.trim() || "Anonymous reviewer";
+    return encodeURIComponent(
+      [
+        "## ADL Whitepaper Review",
+        "",
+        `Reviewer: ${name}`,
+        "",
+        "### Focus",
+        focus,
+        "",
+        "### Suggested improvement",
+        "",
+        "- ",
+      ].join("\n"),
+    );
+  }, [reviewFocus, reviewName]);
+
+  const reviewUrl = `https://github.com/nissan/reddi-agent-protocol/issues/new?title=${encodeURIComponent(
+    "[ADL Review] Whitepaper feedback",
+  )}&body=${reviewBody}`;
+
+  async function runDemo() {
+    setRunState("running");
+    setError("");
+    setRunOutput("");
+
+    if (mode === "mock") {
+      window.setTimeout(() => {
+        setRunOutput(selected.mockResponse);
+        setRunState("complete");
+      }, 350);
+      return;
+    }
+
+    if (!agentApiAddress.trim()) {
+      setError("Enter your agent API address or switch back to mock mode.");
+      setRunState("error");
+      return;
+    }
+
+    try {
+      const response = await fetch(agentApiAddress.trim(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(livePayload),
+      });
+      const text = await response.text();
+      setRunOutput(text || `Endpoint returned HTTP ${response.status}.`);
+      setRunState(response.ok ? "complete" : "error");
+      if (!response.ok) setError(`Endpoint returned HTTP ${response.status}.`);
+    } catch (caught) {
+      setRunState("error");
+      setError(caught instanceof Error ? caught.message : "Live endpoint call failed.");
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-page text-white">
+      <header className="border-b border-white/10">
+        <div className="mx-auto max-w-6xl px-4 py-14 sm:px-6 lg:px-8">
+          <div className="max-w-4xl space-y-5">
+            <p className="section-label">Agent Definition Language</p>
+            <h1 className="font-display text-4xl font-bold sm:text-5xl">
+              A specification for agents that can discover, pay, verify, and improve each other
+            </h1>
+            <p className="max-w-3xl text-base leading-7 text-gray-300">
+              ADL is the source-of-truth contract behind Reddi Agent Protocol. It describes agent capability,
+              authority, payment intent, receipt requirements, eval gates, runtime posture, and reputation signals
+              before any autonomous agent-to-agent payment is trusted.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/ADL-WHITEPAPER-v0.1.md"
+                className="inline-flex min-h-10 items-center gap-2 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-black focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page"
+              >
+                <FileText aria-hidden="true" size={16} />
+                Read whitepaper
+              </Link>
+              <a
+                href={reviewUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-white/20 px-4 py-2 text-sm font-semibold text-white/90 hover:border-[#14F195]/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page"
+              >
+                <MessageSquare aria-hidden="true" size={16} />
+                Open review issue
+              </a>
+              <Link
+                href="/economic-demo/paid-workflow"
+                className="inline-flex min-h-10 items-center gap-2 rounded-lg border border-white/20 px-4 py-2 text-sm font-semibold text-white/90 hover:border-[#14F195]/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page"
+              >
+                <ExternalLink aria-hidden="true" size={16} />
+                Existing payment demo
+              </Link>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section className="mx-auto grid max-w-6xl gap-4 px-4 py-10 sm:px-6 md:grid-cols-3 lg:px-8">
+        {[
+          ["Define", "Model, tools, data, memory, policies, eval gates, runtime, deployment, observability."],
+          ["Transact", "Quote, approve, pay, receive work, verify receipts, and decide reputation changes."],
+          ["Export", "Map into RAP, x402 wrappers, Agent Spec targets, and framework templates without silent loss."],
+        ].map(([title, body]) => (
+          <div key={title} className="rounded-lg border border-white/10 bg-card/35 p-5">
+            <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-lg border border-[#14F195]/30 bg-[#14F195]/10">
+              <ShieldCheck aria-hidden="true" size={18} className="text-[#14F195]" />
+            </div>
+            <h2 className="font-display text-xl font-semibold">{title}</h2>
+            <p className="mt-2 text-sm leading-6 text-gray-300">{body}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="border-y border-white/10 bg-surface/35">
+        <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+          <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="section-label">Use cases</p>
+              <h2 className="font-display text-3xl font-bold">ADL payment flows in action</h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-300">
+                Each scenario is built from the same payment contract: discover a seller agent, quote the work,
+                apply buyer policy, capture a receipt, attest the result, and keep reputation changes evidence-bound.
+              </p>
+            </div>
+            <div className="flex rounded-lg border border-white/10 bg-card/60 p-1">
+              {(["mock", "live"] as const).map((candidate) => (
+                <button
+                  key={candidate}
+                  type="button"
+                  onClick={() => setMode(candidate)}
+                  className={`min-h-10 rounded-md px-4 text-sm font-semibold focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page ${
+                    mode === candidate ? "bg-white text-black" : "text-gray-300 hover:text-white"
+                  }`}
+                >
+                  {candidate === "mock" ? "Mock mode" : "Live endpoint"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+            <div className="space-y-3">
+              {adlUseCases.map((useCase) => (
+                <button
+                  key={useCase.id}
+                  type="button"
+                  onClick={() => setSelectedId(useCase.id)}
+                  className={`min-h-10 w-full rounded-lg border p-4 text-left transition focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page ${
+                    selected.id === useCase.id
+                      ? "border-[#14F195]/60 bg-[#14F195]/10"
+                      : "border-white/10 bg-card/35 hover:border-white/25"
+                  }`}
+                >
+                  <span className="block text-sm font-semibold text-white">{useCase.title}</span>
+                  <span className="mt-2 block text-xs leading-5 text-gray-400">{useCase.price} via {useCase.paymentRail}</span>
+                </button>
+              ))}
+            </div>
+
+            <div className="rounded-lg border border-white/10 bg-card/45 p-5">
+              <div className="grid gap-5 xl:grid-cols-[1fr_340px]">
+                <div>
+                  <h3 className="font-display text-2xl font-semibold">{selected.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-gray-300">{selected.summary}</p>
+
+                  <dl className="mt-5 grid gap-3 sm:grid-cols-2">
+                    {[
+                      ["Buyer", selected.buyerAgent],
+                      ["Seller", selected.sellerAgent],
+                      ["Attestor", selected.attestorAgent],
+                      ["ADL fields", selected.adlRef],
+                    ].map(([label, value]) => (
+                      <div key={label} className="rounded-lg border border-white/10 bg-white/5 p-3">
+                        <dt className="text-xs uppercase tracking-wide text-gray-500">{label}</dt>
+                        <dd className="mt-1 text-sm text-gray-200">{value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+
+                  <div className="mt-5 space-y-3">
+                    {selected.steps.map((step) => (
+                      <div key={step.id} className="rounded-lg border border-white/10 bg-page/50 p-4">
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="flex items-center gap-2">
+                            <CheckCircle2 aria-hidden="true" size={17} className="text-[#14F195]" />
+                            <h4 className="text-sm font-semibold text-white">{step.label}</h4>
+                          </div>
+                          <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${stateClass(step.state)}`}>
+                            {step.state}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-sm leading-6 text-gray-300">{step.detail}</p>
+                        <p className="mt-2 break-all font-mono text-xs text-gray-500">{step.evidence}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <aside className="rounded-lg border border-white/10 bg-page/60 p-4">
+                  <h4 className="font-display text-xl font-semibold">Run this flow</h4>
+                  <p className="mt-2 text-sm leading-6 text-gray-300">
+                    Mock mode uses packaged responses. Live mode sends the same ADL request from your browser to
+                    your supplied agent API address.
+                  </p>
+
+                  {mode === "live" && (
+                    <div className="mt-4 space-y-2">
+                      <label htmlFor="agent-api-address" className="text-sm font-semibold text-white">
+                        Agent API address
+                      </label>
+                      <input
+                        id="agent-api-address"
+                        type="url"
+                        inputMode="url"
+                        autoComplete="url"
+                        value={agentApiAddress}
+                        onChange={(event) => setAgentApiAddress(event.target.value)}
+                        placeholder="https://your-agent.example.com/run"
+                        className="min-h-10 w-full rounded-lg border border-white/10 bg-card/70 px-3 py-2 text-sm text-white placeholder:text-gray-500 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page"
+                      />
+                      <p className="text-xs leading-5 text-gray-500">
+                        The site does not store this address. Your browser makes the request directly.
+                      </p>
+                    </div>
+                  )}
+
+                  <button
+                    type="button"
+                    onClick={runDemo}
+                    disabled={runState === "running"}
+                    className="mt-4 inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg bg-[#14F195] px-4 py-2 text-sm font-bold text-black transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page"
+                  >
+                    <Play aria-hidden="true" size={16} />
+                    {runState === "running" ? "Running..." : mode === "mock" ? "Run mock flow" : "Run live endpoint"}
+                  </button>
+
+                  <div className="mt-4 rounded-lg border border-white/10 bg-black/30 p-3">
+                    <p className="text-xs uppercase tracking-wide text-gray-500">Request</p>
+                    <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words text-xs text-gray-300">
+                      {JSON.stringify(livePayload, null, 2)}
+                    </pre>
+                  </div>
+
+                  {(runOutput || error) && (
+                    <div className="mt-4 rounded-lg border border-white/10 bg-black/30 p-3" role="status">
+                      <p className="text-xs uppercase tracking-wide text-gray-500">Result</p>
+                      {error && <p className="mt-2 text-sm text-red-200">{error}</p>}
+                      {runOutput && <p className="mt-2 text-sm leading-6 text-gray-200">{runOutput}</p>}
+                    </div>
+                  )}
+                </aside>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
+          <div className="rounded-lg border border-white/10 bg-card/35 p-5">
+            <p className="section-label">Whitepaper review</p>
+            <h2 className="mt-2 font-display text-3xl font-bold">Open ADL for comments and improvements</h2>
+            <p className="mt-3 text-sm leading-6 text-gray-300">
+              Use the review packet to flag missing ADL fields, ambiguous payment semantics, export loss, or any
+              demo copy that could overclaim live settlement.
+            </p>
+            <div className="mt-5 grid gap-3 sm:grid-cols-2">
+              <div>
+                <label htmlFor="review-name" className="text-sm font-semibold text-white">Name or handle</label>
+                <input
+                  id="review-name"
+                  value={reviewName}
+                  onChange={(event) => setReviewName(event.target.value)}
+                  autoComplete="name"
+                  className="mt-2 min-h-10 w-full rounded-lg border border-white/10 bg-card/70 px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page"
+                />
+              </div>
+              <div>
+                <label htmlFor="review-focus" className="text-sm font-semibold text-white">Review focus</label>
+                <input
+                  id="review-focus"
+                  value={reviewFocus}
+                  onChange={(event) => setReviewFocus(event.target.value)}
+                  placeholder="Payment receipts, schema fields, exports..."
+                  className="mt-2 min-h-10 w-full rounded-lg border border-white/10 bg-card/70 px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page"
+                />
+              </div>
+            </div>
+            <a
+              href={reviewUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-5 inline-flex min-h-10 items-center gap-2 rounded-lg border border-[#14F195]/40 bg-[#14F195]/10 px-4 py-2 text-sm font-semibold text-[#14F195] hover:bg-[#14F195]/15 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-page"
+            >
+              <MessageSquare aria-hidden="true" size={16} />
+              Draft GitHub review
+            </a>
+          </div>
+
+          <div className="rounded-lg border border-white/10 bg-card/35 p-5">
+            <h2 className="font-display text-2xl font-semibold">What ADL protects</h2>
+            <ul className="mt-4 space-y-3 text-sm leading-6 text-gray-300">
+              {selected.adlHighlights.map((highlight) => (
+                <li key={highlight} className="flex gap-3">
+                  <CheckCircle2 aria-hidden="true" size={16} className="mt-1 shrink-0 text-[#14F195]" />
+                  <span>{highlight}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/app/adl/page.tsx
+++ b/app/adl/page.tsx
@@ -355,4 +355,3 @@ export default function AdlPage() {
     </div>
   );
 }
-

--- a/app/whitepaper/page.tsx
+++ b/app/whitepaper/page.tsx
@@ -50,6 +50,9 @@ export default function WhitepaperPage() {
             <Link href="https://github.com/nissan/reddi-agent-protocol/blob/main/docs/whitepaper/GLOSSARY.md" className="rounded-lg border border-white/20 px-4 py-2 text-sm font-medium text-white/90">
               Glossary
             </Link>
+            <Link href="/adl" className="rounded-lg border border-[#14F195]/40 bg-[#14F195]/10 px-4 py-2 text-sm font-medium text-[#14F195]">
+              ADL whitepaper and demo
+            </Link>
           </div>
         </header>
 

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -38,6 +38,7 @@ const navLinks: { href: string; label: string; badge?: string }[] = [
   { href: "/consumer", label: "Consumer" },
   { href: "/audit", label: "Audit Trail" },
   { href: "/dogfood", label: "Dogfood", badge: "New" },
+  { href: "/adl", label: "ADL", badge: "Docs" },
   { href: "/whitepaper", label: "Whitepaper", badge: "Docs" },
   { href: "/orchestrator", label: "Settings" },
 ];

--- a/docs/ADL-WHITEPAPER-REVIEW-DEMO-PLAN-2026-07-20.md
+++ b/docs/ADL-WHITEPAPER-REVIEW-DEMO-PLAN-2026-07-20.md
@@ -48,4 +48,3 @@ As a builder evaluating Reddi Agent Protocol, I want to read the ADL whitepaper,
 - `npm run build`
 - `git diff --check`
 - Playwright `/adl` smoke when local browser cache is healthy.
-

--- a/docs/ADL-WHITEPAPER-REVIEW-DEMO-PLAN-2026-07-20.md
+++ b/docs/ADL-WHITEPAPER-REVIEW-DEMO-PLAN-2026-07-20.md
@@ -1,0 +1,51 @@
+# ADL Whitepaper, Review Intake, And Payment Demo Plan
+
+_Issue: #611. Requested: 2026-07-20 02:50 AEST._
+
+## Intent
+
+Publish ADL as a first-class public concept on the Reddi Agent Protocol site: a whitepaper, an open review path, and a demo surface that shows how ADL describes autonomous agent-to-agent payment flows.
+
+## User Story
+
+As a builder evaluating Reddi Agent Protocol, I want to read the ADL whitepaper, comment on the specification, and run realistic mock payment-flow examples so I can understand how ADL defines buyer agents, seller agents, receipts, policy, attestation, and reputation before I connect my own agent endpoint.
+
+## Scope
+
+- Add a public `/adl` route.
+- Add a durable ADL whitepaper markdown document.
+- Link ADL from navigation and the existing `/whitepaper` route.
+- Provide at least three ADL-backed autonomous payment use cases.
+- Default to mock mode with packaged responses.
+- Offer live endpoint mode where users can provide their own agent API address.
+- Generate a structured GitHub review issue link from on-page review fields.
+
+## Acceptance Criteria
+
+- `/adl` renders the ADL positioning, whitepaper links, review path, and demo controls.
+- The demo includes three use cases:
+  - research agent buys a specialist brief;
+  - builder agent hires a code review specialist;
+  - commerce agent pays an attestor/evidence specialist for dispute evidence.
+- Every use case displays buyer, seller, attestor, ADL field references, price, payment rail, and the flow from discovery/scope to quote, policy, receipt, verification/attestation, and reputation/release outcome.
+- Mock mode runs without an API address.
+- Live endpoint mode requires a user-supplied URL and sends the structured request from the browser.
+- The site does not store API addresses, credentials, private keys, or review text.
+- Copy distinguishes mock/static demo behavior from live user-supplied endpoint behavior.
+- Focused data tests cover the use case contract and live payload guardrails.
+
+## Guardrails
+
+- No direct push to `main`; feature branch and PR only.
+- No mainnet, paid calls, wallet private keys, credentials, or server-side endpoint storage.
+- No live user endpoint calls during automated validation.
+- Production publish remains gated by Nissan's merge/deploy path.
+
+## Validation Plan
+
+- `npx jest lib/__tests__/adl-demo-use-cases.test.ts --runInBand`
+- `npx eslint app/adl/page.tsx app/whitepaper/page.tsx components/NavBar.tsx lib/adl/demo-use-cases.ts lib/__tests__/adl-demo-use-cases.test.ts e2e/adl.spec.ts e2e/navigation.spec.ts`
+- `npm run build`
+- `git diff --check`
+- Playwright `/adl` smoke when local browser cache is healthy.
+

--- a/docs/ADL-WHITEPAPER-v0.1.md
+++ b/docs/ADL-WHITEPAPER-v0.1.md
@@ -1,0 +1,80 @@
+# Agent Definition Language Whitepaper v0.1
+
+_Status: review draft. Published for comments and implementation feedback._
+
+## Abstract
+
+Agent Definition Language (ADL) is the canonical source-of-truth format for describing an agent before that agent is exported, reviewed, executed, paid, or trusted. In Reddi Agent Protocol (RAP), ADL gives each agent a portable contract for model requirements, harness behavior, tool access, policy boundaries, payment intent, receipts, evaluation gates, runtime posture, observability, recovery, and reputation signals.
+
+The purpose is not to create another agent runtime. ADL is the neutral definition layer that lets agent systems interoperate while preserving the information needed for autonomous agent-to-agent payments: what the buyer asked for, what the seller promised, which policy allowed spend, which receipt proved payment, which evaluator accepted the work, and which reputation signal may safely change.
+
+## Why ADL Exists
+
+Agent commerce fails when capability, policy, payment, and trust live in separate documents. A marketplace listing might say an agent can do research, a runtime might expose a tool endpoint, a payment wrapper might issue a challenge, and an attestor might later judge the result. Without a shared definition, each layer has to infer the rest.
+
+ADL makes those assumptions explicit. A buyer agent can inspect a seller agent before payment. A seller can quote a job against declared capability and policy. An attestor can evaluate the output against the same contract. A protocol adapter can export to another ecosystem while reporting any semantic loss.
+
+## Core Model
+
+An ADL document describes one agent:
+
+- `metadata`: identity, description, ownership, and versioning context.
+- `model`: capability, provider preferences, structured-output requirements, modality, context, latency, and cost constraints.
+- `harness`: instructions, tools, functions, skills, data sources, memory, policies, eval gates, runtime, deployment, observability, and recovery.
+- `extensions`: namespaced fields for payment, reputation, protocol bridges, provider-specific adapters, and future compatibility targets.
+
+RAP treats ADL as the definition layer and treats external formats as target views. Open Agent Specification, Agent Cards, MCP manifests, x402 payment wrappers, provider manifests, and framework-specific templates can be generated from ADL, but they do not replace it. If a target cannot represent a Reddi-specific payment, policy, receipt, or reputation rule, the export must say so.
+
+## Payment Semantics
+
+ADL payment semantics are intentionally policy-first:
+
+1. The buyer declares spend limits and authority constraints.
+2. The seller declares capability, price, rail, receipt requirements, and evidence expectations.
+3. A payment challenge quotes the exact job.
+4. Buyer policy accepts, rejects, or asks for human approval.
+5. Payment completion creates a receipt.
+6. The work product, receipt, and trace are evaluated together.
+7. Reputation changes only after attestation accepts the chain.
+
+This gives autonomous agents room to transact without turning every tool call into an unchecked payment. A live system can use x402, devnet rails, future AUDD/Solana flows, or another compatible rail, but the ADL contract keeps the authority and evidence boundaries stable.
+
+## Review And Improvement Loop
+
+ADL should stay open to review because agent payment semantics will evolve. The public website exposes:
+
+- a readable whitepaper page;
+- a structured comment link for GitHub review;
+- example use cases with mock responses;
+- a live endpoint mode that lets users test against their own agent API address without storing that address in RAP infrastructure.
+
+Reviewers should focus on:
+
+- missing fields needed by real agent systems;
+- policy or receipt ambiguity;
+- export loss to existing agent manifests;
+- payment-rail assumptions;
+- places where mock demos could accidentally imply live settlement.
+
+## Demonstrated Use Cases
+
+### Research Agent Buys A Specialist Brief
+
+A coordinating research agent selects a specialist from ADL capability metadata, receives an x402-style quote, pays under a task budget, and sends the result through source-coverage evaluation. ADL fields involved: approved data sources, tool scope, payment intent, receipt requirement, and source eval gates.
+
+### Builder Agent Hires A Code Review Specialist
+
+A builder agent submits a pinned ADL artifact hash to a review specialist. The seller quotes the review. Buyer policy allows one bounded review call. The release gate stays blocked until the review packet and tests are attached. ADL fields involved: policy constraints, receipt binding, eval gates, recovery, and release decision metadata.
+
+### Commerce Agent Pays For Dispute Evidence
+
+A marketplace coordinator pays an evidence specialist to collect order, invoice, and refund-policy evidence. An attestor reviews the chain and keeps reputation changes in preview when the evidence conflicts. ADL fields involved: payment/reputation extensions, observability trace requirements, recovery rules, and attestation gates.
+
+## Safety Boundaries
+
+The public demo defaults to mock mode. Live mode requires the user to provide their own endpoint address and press the live-run button. The site does not need to store API addresses, private keys, credentials, review text, or wallet secrets. Production payment rails, mainnet actions, and automatic paid calls remain outside this whitepaper/demo slice unless a future operator-gated issue explicitly enables them.
+
+## Current Status
+
+ADL v0.1 is a reviewable specification and interoperability contract. It is stable enough to explain, validate, export, and demonstrate. The next improvements should come from real implementer feedback: agent runtimes, payment wrappers, attestors, marketplace builders, and operators trying to map their existing systems into ADL without losing safety or payment semantics.
+

--- a/docs/ADL-WHITEPAPER-v0.1.md
+++ b/docs/ADL-WHITEPAPER-v0.1.md
@@ -77,4 +77,3 @@ The public demo defaults to mock mode. Live mode requires the user to provide th
 ## Current Status
 
 ADL v0.1 is a reviewable specification and interoperability contract. It is stable enough to explain, validate, export, and demonstrate. The next improvements should come from real implementer feedback: agent runtimes, payment wrappers, attestors, marketplace builders, and operators trying to map their existing systems into ADL without losing safety or payment semantics.
-

--- a/e2e/adl.spec.ts
+++ b/e2e/adl.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("ADL whitepaper and demo", () => {
+  test("loads the ADL page with review and mock/live controls", async ({ page }) => {
+    const response = await page.goto("/adl", {
+      waitUntil: "domcontentloaded",
+      timeout: 15000,
+    });
+
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { name: /agent definition language/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /read whitepaper/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /open review issue/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /mock mode/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /live endpoint/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /run mock flow/i })).toBeVisible();
+  });
+
+  test("runs the packaged mock flow without a user endpoint", async ({ page }) => {
+    await page.goto("/adl");
+    await page.getByRole("button", { name: /run mock flow/i }).click();
+
+    await expect(page.getByRole("status")).toContainText(/accepted|complete|ready/i);
+  });
+});
+

--- a/e2e/adl.spec.ts
+++ b/e2e/adl.spec.ts
@@ -23,4 +23,3 @@ test.describe("ADL whitepaper and demo", () => {
     await expect(page.getByRole("status")).toContainText(/accepted|complete|ready/i);
   });
 });
-

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -8,6 +8,7 @@ test.describe('Navigation', () => {
       '/register',
       '/setup',
       '/onboarding',
+      '/adl',
       '/customize',
       '/dashboard',
       '/manager',

--- a/lib/__tests__/adl-demo-use-cases.test.ts
+++ b/lib/__tests__/adl-demo-use-cases.test.ts
@@ -1,0 +1,49 @@
+import {
+  adlUseCases,
+  buildAdlLivePayload,
+  getAdlUseCase,
+} from "@/lib/adl/demo-use-cases";
+
+describe("ADL public demo use cases", () => {
+  it("ships at least three agent-to-agent payment use cases", () => {
+    expect(adlUseCases).toHaveLength(3);
+    expect(adlUseCases.every((useCase) => useCase.steps.length >= 5)).toBe(true);
+    expect(adlUseCases.every((useCase) => useCase.price.includes("USDC"))).toBe(true);
+  });
+
+  it("covers the required payment flow states for every use case", () => {
+    const requiredLabels = [/quote/i, /receipt/i];
+
+    for (const useCase of adlUseCases) {
+      const labels = useCase.steps.map((step) => step.label).join(" ");
+      expect(labels).toMatch(/discover|scope|find/i);
+      for (const required of requiredLabels) {
+        expect(labels).toMatch(required);
+      }
+      expect(labels).toMatch(/attest|verify|release/i);
+      expect(useCase.steps.some((step) => step.state === "mocked")).toBe(true);
+      expect(JSON.stringify(useCase)).not.toMatch(/private key|mainnet transfer/i);
+    }
+  });
+
+  it("builds a live endpoint payload without storing secrets or enabling mainnet", () => {
+    const useCase = getAdlUseCase("research-brief");
+    const payload = buildAdlLivePayload(useCase, "https://agent.example.com/run");
+
+    expect(payload).toMatchObject({
+      schemaVersion: "reddi.adl.demo-request.v1",
+      mode: "live-user-endpoint",
+      agentApiAddress: "https://agent.example.com/run",
+      useCaseId: "research-brief",
+      guardrails: {
+        noMainnet: true,
+        noStoredSecrets: true,
+        userSuppliedEndpointOnly: true,
+        mockModeDefault: true,
+      },
+    });
+    expect(payload.expectedPaymentFlow.map((step) => step.id)).toEqual(
+      useCase.steps.map((step) => step.id),
+    );
+  });
+});

--- a/lib/adl/demo-use-cases.ts
+++ b/lib/adl/demo-use-cases.ts
@@ -1,0 +1,249 @@
+export type AdlPaymentStepState =
+  | "complete"
+  | "pending"
+  | "blocked"
+  | "mocked";
+
+export interface AdlPaymentStep {
+  id: string;
+  label: string;
+  state: AdlPaymentStepState;
+  detail: string;
+  evidence: string;
+}
+
+export interface AdlUseCase {
+  id: string;
+  title: string;
+  buyerAgent: string;
+  sellerAgent: string;
+  attestorAgent: string;
+  adlRef: string;
+  paymentRail: string;
+  price: string;
+  summary: string;
+  mockRequest: string;
+  mockResponse: string;
+  steps: AdlPaymentStep[];
+  adlHighlights: string[];
+}
+
+export const adlUseCases: AdlUseCase[] = [
+  {
+    id: "research-brief",
+    title: "Research agent buys a specialist brief",
+    buyerAgent: "OpenClaw research coordinator",
+    sellerAgent: "Market research specialist",
+    attestorAgent: "Evidence review attestor",
+    adlRef: "harness.tools + payment.intent + evalGates",
+    paymentRail: "x402 over USDC devnet semantics",
+    price: "0.025 USDC",
+    summary:
+      "A coordinating agent discovers a research specialist, receives a price challenge, pays under a budget policy, and routes the answer through evidence review before reputation changes.",
+    mockRequest:
+      "Produce a sourced market brief for agent-to-agent payments in developer tools.",
+    mockResponse:
+      "Brief accepted. Three cited findings, risk notes, and receipt refs returned for attestation.",
+    adlHighlights: [
+      "ADL declares approved web/data sources before the buyer can ask for paid research.",
+      "The payment intent caps spend and requires a receipt before completion.",
+      "Eval gates require source coverage and receipt linkage before reputation updates.",
+    ],
+    steps: [
+      {
+        id: "discover",
+        label: "Discover specialist",
+        state: "complete",
+        detail:
+          "Buyer reads ADL capability metadata and selects a research specialist with a matching source policy.",
+        evidence: "adl.capabilities.research.market_brief",
+      },
+      {
+        id: "challenge",
+        label: "Quote challenge",
+        state: "complete",
+        detail:
+          "Seller returns an x402-style quote with amount, asset, network, and receipt requirements.",
+        evidence: "receipt.challenge.research-brief.001",
+      },
+      {
+        id: "approval",
+        label: "Policy approval",
+        state: "complete",
+        detail:
+          "Buyer ADL policy accepts the spend because it is below task cap and source-bound.",
+        evidence: "policy.maxUsdPerTask <= 0.05",
+      },
+      {
+        id: "receipt",
+        label: "Payment receipt",
+        state: "mocked",
+        detail:
+          "Mock mode packages a deterministic receipt. Live mode expects the supplied endpoint to return one.",
+        evidence: "mock.receipt.research-brief",
+      },
+      {
+        id: "attest",
+        label: "Attest output",
+        state: "complete",
+        detail:
+          "Attestor checks source coverage, result shape, and receipt chain before marking work reusable.",
+        evidence: "evalGate.sourceCoverage.pass",
+      },
+    ],
+  },
+  {
+    id: "code-review",
+    title: "Builder agent hires a code review specialist",
+    buyerAgent: "ADL builder assistant",
+    sellerAgent: "Security/code review specialist",
+    attestorAgent: "Release gate attestor",
+    adlRef: "harness.policies + evalGates + receipts",
+    paymentRail: "RAP receipt-bound payment plan",
+    price: "0.04 USDC",
+    summary:
+      "A builder agent turns an ADL export into a review request, pays a specialist only after quote approval, and blocks release until review evidence is attached.",
+    mockRequest:
+      "Review the generated local runner package for unsafe command execution and receipt leakage.",
+    mockResponse:
+      "Review complete. One unsafe command pattern blocked, two tests required, release gate remains hold until patched.",
+    adlHighlights: [
+      "ADL policies describe forbidden command classes and credential boundaries.",
+      "Receipts bind review cost to a specific source artifact hash.",
+      "Release eval gates consume the review verdict rather than trusting seller self-claims.",
+    ],
+    steps: [
+      {
+        id: "scope",
+        label: "Bind artifact scope",
+        state: "complete",
+        detail:
+          "Buyer passes a pinned ADL artifact hash so the seller cannot review a different package.",
+        evidence: "source.sha256.builder-runner",
+      },
+      {
+        id: "challenge",
+        label: "Review quote",
+        state: "complete",
+        detail:
+          "Seller quotes review cost and declares no live runtime, no secrets, and no mainnet scope.",
+        evidence: "x402.challenge.code-review",
+      },
+      {
+        id: "approve",
+        label: "Budget gate",
+        state: "complete",
+        detail:
+          "The buyer policy allows one paid review under the task budget and blocks follow-up spend.",
+        evidence: "payment.intent.single_call",
+      },
+      {
+        id: "work",
+        label: "Receipt-bound result",
+        state: "mocked",
+        detail:
+          "Mock mode returns a review packet. Live mode POSTs the same structured request to the user endpoint.",
+        evidence: "mock.review.packet",
+      },
+      {
+        id: "release",
+        label: "Release decision",
+        state: "blocked",
+        detail:
+          "Release remains blocked until required tests and attestation evidence are present.",
+        evidence: "evalGate.release.hold",
+      },
+    ],
+  },
+  {
+    id: "commerce-dispute",
+    title: "Commerce agent pays an attestor for dispute evidence",
+    buyerAgent: "Marketplace settlement coordinator",
+    sellerAgent: "Order evidence specialist",
+    attestorAgent: "Payment dispute attestor",
+    adlRef: "payment.reputation + recovery + observability",
+    paymentRail: "RAP x402 receipt and reputation preview",
+    price: "0.015 USDC",
+    summary:
+      "A settlement coordinator asks a specialist agent for order evidence, pays for the evidence bundle, then lets an attestor decide whether reputation can change.",
+    mockRequest:
+      "Collect delivery, invoice, and refund-policy evidence for order AGT-204 before settlement.",
+    mockResponse:
+      "Evidence bundle ready. Refund policy conflicts with seller claim; reputation mutation remains disabled pending human review.",
+    adlHighlights: [
+      "ADL observability fields require trace events for quote, payment, work, and attestation.",
+      "Recovery fields define refund/rollback evidence before any reputation mutation.",
+      "Reputation signals are previewed until the attestor signs the receipt chain.",
+    ],
+    steps: [
+      {
+        id: "discover",
+        label: "Find evidence agent",
+        state: "complete",
+        detail:
+          "Coordinator selects a seller that declares order evidence capability and refund policy awareness.",
+        evidence: "capability.order_evidence",
+      },
+      {
+        id: "quote",
+        label: "Quote evidence bundle",
+        state: "complete",
+        detail:
+          "Seller issues a small x402 quote tied to one order id and a maximum evidence window.",
+        evidence: "quote.order.AGT-204",
+      },
+      {
+        id: "pay",
+        label: "Receipt capture",
+        state: "mocked",
+        detail:
+          "Mock receipt proves ordering. Live mode expects the supplied endpoint to return receipt metadata.",
+        evidence: "receipt.order-evidence.mock",
+      },
+      {
+        id: "verify",
+        label: "Dispute attestation",
+        state: "complete",
+        detail:
+          "Attestor checks invoice, policy, and delivery evidence before deciding if settlement can continue.",
+        evidence: "attestation.dispute.reviewed",
+      },
+      {
+        id: "reputation",
+        label: "Reputation preview",
+        state: "blocked",
+        detail:
+          "Reputation stays preview-only because the scenario identifies a policy conflict.",
+        evidence: "reputation.preview.no_mutation",
+      },
+    ],
+  },
+];
+
+export function getAdlUseCase(id: string) {
+  return adlUseCases.find((useCase) => useCase.id === id) ?? adlUseCases[0];
+}
+
+export function buildAdlLivePayload(useCase: AdlUseCase, agentApiAddress: string) {
+  return {
+    schemaVersion: "reddi.adl.demo-request.v1",
+    mode: "live-user-endpoint",
+    agentApiAddress,
+    useCaseId: useCase.id,
+    buyerAgent: useCase.buyerAgent,
+    sellerAgent: useCase.sellerAgent,
+    attestorAgent: useCase.attestorAgent,
+    request: useCase.mockRequest,
+    expectedPaymentFlow: useCase.steps.map((step) => ({
+      id: step.id,
+      label: step.label,
+      evidence: step.evidence,
+    })),
+    guardrails: {
+      noMainnet: true,
+      noStoredSecrets: true,
+      userSuppliedEndpointOnly: true,
+      mockModeDefault: true,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Closes #611.

Adds an ADL-specific public site slice:

- `/adl` route with ADL positioning, whitepaper links, review intake, and interactive demo controls.
- `docs/ADL-WHITEPAPER-v0.1.md` as the durable ADL whitepaper review draft.
- `docs/ADL-WHITEPAPER-REVIEW-DEMO-PLAN-2026-07-20.md` as the OAD plan artifact.
- Three ADL use cases for agent-to-agent autonomous payments:
  - research agent buys a specialist brief;
  - builder agent hires a code review specialist;
  - commerce agent pays for dispute/evidence attestation.
- Mock mode defaults to packaged responses.
- Live endpoint mode requires a user-supplied API URL and sends the request from the browser only.
- Navigation and existing `/whitepaper` page link to the ADL page.

## Guardrails

- No direct push to `main`.
- No server-side storage of API addresses or review text.
- No secrets, wallet private keys, mainnet, production settlement, or automated paid calls.
- No live user endpoint calls during validation.
- Production publish remains gated by Nissan merge/deploy path.

## Validation

- `npx jest lib/__tests__/adl-demo-use-cases.test.ts --runInBand` passed.
- `npx eslint app/adl/page.tsx app/whitepaper/page.tsx components/NavBar.tsx lib/adl/demo-use-cases.ts lib/__tests__/adl-demo-use-cases.test.ts e2e/adl.spec.ts e2e/navigation.spec.ts` passed.
- `npm run build` passed; `/adl` prerendered as a static route.
- `git diff --check` passed.

## Known validation notes

- Full `npm run lint` is red on existing unrelated files across app/package/script surfaces, including `app/tour/page.tsx`, `jest.config.js`, package `dist` files, and old package tests. Scoped lint for this PR's touched files is clean.
- Playwright `/adl` smoke was added but local execution was blocked because the Playwright Chromium browser binary was missing; an attempted browser install stalled after download and was stopped. No product/runtime action depended on it.
- `npm ci` reported existing dependency audit findings; this PR does not change dependencies.
- `npm run build` emits an existing Turbopack NFT trace warning from `app/api/economic-demo/webpage-live-workflow/route.ts`, unrelated to this ADL slice.
